### PR TITLE
Aligned pixel format when set a mismatching one 

### DIFF
--- a/kernel/nvidia/0035-Aligned-pixel-format-when-set-a-mismatching-one.patch
+++ b/kernel/nvidia/0035-Aligned-pixel-format-when-set-a-mismatching-one.patch
@@ -1,0 +1,49 @@
+From 08c0ae2f296a42b9ef36e205b6210ea4444a2e0e Mon Sep 17 00:00:00 2001
+From: Shikun Ding <shikun.ding@intel.com>
+Date: Tue, 1 Mar 2022 14:18:23 +0800
+Subject: [PATCH] Aligned pixel format when set a mismatching one
+
+The behavior between set_fmt in D4xx and tegra_channel_try_format
+in channel.c is mismatch. Since set_fmt in D4xx will set it to a
+default when the format was not found after searching mbus_code.
+tegra_channel_try_format or tegra_channel_set_format still updated
+to the mismatch one.
+
+As the description on ioctl VIDIOC_S_FMT in
+https://www.kernel.org/doc/html/v4.9/media/uapi/v4l/vidioc-g-fmt.html#description
+says that 'Drivers should not return an error code unless the type
+field is invalid, this is a mechanism to fathom device capabilities
+and to approach parameters acceptable for both the application and
+driver', this fix is to make ioctl VIDIOC_S_FMT not return any error
+message on both user space and kernel space by updating the pixel
+format to the correct one instead of the mismatch one in the above
+scenario.
+
+Signed-off-by: Shikun Ding <shikun.ding@intel.com>
+---
+ drivers/media/platform/tegra/camera/vi/channel.c | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/drivers/media/platform/tegra/camera/vi/channel.c b/drivers/media/platform/tegra/camera/vi/channel.c
+index a57cf8645..eddc73049 100644
+--- a/drivers/media/platform/tegra/camera/vi/channel.c
++++ b/drivers/media/platform/tegra/camera/vi/channel.c
+@@ -1912,6 +1912,15 @@ __tegra_channel_try_format(struct tegra_channel *chan,
+ 	v4l2_fill_mbus_format(&fmt.format, pix, vfmt->code);
+ 
+ 	ret = v4l2_subdev_call(sd, pad, set_fmt, NULL, &fmt);
++	/* if set_fmt not found target format and specify the default one, update
++	 * pix->pixelformat and vfmt to keep aligned with format set by set_fmt
++	 */
++	if (!ret && fmt.format.code != vfmt->code) {
++		int idx = tegra_core_get_idx_by_code(chan, fmt.format.code, 0);
++		pix->pixelformat = tegra_core_get_fourcc_by_idx(chan, idx);
++		vfmt = tegra_core_get_format_by_fourcc(chan, pix->pixelformat);
++	}
++
+ 	if (ret == -ENOIOCTLCMD)
+ 		return -ENOTTY;
+ 
+-- 
+2.17.1
+


### PR DESCRIPTION
The issue to be fixed is when user set a unconfigurable format to video node using v4l2-ctl tool:
```bash
v4l2-ctl -d /dev/video2 --set-fmt-video=pixelformat=GREY --stream-mmap=3 --stream-count=5
```
In user space, there's no error reply but dmesg has a _no reply from camera processor_ message. 
![mismatch](https://user-images.githubusercontent.com/89249282/156139548-18d3e091-712b-497f-9a59-b582a649e337.png)

This may confuse the user while the streaming is not working as expected . 

__This issue caused of:__
The behavior between set_fmt in D4xx and tegra_channel_try_format in channel.c is mismatch. Since set_fmt in D4xx will set it to a default when the format was not found after searching mbus_code. tegra_channel_try_format or tegra_channel_set_format still updated to the mismatch one.

__Current solution:__
As the official description on [ioctl VIDIOC_S_FMT](https://www.kernel.org/doc/html/v4.9/media/uapi/v4l/vidioc-g-fmt.html#description) says that '_Drivers should not return an error code unless the type field is invalid, this is a mechanism to fathom device capabilities and to approach parameters acceptable for both the application and driver_', this fix is to make ioctl VIDIOC_S_FMT not return any error message on both user space and kernel space by updating the pixel format to the correct one instead of the mismatch one in the above scenario.
