### PR TITLE
Fix fps setting and metadata issue

### DIFF
--- a/kernel/nvidia/0024-D4XX-Fix-framerate-setting-issue.patch
+++ b/kernel/nvidia/0024-D4XX-Fix-framerate-setting-issue.patch
@@ -1,0 +1,79 @@
+From f17ba829cf5c21514d02deeca8658c0d91e8e871 Mon Sep 17 00:00:00 2001
+From: Xin Zhang <xin.x.zhang@intel.com>
+Date: Sun, 16 Jan 2022 14:25:11 +0800
+Subject: [PATCH 1/2] D4XX: Fix framerate setting issue
+
+- Fix the wrong assumption of numerator always 1 and framerate overflow;
+- Choose the close framerate for current resolution if not exactly match.
+
+Signed-off-by: Xin Zhang <xin.x.zhang@intel.com>
+---
+ drivers/media/i2c/d4xx.c | 39 ++++++++++++++++++++++++++++-----------
+ 1 file changed, 28 insertions(+), 11 deletions(-)
+
+diff --git a/drivers/media/i2c/d4xx.c b/drivers/media/i2c/d4xx.c
+index e3a166d6b..78de6aafc 100644
+--- a/drivers/media/i2c/d4xx.c
++++ b/drivers/media/i2c/d4xx.c
+@@ -2395,30 +2395,47 @@ static int ds5_mux_g_frame_interval(struct v4l2_subdev *sd,
+ 	return 0;
+ }
+ 
++static u8 __ds5_probe_framerate(const struct ds5_resolution *res, u8 target)
++{
++	int i;
++	u8 framerate;
++
++	for (i = 0; i < res->n_framerates; i++) {
++		framerate = res->framerates[i];
++		if (target <= framerate)
++			return framerate;
++	}
++
++	return res->framerates[res->n_framerates - 1];
++}
++
+ static int ds5_mux_s_frame_interval(struct v4l2_subdev *sd,
+ 				    struct v4l2_subdev_frame_interval *fi)
+ {
+ 	struct ds5 *state = container_of(sd, struct ds5, mux.sd.subdev);
+-	struct ds5_sensor *depth = &state->depth.sensor;
+-	struct ds5_sensor *motion = &state->motion_t.sensor;
+-	struct ds5_sensor *rgb = &state->rgb.sensor;
+-	struct ds5_sensor *imu = &state->imu.sensor;
+-
++	struct ds5_sensor *sensor = NULL;
++	u8 framerate = 1;
+ 
+-	if (NULL == sd || NULL == fi)
++	if (NULL == sd || NULL == fi || fi->interval.numerator == 0)
+ 		return -EINVAL;
+ 
+ 	dev_info(sd->dev, "%s(): %s %d\n", __func__, sd->name, fi->pad);
+ 
+-
+ 	if(state->is_rgb)
+-		rgb->config.framerate = fi->interval.denominator;
++		sensor = &state->rgb.sensor;
+ 	if (state->is_depth)
+-		depth->config.framerate = fi->interval.denominator;
++		sensor = &state->depth.sensor;
+ 	if (state->is_y8)
+-		motion->config.framerate = fi->interval.denominator;
++		sensor = &state->motion_t.sensor;
+ 	if (state->is_imu)
+-		imu->config.framerate = fi->interval.denominator;
++		sensor = &state->imu.sensor;
++
++	framerate = fi->interval.denominator / fi->interval.numerator;
++	framerate = __ds5_probe_framerate(sensor->config.resolution, framerate);
++	sensor->config.framerate = framerate;
++	fi->interval.numerator = 1;
++	fi->interval.denominator = framerate;
++
+ 	return 0;
+ }
+ 
+-- 
+2.17.1
+

