### PR TITLE
Correct gain auto_exposure settings for depth/rgb

### DIFF
--- a/kernel/nvidia/0033-Correct-gain-auto_exposure-exposure_absolute-for-dep.patch
+++ b/kernel/nvidia/0033-Correct-gain-auto_exposure-exposure_absolute-for-dep.patch
@@ -1,0 +1,271 @@
+From e5df337e629206461b0a5445f77dbde27a32ce1d Mon Sep 17 00:00:00 2001
+From: Xin Zhang <xin.x.zhang@intel.com>
+Date: Mon, 24 Jan 2022 16:08:18 +0800
+Subject: [PATCH] Correct gain/auto_exposure/exposure_absolute for depth/color
+
+- Follow the standard v4l2 auto_exposure menu number setting:
+  1 manual,
+  3 aperture_priority;
+- Correct code for exposure value setting;
+- Correct code for depth/color gain setting;
+- Cleanup ctrl setting code.
+
+Signed-off-by: Xin Zhang <xin.x.zhang@intel.com>
+---
+ drivers/media/i2c/d4xx.c | 176 +++++++++++++++++----------------------
+ 1 file changed, 78 insertions(+), 98 deletions(-)
+
+diff --git a/drivers/media/i2c/d4xx.c b/drivers/media/i2c/d4xx.c
+index 964a3e31e..af3aa74b6 100644
+--- a/drivers/media/i2c/d4xx.c
++++ b/drivers/media/i2c/d4xx.c
+@@ -78,9 +78,10 @@
+ 
+ #define MIPI_LANE_RATE	1000
+ 
+-#define MAX_DEPTH_EXP	200
+-#define MAX_RGB_EXP		1000
+-#define MIN_EXP			1
++#define MAX_DEPTH_EXP	2000
++#define MAX_RGB_EXP	10000
++#define DEF_DEPTH_EXP	330
++#define DEF_RGB_EXP	1660
+ 
+ /* Currently both depth and IR use VC 0 */
+ #define DS5_DEPTH_VCHAN_N		0
+@@ -267,7 +268,7 @@ struct ds5_ctrls {
+ 		struct v4l2_ctrl *manual_laser_power;
+ 		struct v4l2_ctrl *auto_exp;
+ 		struct v4l2_ctrl *exposure;
+-		/* TODO: double-check: in DS5 manual gain only works with manual exposure */
++		/* in DS5 manual gain only works with manual exposure */
+ 		struct v4l2_ctrl *gain;
+ 	};
+ };
+@@ -1168,71 +1169,47 @@ static const struct v4l2_subdev_ops ds5_imu_subdev_ops = {
+ 	.video = &ds5_sensor_video_ops,
+ };
+ 
+-static int ds5_hw_set_auto_exposure(struct ds5 *state, u32 val)
++static int ds5_hw_set_auto_exposure(struct ds5 *state, u32 base, u32 val)
+ {
+-	int ret;
+-	u16 value;
+-	if (state->is_rgb) {
+-		if (0 == val)
++	if (val != V4L2_EXPOSURE_APERTURE_PRIORITY &&
++	    val != V4L2_EXPOSURE_MANUAL)
++		return -EINVAL;
++
++	/*
++	 * In firmware color auto exposure setting follow the uvc_menu_info
++	 * exposure_auto_controls numbers, in drivers/media/usb/uvc/uvc_ctrl.c.
++	 */
++	if (state->is_rgb && val == V4L2_EXPOSURE_APERTURE_PRIORITY)
++		val = 8;
++
++	/*
++	 * In firmware depth auto exposure on: 1, off: 0.
++	 */
++	if (!state->is_rgb) {
++		if (val == V4L2_EXPOSURE_APERTURE_PRIORITY)
+ 			val = 1;
+-		else
+-			val = 8;
+-		ds5_read(state, DS5_RGB_CONTROL_BASE | DS5_AUTO_EXPOSURE_MODE, &value);
+-		ret = ds5_write(state, DS5_RGB_CONTROL_BASE | DS5_AUTO_EXPOSURE_MODE, val);
+-		ds5_read(state, DS5_RGB_CONTROL_BASE | DS5_AUTO_EXPOSURE_MODE, &value);
+-		ds5_read(state, 0x401C, &value);
+-		ds5_read(state, 0x403C, &value);
+-	}
+-	else {
+-		ds5_read(state, DS5_DEPTH_CONTROL_BASE | DS5_AUTO_EXPOSURE_MODE, &value);
+-		ret = ds5_write(state, DS5_DEPTH_CONTROL_BASE | DS5_AUTO_EXPOSURE_MODE, val);
+-		ds5_read(state, DS5_DEPTH_CONTROL_BASE | DS5_AUTO_EXPOSURE_MODE, &value);
+-		ds5_read(state, 0x401C, &value);
+-		ds5_read(state, 0x403C, &value);
++		else if (val == V4L2_EXPOSURE_MANUAL)
++			val = 0;
+ 	}
+-	return ret;
++
++	return ds5_write(state, base | DS5_AUTO_EXPOSURE_MODE, val);
+ }
+ 
+-/* Manual exposure in us between 1 and 200ms */
+-static int ds5_hw_set_exposure(struct ds5 *state, u32 val)
++/*
++ * Manual exposure in us
++ * Depth/Y8: between 100 and 200000 (200ms)
++ * Color: between 100 and 1000000 (1s)
++ */
++static int ds5_hw_set_exposure(struct ds5 *state, u32 base, u32 val)
+ {
+ 	int ret;
+-	u16 value;
+-
+-	if (!state->is_rgb) {
+-		if (val < MIN_EXP * 10)
+-			val = MIN_EXP * 1000;
+-		else if (val > MAX_DEPTH_EXP * 10)
+-			val = MAX_DEPTH_EXP * 1000;
+-		else
+-			val *= 100;
+-	} else {
+-		if (val < MIN_EXP)
+-			val = MIN_EXP;
+-		else if (val > MAX_RGB_EXP * 10)
+-			val = MAX_RGB_EXP * 10;
+-	}
+-
+-	if (state->is_rgb) {
+-		ret = ds5_write(state, DS5_RGB_CONTROL_BASE | DS5_MANUAL_EXPOSURE_MSB, val >> 16);
+-	}
+-	else
+-		ret = ds5_write(state, DS5_DEPTH_CONTROL_BASE | DS5_MANUAL_EXPOSURE_MSB, val >> 16);
+ 
+-	if (!ret) {
+-		if (state->is_rgb) {
+-			ret = ds5_write(state, DS5_RGB_CONTROL_BASE | DS5_MANUAL_EXPOSURE_LSB, val & 0xffff);
+-		}
+-		else
+-			ret = ds5_write(state, DS5_DEPTH_CONTROL_BASE | DS5_MANUAL_EXPOSURE_LSB, val & 0xffff);
+-	}
++	val *= 100;
+ 
+-	ds5_read(state, DS5_DEPTH_CONTROL_BASE | DS5_MANUAL_EXPOSURE_LSB, &value);
+-	ds5_read(state, DS5_DEPTH_CONTROL_BASE | DS5_MANUAL_EXPOSURE_MSB, &value);
+-	ds5_read(state, DS5_RGB_CONTROL_BASE | DS5_MANUAL_EXPOSURE_LSB, &value);
+-	ds5_read(state, DS5_RGB_CONTROL_BASE | DS5_MANUAL_EXPOSURE_MSB, &value);
+-	ds5_read(state, 0x401C, &value);
+-	ds5_read(state, 0x403C, &value);
++	ret = ds5_write(state, base | DS5_MANUAL_EXPOSURE_MSB, val >> 16);
++	if (!ret)
++		ret = ds5_write(state, base | DS5_MANUAL_EXPOSURE_LSB,
++				val & 0xffff);
+ 
+ 	return ret;
+ }
+@@ -1336,37 +1313,39 @@ static int ds5_s_ctrl(struct v4l2_ctrl *ctrl)
+ 	struct ds5 *state = container_of(ctrl->handler, struct ds5,
+ 					 ctrls.handler);
+ 	struct v4l2_subdev *sd = &state->mux.sd.subdev;
+-	int ret;
++	int ret = -EINVAL;
++	u16 base = DS5_DEPTH_CONTROL_BASE;
+ 
+-	v4l2_dbg(1, 1, sd, "ctrl: %s, value: %d\n", ctrl->name, ctrl->val);
++	if (state->is_rgb)
++		base = DS5_RGB_CONTROL_BASE;
++	else if (state->is_imu)
++		return ret;
+ 
+-// FIXME: Check for streaming statuus "success"
++	v4l2_dbg(1, 1, sd, "ctrl: %s, value: %d\n", ctrl->name, ctrl->val);
+ 
+ 	mutex_lock(&state->lock);
+ 
+-	//if (state->power == 0)
+-	//	goto unlock;
+-
+ 	switch (ctrl->id) {
+ 	case V4L2_CID_ANALOGUE_GAIN:
+-		/* FIXME: unit conversion! */
+-		ds5_write(state, DS5_MANUAL_GAIN, ctrl->val);
++		ret = ds5_write(state, base | DS5_MANUAL_GAIN, ctrl->val);
+ 		break;
+ 
+ 	case V4L2_CID_EXPOSURE_AUTO:
+-		ds5_hw_set_auto_exposure(state, ctrl->val);
++		ret = ds5_hw_set_auto_exposure(state, base, ctrl->val);
+ 		break;
+ 
+ 	case V4L2_CID_EXPOSURE_ABSOLUTE:
+-		ds5_hw_set_exposure(state, ctrl->val);
++		ret = ds5_hw_set_exposure(state, base, ctrl->val);
+ 		break;
+ 	case DS5_CAMERA_CID_LASER_POWER:
+-		if (!state->is_rgb && !state->is_imu)
+-			ds5_write(state, DS5_DEPTH_CONTROL_BASE | DS5_LASER_POWER, ctrl->val);
++		if (!state->is_rgb)
++			ret = ds5_write(state, base | DS5_LASER_POWER,
++					ctrl->val);
+ 		break;
+ 	case DS5_CAMERA_CID_MANUAL_LASER_POWER:
+-		if (!state->is_rgb && !state->is_imu)
+-			ds5_write(state, DS5_DEPTH_CONTROL_BASE | DS5_MANUAL_LASER_POWER, ctrl->val);
++		if (!state->is_rgb)
++			ret = ds5_write(state, base | DS5_MANUAL_LASER_POWER,
++					ctrl->val);
+ 		break;
+ 	case DS5_CAMERA_DEPTH_CALIBRATION_TABLE_SET: {
+ 		struct hwm_cmd *calib_cmd;
+@@ -1514,9 +1493,6 @@ static int ds5_s_ctrl(struct v4l2_ctrl *ctrl)
+ 		break;
+ 	}
+ 
+-//unlock:
+-	// TODO: why to ret = 0 ?
+-	ret = 0/*ds5_clear_error(state)*/;
+ 	mutex_unlock(&state->lock);
+ 
+ 	return ret;
+@@ -1942,30 +1918,34 @@ static int ds5_ctrl_init(struct ds5 *state)
+ 	ctrls->laser_power = v4l2_ctrl_new_custom(hdl, &ds5_ctrl_laser_power, NULL);
+ 	ctrls->manual_laser_power = v4l2_ctrl_new_custom(hdl, &ds5_ctrl_manual_laser_power, NULL);
+ 
+-	// TODO: remove this comment
+-	// V4L2 Doc: It is recommended to add controls in ascending control ID order:
+-	//           it will be a bit faster that way
+-
+-	/* Exposure time: x 100 us. */
+-	if (!state->is_rgb) {
+-		ctrls->exposure = v4l2_ctrl_new_std(hdl, ops, V4L2_CID_EXPOSURE_ABSOLUTE,
+-					    10, MAX_DEPTH_EXP * 10, 1, 2 * 10);
+-	} else {
+-		ctrls->exposure = v4l2_ctrl_new_std(hdl, ops, V4L2_CID_EXPOSURE_ABSOLUTE,
+-					    10, MAX_RGB_EXP * 10, 1, 2 * 10);
+-	}
+-
+ 	/* Total gain */
+-	ctrls->gain = v4l2_ctrl_new_std(hdl, ops, V4L2_CID_ANALOGUE_GAIN,
+-					16, 248, 1, 16);
++	if (state->is_depth || state->is_y8) {
++		ctrls->gain = v4l2_ctrl_new_std(hdl, ops,
++						V4L2_CID_ANALOGUE_GAIN,
++						16, 248, 1, 16);
++	} else if (state->is_rgb) {
++		ctrls->gain = v4l2_ctrl_new_std(hdl, ops,
++						V4L2_CID_ANALOGUE_GAIN,
++						0, 128, 1, 64);
++	}
+ 
+-	/* Assume both shutter and aperture priorities are supported */
+ 	ctrls->auto_exp = v4l2_ctrl_new_std_menu(hdl, ops,
+-						 V4L2_CID_EXPOSURE_AUTO,
+-						 V4L2_EXPOSURE_MANUAL, 0, (u8)V4L2_CID_EXPOSURE_AUTO);
+-
+-	// TODO: this prevents setting of manual exposure
+-	// v4l2_ctrl_auto_cluster(3, &ctrls->auto_exp, 0, false);
++				V4L2_CID_EXPOSURE_AUTO,
++				V4L2_EXPOSURE_APERTURE_PRIORITY,
++				~((1 << V4L2_EXPOSURE_MANUAL) |
++				  (1 << V4L2_EXPOSURE_APERTURE_PRIORITY)),
++				V4L2_EXPOSURE_APERTURE_PRIORITY);
++
++	/* Exposure time: V4L2_CID_EXPOSURE_ABSOLUTE unit: 100 us. */
++	if (state->is_depth || state->is_y8) {
++		ctrls->exposure = v4l2_ctrl_new_std(hdl, ops,
++					V4L2_CID_EXPOSURE_ABSOLUTE,
++					1, MAX_DEPTH_EXP, 1, DEF_DEPTH_EXP);
++	} else if (state->is_rgb) {
++		ctrls->exposure = v4l2_ctrl_new_std(hdl, ops,
++					V4L2_CID_EXPOSURE_ABSOLUTE,
++					1, MAX_RGB_EXP, 1, DEF_RGB_EXP);
++	}
+ 
+ 	if (hdl->error) {
+ 		v4l2_err(sd, "error creating controls (%d)\n", hdl->error);
+-- 
+2.17.1
+

--- a/utilities/streamApp/camera_sub_system/Stream.cpp
+++ b/utilities/streamApp/camera_sub_system/Stream.cpp
@@ -512,7 +512,7 @@ int Stream::setAE (bool value)
     struct v4l2_ext_control aeModeCtrl {0};
     aeModeCtrl.id = V4L2_CID_EXPOSURE_AUTO;
     aeModeCtrl.size = 0;
-    aeModeCtrl.value = value;
+    aeModeCtrl.value = value ? V4L2_EXPOSURE_APERTURE_PRIORITY : V4L2_EXPOSURE_MANUAL;
 
     // set auto exposure mode
     struct v4l2_ext_controls ext {0};
@@ -553,7 +553,7 @@ int Stream::getAE (bool* value)
         return -1;
     }
 
-    *value = static_cast<bool>(aeModeCtrl.value);
+    *value = (aeModeCtrl.value != V4L2_EXPOSURE_MANUAL) ? true : false;
 
     return 0;
 }
