### PR TITLE
Fix D4XX crash when listing RGB supporting frame formats

### DIFF
--- a/kernel/nvidia/0027-Fix-D4XX-crash-when-listing-RGB-supporting-frame-for.patch
+++ b/kernel/nvidia/0027-Fix-D4XX-crash-when-listing-RGB-supporting-frame-for.patch
@@ -1,0 +1,54 @@
+From 2661e202756181f79bbe772a999914acdf4bf5a0 Mon Sep 17 00:00:00 2001
+From: Xin Zhang <xin.x.zhang@intel.com>
+Date: Thu, 27 Jan 2022 16:18:49 +0800
+Subject: [PATCH] Fix D4XX crash when listing RGB supporting frame formats
+
+The right ds5 struct should be found for further processing. The
+previous code only worked for depth stream.
+
+Signed-off-by: Xin Zhang <xin.x.zhang@intel.com>
+---
+ drivers/media/i2c/d4xx.c | 18 +-----------------
+ 1 file changed, 1 insertion(+), 17 deletions(-)
+
+diff --git a/drivers/media/i2c/d4xx.c b/drivers/media/i2c/d4xx.c
+index 11f35d4da..54f7e4b5d 100644
+--- a/drivers/media/i2c/d4xx.c
++++ b/drivers/media/i2c/d4xx.c
+@@ -814,32 +814,16 @@ static int ds5_sensor_enum_frame_size(struct v4l2_subdev *sd,
+ 				      struct v4l2_subdev_frame_size_enum *fse)
+ {
+ 	struct ds5_sensor *sensor = container_of(sd, struct ds5_sensor, sd);
+-	struct ds5 *state = NULL;
++	struct ds5 *state = v4l2_get_subdevdata(sd);
+ 	const struct ds5_format *fmt;
+ 	unsigned int i;
+ 
+ 	dev_info(sensor->sd.dev, "%s(): sensor %s \n", __func__, sensor->sd.name);
+-
+-	//if (fse->pad)
+-	//	return -EINVAL;
+-
+-	// TODO: workaround for RGB enum framesizes, due to double instances of
+-	//       the driver, should be removed in 4.9.
+-	state = container_of(sd, struct ds5, depth.sensor.sd);
+ 	dev_info(sensor->sd.dev, "%s(): state->is_rgb %d\n", __func__, state->is_rgb);
+ 	dev_info(sensor->sd.dev, "%s(): state->is_depth %d\n", __func__, state->is_depth);
+ 	dev_info(sensor->sd.dev, "%s(): state->is_y8 %d\n", __func__, state->is_y8);
+ 	dev_info(sensor->sd.dev, "%s(): state->is_imu %d\n", __func__, state->is_imu);
+ 
+-	if (state->is_rgb)
+-		sensor = &state->rgb.sensor;
+-	if (state->is_depth)
+-		sensor = &state->depth.sensor;
+-	if (state->is_y8)
+-		sensor = &state->motion_t.sensor;
+-	if (state->is_imu)
+-		sensor = &state->imu.sensor;
+-
+ 	for (i = 0, fmt = sensor->formats; i < sensor->n_formats; i++, fmt++)
+ 		if (fse->code == fmt->mbus_code)
+ 			break;
+-- 
+2.17.1
+


### PR DESCRIPTION
The right ds5 struct should be found for further processing. The previous code only worked for depth stream.

```
[   72.921823] d4xx 33-0010: ds5_sensor_enum_frame_size(): sensor D4XX rgb 33-0010
[   72.921844] d4xx 33-0010: ds5_sensor_enum_frame_size(): state->is_rgb 7562095
[   72.921854] d4xx 33-0010: ds5_sensor_enum_frame_size(): state->is_depth 1970238055
[   72.921861] d4xx 33-0010: ds5_sensor_enum_frame_size(): state->is_y8 1919954544
[   72.921898] d4xx 33-0010: ds5_sensor_enum_frame_size(): state->is_imu 29539
[   72.925897] Unable to handle kernel paging request at virtual address 9e26b9c0
[   72.926108] Mem abort info:
[   72.926173]   ESR = 0x96000005
[   72.926278]   Exception class = DABT (current EL), IL = 32 bits
[   72.926395]   SET = 0, FnV = 0
[   72.926461]   EA = 0, S1PTW = 0
[   72.926551] Data abort info:
[   72.926612]   ISV = 0, ISS = 0x00000005
[   72.926682]   CM = 0, WnR = 0
[   72.926746] user pgtable: 4k pages, 39-bit VAs, pgd = ffffffc7786b0000
[   72.926855] [000000009e26b9c0] *pgd=0000000000000000, *pud=0000000000000000
[   72.927000] Internal error: Oops: 96000005 [#1] PREEMPT SMP
[   72.927120] Modules linked in: bnep fuse overlay zram d4xx nvgpu bluedroid_pm ip_tables x_tables
[   72.927434] CPU: 0 PID: 9162 Comm: rs_viewer Not tainted 4.9.140-tegra #12
[   72.927554] Hardware name: Jetson-AGX (DT)
[   72.927665] task: ffffffc7559fc600 task.stack: ffffffc79f204000
[   72.928137] PC is at ds5_sensor_enum_frame_size+0x134/0x190 [d4xx]
[   72.928613] LR is at ds5_sensor_enum_frame_size+0x88/0x190 [d4xx]
[   72.929060] pc : [<ffffff80011ab3b4>] lr : [<ffffff80011ab308>] pstate: 80400145
[   72.935915] sp : ffffffc79f207ac0
[   72.939150] x29: ffffffc79f207ac0 x28: 0000000000000000
[   72.944921] x27: ffffffc7a6b50030 x26: 0000000000000000
[   72.950346] x25: ffffff8009fffd88 x24: 000000000000004a
[   72.955947] x23: 0000007fc3ff9408 x22: ffffffc79f207b20
[   72.961035] x21: ffffff80011b01e8 x20: ffffffc79f207b20
[   72.966372] x19: ffffffc7daad9950 x18: 0000000000000001
[   72.972221] x17: 0000007fa9a5db10 x16: ffffff8008273850
[   72.977908] x15: ffffffffffffffff x14: ffffff800a174260
[   72.983595] x13: 0000000000000000 x12: 0000000000000006
[   72.989042] x11: 0000000000000006 x10: 000000000000055a
[   72.994645] x9 : 0000000000000001 x8 : ffffffc7ffdec688
[   73.000410] x7 : 0000000000000000 x6 : 000000000cc0663c
[   73.006176] x5 : 0000000000000000 x4 : 0000000000002011
[   73.011261] x3 : 000000009e26b9c0 x2 : 0000000000000000
[   73.016846] x1 : ffffffc79f2079a0 x0 : 0000000000000000

[   73.023353] Process rs_viewer (pid: 9162, stack limit = 0xffffffc79f204000)
[   73.029978] Call trace:
[   73.032664] [<ffffff80011ab3b4>] ds5_sensor_enum_frame_size+0x134/0x190 [d4xx]
[   73.039382] [<ffffff80011ab498>] ds5_mux_enum_frame_size+0x88/0x170 [d4xx]
[   73.045766] [<ffffff8008b28f34>] tegra_channel_enum_framesizes+0x6c/0xa0
[   73.052116] [<ffffff8008afe3ac>] __v4l_vidioc_enum_framesizes_fnc+0x3c/0x50
[   73.058766] [<ffffff8008b02bbc>] __video_do_ioctl+0x204/0x2c8
[   73.064103] [<ffffff8008b02568>] video_usercopy+0x2a0/0x6a0
[   73.069439] [<ffffff8008b029a4>] video_ioctl2+0x3c/0x50
[   73.074018] [<ffffff8008afc3f0>] v4l2_ioctl+0x88/0x118
[   73.079067] [<ffffff8008273028>] do_vfs_ioctl+0xb0/0x8d8
[   73.084139] [<ffffff80082738dc>] SyS_ioctl+0x8c/0xa8
[   73.088783] [<ffffff80080838c0>] el0_svc_naked+0x34/0x38
[   73.094474] ---[ end trace 91c3c1da6e08b6b7 ]---
```

Signed-off-by: Xin Zhang <xin.x.zhang@intel.com>