### PR TITLE
rs_viewer: Revert the num of v4l2 buffers for latency on depth 720p and fps fix

### DIFF
--- a/utilities/streamApp/gui/StreamView.cpp
+++ b/utilities/streamApp/gui/StreamView.cpp
@@ -364,7 +364,11 @@ int StreamView::setLaserValue(int value) {
 
 int StreamView::setFPS(int value) {
     RS_AUTOLOG();
-    return mStream.setFPS((uint32_t)value);
+    int ret;
+    if ((ret = mStream.setFPS((uint32_t)value)) == 0)
+        mFormat.fps = (uint32_t)value;
+
+    return ret;
 }
 
 int StreamView::setResolution(uint32_t width, uint32_t height)

--- a/utilities/streamApp/gui/include/StreamView.h
+++ b/utilities/streamApp/gui/include/StreamView.h
@@ -105,7 +105,7 @@ private:
     bool mSlaveMode;
 
     // Number of buffers for streaming
-    const std::uint8_t mBuffersCount {16};
+    const std::uint8_t mBuffersCount {4};
     uint32_t mMemoryType;
 
     std::vector<realsense::camera_sub_system::RsBuffer> mRsBuffers;


### PR DESCRIPTION
- Revert the number of buffers from 16 to original 4. More buffers cause the noticeable latency on depth at 720p.
- Fix fps set first but not used when streaming. https://rsjira.intel.com/browse/DSO-18150