### PR TITLE
IR Y8I enabling changes

### DIFF
--- a/kernel/nvidia/0042-IR-Y8I-enabling-changes.patch
+++ b/kernel/nvidia/0042-IR-Y8I-enabling-changes.patch
@@ -1,0 +1,134 @@
+From 4c3968c97784c13063699685cabce06b502ae126 Mon Sep 17 00:00:00 2001
+From: Xin Zhang <xin.x.zhang@intel.com>
+Date: Fri, 11 Mar 2022 11:10:14 +0800
+Subject: [PATCH] IR Y8I enabling changes
+
+The IR Y8I uses MIPI user defined 0x32 data type in document, the
+max9295/9296 and MIPI will use standard known 0x1E (16bit per pixel):
+- Correct max9295/9296 Pipe Z data type setting;
+- Add Y8I data type in IR stream in d4xx;
+- Map V4L2 Y8I data type in VI.
+
+Signed-off-by: Xin Zhang <xin.x.zhang@intel.com>
+---
+ drivers/media/i2c/d4xx.c                          | 15 +++++++++++++--
+ drivers/media/i2c/max9295.c                       |  2 +-
+ drivers/media/i2c/max9296.c                       |  4 ++--
+ .../media/platform/tegra/camera/vi/vi4_formats.h  |  7 ++++---
+ .../media/platform/tegra/camera/vi/vi5_formats.h  |  6 ++++--
+ 5 files changed, 24 insertions(+), 10 deletions(-)
+
+diff --git a/drivers/media/i2c/d4xx.c b/drivers/media/i2c/d4xx.c
+index 0457c5863..6d2fb81c6 100644
+--- a/drivers/media/i2c/d4xx.c
++++ b/drivers/media/i2c/d4xx.c
+@@ -757,6 +757,11 @@ static const struct ds5_format ds5_y_formats_ds5u[] = {
+ 		.mbus_code = MEDIA_BUS_FMT_Y8_1X8,
+ 		.n_resolutions = ARRAY_SIZE(y8_sizes),
+ 		.resolutions = y8_sizes,
++	}, {
++		.data_type = 0x1e,	/* Y8I */
++		.mbus_code = MEDIA_BUS_FMT_VYUY8_1X16,
++		.n_resolutions = ARRAY_SIZE(y8_sizes),
++		.resolutions = y8_sizes,
+ 	}, {
+ 		.data_type = 0x24,	/* 24-bit Calibration */
+ 		.mbus_code = MEDIA_BUS_FMT_RGB888_1X24,	/* FIXME */
+@@ -1083,9 +1088,15 @@ static int ds5_configure(struct ds5 *state)
+ 	fmt = sensor->streaming ? sensor->config.format->data_type : 0;
+ 	md_fmt = 0x12;
+ 
+-	// Still set depth stream data type as original 0x31
+-	if (state->is_depth)
++	/*
++	 * Set depth stream Z16 data type as 0x31
++	 * Set IR stream Y8I data type as 0x32
++	 */
++	if (state->is_depth && fmt != 0)
+ 		ret = ds5_write(state, dt_addr, 0x31);
++	else if (state->is_y8 && fmt != 0 &&
++		 sensor->config.format->data_type == 0x1e)
++		ret = ds5_write(state, dt_addr, 0x32);
+ 	else
+ 		ret = ds5_write(state, dt_addr, fmt);
+ 	if (ret < 0)
+diff --git a/drivers/media/i2c/max9295.c b/drivers/media/i2c/max9295.c
+index 8921da36c..aaf5e990d 100644
+--- a/drivers/media/i2c/max9295.c
++++ b/drivers/media/i2c/max9295.c
+@@ -540,7 +540,7 @@ static struct reg_pair map_pipe_y_control[] = {
+ static struct reg_pair map_pipe_z_y8_y8i_control[] = {
+ 	/* addr, val */
+ 	{0x0318, 0x6A}, // Pipe Z pulls Y8 (DT 0x2A)
+-	{0x0319, 0x72}, // Pipe Z pulls Y8I (DT 0x32)
++	{0x0319, 0x5E}, // Pipe Z pulls Y8I (DT 0x1E)
+ 	{0x030D, 0x04}, // Pipe Z pulls VC2
+ 	{0x030E, 0x00},
+ 	{0x031E, 0x30}, // BPP = 16 in pipe Z
+diff --git a/drivers/media/i2c/max9296.c b/drivers/media/i2c/max9296.c
+index 66bfecfce..9d209f1bc 100644
+--- a/drivers/media/i2c/max9296.c
++++ b/drivers/media/i2c/max9296.c
+@@ -859,8 +859,8 @@ static struct reg_pair map_pipe_z_y8_y8i_control[] = {
+ 	{0x0490, 0x80},
+ 	{0x0491, 0x81}, // Map frame end  VC2
+ 	{0x0492, 0x81},
+-	{0x0493, 0xB2}, // Map Y8I, VC2
+-	{0x0494, 0xB2},
++	{0x0493, 0x9E}, // Map Y8I, VC2
++	{0x0494, 0x9E},
+ 	{0x04AD, 0x55}, // Map to PHY1 (master for port A)
+ 
+ 	// SEQ_MISS_EN: Disabled / DIS_PKT_DET: Disabled
+diff --git a/drivers/media/platform/tegra/camera/vi/vi4_formats.h b/drivers/media/platform/tegra/camera/vi/vi4_formats.h
+index 6f8b1fac7..50e7c1862 100644
+--- a/drivers/media/platform/tegra/camera/vi/vi4_formats.h
++++ b/drivers/media/platform/tegra/camera/vi/vi4_formats.h
+@@ -128,8 +128,8 @@ static const struct tegra_video_format vi4_video_formats[] = {
+ 	/* YUV422 */
+ 	//TEGRA_VIDEO_FORMAT(YUV422, 16, UYVY8_1X16, 2, 1, T_U8_Y8__V8_Y8,
+ 	//			YUV422_8, UYVY, "YUV 4:2:2"),
+-	TEGRA_VIDEO_FORMAT(YUV422, 16, VYUY8_1X16, 2, 1, T_V8_Y8__U8_Y8,
+-				YUV422_8, VYUY, "YUV 4:2:2"),
++	//TEGRA_VIDEO_FORMAT(YUV422, 16, VYUY8_1X16, 2, 1, T_V8_Y8__U8_Y8,
++	//			YUV422_8, VYUY, "YUV 4:2:2"),
+ 	TEGRA_VIDEO_FORMAT(YUV422, 16, YUYV8_1X16, 2, 1, T_Y8_U8__Y8_V8,
+ 				YUV422_8, YUYV, "YUV 4:2:2"),
+ 	TEGRA_VIDEO_FORMAT(YUV422, 16, YVYU8_1X16, 2, 1, T_Y8_V8__Y8_U8,
+@@ -147,7 +147,8 @@ static const struct tegra_video_format vi4_video_formats[] = {
+ 
+ 	TEGRA_VIDEO_FORMAT(YUV422, 16, UYVY8_1X16, 2, 1, T_U8_Y8__V8_Y8,
+ 				YUV422_8, Z16, "Depth 16"),
+-
++	TEGRA_VIDEO_FORMAT(YUV422, 16, VYUY8_1X16, 2, 1, T_V8_Y8__U8_Y8,
++				YUV422_8, Y8I, "Y8I 16"),
+ 	// TODO: RealSesne calibration format Y12I should be 3-byte,
+ 	// R[7:3]R[3:0] | L[3:0]R[11:8] | L[11:8]L[7:4]
+ 	// but, currently, it's 4-byte, one byte is added as alignment
+diff --git a/drivers/media/platform/tegra/camera/vi/vi5_formats.h b/drivers/media/platform/tegra/camera/vi/vi5_formats.h
+index 7d2169ee0..0de34514c 100644
+--- a/drivers/media/platform/tegra/camera/vi/vi5_formats.h
++++ b/drivers/media/platform/tegra/camera/vi/vi5_formats.h
+@@ -127,8 +127,8 @@ static const struct tegra_video_format vi5_video_formats[] = {
+ 	/* YUV422 */
+ 	//TEGRA_VIDEO_FORMAT(YUV422, 16, UYVY8_1X16, 2, 1, T_U8_Y8__V8_Y8,
+ 	//			YUV422_8, UYVY, "YUV 4:2:2"),
+-	TEGRA_VIDEO_FORMAT(YUV422, 16, VYUY8_1X16, 2, 1, T_V8_Y8__U8_Y8,
+-				YUV422_8, VYUY, "YUV 4:2:2"),
++	//TEGRA_VIDEO_FORMAT(YUV422, 16, VYUY8_1X16, 2, 1, T_V8_Y8__U8_Y8,
++	//			YUV422_8, VYUY, "YUV 4:2:2"),
+ 	TEGRA_VIDEO_FORMAT(YUV422, 16, YUYV8_1X16, 2, 1, T_Y8_U8__Y8_V8,
+ 				YUV422_8, YUYV, "YUV 4:2:2"),
+ 	TEGRA_VIDEO_FORMAT(YUV422, 16, YVYU8_1X16, 2, 1, T_Y8_V8__Y8_U8,
+@@ -146,6 +146,8 @@ static const struct tegra_video_format vi5_video_formats[] = {
+ 
+ 	TEGRA_VIDEO_FORMAT(YUV422, 16, UYVY8_1X16, 2, 1, T_U8_Y8__V8_Y8,
+ 				YUV422_8, Z16, "Depth 16"),
++	TEGRA_VIDEO_FORMAT(YUV422, 16, VYUY8_1X16, 2, 1, T_V8_Y8__U8_Y8,
++				YUV422_8, Y8I, "Y8I 16"),
+ 	// TODO: RealSesne calibration format Y12I should be 3-byte,
+ 	// R[7:3]R[3:0] | L[3:0]R[11:8] | L[11:8]L[7:4]
+ 	// but, currently, it's 4-byte, one byte is added as alignment
+-- 
+2.17.1
+


### PR DESCRIPTION
The IR Y8I uses MIPI user defined 0x32 data type in document, the max9295/9296 and MIPI will use standard known 0x1E (16bit per pixel):
- Correct max9295/9296 Pipe Z data type setting;
- Add Y8I data type in IR stream in d4xx;
- Map V4L2 Y8I data type in VI.