### PR TITLE
Fix error handling flow in `s_stream` handler - rebased to JetPack v4.6

### DIFF
--- a/kernel/nvidia/0030-Fix-s_stream-handler-pn-failure.-Preserve-internal-s.patch
+++ b/kernel/nvidia/0030-Fix-s_stream-handler-pn-failure.-Preserve-internal-s.patch
@@ -1,0 +1,158 @@
+From 3b47b5a2710132702b0c7ed9372ddeca3099832a Mon Sep 17 00:00:00 2001
+From: Evgeni Raikhel <evgeni.raikhel@intel.com>
+Date: Tue, 1 Mar 2022 14:58:35 +0800
+Subject: [PATCH] Fix s_stream handler pn failure. Preserve internal state
+
+Signed-off-by: Evgeni Raikhel <evgeni.raikhel@intel.com>
+---
+ drivers/media/i2c/d4xx.c | 51 ++++++++++++++++++++++++++--------------
+ 1 file changed, 34 insertions(+), 17 deletions(-)
+
+diff --git a/drivers/media/i2c/d4xx.c b/drivers/media/i2c/d4xx.c
+index 85f1d8233..ad7b9a7d8 100644
+--- a/drivers/media/i2c/d4xx.c
++++ b/drivers/media/i2c/d4xx.c
+@@ -1109,7 +1109,7 @@ static const struct v4l2_subdev_pad_ops ds5_depth_pad_ops = {
+ static int ds5_sensor_s_stream(struct v4l2_subdev *sd, int on)
+ {
+ 	struct ds5_sensor *sensor = container_of(sd, struct ds5_sensor, sd);
+-	dev_info(sensor->sd.dev, "%s(): sensor: name=%s\n", __func__, sensor->sd.name);
++	dev_info(sensor->sd.dev, "%s(): sensor: name=%s state=%d\n", __func__, sensor->sd.name, on);
+ 
+ 	sensor->streaming = on;
+ 
+@@ -2456,9 +2456,11 @@ static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on)
+ 	u16 streaming, status, depth_status, ir_status, rgb_status;
+ 	int ret = 0;
+ 	unsigned int i = 0;
++	int restore_val = 0;
+ 
+-	dev_info(&state->client->dev, "%s(): %s on = %d\n", __func__, state->mux.last_set->sd.name, on);
++	dev_info(&state->client->dev, "%s(): called for stream %s, on = %d\n", __func__, state->mux.last_set->sd.name, on);
+ 
++	restore_val = state->mux.last_set->streaming;
+ 	state->mux.last_set->streaming = on;
+ 
+ 	if (state->is_imu)
+@@ -2469,7 +2471,7 @@ static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on)
+ 		ret = ds5_configure(state);
+ 
+ 		// TODO: remove, workaround for FW crash in start
+-		msleep_range(100);
++		//msleep_range(100); - removed)
+ 
+ 		if (!ret) {
+ 			// start IR
+@@ -2477,7 +2479,7 @@ static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on)
+ 				dev_info(&state->client->dev, "%s(): starting IR stream\n", __func__);
+ 				ret = ds5_write(state, DS5_START_STOP_STREAM, 0x204);
+ 				if (ret < 0)
+-					return ret;
++					goto restore_s_state;
+ 			}
+ 
+ 			// start DEPTH
+@@ -2485,7 +2487,7 @@ static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on)
+ 				dev_info(&state->client->dev, "%s(): starting DEPTH stream\n", __func__);
+ 				ret = ds5_write(state, DS5_START_STOP_STREAM, 0x200);
+ 				if (ret < 0)
+-					return ret;
++					goto restore_s_state;
+ 			}
+ 
+ 			// start RGB
+@@ -2493,7 +2495,7 @@ static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on)
+ 				dev_info(&state->client->dev, "%s(): starting RGB stream\n", __func__);
+ 				ret = ds5_write(state, DS5_START_STOP_STREAM, 0x201);
+ 				if (ret < 0)
+-					return ret;
++					goto restore_s_state;
+ 			}
+ 
+ 			// check streaming status from FW
+@@ -2517,24 +2519,25 @@ static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on)
+ 				msleep_range(DS5_START_POLL_TIME);
+ 			}
+ 
+-			if(on && (DS5_START_MAX_COUNT == i)) {
+-				dev_err(&state->client->dev, "%s(): start streaming failed\n", __func__);
+-				ret = EAGAIN;
++			if (on && (DS5_START_MAX_COUNT == i)) {
++				dev_err(&state->client->dev, "%s(): start streaming failed, exit on timeout\n", __func__);
++				ret = -1;
++			} else {
++				dev_info(&state->client->dev, "%s(): started after %dms \n", __func__, i*DS5_START_POLL_TIME);
+ 			}
+-			dev_info(&state->client->dev, "%s(): it took %dms to start stream\n", __func__, i*DS5_START_POLL_TIME);
+ 		}
+ 	} else {
+ 		dev_info(&state->client->dev, "%s(): stopping stream\n", __func__);
+ 
+ 		// TODO: remove, workaround for FW crash in start
+-		msleep_range(100);
++		//msleep_range(100); - removed
+ 
+ 		// stop IR
+ 		if (state->is_y8) {
+ 			dev_info(&state->client->dev, "%s(): stopping IR stream\n", __func__);
+ 			ret = ds5_write(state, DS5_START_STOP_STREAM, 0x104);
+ 			if (ret < 0)
+-				return ret;
++				goto restore_s_state;
+ 		}
+ 
+ 		// stop DEPTH
+@@ -2542,7 +2545,7 @@ static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on)
+ 			dev_info(&state->client->dev, "%s(): stopping DEPTH stream\n", __func__);
+ 			ret = ds5_write(state, DS5_START_STOP_STREAM, 0x100);
+ 			if (ret < 0)
+-				return ret;
++				goto restore_s_state;
+ 		}
+ 
+ 		// stop RGB
+@@ -2550,7 +2553,7 @@ static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on)
+ 			dev_info(&state->client->dev, "%s(): stopping RGB stream\n", __func__);
+ 			ret = ds5_write(state, DS5_START_STOP_STREAM, 0x101);
+ 			if (ret < 0)
+-				return ret;
++				goto restore_s_state;
+ 		}
+ 	}
+ 
+@@ -2558,10 +2561,24 @@ static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on)
+ 	ds5_read(state, 0x4802, &rgb_status);
+ 	ds5_read(state, 0x4808, &ir_status);
+ 
+-	dev_info(&state->client->dev, "%s(): streaming %x depth status 0x%04x, ir status 0x%04x, rgb status 0x%04x\n", __func__,
+-		 streaming, depth_status, ir_status, rgb_status);
++	dev_info(&state->client->dev, "%s(): streaming %x depth status 0x%04x, ir status 0x%04x, rgb status 0x%04x, ret=%d\n", __func__,
++		 streaming, depth_status, ir_status, rgb_status, ret);
+ 
+ 	return ret;
++
++restore_s_state:
++
++	// Obtain the last known FW status
++	ds5_read(state, 0x4800, &depth_status);
++	ds5_read(state, 0x4802, &rgb_status);
++	ds5_read(state, 0x4808, &ir_status);
++
++	dev_info(&state->client->dev, "%s(): stream toggle failed! %x depth status 0x%04x, ir status 0x%04x, rgb status 0x%04x\n",
++		__func__, restore_val, depth_status, ir_status, rgb_status);
++	// Revert on the failure update
++	state->mux.last_set->streaming = restore_val;
++
++	return -1;
+ }
+ 
+ //static int ds5_set_power(struct ds5 *state, int on)
+@@ -3469,4 +3486,4 @@ module_i2c_driver(ds5_i2c_driver);
+ MODULE_DESCRIPTION("Intel D4XX camera driver");
+ MODULE_AUTHOR("Emil Jahshan (emil.jahshan@intel.com)");
+ MODULE_LICENSE("GPL v2");
+-MODULE_VERSION("1.0.1.0");
++MODULE_VERSION("1.0.1.3");
+-- 
+2.17.1
+