@@ -563,7 +563,7 @@ int Stream::setExposure (int value) {
     struct v4l2_ext_control aeModeCtrl {0};
     aeModeCtrl.id = V4L2_CID_EXPOSURE_AUTO;
     aeModeCtrl.size = 0;
-    aeModeCtrl.value = 0;
+    aeModeCtrl.value = V4L2_EXPOSURE_MANUAL;
 
     struct v4l2_ext_controls ext {0};
     ext.ctrl_class = V4L2_CTRL_CLASS_CAMERA;

--- a/utilities/streamApp/gui/StreamView.cpp
+++ b/utilities/streamApp/gui/StreamView.cpp
@@ -57,10 +57,9 @@ void StreamView::draw()
     RS_AUTOLOG();
 
     namedWindow(mNodeStr.c_str(), WINDOW_FREERATIO);
-    string vn {mNodeStr};
-    vn += {" control"};
-    namedWindow(vn.c_str(), WINDOW_NORMAL);
-    createTrackbar("stream on/off", vn.c_str(), &mStartStopTBVlaue, 1, StreamView::startStopTrackbarCB, static_cast<void*>(this));
+    mCtrlWinName = mNodeStr + " control";
+    namedWindow(mCtrlWinName.c_str(), WINDOW_NORMAL);
+    createTrackbar("stream on/off", mCtrlWinName.c_str(), &mStartStopTBVlaue, 1, StreamView::startStopTrackbarCB, static_cast<void*>(this));
     switch(mStreamType) {
     case V4L2Utils::StreamUtils::StreamType::RS_Y8_STREAM:
     case V4L2Utils::StreamUtils::StreamType::RS_Y12I_STREAM:
@@ -79,11 +78,11 @@ void StreamView::draw()
 
             int val;
             val = static_cast<int>(ae);
-            createTrackbar("ae", vn.c_str(), &val, 1, StreamView::aETrackbarCB, static_cast<void*>(this));
-            createTrackbar("exposure", vn.c_str(), &exp, 2000, StreamView::exposureTrackbarCB, static_cast<void*>(this));
+            createTrackbar("ae", mCtrlWinName.c_str(), &val, 1, StreamView::aETrackbarCB, static_cast<void*>(this));
+            createTrackbar("exposure", mCtrlWinName.c_str(), &exp, 2000, StreamView::exposureTrackbarCB, static_cast<void*>(this));
             val = static_cast<int>(laserMode);
-            createTrackbar("laser power mode", vn.c_str(), &val, 1, StreamView::laserModeTrackbarCB, static_cast<void*>(this));
-            createTrackbar("laser power value", vn.c_str(), nullptr, 10, StreamView::laserValueTrackbarCB, static_cast<void*>(this));
+            createTrackbar("laser power mode", mCtrlWinName.c_str(), &val, 1, StreamView::laserModeTrackbarCB, static_cast<void*>(this));
+            createTrackbar("laser power value", mCtrlWinName.c_str(), nullptr, 10, StreamView::laserValueTrackbarCB, static_cast<void*>(this));
         }
         break;
     case V4L2Utils::StreamUtils::StreamType::RS_RGB_STREAM:
@@ -97,9 +96,9 @@ void StreamView::draw()
             RS_LOGI("exposure %d ++++++++++++++++++++++++++++++", exp);
 
             int val;
-            val = static_cast<int>(ae ? 8 : 0);
-            createTrackbar("ae", vn.c_str(), &val, 8, StreamView::aETrackbarCB, static_cast<void*>(this));
-            createTrackbar("exposure", vn.c_str(), &exp, 1000, StreamView::exposureTrackbarCB, static_cast<void*>(this));
+            val = static_cast<int>(ae);
+            createTrackbar("ae", mCtrlWinName.c_str(), &val, 1, StreamView::aETrackbarCB, static_cast<void*>(this));
+            createTrackbar("exposure", mCtrlWinName.c_str(), &exp, 10000, StreamView::exposureTrackbarCB, static_cast<void*>(this));
         }
         break;
     }