--- a/kernel/nvidia/0025-Fix-depth-color-metadata-corruption-issue.patch
+++ b/kernel/nvidia/0025-Fix-depth-color-metadata-corruption-issue.patch
@@ -1,0 +1,182 @@
+From 6a51d47e861b3c09e8ac522867950d64aec3032d Mon Sep 17 00:00:00 2001
+From: Xin Zhang <xin.x.zhang@intel.com>
+Date: Wed, 19 Jan 2022 09:56:22 +0800
+Subject: [PATCH 2/2] Fix depth/color metadata corruption issue
+
+Set up per channel DMA buffer for metadata instead of using the original
+one in tegra_mc_vi. Previously the depth metadata directly uses the DMA
+buffer in tegra_mc_vi for embedded, then later when enabling the color
+metadata it still uses the same structure.
+
+Signed-off-by: Xin Zhang <xin.x.zhang@intel.com>
+---
+ .../media/platform/tegra/camera/vi/channel.c  |  8 +++----
+ .../media/platform/tegra/camera/vi/vi4_fops.c | 20 ++++++++--------
+ .../media/platform/tegra/camera/vi/vi5_fops.c | 24 +++++++++----------
+ include/media/mc_common.h                     |  7 +++---
+ 4 files changed, 30 insertions(+), 29 deletions(-)
+
+diff --git a/drivers/media/platform/tegra/camera/vi/channel.c b/drivers/media/platform/tegra/camera/vi/channel.c
+index fd3aad4f4..d115e98d6 100644
+--- a/drivers/media/platform/tegra/camera/vi/channel.c
++++ b/drivers/media/platform/tegra/camera/vi/channel.c
+@@ -2673,11 +2673,11 @@ ctrl_init_error:
+ int tegra_channel_cleanup(struct tegra_channel *chan)
+ {
+ 	/* release embedded data buffer */
+-	if (chan->vi->emb_buf_size > 0) {
++	if (chan->vi->emb_buf_size[chan->id] > 0) {
+ 		dma_free_coherent(chan->vi->dev,
+-			chan->vi->emb_buf_size,
+-			chan->vi->emb_buf_addr, chan->vi->emb_buf);
+-		chan->vi->emb_buf_size = 0;
++			chan->vi->emb_buf_size[chan->id],
++			chan->vi->emb_buf_addr[chan->id], chan->vi->emb_buf[chan->id]);
++		chan->vi->emb_buf_size[chan->id] = 0;
+ 		vb2_queue_release(&chan->embedded.queue);
+ #if defined(CONFIG_VIDEOBUF2_DMA_CONTIG)
+ 		tegra_vb2_dma_cleanup(chan->vi->dev, chan->embedded.alloc_ctx,
+diff --git a/drivers/media/platform/tegra/camera/vi/vi4_fops.c b/drivers/media/platform/tegra/camera/vi/vi4_fops.c
+index 0b397c1fe..c7748aee0 100644
+--- a/drivers/media/platform/tegra/camera/vi/vi4_fops.c
++++ b/drivers/media/platform/tegra/camera/vi/vi4_fops.c
+@@ -236,7 +236,7 @@ static void tegra_channel_surface_setup(
+ 
+ 	if (chan->embedded.height > 0)
+ 		vi4_channel_write(chan, vnc_id, ATOMP_EMB_SURFACE_OFFSET0,
+-						  chan->vi->emb_buf);
++						  chan->vi->emb_buf[chan->id]);
+ 	else
+ 		vi4_channel_write(chan, vnc_id, ATOMP_EMB_SURFACE_OFFSET0, 0);
+ 	vi4_channel_write(chan, vnc_id, ATOMP_EMB_SURFACE_OFFSET0_H, 0x0);
+@@ -999,29 +999,29 @@ static int vi4_channel_start_streaming(struct vb2_queue *vq, u32 count)
+ 		}
+ 
+ 		/* Allocate buffer for Embedded Data if need to*/
+-		if (emb_buf_size > chan->vi->emb_buf_size) {
++		if (emb_buf_size > chan->vi->emb_buf_size[chan->id]) {
+ 			/*
+ 			 * if old buffer is smaller than what we need,
+ 			 * release the old buffer and re-allocate a bigger
+ 			 * one below
+ 			 */
+-			if (chan->vi->emb_buf_size > 0) {
++			if (chan->vi->emb_buf_size[chan->id] > 0) {
+ 				dma_free_coherent(chan->vi->dev,
+-					chan->vi->emb_buf_size,
+-					chan->vi->emb_buf_addr, chan->vi->emb_buf);
+-				chan->vi->emb_buf_size = 0;
++					chan->vi->emb_buf_size[chan->id],
++					chan->vi->emb_buf_addr[chan->id], chan->vi->emb_buf[chan->id]);
++				chan->vi->emb_buf_size[chan->id] = 0;
+ 			}
+ 
+-			chan->vi->emb_buf_addr =
++			chan->vi->emb_buf_addr[chan->id] =
+ 				dma_alloc_coherent(chan->vi->dev,
+ 					emb_buf_size,
+-					&chan->vi->emb_buf, GFP_KERNEL);
+-			if (!chan->vi->emb_buf_addr) {
++					&chan->vi->emb_buf[chan->id], GFP_KERNEL);
++			if (!chan->vi->emb_buf_addr[chan->id]) {
+ 				dev_err(&chan->video.dev,
+ 						"Can't allocate memory for embedded data\n");
+ 				goto error_capture_setup;
+ 			}
+-			chan->vi->emb_buf_size = emb_buf_size;
++			chan->vi->emb_buf_size[chan->id] = emb_buf_size;
+ 		}
+ 	}
+ 
+diff --git a/drivers/media/platform/tegra/camera/vi/vi5_fops.c b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
+index ccf24326f..96e98945b 100644
+--- a/drivers/media/platform/tegra/camera/vi/vi5_fops.c
++++ b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
+@@ -302,9 +302,9 @@ static void vi5_setup_surface(struct tegra_channel *chan,
+ 		desc->ch_cfg.frame.embed_x = chan->embedded.width * BPP_MEM;
+ 		desc->ch_cfg.frame.embed_y = chan->embedded.height;
+ 		desc->ch_cfg.atomp.surface[VI_ATOMP_SURFACE_EMBEDDED].offset
+-			= (u32)chan->vi->emb_buf;
++			= (u32)chan->vi->emb_buf[chan->id];
+ 		desc->ch_cfg.atomp.surface[VI_ATOMP_SURFACE_EMBEDDED].offset_hi
+-			= (u32)(chan->vi->emb_buf >> 32U);
++			= (u32)(chan->vi->emb_buf[chan->id] >> 32U);
+ 		desc->ch_cfg.atomp.surface_stride[VI_ATOMP_SURFACE_EMBEDDED]
+ 			= chan->embedded.width * BPP_MEM;
+ 	}
+@@ -340,7 +340,7 @@ static void vi5_release_buffer(struct tegra_channel *chan,
+ 		if(evb) {
+ 			frm_buffer = vb2_plane_vaddr(evb, 0);
+ 			if(frm_buffer != NULL) {
+-				memcpy(frm_buffer,chan->vi->emb_buf_addr,256);
++				memcpy(frm_buffer,chan->vi->emb_buf_addr[chan->id], 256);
+ 			}
+ 		}
+ 	}
+@@ -773,29 +773,29 @@ static int vi5_channel_start_streaming(struct vb2_queue *vq, u32 count)
+ 		}
+ 
+ 		/* Allocate buffer for Embedded Data if need to*/
+-		if (emb_buf_size > chan->vi->emb_buf_size) {
++		if (emb_buf_size > chan->vi->emb_buf_size[chan->id]) {
+ 			/*
+ 			 * if old buffer is smaller than what we need,
+ 			 * release the old buffer and re-allocate a bigger
+ 			 * one below
+ 			 */
+-			if (chan->vi->emb_buf_size > 0) {
++			if (chan->vi->emb_buf_size[chan->id] > 0) {
+ 				dma_free_coherent(chan->vi->dev,
+-					chan->vi->emb_buf_size,
+-					chan->vi->emb_buf_addr, chan->vi->emb_buf);
+-				chan->vi->emb_buf_size = 0;
++					chan->vi->emb_buf_size[chan->id],
++					chan->vi->emb_buf_addr[chan->id], chan->vi->emb_buf[chan->id]);
++				chan->vi->emb_buf_size[chan->id] = 0;
+ 			}
+ 
+-			chan->vi->emb_buf_addr =
++			chan->vi->emb_buf_addr[chan->id] =
+ 				dma_alloc_coherent(chan->vi->dev,
+ 					emb_buf_size,
+-					&chan->vi->emb_buf, GFP_KERNEL);
+-			if (!chan->vi->emb_buf_addr) {
++					&chan->vi->emb_buf[chan->id], GFP_KERNEL);
++			if (!chan->vi->emb_buf_addr[chan->id]) {
+ 				dev_err(&chan->video.dev,
+ 						"Can't allocate memory for embedded data\n");
+ 				goto error;
+ 			}
+-			chan->vi->emb_buf_size = emb_buf_size;
++			chan->vi->emb_buf_size[chan->id] = emb_buf_size;
+ 		}
+ 	}
+ 
+diff --git a/include/media/mc_common.h b/include/media/mc_common.h
+index d2d3667fa..1fb24fa5b 100644
+--- a/include/media/mc_common.h
++++ b/include/media/mc_common.h
+@@ -40,6 +40,7 @@
+ #define	ENABLE		1
+ #define	DISABLE		0
+ #define MAX_SYNCPT_PER_CHANNEL	3
++#define MAX_CHANNELS 6
+ 
+ #define CAPTURE_MIN_BUFFERS	1U
+ #define CAPTURE_MAX_BUFFERS	240U
+@@ -328,9 +329,9 @@ struct tegra_mc_vi {
+ 
+ 	const struct tegra_vi_fops *fops;
+ 
+-	dma_addr_t emb_buf;
+-	void *emb_buf_addr;
+-	unsigned int emb_buf_size;
++	dma_addr_t emb_buf[MAX_CHANNELS];
++	void *emb_buf_addr[MAX_CHANNELS];
++	unsigned int emb_buf_size[MAX_CHANNELS];
+ };
+ 
+ int tegra_vi_get_port_info(struct tegra_channel *chan,
+-- 
+2.17.1
+


### PR DESCRIPTION
Framerate setting fix patch:

- Fix the wrong assumption of numerator always 1 and framerate overflow;
- Choose the close framerate for current resolution if not exactly match.

Metadata issue fix patch:

Set up per channel DMA buffer for metadata instead of using the original one in tegra_mc_vi. Previously the depth metadata directly uses the DMA buffer in tegra_mc_vi for embedded, then later when enabling the color metadata it still uses the same structure.