### PR TITLE
stop stream

### DIFF
--- a/kernel/nvidia/0023-stop-stream-logic.patch
+++ b/kernel/nvidia/0023-stop-stream-logic.patch
@@ -1,0 +1,126 @@
+From 84fdb8f6a163e481207138182b35d6fc1ef9c83f Mon Sep 17 00:00:00 2001
+From: Emil Jahshan <emil.jahshan@intel.com>
+Date: Wed, 12 Jan 2022 15:17:14 +0200
+Subject: [PATCH] stop stream logic
+
+ - before stopping a stream, a configuration to DT was added.
+   meaning, if we want to stop depth stream, we configure depth DT
+   then we send a stop command.
+ - removed unnecessery logs
+
+Signed-off-by: Emil Jahshan <emil.jahshan@intel.com>
+---
+ drivers/media/i2c/d4xx.c | 38 +++++++++++++++++++++++++-------------
+ 1 file changed, 25 insertions(+), 13 deletions(-)
+
+diff --git a/drivers/media/i2c/d4xx.c b/drivers/media/i2c/d4xx.c
+index 41994f68c..e3a166d6b 100644
+--- a/drivers/media/i2c/d4xx.c
++++ b/drivers/media/i2c/d4xx.c
+@@ -380,6 +380,9 @@ static int ds5_write(struct ds5 *state, u16 reg, u16 val)
+ 	value[1] = val >> 8;
+ 	value[0] = val & 0x00FF;
+ 
++	dev_info(&state->client->dev, "%s(): writing to register: 0x%04x, value1: 0x%x, value2:0x%x\n",
++				 __func__, reg, value[1], value[0]);
++
+ 	ret = regmap_raw_write(state->regmap, reg, value, sizeof(value));
+ 	if (ret < 0)
+ 		dev_err(&state->client->dev, "%s(): i2c write failed %d, 0x%04x = 0x%x\n",
+@@ -811,24 +814,18 @@ static int ds5_sensor_enum_frame_size(struct v4l2_subdev *sd,
+ 	if (state->is_imu)
+ 		sensor = &state->imu.sensor;
+ 
+-	dev_info(sensor->sd.dev, "%s(): after state->is_\n", __func__);
+ 	for (i = 0, fmt = sensor->formats; i < sensor->n_formats; i++, fmt++)
+ 		if (fse->code == fmt->mbus_code)
+ 			break;
+-	dev_info(sensor->sd.dev, "%s(): after loop\n", __func__);
+ 
+ 	if (i == sensor->n_formats)
+ 		return -EINVAL;
+-	dev_info(sensor->sd.dev, "%s(): after n_formats\n", __func__);
+ 
+ 	if (fse->index >= fmt->n_resolutions)
+ 		return -EINVAL;
+-	dev_info(sensor->sd.dev, "%s(): after n_res\n", __func__);
+ 
+ 	fse->min_width = fse->max_width = fmt->resolutions[fse->index].width;
+-	dev_info(sensor->sd.dev, "%s(): after wid\n", __func__);
+ 	fse->min_height = fse->max_height = fmt->resolutions[fse->index].height;
+-	dev_info(sensor->sd.dev, "%s(): after he\n", __func__);
+ 
+ 	return 0;
+ }
+@@ -952,14 +949,11 @@ static int __ds5_sensor_set_fmt(struct ds5 *state, struct ds5_sensor *sensor,
+ 
+ 	if (fmt->pad)
+ 		return -EINVAL;
+-	dev_info(sensor->sd.dev, "%s(): after fmt->pad  %d\n", __func__, fmt->pad);
+ 
+ 	mutex_lock(&state->lock);
+-	dev_info(sensor->sd.dev, "%s(): after state->lock \n", __func__);
+ 
+ 	sensor->config.format = ds5_sensor_find_format(sensor, mf,
+ 						&sensor->config.resolution);
+-	dev_info(sensor->sd.dev, "%s(): after ds5_sensor_find_format \n", __func__);
+ 	//r = DS5_FRAMERATE_DEFAULT_IDX < sensor->config.resolution->n_framerates ?
+ 	//	DS5_FRAMERATE_DEFAULT_IDX : 0;
+ 	/* FIXME: check if a framerate has been set */
+@@ -973,10 +967,8 @@ static int __ds5_sensor_set_fmt(struct ds5 *state, struct ds5_sensor *sensor,
+ 	else
+ // FIXME: use this format in .s_stream()
+ 		sensor->format = *mf;
+-	dev_info(sensor->sd.dev, "%s(): after sensor->format = *mf \n", __func__);
+ 
+ 	state->mux.last_set = sensor;
+-	dev_info(sensor->sd.dev, "%s(): after state->mux.last_set = sensor \n", __func__);
+ 
+ 	mutex_unlock(&state->lock);
+ 
+@@ -2436,6 +2428,10 @@ static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on)
+ 	u16 streaming, rate, depth_status, rgb_status;
+ 	int ret = 0;
+ 	unsigned int i = 0;
++	/*const*/ struct ds5_sensor *depth = &state->depth.sensor;
++	/*const*/ struct ds5_sensor *motion_t = &state->motion_t.sensor;
++	u8 dfmt = depth->streaming ? 0x31 : 0;
++	u8 mfmt = motion_t->streaming ? motion_t->config.format->data_type : 0;
+ 
+ 	dev_info(&state->client->dev, "%s(): %s on = %d\n", __func__, state->mux.last_set->sd.name, on);
+ 
+@@ -2444,8 +2440,24 @@ static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on)
+ 	if (state->is_imu)
+ 		return 0;
+ 
+-	if (on)
++	if (on) {
++		dev_info(&state->client->dev, "%s(): starting stream\n", __func__);
+ 		ret = ds5_configure(state);
++	} else {
++		dev_info(&state->client->dev, "%s(): stopping stream\n", __func__);
++
++		if (state->is_y8) {
++			dev_info(&state->client->dev, "%s(): stopping IR stream\n", __func__);
++			ret = ds5_write(state, DS5_DEPTH_Y_STREAMS_DT, (mfmt << 8));
++			if (ret < 0)
++				return ret;
++		} else {
++			dev_info(&state->client->dev, "%s(): stopping DEPTH stream\n", __func__);
++			ret = ds5_write(state, DS5_DEPTH_Y_STREAMS_DT, dfmt);
++			if (ret < 0)
++				return ret;
++		}
++	}
+ 
+ 	// TODO: remove, workaround for FW crash in start
+ 	msleep_range(100);
+@@ -3393,4 +3405,4 @@ module_i2c_driver(ds5_i2c_driver);
+ MODULE_DESCRIPTION("Intel D4XX camera driver");
+ MODULE_AUTHOR("Emil Jahshan (emil.jahshan@intel.com)");
+ MODULE_LICENSE("GPL v2");
+-MODULE_VERSION("1.0.0.6");
++MODULE_VERSION("1.0.0.7");
+-- 
+2.17.1
+


### PR DESCRIPTION
 - before stopping a stream, a configuration to DT was added.
   meaning, if we want to stop depth stream, we configure depth DT
   then we send a stop command.
 - removed unnecessary logs
Signed-off-by: Emil Jahshan <emil.jahshan@intel.com>