### PR TITLE
Backport preferred_stride control from newer JetPack

### DIFF
--- a/kernel/nvidia/0032-tegra-camera-add-preferred-stride-controls.patch
+++ b/kernel/nvidia/0032-tegra-camera-add-preferred-stride-controls.patch
@@ -1,0 +1,139 @@
+From 5e77c0609154eb3f83310aaaaa667079dc66e2cf Mon Sep 17 00:00:00 2001
+From: Jerry Chang <jerchang@nvidia.com>
+Date: Mon, 25 Nov 2019 17:16:41 +0800
+Subject: [PATCH] tegra: camera: add preferred stride controls
+
+add preferred stride cid control for stride adjustment
+
+Bug 2722149
+
+Change-Id: Ifef54fc2e9410abd71fcf3e575c2fdfb68ff7ee8
+Signed-off-by: Jerry Chang <jerchang@nvidia.com>
+Reviewed-on: https://git-master.nvidia.com/r/2246839
+Reviewed-by: Automatic_Commit_Validation_User
+GVS: Gerrit_Virtual_Submit
+Reviewed-by: Frank Chen <frankc@nvidia.com>
+Reviewed-by: Joshua Widen <jwiden@nvidia.com>
+Reviewed-by: mobile promotions <svcmobile_promotions@nvidia.com>
+Tested-by: mobile promotions <svcmobile_promotions@nvidia.com>
+---
+ .../media/platform/tegra/camera/vi/channel.c  | 35 +++++++++++++++++--
+ include/media/mc_common.h                     |  1 +
+ include/media/tegra-v4l2-camera.h             |  1 +
+ 3 files changed, 34 insertions(+), 3 deletions(-)
+
+diff --git a/drivers/media/platform/tegra/camera/vi/channel.c b/drivers/media/platform/tegra/camera/vi/channel.c
+index d115e98d6..56ad42c01 100644
+--- a/drivers/media/platform/tegra/camera/vi/channel.c
++++ b/drivers/media/platform/tegra/camera/vi/channel.c
+@@ -245,6 +245,10 @@ static void tegra_channel_update_format(struct tegra_channel *chan,
+ 	chan->format.pixelformat = fourcc;
+ 	chan->format.bytesperline = preferred_stride ?: bytesperline;
+ 
++	dev_dbg(&chan->video.dev,
++			"%s: Resolution= %dx%d bytesperline=%d\n",
++			__func__, width, height, chan->format.bytesperline);
++
+ 	tegra_channel_fmt_align(chan, chan->fmtinfo,
+ 				&chan->format.width,
+ 				&chan->format.height,
+@@ -320,7 +324,8 @@ static void tegra_channel_fmts_bitmap_init(struct tegra_channel *chan)
+ 	tegra_channel_update_format(chan, chan->format.width,
+ 				chan->format.height,
+ 				chan->fmtinfo->fourcc,
+-				&chan->fmtinfo->bpp, 0);
++				&chan->fmtinfo->bpp,
++				chan->preferred_stride);
+ 
+ 	if (chan->total_ports > 1)
+ 		update_gang_mode(chan);
+@@ -1122,7 +1127,8 @@ tegra_channel_s_dv_timings(struct file *file, void *fh,
+ 
+ 	if (!ret)
+ 		tegra_channel_update_format(chan, bt->width, bt->height,
+-			chan->fmtinfo->fourcc, &chan->fmtinfo->bpp, 0);
++			chan->fmtinfo->fourcc, &chan->fmtinfo->bpp,
++			chan->preferred_stride);
+ 
+ 	if (chan->total_ports > 1)
+ 		update_gang_mode(chan);
+@@ -1226,6 +1232,14 @@ int tegra_channel_s_ctrl(struct v4l2_ctrl *ctrl)
+ 	case TEGRA_CAMERA_CID_LOW_LATENCY:
+ 		chan->low_latency = ctrl->val;
+ 		break;
++	case TEGRA_CAMERA_CID_VI_PREFERRED_STRIDE:
++		chan->preferred_stride = ctrl->val;
++		tegra_channel_update_format(chan, chan->format.width,
++				chan->format.height,
++				chan->format.pixelformat,
++				&chan->fmtinfo->bpp,
++				chan->preferred_stride);
++		break;
+ 	default:
+ 		dev_err(&chan->video.dev, "%s: Invalid ctrl %u\n",
+ 			__func__, ctrl->id);
+@@ -1360,6 +1374,16 @@ static const struct v4l2_ctrl_config common_custom_ctrls[] = {
+ 		.max = 1,
+ 		.step = 1,
+ 	},
++	{
++		.ops = &channel_ctrl_ops,
++		.id = TEGRA_CAMERA_CID_VI_PREFERRED_STRIDE,
++		.name = "Preferred Stride",
++		.type = V4L2_CTRL_TYPE_INTEGER,
++		.min = 0,
++		.max = 65535,
++		.step = 1,
++		.def = 0,
++	},
+ };
+ 
+ #define GET_TEGRA_CAMERA_CTRL(id, c)					\
+@@ -1906,6 +1930,10 @@ __tegra_channel_set_format(struct tegra_channel *chan,
+ 	if (!ret) {
+ 		chan->format = *pix;
+ 		chan->fmtinfo = vfmt;
++
++		if (chan->preferred_stride)
++			pix->bytesperline = chan->preferred_stride;
++
+ 		tegra_channel_update_format(chan, pix->width,
+ 			pix->height, vfmt->fourcc, &vfmt->bpp,
+ 			pix->bytesperline);
+@@ -2575,7 +2603,8 @@ int tegra_channel_init(struct tegra_channel *chan)
+ 	tegra_channel_update_format(chan, TEGRA_DEF_WIDTH,
+ 				TEGRA_DEF_HEIGHT,
+ 				chan->fmtinfo->fourcc,
+-				&chan->fmtinfo->bpp, 0);
++				&chan->fmtinfo->bpp,
++				chan->preferred_stride);
+ 
+ 	chan->buffer_offset[0] = 0;
+ 
+diff --git a/include/media/mc_common.h b/include/media/mc_common.h
+index 1fb24fa5b..5bf56fd13 100644
+--- a/include/media/mc_common.h
++++ b/include/media/mc_common.h
+@@ -204,6 +204,7 @@ struct tegra_channel {
+ 
+ 	void __iomem *csibase[TEGRA_CSI_BLOCKS];
+ 	unsigned int stride_align;
++	unsigned int preferred_stride;
+ 	unsigned int width_align;
+ 	unsigned int height_align;
+ 	unsigned int size_align;
+diff --git a/include/media/tegra-v4l2-camera.h b/include/media/tegra-v4l2-camera.h
+index d1c71fc15..1e575b5aa 100644
+--- a/include/media/tegra-v4l2-camera.h
++++ b/include/media/tegra-v4l2-camera.h
+@@ -53,6 +53,7 @@
+ #define TEGRA_CAMERA_CID_SENSOR_CONTROL_PROPERTIES (TEGRA_CAMERA_CID_BASE+107)
+ #define TEGRA_CAMERA_CID_SENSOR_DV_TIMINGS         (TEGRA_CAMERA_CID_BASE+108)
+ #define TEGRA_CAMERA_CID_LOW_LATENCY         (TEGRA_CAMERA_CID_BASE+109)
++#define TEGRA_CAMERA_CID_VI_PREFERRED_STRIDE (TEGRA_CAMERA_CID_BASE+110)
+ 
+ /**
+  * This is temporary with the current v4l2 infrastructure
+-- 
+2.17.1
+

--- a/utilities/streamApp/camera_sub_system/Stream.cpp
+++ b/utilities/streamApp/camera_sub_system/Stream.cpp
@@ -266,12 +266,14 @@ int Stream::configure(realsense::camera_sub_system::Format format)
     mFormat.width = format.width;
     mFormat.height = format.height;
     mFormat.fps = format.fps;
+    mFormat.bytesperline = format.bytesperline;
 
     struct v4l2_format v4l2Format;
     v4l2Format.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
     v4l2Format.fmt.pix.pixelformat = mFormat.v4l2Format;
     v4l2Format.fmt.pix.width = mFormat.width;
     v4l2Format.fmt.pix.height = mFormat.height;
+    v4l2Format.fmt.pix.bytesperline = mFormat.bytesperline;
     int ret = ioctl(fd.get(), VIDIOC_S_FMT, &v4l2Format);
     if (ret < 0) {
         RS_LOGE("VIDIOC_S_FMT failed, errno %d", errno);
@@ -300,6 +302,15 @@ int Stream::configure(realsense::camera_sub_system::Format format)
         RS_LOGE("VIDIOC_S_PARM failed, errno %d", errno);
     } else
         RS_LOGI("FPS set to to %d ", mFormat.fps);
+
+    struct v4l2_control setStride {0};
+    setStride.id = 0x9a206e; // the value of TEGRA_CAMERA_CID_VI_PREFERRED_STRIDE, not available in user space header
+    setStride.value = mFormat.bytesperline;
+    ret = ioctl(fd.get(), VIDIOC_S_CTRL, &setStride);
+    if (ret < 0) {
+        RS_LOGE("VIDIOC_S_CTRL failed, errno %d", errno);
+    } else
+        RS_LOGI("preferred_stride set to to %d ", setStride.value);
 
     return ret;
 }
@@ -758,7 +769,7 @@ int Stream::initMmap(vector<RsBuffer*> rsBuffers)
         }
 
         rsBuffer->buffer = (struct buffer*)mmap(nullptr,
-                                                rsBuffer->length,
+                                                mV4l2Buffer.length,
                                                 PROT_READ | PROT_WRITE,
                                                 MAP_SHARED,
                                                 mFileDescriptor,

--- a/utilities/streamApp/camera_sub_system/include/CSSTypes.h
+++ b/utilities/streamApp/camera_sub_system/include/CSSTypes.h
@@ -25,6 +25,7 @@
 #include <functional>
 #include <stdexcept>
 #include <memory>
+#include <linux/videodev2.h>
 
 #include "CameraCapabilities.h"
 
@@ -114,9 +115,25 @@ struct Format {
     uint32_t width;
     uint32_t height;
     uint32_t fps;
+    uint32_t bytesperline;
 
     Format (uint32_t f, uint32_t w, uint32_t h, uint32_t fps)
-    : v4l2Format(f), width(w), height(h), fps(fps) { }
+    : v4l2Format(f), width(w), height(h), fps(fps)
+    {
+        calc64BytesAlignedStride();
+    }
+
+    uint32_t calc64BytesAlignedStride(void)
+    {
+        bytesperline = ((width / 64) + ((width % 64) ? 1 : 0)) * 64;
+
+        if (v4l2Format == V4L2_PIX_FMT_YUYV || v4l2Format == V4L2_PIX_FMT_Z16)
+            bytesperline *= 2;
+        else if (v4l2Format == V4L2_PIX_FMT_Y12I)
+            bytesperline *= 4;
+
+        return bytesperline;
+    }
 };
 
 /**


### PR DESCRIPTION
Use preferred_stride control to set the bytesperline value to be 64B
align, to support the resolutions those width is not 64B align. This
requirement is not seen in documents but mentioned in NVIDIA's forum.
VI driver handles this and the v4l2 format's bytesperline is set too.

Modify the GUI app streamApp to set preferred_stride automatically for
the stream width.

Signed-off-by: Xin Zhang <xin.x.zhang@intel.com>

Tracked on: DSO-17601