### PR TITLE
SerDes: Setup SerDes settings in driver

### DIFF
--- a/hardware/nvidia/platform/t19x/galen/kernel-dts/0006-SerDes-Add-SerDes-configuration-under-I2C-MUX.patch
+++ b/hardware/nvidia/platform/t19x/galen/kernel-dts/0006-SerDes-Add-SerDes-configuration-under-I2C-MUX.patch
@@ -1,0 +1,93 @@
+From e2a63de8a9d57b736c0aab4e78605004c1e2ad59 Mon Sep 17 00:00:00 2001
+From: Qingwu Zhang <qingwu.zhang@intel.com>
+Date: Tue, 1 Mar 2022 17:33:46 +0800
+Subject: [PATCH] SerDes: Add SerDes configuration under I2C MUX
+
+Enable max9295 and max9296 driver.
+Link d4xx to SerDes.
+
+Signed-off-by: Qingwu Zhang <qingwu.zhang@intel.com>
+---
+ common/tegra194-camera-d4xx.dtsi | 38 ++++++++++++++++++++++++++++++++
+ 1 file changed, 38 insertions(+)
+
+diff --git a/common/tegra194-camera-d4xx.dtsi b/common/tegra194-camera-d4xx.dtsi
+index 500101d..3c35c52 100644
+--- a/common/tegra194-camera-d4xx.dtsi
++++ b/common/tegra194-camera-d4xx.dtsi
+@@ -25,6 +25,36 @@
+ 				i2c-mux,deselect-on-exit;
+ 				#size-cells = <0x0>;
+ 
++				dser: max9296@48 {
++					status = "ok";
++					reg = <0x48>;
++					compatible = "nvidia,max9296";
++					#address-cells = <1>;
++					#size-cells = <0>;
++					skip_mux_detect = "yes";
++					vcc-supply = <&p2822_vdd_1v8_cvb>;
++					/*vcc-pullup-supply = <&battery_reg>;*/
++					force_bus_start = <CAMERA_I2C_MUX_BUS(0)>;
++					vcc_lp = "vcc";
++					csi-mode = "2x4";
++					max-src = <1>;
++				};
++
++				ser_prim: max9295_prim@40 {
++					status = "ok";
++					reg = <0x40>;
++					compatible = "nvidia,max9295";
++					#address-cells = <1>;
++					#size-cells = <0>;
++					skip_mux_detect = "yes";
++					vcc-supply = <&p2822_vdd_1v8_cvb>;
++					/*vcc-pullup-supply = <&battery_reg>;*/
++					force_bus_start = <CAMERA_I2C_MUX_BUS(0)>;
++					vcc_lp = "vcc";
++					is-prim-ser;
++				};
++
++
+ 				d4m0: d4m@10 {
+ 					status = "ok";
+ 					reg = <0x10>;
+@@ -32,6 +62,8 @@
+ 					vcc-supply = <&p2822_vdd_1v8_cvb>;
+ 					/*reset-gpios = <&tegra_main_gpio CAM0_RST_L GPIO_ACTIVE_HIG>;*/
+ 					cam-type = "Depth";
++					nvidia,gmsl-ser-device = <&ser_prim>;
++					nvidia,gmsl-dser-device = <&dser>;
+ 					ports {
+ 						#address-cells = <1>;
+ 						#size-cells = <0>;
+@@ -88,6 +120,8 @@
+ 					vcc-supply = <&p2822_vdd_1v8_cvb>;
+ 					/*reset-gpios = <&tegra_main_gpio CAM0_RST_L GPIO_ACTIVE_HIG>;*/
+ 					cam-type = "RGB";
++					nvidia,gmsl-ser-device = <&ser_prim>;
++					nvidia,gmsl-dser-device = <&dser>;
+ 					ports {
+ 						#address-cells = <1>;
+ 						#size-cells = <0>;
+@@ -140,6 +174,8 @@
+ 					vcc-supply = <&p2822_vdd_1v8_cvb>;
+ 					/*reset-gpios = <&tegra_main_gpio CAM0_RST_L GPIO_ACTIVE_HIG>;*/
+ 					cam-type = "Y8";
++					nvidia,gmsl-ser-device = <&ser_prim>;
++					nvidia,gmsl-dser-device = <&dser>;
+ 					ports {
+ 						#address-cells = <1>;
+ 						#size-cells = <0>;
+@@ -195,6 +231,8 @@
+ 					vcc-supply = <&p2822_vdd_1v8_cvb>;
+ 					/*reset-gpios = <&tegra_main_gpio CAM0_RST_L GPIO_ACTIVE_HIG>;*/
+ 					cam-type = "IMU";
++					nvidia,gmsl-ser-device = <&ser_prim>;
++					nvidia,gmsl-dser-device = <&dser>;
+ 					ports {
+ 						#address-cells = <1>;
+ 						#size-cells = <0>;
+-- 
+2.17.1
+

--- a/kernel/nvidia/0035-max9295-max9296-Add-SerDes-APIs-to-setup-registers.patch
+++ b/kernel/nvidia/0035-max9295-max9296-Add-SerDes-APIs-to-setup-registers.patch
@@ -1,0 +1,621 @@
+From ae50e9b84ad32ae46a46d2e341abef3cec7eda3b Mon Sep 17 00:00:00 2001
+From: Qingwu Zhang <qingwu.zhang@intel.com>
+Date: Tue, 1 Mar 2022 18:36:55 +0800
+Subject: [PATCH] max9295/max9296: Add SerDes APIs to setup registers
+
+Add SerDes APIs to setup registers.
+
+Add param max9295_dynamic_update to control dynamically.
+Add param max9296_dynamic_update to control dynamically.
+
+Add param max9295_setting_verison to print version.
+Add param max9296_setting_verison to print version.
+
+Signed-off-by: Qingwu Zhang <qingwu.zhang@intel.com>
+---
+ drivers/media/i2c/d4xx.c    |  68 ++++++++++++
+ drivers/media/i2c/max9295.c | 194 ++++++++++++++++++++++++++++++++
+ drivers/media/i2c/max9296.c | 215 ++++++++++++++++++++++++++++++++++++
+ include/media/gmsl-link.h   |   7 ++
+ include/media/max9295.h     |   1 +
+ include/media/max9296.h     |   2 +
+ 6 files changed, 487 insertions(+)
+
+diff --git a/drivers/media/i2c/d4xx.c b/drivers/media/i2c/d4xx.c
+index 12ece6b11..001c71ccd 100644
+--- a/drivers/media/i2c/d4xx.c
++++ b/drivers/media/i2c/d4xx.c
+@@ -35,6 +35,12 @@
+ #include <media/v4l2-subdev.h>
+ #include <media/v4l2-mediabus.h>
+ 
++#ifdef CONFIG_TEGRA_CAMERA_PLATFORM
++#include <media/gmsl-link.h>
++#include <media/max9296.h>
++#include <media/max9295.h>
++#endif
++
+ //#define DS5_DRIVER_NAME "DS5 RealSense camera driver"
+ #define DS5_DRIVER_NAME "d4xx"
+ #define DS5_DRIVER_NAME_AWG "d4xx-awg"
+@@ -367,6 +373,9 @@ struct ds5 {
+ 	int is_imu;
+ 	u16 fw_version;
+ 	u16 fw_build;
++
++	struct device *dser_dev;
++	struct device *ser_dev;
+ };
+ 
+ struct ds5_counters {
+@@ -1008,6 +1017,39 @@ static int ds5_configure(struct ds5 *state)
+ 	u8 rgbfmt = rgb->streaming ? rgb->config.format->data_type : 0;
+ 	int ret;
+ 
++#ifdef CONFIG_TEGRA_CAMERA_PLATFORM
++	if (state->dser_dev) {
++		if (depth->streaming) {
++			ret = max9296_update_pipe(state->dser_dev, DEPTH_SENSOR, dfmt);
++		} else if (motion_t->streaming) {
++			ret = max9296_update_pipe(state->dser_dev, IR_SENSOR, mfmt);
++		} else if (rgb->streaming) {
++			ret = max9296_update_pipe(state->dser_dev, RGB_SENSOR, rgbfmt);
++		}
++
++		dev_info(state->dser_dev, "d %x %d, m %x %d, rgb %x %d",
++			 dfmt, depth->streaming, mfmt, motion_t->streaming,
++			 rgbfmt, rgb->streaming);
++		if (ret < 0)
++			return ret;
++	}
++	if (state->ser_dev) {
++		if (depth->streaming) {
++			ret = max9295_update_pipe(state->ser_dev, DEPTH_SENSOR, dfmt);
++		} else if (motion_t->streaming) {
++			ret = max9295_update_pipe(state->ser_dev, IR_SENSOR, mfmt);
++		} else if (rgb->streaming) {
++			ret = max9295_update_pipe(state->ser_dev, RGB_SENSOR, rgbfmt);
++		}
++
++		dev_info(state->ser_dev, "d %x %d, m %x %d, rgb %x %d",
++			 dfmt, depth->streaming, mfmt, motion_t->streaming,
++			 rgbfmt, rgb->streaming);
++		if (ret < 0)
++			return ret;
++	}
++#endif
++
+ 	// IR Camera
+ 	if (state->is_y8) {
+ 		ret = ds5_write(state, DS5_IR_STREAM_DT, mfmt);
+@@ -3334,6 +3376,10 @@ static int ds5_probe(struct i2c_client *c, const struct i2c_device_id *id)
+ 	u16 rec_state;
+ 	int ret, err = 0;
+ 	const char *str;
++	struct device_node *dser_node = NULL;
++	struct i2c_client *dser_i2c = NULL;
++	struct device_node *ser_node = NULL;
++	struct i2c_client *ser_i2c = NULL;
+ 
+ 	if (!state)
+ 		return -ENOMEM;
+@@ -3396,6 +3442,28 @@ static int ds5_probe(struct i2c_client *c, const struct i2c_device_id *id)
+ 	if (!err && !strncmp(str, "IMU", strlen("IMU")))
+ 		state->is_imu = 1;
+ 
++	state->dser_dev = NULL;
++	dser_node = of_parse_phandle(c->dev.of_node, "nvidia,gmsl-dser-device", 0);
++	if (dser_node) {
++		dser_i2c = of_find_i2c_device_by_node(dser_node);
++		of_node_put(dser_node);
++		if (dser_i2c) {
++			dev_info(&c->dev, "dser_i2c->addr 0x%x", dser_i2c->addr);
++			state->dser_dev = &dser_i2c->dev;
++		}
++	}
++
++	state->ser_dev = NULL;
++	ser_node = of_parse_phandle(c->dev.of_node, "nvidia,gmsl-ser-device", 0);
++	if (ser_node) {
++		ser_i2c = of_find_i2c_device_by_node(ser_node);
++		of_node_put(ser_node);
++		if (ser_i2c) {
++			dev_info(&c->dev, "ser_i2c->addr 0x%x", ser_i2c->addr);
++			state->ser_dev = &ser_i2c->dev;
++		}
++	}
++
+ 	dev_info(&c->dev, "%s(): state->is_rgb %d\n", __func__, state->is_rgb);
+ 	dev_info(&c->dev, "%s(): state->is_depth %d\n", __func__, state->is_depth);
+ 	dev_info(&c->dev, "%s(): state->is_y8 %d\n", __func__, state->is_y8);
+diff --git a/drivers/media/i2c/max9295.c b/drivers/media/i2c/max9295.c
+index 4adf76567..117f86983 100644
+--- a/drivers/media/i2c/max9295.c
++++ b/drivers/media/i2c/max9295.c
+@@ -473,6 +473,197 @@ static  struct regmap_config max9295_regmap_config = {
+ 	.cache_type = REGCACHE_RBTREE,
+ };
+ 
++static bool max9295_dynamic_update = true;
++module_param(max9295_dynamic_update, bool, 0664);
++MODULE_PARM_DESC(max9295_dynamic_update, "Update max9295 settings dynamically");
++
++
++static char *max9295_setting_verison = "1.0.0.6";
++module_param(max9295_setting_verison, charp, 0444);
++MODULE_PARM_DESC(max9295_setting_verison, "Print max9295 setting version");
++
++struct reg_pair {
++	u16 addr;
++	u8 val;
++};
++
++static struct reg_pair map_cmu_regulator[] = {
++	{0x0302, 0x10}, // lllIncrease CMU regulator voltage
++};
++
++static struct reg_pair map_pipe_opt[] = {
++	{0x0002, 0xF3}, // # Enable all pipes
++
++	{0x0331, 0x11}, // Write 0x33 for 4 lanes
++	{0x0308, 0x6F}, // All pipes pull clock from port B
++	{0x0311, 0xF0}, // All pipes pull data from port B
++	{0x0312, 0x07}, // Double 8-bit data on pipe X, Y, Z
++};
++
++static struct reg_pair map_pipe_x_control[] = {
++	/* addr, val */
++	{0x0314, 0x5E}, // Pipe X pulls Depth (DT 0x1E)
++	{0x0315, 0x52}, // Pipe X pulls EMB8 (DT 0x12)
++	{0x0309, 0x01}, // # Pipe X pulls VC0
++	{0x030A, 0x00},
++	{0x031C, 0x30}, // BPP = 16 in pipe X
++	{0x0102, 0x0E}, // LIM_HEART Pipe X: Disabled
++};
++
++static struct reg_pair map_pipe_y_control[] = {
++	/* addr, val */
++	{0x0316, 0x5E}, // Pipe Y pulls RGB (DT 0x1E)
++	{0x0317, 0x52}, // Pipe Y pulls EMB8 (DT 0x12)
++	{0x030B, 0x02}, // Pipe Y pulls VC1
++	{0x030C, 0x00},
++	{0x031D, 0x30}, // BPP = 16 in pipe Y
++	{0x010A, 0x0E}, // LIM_HEART Pipe Y: Disabled
++};
++
++static struct reg_pair map_pipe_z_control[] = {
++	/* addr, val */
++	{0x0318, 0x6A}, // Pipe Z pulls Y8 (DT 0x2A)
++	{0x0319, 0x72}, // Pipe Z pulls Y8I (DT 0x32)
++	{0x030D, 0x04}, // Pipe Z pulls VC2
++	{0x030E, 0x00},
++	{0x031E, 0x30}, // BPP = 16 in pipe Z
++	{0x0112, 0x0E}, // LIM_HEART Pipe Z: Disabled
++};
++
++static struct reg_pair map_pipe_u_control[] = {
++	/* addr, val */
++	{0x031A, 0x64}, // Pipe U pulls Y12I (DT 0x24)
++	{0x030F, 0x04}, // Pipe U pulls VC2
++	{0x0310, 0x00},
++
++	{0x0315, 0xD2}, // Enable independent VC's
++	{0x011A, 0x0E}, // LIM_HEART Pipe U: Disabled
++};
++
++static struct reg_pair map_depth_trigger[] = {
++	{0x02D6, 0x84}, // #MFP8
++	{0x02D7, 0x60}, // #OUT_TYPE bit to 1
++	{0x02D8, 0x1F},
++};
++
++static struct reg_pair map_rgb_trigger[] = {
++	{0x02BE, 0x84}, // #MFP0
++	{0x02BF, 0x60}, // #OUT_TYPE bit to 1
++	{0x02C0, 0x1B},
++};
++
++static bool init_done = false;
++static bool probe_done = false;
++
++static int max9295_set_registers(struct device *dev, struct reg_pair *map,
++				 u32 count)
++{
++	struct max9295 *priv = dev_get_drvdata(dev);
++	int err = 0;
++	u32 j = 0;
++
++	mutex_lock(&priv->lock);
++
++	dev_info(dev, "%s count %u\n", __func__, count);
++
++	for (j = 0; j < count; j++) {
++		err = max9295_write_reg(dev,
++			map[j].addr, map[j].val);
++		if (err != 0) break;
++	}
++
++	mutex_unlock(&priv->lock);
++
++	return err;
++}
++
++static int max9295_init_settings(struct device *dev)
++{
++	int err = 0;
++
++	// Set CMU
++	err = max9295_set_registers(dev, map_cmu_regulator,
++				    ARRAY_SIZE(map_cmu_regulator));
++	// Init control
++	err |= max9295_set_registers(dev, map_pipe_opt,
++				     ARRAY_SIZE(map_pipe_opt));
++
++	// Pipe X
++	err |= max9295_set_registers(dev, map_pipe_x_control,
++				     ARRAY_SIZE(map_pipe_x_control));
++	// Pipe Y
++	err |= max9295_set_registers(dev, map_pipe_y_control,
++				     ARRAY_SIZE(map_pipe_x_control));
++	// Pipe Z
++	err |= max9295_set_registers(dev, map_pipe_z_control,
++				     ARRAY_SIZE(map_pipe_z_control));
++	// Pipe U
++	err |= max9295_set_registers(dev, map_pipe_u_control,
++				     ARRAY_SIZE(map_pipe_u_control));
++
++	// Trigger Depth
++	err |= max9295_set_registers(dev, map_depth_trigger,
++				     ARRAY_SIZE(map_depth_trigger));
++	// Trigger RGB
++	err |= max9295_set_registers(dev, map_rgb_trigger,
++				     ARRAY_SIZE(map_rgb_trigger));
++
++	if (err == 0) {
++		dev_info(dev, "%s done\n", __func__);
++		init_done = true;
++	} else {
++		dev_err(dev, "%s, failed to init settings \n", __func__);
++	}
++
++	return err;
++}
++
++static int max9295_check_status(struct device *dev)
++{
++	u32 val = 0;
++	struct max9295 *priv = dev_get_drvdata(dev);
++	int err;
++	u32 j = 0;
++
++	mutex_lock(&priv->lock);
++
++	for (j = 0; j < ARRAY_SIZE(map_pipe_opt); j++) {
++		val = 0;
++		err = regmap_read(priv->regmap, map_pipe_opt[j].addr, &val);
++
++		dev_info(dev,
++			"%s:i2c read, err %x, cmu value %x\n",
++			__func__, err, val);
++	};
++
++	mutex_unlock(&priv->lock);
++
++	return 0;
++}
++
++int max9295_update_pipe(struct device *dev, int sensor_type, int data_type)
++{
++	int err = 0;
++
++	if (!probe_done)
++		return 0;
++
++	if (!max9295_dynamic_update) {
++		dev_info(dev, "%s, don't update dynamically", __func__);
++		return 0;
++	}
++
++	dev_info(dev, "%s st %d, dt %d \n", __func__, sensor_type, data_type);
++
++	if (!init_done) {
++		err = max9295_init_settings(dev);
++		max9295_check_status(dev);
++	}
++
++	return err;
++}
++EXPORT_SYMBOL(max9295_update_pipe);
++
+ static int max9295_probe(struct i2c_client *client,
+ 				const struct i2c_device_id *id)
+ {
+@@ -512,6 +703,9 @@ static int max9295_probe(struct i2c_client *client,
+ 
+ 	dev_set_drvdata(&client->dev, priv);
+ 
++	max9295_init_settings(&client->dev);
++	probe_done = true;
++
+ 	/* dev communication gets validated when GMSL link setup is done */
+ 	dev_info(&client->dev, "%s:  success\n", __func__);
+ 
+diff --git a/drivers/media/i2c/max9296.c b/drivers/media/i2c/max9296.c
+index dc1b3ea42..8b52d8726 100644
+--- a/drivers/media/i2c/max9296.c
++++ b/drivers/media/i2c/max9296.c
+@@ -780,6 +780,218 @@ ret:
+ }
+ EXPORT_SYMBOL(max9296_setup_streaming);
+ 
++static bool max9296_dynamic_update = true;
++module_param(max9296_dynamic_update, bool, 0664);
++MODULE_PARM_DESC(max9296_dynamic_update, "Update max9296 settings dynamically");
++
++
++static char *max9296_setting_verison = "1.0.0.6";
++module_param(max9296_setting_verison, charp, 0444);
++MODULE_PARM_DESC(max9296_setting_verison, "Print max9296 setting version");
++
++static struct reg_pair map_cmu_regulator[] = {
++	{0x0302, 0x10}, // Increase CMU regulator voltage
++};
++
++static struct reg_pair map_pipe_opt[] = {
++	{0x1458, 0x28}, // PHY A Optimization
++	{0x1459, 0x68}, // PHY A Optimization
++	{0x1558, 0x28}, // PHY B Optimization
++	{0x1559, 0x68}, // PHY B Optimization
++	{0x0010, 0x31}, // One-shot reset  enable auto-link
++
++	{0x044A, 0x50}, // 4 lanes on port A, write 0x50 for 2 lanes
++	{0x0320, 0x2F}, // 1500Mbps/lane on port A
++	{0x031C, 0x00}, // Do not un-double 8bpp (Un-double 8bpp data)
++	{0x031F, 0x00}, // Do not un-double 8bpp
++	{0x0473, 0x10}, // 0x02: ALT_MEM_MAP8, 0x10: ALT2_MEM_MAP8
++	// VC2 VS will come from pipe Z, not needed for pipe U
++	{0x0239, 0x39}, // Force VS low in pipe U
++};
++
++static struct reg_pair map_pipe_x_control[] = {
++	/* addr, val */
++	{0x040B, 0x0F}, // Enable 4 mappings for Pipe X
++	{0x040D, 0x1E}, // Map Depth VC0
++	{0x040E, 0x1E},
++	{0x040F, 0x00}, // Map frame start  VC0
++	{0x0410, 0x00},
++	{0x0411, 0x01}, // Map frame end  VC0
++	{0x0412, 0x01},
++	{0x0413, 0x12}, // Map EMB8, VC0
++	{0x0414, 0x12},
++	{0x042D, 0x55}, // All mappings to PHY1 (master for port A)
++
++	// SEQ_MISS_EN: Disabled / DIS_PKT_DET: Disabled
++	{0x0100, 0x23}, // pipe X
++};
++
++static struct reg_pair map_pipe_y_control[] = {
++	/* addr, val */
++	{0x044B, 0x0F}, // Enable 4 mappings for Pipe Y
++	{0x044D, 0x5E}, // Map RGB VC1
++	{0x044E, 0x5E},
++	{0x044F, 0x40}, // Map frame start  VC1
++	{0x0450, 0x40},
++	{0x0451, 0x41}, // Map frame end  VC1
++	{0x0452, 0x41},
++	{0x0453, 0x52}, // Map EMB8, VC1
++	{0x0454, 0x52},
++	{0x046D, 0x55}, // All mappings to PHY1 (master for port A)
++
++	// SEQ_MISS_EN: Disabled / DIS_PKT_DET: Disabled
++	{0x0112, 0x23}, // pipe Y
++};
++
++static struct reg_pair map_pipe_z_control[] = {
++	/* addr, val */
++	{0x048B, 0x0F}, // Enable 4 mappings for Pipe Z
++	{0x048D, 0xAA}, // Map Y8 VC1
++	{0x048E, 0xAA},
++	{0x048F, 0x80}, // Map frame start  VC2
++	{0x0490, 0x80},
++	{0x0491, 0x81}, // Map frame end  VC2
++	{0x0492, 0x81},
++	{0x0493, 0xB2}, // Map Y8I, VC2
++	{0x0494, 0xB2},
++	{0x04AD, 0x55}, // Map to PHY1 (master for port A)
++
++	// SEQ_MISS_EN: Disabled / DIS_PKT_DET: Disabled
++	{0x0124, 0x23}, // pipe Z
++};
++
++static struct reg_pair map_pipe_u_control[] = {
++	/* addr, val */
++	// VC2 FS/FE will come from pipe Z, not needed in pipe U
++	{0x04CB, 0x01}, // Enable 1 mappings for Pipe U
++	{0x04CD, 0xA4}, // Map Y12I VC2
++	{0x04CE, 0xA4},
++	{0x04ED, 0x01}, // Map to PHY1 (master for port A)
++
++	// SEQ_MISS_EN: Disabled / DIS_PKT_DET: Disabled
++	{0x0136, 0x23}, // pipe U
++};
++
++static struct reg_pair map_depth_trigger[] = {
++	{0x02C5, 0x82}, // #MFP7
++	{0x02C6, 0x1F},
++};
++
++static struct reg_pair map_rgb_trigger[] = {
++	{0x02CB, 0x82}, // #MFP9
++	{0x02CC, 0x1B},
++};
++
++static bool init_done = false;
++static bool probe_done = false;
++
++static int max9296_set_registers(struct device *dev, struct reg_pair *map,
++				 u32 count)
++{
++	struct max9296 *priv = dev_get_drvdata(dev);
++	int err = 0;
++	u32 j = 0;
++
++	mutex_lock(&priv->lock);
++
++	dev_info(dev, "%s count %u\n", __func__, count);
++
++	for (j = 0; j < count; j++) {
++		err = max9296_write_reg(dev,
++			map[j].addr, map[j].val);
++		if (err != 0) break;
++	}
++
++	mutex_unlock(&priv->lock);
++
++	return err;
++}
++
++static int max9296_init_settings(struct device *dev)
++{
++	int err = 0;
++
++	// Set CMU
++	err = max9296_set_registers(dev, map_cmu_regulator,
++				    ARRAY_SIZE(map_cmu_regulator));
++	// Init control
++	err |= max9296_set_registers(dev, map_pipe_opt,
++				     ARRAY_SIZE(map_pipe_opt));
++
++	// Pipe X
++	err |= max9296_set_registers(dev, map_pipe_x_control,
++				     ARRAY_SIZE(map_pipe_x_control));
++	// Pipe Y
++	err |= max9296_set_registers(dev, map_pipe_y_control,
++				     ARRAY_SIZE(map_pipe_x_control));
++	// Pipe Z
++	err |= max9296_set_registers(dev, map_pipe_z_control,
++				     ARRAY_SIZE(map_pipe_z_control));
++	// Pipe U
++	err |= max9296_set_registers(dev, map_pipe_u_control,
++				     ARRAY_SIZE(map_pipe_u_control));
++
++	// Trigger Depth
++	err |= max9296_set_registers(dev, map_depth_trigger,
++				     ARRAY_SIZE(map_depth_trigger));
++	// Trigger RGB
++	err |= max9296_set_registers(dev, map_rgb_trigger,
++				     ARRAY_SIZE(map_rgb_trigger));
++
++	if (err == 0) {
++		dev_info(dev, "%s done\n", __func__);
++		init_done = true;
++	} else {
++		dev_err(dev, "%s, failed to init settings \n", __func__);
++	}
++
++	return err;
++}
++
++static int max9296_check_status(struct device *dev)
++{
++	u32 val = 0;
++	struct max9296 *priv = dev_get_drvdata(dev);
++	int err;
++	u32 j = 0;
++
++	mutex_lock(&priv->lock);
++
++	for (j = 0; j < ARRAY_SIZE(map_pipe_opt); j++) {
++		val = 0;
++		err = regmap_read(priv->regmap, map_pipe_opt[j].addr, &val);
++		dev_info(dev,
++			"%s:i2c read, err %x, cmu value %x\n",
++			__func__, err, val);
++	};
++
++	mutex_unlock(&priv->lock);
++	return 0;
++}
++
++int max9296_update_pipe(struct device *dev, int sensor_type, int data_type)
++{
++	int err = 0;
++
++	if (!probe_done)
++		return 0;
++
++	if (!max9296_dynamic_update) {
++		dev_info(dev, "%s, don't update dynamically", __func__);
++		return 0;
++	}
++
++	dev_info(dev, "%s st %d, dt %d \n", __func__, sensor_type, data_type);
++
++	if (!init_done) {
++		err = max9296_init_settings(dev);
++		max9296_check_status(dev);
++	}
++
++	return err;
++}
++EXPORT_SYMBOL(max9296_update_pipe);
++
+ const struct of_device_id max9296_of_match[] = {
+ 	{ .compatible = "nvidia,max9296", },
+ 	{ },
+@@ -895,6 +1107,9 @@ static int max9296_probe(struct i2c_client *client,
+ 
+ 	dev_set_drvdata(&client->dev, priv);
+ 
++	max9296_init_settings(&client->dev);
++	probe_done = true;
++
+ 	/* dev communication gets validated when GMSL link setup is done */
+ 	dev_info(&client->dev, "%s:  success\n", __func__);
+ 
+diff --git a/include/media/gmsl-link.h b/include/media/gmsl-link.h
+index 1eab7bac9..9cfd907bd 100644
+--- a/include/media/gmsl-link.h
++++ b/include/media/gmsl-link.h
+@@ -56,6 +56,13 @@
+ 
+ #define GMSL_ST_ID_UNUSED 0xFF
+ 
++enum sensor_type {
++	DEPTH_SENSOR,
++	RGB_SENSOR,
++	IR_SENSOR,
++	IMU_SENSOR,
++};
++
+ /**
+  * Maximum number of data streams (\ref gmsl_stream elements) in a GMSL link
+  * (\ref gmsl_link_ctx).
+diff --git a/include/media/max9295.h b/include/media/max9295.h
+index cff6b867d..1d15a5457 100644
+--- a/include/media/max9295.h
++++ b/include/media/max9295.h
+@@ -35,6 +35,7 @@
+  * @{
+  */
+ 
++int max9295_update_pipe(struct device *dev, int sensor_type, int data_type);
+ 
+ /**
+  * @brief  Powers on a serializer device and performs the I2C overrides
+diff --git a/include/media/max9296.h b/include/media/max9296.h
+index 61435e263..e05780ec9 100644
+--- a/include/media/max9296.h
++++ b/include/media/max9296.h
+@@ -35,6 +35,8 @@
+  * @{
+  */
+ 
++int max9296_update_pipe(struct device *dev, int sensor_type, int data_type);
++
+ /**
+  * Puts a deserializer device in single exclusive link mode, so link-specific
+  * I2C overrides can be performed for sensor and serializer devices.
+-- 
+2.17.1
+


### PR DESCRIPTION
Add SerDes configuration under I2C MUX;
Add SerDes APIs to setup registers.

Signed-off-by: Qingwu Zhang <qingwu.zhang@intel.com>