### PR TITLE
Add driver support for IMU stream

### DIFF
--- a/kernel/nvidia/0040-Add-D457-driver-support-for-IMU.patch
+++ b/kernel/nvidia/0040-Add-D457-driver-support-for-IMU.patch
@@ -1,0 +1,74 @@
+From 4a5a65d56689ae48163b7a0c609fe5b2324d8ea9 Mon Sep 17 00:00:00 2001
+From: Xin Zhang <xin.x.zhang@intel.com>
+Date: Thu, 3 Mar 2022 16:02:54 +0800
+Subject: [PATCH] Add D457 driver support for IMU
+
+Signed-off-by: Xin Zhang <xin.x.zhang@intel.com>
+---
+ drivers/media/i2c/d4xx.c | 20 ++++++++++++++++++--
+ 1 file changed, 18 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/media/i2c/d4xx.c b/drivers/media/i2c/d4xx.c
+index 0457c5863..e696bb1d7 100644
+--- a/drivers/media/i2c/d4xx.c
++++ b/drivers/media/i2c/d4xx.c
+@@ -1058,6 +1058,7 @@ static int ds5_configure(struct ds5 *state)
+ 		height_addr = DS5_DEPTH_RES_HEIGHT;
+ 		// TODO: read VC from device tree
+ 		vc_id = 0;
++		md_fmt = 0x12;
+ 	} else if (state->is_rgb) {
+ 		sensor = &state->rgb.sensor;
+ 		dt_addr = DS5_RGB_STREAM_DT;
+@@ -1067,6 +1068,7 @@ static int ds5_configure(struct ds5 *state)
+ 		width_addr = DS5_RGB_RES_WIDTH;
+ 		height_addr = DS5_RGB_RES_HEIGHT;
+ 		vc_id = 1;
++		md_fmt = 0x12;
+ 	} else if (state->is_y8) {
+ 		sensor = &state->motion_t.sensor;
+ 		dt_addr = DS5_IR_STREAM_DT;
+@@ -1076,12 +1078,22 @@ static int ds5_configure(struct ds5 *state)
+ 		width_addr = DS5_IR_RES_WIDTH;
+ 		height_addr = DS5_IR_RES_HEIGHT;
+ 		vc_id = 2;
++		md_fmt = 0x12;
++	} else if (state->is_imu) {
++		sensor = &state->imu.sensor;
++		dt_addr = DS5_IMU_STREAM_DT;
++		md_addr = DS5_IMU_STREAM_MD;
++		override_addr = 0;
++		fps_addr = DS5_IMU_FPS;
++		width_addr = DS5_IMU_RES_WIDTH;
++		height_addr = DS5_IMU_RES_HEIGHT;
++		vc_id = 3;
++		md_fmt = 0x0;
+ 	} else {
+ 		return -EINVAL;
+ 	}
+ 
+ 	fmt = sensor->streaming ? sensor->config.format->data_type : 0;
+-	md_fmt = 0x12;
+ 
+ 	// Still set depth stream data type as original 0x31
+ 	if (state->is_depth)
+@@ -2484,6 +2496,10 @@ static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on)
+ 		config_status_base = DS5_IR_CONFIG_STATUS;
+ 		stream_status_base = DS5_IR_STREAM_STATUS;
+ 		stream_id = DS5_STREAM_IR;
++	} else if (state->is_imu) {
++		config_status_base = DS5_IMU_CONFIG_STATUS;
++		stream_status_base = DS5_IMU_STREAM_STATUS;
++		stream_id = DS5_STREAM_IMU;
+ 	} else {
+ 		return -EINVAL;
+ 	}
+@@ -3455,4 +3471,4 @@ MODULE_AUTHOR( "Guennadi Liakhovetski <guennadi.liakhovetski@intel.com>,\n\
+ 				Alexander Gantman <alexander.gantman@intel.com>,\n\
+ 				Emil Jahshan <emil.jahshan@intel.com>");
+ MODULE_LICENSE("GPL v2");
+-MODULE_VERSION("1.0.1.3");
++MODULE_VERSION("1.0.1.4");
+-- 
+2.17.1
+


### PR DESCRIPTION
Temporary changes to support IMU stream in driver, because of original existing code and previous cleanup it's very clean to enable IMU: only add flow for IMU i2c addresses in s_stream path.

WIP with @qingwuzh on the SerDes setting to enable IMU stream, we tried to set channel 3 like others but right now when starting the IMU stream the IMU stream configuration status 0x4804 bit0 is always 0 so streaming fails.

With FW from https://rsjira.intel.com/browse/DSO-17212.