@@ -131,13 +130,17 @@ void StreamView::aETrackbarCB (int pos, void *userData) {
     RS_LOGI("pos %d, userdata %p", pos, userData);
     StreamView* sv = static_cast<StreamView*>(userData);
     sv->setAE(pos);
+    if (!pos)
+        sv->setExposure(getTrackbarPos("exposure", sv->mCtrlWinName.c_str()));
 }
 
 void StreamView::exposureTrackbarCB (int pos, void *userData) {
     RS_LOGI("pos %d, userdata %p", pos, userData);
     StreamView* sv = static_cast<StreamView*>(userData);
-    sv->setExposure(pos);
-    // TODO: update ae bar
+    if (getTrackbarPos("ae", sv->mCtrlWinName.c_str()))
+        setTrackbarPos("ae", sv->mCtrlWinName.c_str(), 0);
+    else
+        sv->setExposure(pos);
 }
 
 void StreamView::laserModeTrackbarCB (int pos, void *userData) {

--- a/utilities/streamApp/gui/include/StreamView.h
+++ b/utilities/streamApp/gui/include/StreamView.h
@@ -95,6 +95,7 @@ private:
     // This node must be streaming node and not meta data node.
     const std::uint8_t mNodeNumber;
     std::string mNodeStr {""};
+    std::string mCtrlWinName {};
     realsense::utils::V4L2Utils::StreamUtils::StreamType mStreamType {realsense::utils::V4L2Utils::StreamUtils::StreamType::RS_DEPTH_STREAM};
     std::mutex mMutex {};
 


### PR DESCRIPTION
d4xx driver:
- Follow the standard v4l2 auto_exposure menu number:
  1 manual,
  3 aperture_priority;
- Correct code for exposure value setting;
- Correct code for depth gain setting;
- Cleanup ctrl setting code.

rs_viewer:
- Follow the standard v4l2 auto_exposure menu number;
- GUI auto_exposure/exposure_absolute trackbar:
  1. when changing auto_exposure from on to off, set exposure as
     trackbar value;
  2. when set exposure trackbar, change auto_exposure to off if on;
  3. exposure value range.

Tracked on: DSO-17880, DSO-17881