--- a/kernel/nvidia/0031-Fix-the-contributors-list.patch
+++ b/kernel/nvidia/0031-Fix-the-contributors-list.patch
@@ -1,0 +1,29 @@
+From be5f3425e5ebbd20aa09edeb5e174f664856e778 Mon Sep 17 00:00:00 2001
+From: Evgeni Raikhel <evgeni.raikhel@intel.com>
+Date: Sat, 12 Feb 2022 23:37:19 +0200
+Subject: [PATCH] Fix the contributors list
+
+---
+ drivers/media/i2c/d4xx.c | 7 +++++--
+ 1 file changed, 5 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/media/i2c/d4xx.c b/drivers/media/i2c/d4xx.c
+index 96834cec9..dc01c088e 100644
+--- a/drivers/media/i2c/d4xx.c
++++ b/drivers/media/i2c/d4xx.c
+@@ -3484,7 +3484,10 @@ static struct i2c_driver ds5_i2c_driver = {
+ 
+ module_i2c_driver(ds5_i2c_driver);
+ 
+-MODULE_DESCRIPTION("Intel D4XX camera driver");
+-MODULE_AUTHOR("Emil Jahshan (emil.jahshan@intel.com)");
++MODULE_DESCRIPTION("Intel RealSense D4XX Camera Driver");
++MODULE_AUTHOR( "Guennadi Liakhovetski <guennadi.liakhovetski@intel.com>,\n\
++				Nael Masalha <nael.masalha@intel.com>,\n\
++				Alexander Gantman <alexander.gantman@intel.com>,\n\
++				Emil Jahshan <emil.jahshan@intel.com>");
+ MODULE_LICENSE("GPL v2");
+ MODULE_VERSION("1.0.1.3");
+-- 
+2.17.1
+


### PR DESCRIPTION
This is the same patch of #55 , except it's rebased to JetPack v4.6 branch after fixing conflicts.

#67 is on top of and includes this, if that one is ok, please merge that one directly.