### PR TITLE
Fix D4XX crash when listing RGB supporting frame formats

### DIFF
--- a/kernel/nvidia/0028-Fix-D4XX-crash-when-listing-RGB-supporting-frame-for.patch
+++ b/kernel/nvidia/0028-Fix-D4XX-crash-when-listing-RGB-supporting-frame-for.patch
@@ -1,0 +1,60 @@
+From 887841b9b25bd3b322f6279428612304967ade47 Mon Sep 17 00:00:00 2001
+From: Emil Jahshan <emil.jahshan@intel.com>
+Date: Thu, 27 Jan 2022 11:59:03 +0200
+Subject: [PATCH] Fix D4XX crash when listing RGB supporting frame formats
+
+ - The right ds5 struct should be found for further processing. The
+   previous code only worked for depth stream.
+
+Signed-off-by: Emil Jahshan <emil.jahshan@intel.com>
+---
+ drivers/media/i2c/d4xx.c | 20 ++------------------
+ 1 file changed, 2 insertions(+), 18 deletions(-)
+
+diff --git a/drivers/media/i2c/d4xx.c b/drivers/media/i2c/d4xx.c
+index 8caa634f9..85f1d8233 100644
+--- a/drivers/media/i2c/d4xx.c
++++ b/drivers/media/i2c/d4xx.c
+@@ -814,32 +814,16 @@ static int ds5_sensor_enum_frame_size(struct v4l2_subdev *sd,
+ 				      struct v4l2_subdev_frame_size_enum *fse)
+ {
+ 	struct ds5_sensor *sensor = container_of(sd, struct ds5_sensor, sd);
+-	struct ds5 *state = NULL;
++	struct ds5 *state = v4l2_get_subdevdata(sd);
+ 	const struct ds5_format *fmt;
+ 	unsigned int i;
+ 
+ 	dev_info(sensor->sd.dev, "%s(): sensor %s \n", __func__, sensor->sd.name);
+-
+-	//if (fse->pad)
+-	//	return -EINVAL;
+-
+-	// TODO: workaround for RGB enum framesizes, due to double instances of
+-	//       the driver, should be removed in 4.9.
+-	state = container_of(sd, struct ds5, depth.sensor.sd);
+ 	dev_info(sensor->sd.dev, "%s(): state->is_rgb %d\n", __func__, state->is_rgb);
+ 	dev_info(sensor->sd.dev, "%s(): state->is_depth %d\n", __func__, state->is_depth);
+ 	dev_info(sensor->sd.dev, "%s(): state->is_y8 %d\n", __func__, state->is_y8);
+ 	dev_info(sensor->sd.dev, "%s(): state->is_imu %d\n", __func__, state->is_imu);
+ 
+-	if (state->is_rgb)
+-		sensor = &state->rgb.sensor;
+-	if (state->is_depth)
+-		sensor = &state->depth.sensor;
+-	if (state->is_y8)
+-		sensor = &state->motion_t.sensor;
+-	if (state->is_imu)
+-		sensor = &state->imu.sensor;
+-
+ 	for (i = 0, fmt = sensor->formats; i < sensor->n_formats; i++, fmt++)
+ 		if (fse->code == fmt->mbus_code)
+ 			break;
+@@ -3485,4 +3469,4 @@ module_i2c_driver(ds5_i2c_driver);
+ MODULE_DESCRIPTION("Intel D4XX camera driver");
+ MODULE_AUTHOR("Emil Jahshan (emil.jahshan@intel.com)");
+ MODULE_LICENSE("GPL v2");
+-MODULE_VERSION("1.0.0.9");
++MODULE_VERSION("1.0.1.0");
+-- 
+2.17.1
+


### PR DESCRIPTION
Follow up on #50 
 - The right ds5 struct should be found for further processing. The
   previous code only worked for depth stream.

Signed-off-by: Emil Jahshan <emil.jahshan@intel.com>