### PR TITLE
SerDes: Move SerDes calling into VI driver

### DIFF
--- a/hardware/nvidia/platform/t19x/galen/kernel-dts/0007-SerDes-Link-SerDes-to-VI-driver.patch
+++ b/hardware/nvidia/platform/t19x/galen/kernel-dts/0007-SerDes-Link-SerDes-to-VI-driver.patch
@@ -1,0 +1,64 @@
+From d76504b944d62cc06baeeaf6828971c347389376 Mon Sep 17 00:00:00 2001
+From: Qingwu Zhang <qingwu.zhang@intel.com>
+Date: Tue, 8 Mar 2022 11:02:39 +0800
+Subject: [PATCH] SerDes: Link SerDes to VI driver
+
+Move SerDes calling into VI driver.
+
+Signed-off-by: Qingwu Zhang <qingwu.zhang@intel.com>
+---
+ common/tegra194-camera-d4xx.dtsi | 10 ++--------
+ 1 file changed, 2 insertions(+), 8 deletions(-)
+
+diff --git a/common/tegra194-camera-d4xx.dtsi b/common/tegra194-camera-d4xx.dtsi
+index 3c35c52..009e0ee 100644
+--- a/common/tegra194-camera-d4xx.dtsi
++++ b/common/tegra194-camera-d4xx.dtsi
+@@ -62,8 +62,6 @@
+ 					vcc-supply = <&p2822_vdd_1v8_cvb>;
+ 					/*reset-gpios = <&tegra_main_gpio CAM0_RST_L GPIO_ACTIVE_HIG>;*/
+ 					cam-type = "Depth";
+-					nvidia,gmsl-ser-device = <&ser_prim>;
+-					nvidia,gmsl-dser-device = <&dser>;
+ 					ports {
+ 						#address-cells = <1>;
+ 						#size-cells = <0>;
+@@ -120,8 +118,6 @@
+ 					vcc-supply = <&p2822_vdd_1v8_cvb>;
+ 					/*reset-gpios = <&tegra_main_gpio CAM0_RST_L GPIO_ACTIVE_HIG>;*/
+ 					cam-type = "RGB";
+-					nvidia,gmsl-ser-device = <&ser_prim>;
+-					nvidia,gmsl-dser-device = <&dser>;
+ 					ports {
+ 						#address-cells = <1>;
+ 						#size-cells = <0>;
+@@ -174,8 +170,6 @@
+ 					vcc-supply = <&p2822_vdd_1v8_cvb>;
+ 					/*reset-gpios = <&tegra_main_gpio CAM0_RST_L GPIO_ACTIVE_HIG>;*/
+ 					cam-type = "Y8";
+-					nvidia,gmsl-ser-device = <&ser_prim>;
+-					nvidia,gmsl-dser-device = <&dser>;
+ 					ports {
+ 						#address-cells = <1>;
+ 						#size-cells = <0>;
+@@ -231,8 +225,6 @@
+ 					vcc-supply = <&p2822_vdd_1v8_cvb>;
+ 					/*reset-gpios = <&tegra_main_gpio CAM0_RST_L GPIO_ACTIVE_HIG>;*/
+ 					cam-type = "IMU";
+-					nvidia,gmsl-ser-device = <&ser_prim>;
+-					nvidia,gmsl-dser-device = <&dser>;
+ 					ports {
+ 						#address-cells = <1>;
+ 						#size-cells = <0>;
+@@ -465,6 +457,8 @@
+ 
+ 		vi_base: vi@15c10000 {
+ 			num-channels = <6>;
++			nvidia,gmsl-ser-device = <&ser_prim>;
++			nvidia,gmsl-dser-device = <&dser>;
+ 
+ 			ports {
+ 				#address-cells = <0x1>;
+-- 
+2.17.1
+

--- a/kernel/nvidia/0039-SerDes-Update-max9295-max9296-settings-in-VI-driver.patch
+++ b/kernel/nvidia/0039-SerDes-Update-max9295-max9296-settings-in-VI-driver.patch
@@ -1,0 +1,257 @@
+From 7cba11732f5c68785270077d7161e413764d9d65 Mon Sep 17 00:00:00 2001
+From: Qingwu Zhang <qingwu.zhang@intel.com>
+Date: Tue, 8 Mar 2022 11:06:19 +0800
+Subject: [PATCH] SerDes: Update max9295/max9296 settings in VI driver
+
+Move SerDes calling into VI driver.
+
+Signed-off-by: Qingwu Zhang <qingwu.zhang@intel.com>
+---
+ drivers/media/i2c/d4xx.c                      | 56 -------------------
+ .../media/platform/tegra/camera/vi/channel.c  | 23 ++++++++
+ .../platform/tegra/camera/vi/mc_common.c      | 32 +++++++++++
+ include/media/mc_common.h                     |  3 +
+ 4 files changed, 58 insertions(+), 56 deletions(-)
+
+diff --git a/drivers/media/i2c/d4xx.c b/drivers/media/i2c/d4xx.c
+index cb84f6fcd..0457c5863 100644
+--- a/drivers/media/i2c/d4xx.c
++++ b/drivers/media/i2c/d4xx.c
+@@ -35,12 +35,6 @@
+ #include <media/v4l2-subdev.h>
+ #include <media/v4l2-mediabus.h>
+ 
+-#ifdef CONFIG_TEGRA_CAMERA_PLATFORM
+-#include <media/gmsl-link.h>
+-#include <media/max9296.h>
+-#include <media/max9295.h>
+-#endif
+-
+ //#define DS5_DRIVER_NAME "DS5 RealSense camera driver"
+ #define DS5_DRIVER_NAME "d4xx"
+ #define DS5_DRIVER_NAME_AWG "d4xx-awg"
+@@ -416,9 +410,6 @@ struct ds5 {
+ 	int is_imu;
+ 	u16 fw_version;
+ 	u16 fw_build;
+-
+-	struct device *dser_dev;
+-	struct device *ser_dev;
+ };
+ 
+ struct ds5_counters {
+@@ -1055,7 +1046,6 @@ static int ds5_configure(struct ds5 *state)
+ 	struct ds5_sensor *sensor;
+ 	u16 fmt, md_fmt, vc_id;
+ 	u16 dt_addr, md_addr, override_addr, fps_addr, width_addr, height_addr;
+-	enum sensor_type type;
+ 	int ret;
+ 
+ 	if (state->is_depth) {
+@@ -1066,7 +1056,6 @@ static int ds5_configure(struct ds5 *state)
+ 		fps_addr = DS5_DEPTH_FPS;
+ 		width_addr = DS5_DEPTH_RES_WIDTH;
+ 		height_addr = DS5_DEPTH_RES_HEIGHT;
+-		type = DEPTH_SENSOR;
+ 		// TODO: read VC from device tree
+ 		vc_id = 0;
+ 	} else if (state->is_rgb) {
+@@ -1077,7 +1066,6 @@ static int ds5_configure(struct ds5 *state)
+ 		fps_addr = DS5_RGB_FPS;
+ 		width_addr = DS5_RGB_RES_WIDTH;
+ 		height_addr = DS5_RGB_RES_HEIGHT;
+-		type = RGB_SENSOR;
+ 		vc_id = 1;
+ 	} else if (state->is_y8) {
+ 		sensor = &state->motion_t.sensor;
+@@ -1087,7 +1075,6 @@ static int ds5_configure(struct ds5 *state)
+ 		fps_addr = DS5_IR_FPS;
+ 		width_addr = DS5_IR_RES_WIDTH;
+ 		height_addr = DS5_IR_RES_HEIGHT;
+-		type = IR_SENSOR;
+ 		vc_id = 2;
+ 	} else {
+ 		return -EINVAL;
+@@ -1096,23 +1083,6 @@ static int ds5_configure(struct ds5 *state)
+ 	fmt = sensor->streaming ? sensor->config.format->data_type : 0;
+ 	md_fmt = 0x12;
+ 
+-#ifdef CONFIG_TEGRA_CAMERA_PLATFORM
+-	if (state->dser_dev) {
+-		if (sensor->streaming) {
+-			ret = max9296_update_pipe(state->dser_dev, type, fmt);
+-			if (ret < 0)
+-				return ret;
+-		}
+-	}
+-	if (state->ser_dev) {
+-		if (sensor->streaming) {
+-			ret = max9295_update_pipe(state->ser_dev, type, fmt);
+-			if (ret < 0)
+-				return ret;
+-		}
+-	}
+-#endif
+-
+ 	// Still set depth stream data type as original 0x31
+ 	if (state->is_depth)
+ 		ret = ds5_write(state, dt_addr, 0x31);
+@@ -3354,10 +3324,6 @@ static int ds5_probe(struct i2c_client *c, const struct i2c_device_id *id)
+ 	u16 rec_state;
+ 	int ret, err = 0;
+ 	const char *str;
+-	struct device_node *dser_node = NULL;
+-	struct i2c_client *dser_i2c = NULL;
+-	struct device_node *ser_node = NULL;
+-	struct i2c_client *ser_i2c = NULL;
+ 
+ 	if (!state)
+ 		return -ENOMEM;
+@@ -3420,28 +3386,6 @@ static int ds5_probe(struct i2c_client *c, const struct i2c_device_id *id)
+ 	if (!err && !strncmp(str, "IMU", strlen("IMU")))
+ 		state->is_imu = 1;
+ 
+-	state->dser_dev = NULL;
+-	dser_node = of_parse_phandle(c->dev.of_node, "nvidia,gmsl-dser-device", 0);
+-	if (dser_node) {
+-		dser_i2c = of_find_i2c_device_by_node(dser_node);
+-		of_node_put(dser_node);
+-		if (dser_i2c) {
+-			dev_info(&c->dev, "dser_i2c->addr 0x%x", dser_i2c->addr);
+-			state->dser_dev = &dser_i2c->dev;
+-		}
+-	}
+-
+-	state->ser_dev = NULL;
+-	ser_node = of_parse_phandle(c->dev.of_node, "nvidia,gmsl-ser-device", 0);
+-	if (ser_node) {
+-		ser_i2c = of_find_i2c_device_by_node(ser_node);
+-		of_node_put(ser_node);
+-		if (ser_i2c) {
+-			dev_info(&c->dev, "ser_i2c->addr 0x%x", ser_i2c->addr);
+-			state->ser_dev = &ser_i2c->dev;
+-		}
+-	}
+-
+ 	dev_info(&c->dev, "%s(): state->is_rgb %d\n", __func__, state->is_rgb);
+ 	dev_info(&c->dev, "%s(): state->is_depth %d\n", __func__, state->is_depth);
+ 	dev_info(&c->dev, "%s(): state->is_y8 %d\n", __func__, state->is_y8);
+diff --git a/drivers/media/platform/tegra/camera/vi/channel.c b/drivers/media/platform/tegra/camera/vi/channel.c
+index eddc73049..8a3ac2b1a 100644
+--- a/drivers/media/platform/tegra/camera/vi/channel.c
++++ b/drivers/media/platform/tegra/camera/vi/channel.c
+@@ -39,6 +39,10 @@
+ #include <media/v4l2-dv-timings.h>
+ #include <media/vi.h>
+ 
++#include <media/gmsl-link.h>
++#include <media/max9296.h>
++#include <media/max9295.h>
++
+ #include <linux/clk/tegra.h>
+ #define CREATE_TRACE_POINTS
+ #include <trace/events/camera_common.h>
+@@ -1952,10 +1956,29 @@ __tegra_channel_set_format(struct tegra_channel *chan,
+ 	const struct tegra_video_format *vfmt;
+ 	struct v4l2_subdev_format fmt;
+ 	struct v4l2_subdev *sd = chan->subdev_on_csi;
++	struct tegra_mc_vi *vi = chan->vi;
+ 	int ret = 0;
+ 
+ 	vfmt = tegra_core_get_format_by_fourcc(chan, pix->pixelformat);
+ 
++	if (vi->dser_dev) {
++		ret = max9296_update_pipe(vi->dser_dev, chan->id, vfmt->img_dt);
++
++		dev_info(vi->dser_dev, "%s, chan id %d, data_type %x\n",
++			 __func__, chan->id, vfmt->img_dt);
++		if (ret < 0)
++			return ret;
++	}
++
++	if (vi->ser_dev) {
++		ret = max9295_update_pipe(vi->ser_dev, chan->id, vfmt->img_dt);
++
++		dev_info(vi->ser_dev, "%s, chan id %d, data_type %x\n",
++			 __func__, chan->id, vfmt->img_dt);
++		if (ret < 0)
++			return ret;
++	}
++
+ 	fmt.which = V4L2_SUBDEV_FORMAT_ACTIVE;
+ 	fmt.pad = 0;
+ 	v4l2_fill_mbus_format(&fmt.format, pix, vfmt->code);
+diff --git a/drivers/media/platform/tegra/camera/vi/mc_common.c b/drivers/media/platform/tegra/camera/vi/mc_common.c
+index 152424d63..ee6a39512 100644
+--- a/drivers/media/platform/tegra/camera/vi/mc_common.c
++++ b/drivers/media/platform/tegra/camera/vi/mc_common.c
+@@ -24,6 +24,10 @@
+ #include <media/vi.h>
+ #include <media/vi2_registers.h>
+ 
++#include <media/gmsl-link.h>
++#include <media/max9296.h>
++#include <media/max9295.h>
++
+ #include "dev.h"
+ #include "host1x/host1x.h"
+ 
+@@ -170,13 +174,41 @@ static int vi_parse_dt(struct tegra_mc_vi *vi, struct platform_device *dev)
+ 	int i;
+ 	struct tegra_channel *item;
+ 	struct device_node *node = dev->dev.of_node;
++	struct device_node *dser_node = NULL;
++	struct i2c_client *dser_i2c = NULL;
++	struct device_node *ser_node = NULL;
++	struct i2c_client *ser_i2c = NULL;
+ 
++	dev_info(&dev->dev, "%s, parse max9295/max9296\n", __func__);
+ 	err = of_property_read_u32(node, "num-channels", &num_channels);
+ 	if (err) {
+ 		dev_dbg(&dev->dev,
+ 			"Failed to find num of channels, set to 0\n");
+ 		num_channels = 0;
+ 	}
++
++	vi->dser_dev = NULL;
++	dser_node = of_parse_phandle(node, "nvidia,gmsl-dser-device", 0);
++	if (dser_node) {
++		dser_i2c = of_find_i2c_device_by_node(dser_node);
++		of_node_put(dser_node);
++		if (dser_i2c) {
++			dev_info(&dev->dev, "dser_i2c->addr 0x%x", dser_i2c->addr);
++			vi->dser_dev = &dser_i2c->dev;
++		}
++	}
++
++	vi->ser_dev = NULL;
++	ser_node = of_parse_phandle(node, "nvidia,gmsl-ser-device", 0);
++	if (ser_node) {
++		ser_i2c = of_find_i2c_device_by_node(ser_node);
++		of_node_put(ser_node);
++		if (ser_i2c) {
++			dev_info(&dev->dev, "ser_i2c->addr 0x%x", ser_i2c->addr);
++			vi->ser_dev = &ser_i2c->dev;
++		}
++	}
++
+ 	vi->num_channels = num_channels;
+ 	for (i = 0; i < num_channels; i++) {
+ 		item = devm_kzalloc(vi->dev, sizeof(*item), GFP_KERNEL);
+diff --git a/include/media/mc_common.h b/include/media/mc_common.h
+index de6c95435..acfdadbe5 100644
+--- a/include/media/mc_common.h
++++ b/include/media/mc_common.h
+@@ -320,6 +320,9 @@ struct tegra_mc_vi {
+ 	unsigned int num_channels;
+ 	unsigned int num_subdevs;
+ 
++	struct device *dser_dev;
++	struct device *ser_dev;
++
+ 	struct tegra_csi_device *csi;
+ 	struct list_head vi_chans;
+ 	struct tegra_channel *tpg_start;
+-- 
+2.17.1
+


### PR DESCRIPTION
SerDes was called in d4xx driver previously,
but now moved into VI driver.

Signed-off-by: Qingwu Zhang <qingwu.zhang@intel.com>