### PR TITLE
Fix color manual exposure value setting

### DIFF
--- a/kernel/nvidia/0034-Fix-color-manual-exposure-value-setting.patch
+++ b/kernel/nvidia/0034-Fix-color-manual-exposure-value-setting.patch
@@ -1,0 +1,41 @@
+From 1e4278001f69d66310cf9f7035080ec318aa6eea Mon Sep 17 00:00:00 2001
+From: Xin Zhang <xin.x.zhang@intel.com>
+Date: Sat, 19 Feb 2022 11:15:44 +0800
+Subject: [PATCH] Fix color manual exposure value setting
+
+The color i2c addresses actually treats the unit as 1 -> 100us.
+
+Signed-off-by: Xin Zhang <xin.x.zhang@intel.com>
+---
+ drivers/media/i2c/d4xx.c | 15 ++++++++++++++-
+ 1 file changed, 14 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/media/i2c/d4xx.c b/drivers/media/i2c/d4xx.c
+index af3aa74b6..1b81ace86 100644
+--- a/drivers/media/i2c/d4xx.c
++++ b/drivers/media/i2c/d4xx.c
+@@ -1204,7 +1204,20 @@ static int ds5_hw_set_exposure(struct ds5 *state, u32 base, u32 val)
+ {
+ 	int ret;
+ 
+-	val *= 100;
++       if (val < 1)
++               val = 1;
++       if ((state->is_depth || state->is_y8) && val > MAX_DEPTH_EXP)
++               val = MAX_DEPTH_EXP;
++       if (state->is_rgb && val > MAX_RGB_EXP)
++               val = MAX_RGB_EXP;
++
++	/*
++	 * Color and depth uses different unit:
++	 *	Color: 1 is 100 us
++	 *	Depth: 1 is 1 us
++	 */
++       if (!state->is_rgb)
++		val *= 100;
+ 
+ 	ret = ds5_write(state, base | DS5_MANUAL_EXPOSURE_MSB, val >> 16);
+ 	if (!ret)
+-- 
+2.17.1
+


### PR DESCRIPTION
Following up #48, the actual behavior seems different, the color manual exposure i2c address seems to treat the unit as 100 us.

The info given in #48 for color manual exposure setting is

| addr | control | min | max | step | default | unit | note |
|-- | -- | -- | -- | -- | -- | -- | -- |
| 0x4200/4202 | color manual exposure | 100 | 1000000 | 1 | 166000 | usec |


But when observing the FPS changes when auto_exposure=manual and setting color manual exposure value, the actual setting seems to be:

| addr | control | min | max | step | default | unit | note |
|-- | -- | -- | -- | -- | -- | -- | -- |
| 0x4200/4202 | color manual exposure | 1 | 10000 | 1 | 1660 | 100 usec | writing 1 means 100 us |

We need to double check from FW side.