### PR TITLE
SerDes: Upgrade SerDes version to 1.0.0.7

### DIFF
--- a/kernel/nvidia/0041-SerDes-Upgrade-SerDes-version-to-1.0.0.7.patch
+++ b/kernel/nvidia/0041-SerDes-Upgrade-SerDes-version-to-1.0.0.7.patch
@@ -1,0 +1,458 @@
+From df14bd599296841af516da85b98ef55e18bb8bdb Mon Sep 17 00:00:00 2001
+From: Qingwu Zhang <qingwu.zhang@intel.com>
+Date: Fri, 11 Mar 2022 16:59:58 +0800
+Subject: [PATCH] SerDes: Upgrade SerDes version to 1.0.0.7
+
+Add IMU support in SerDes.
+
+Signed-off-by: Qingwu Zhang <qingwu.zhang@intel.com>
+---
+ drivers/media/i2c/max9295.c | 119 +++++++++++++++++++++++++++++++----
+ drivers/media/i2c/max9296.c | 120 ++++++++++++++++++++++++++++++++----
+ 2 files changed, 214 insertions(+), 25 deletions(-)
+
+diff --git a/drivers/media/i2c/max9295.c b/drivers/media/i2c/max9295.c
+index 117f86983..8921da36c 100644
+--- a/drivers/media/i2c/max9295.c
++++ b/drivers/media/i2c/max9295.c
+@@ -103,6 +103,12 @@ struct max9295_client_ctx {
+ 	bool st_done;
+ };
+ 
++enum ir_type {
++	Y_NONE = 0,
++	Y8_Y8I,
++	Y12I,
++};
++
+ struct max9295 {
+ 	struct i2c_client *i2c_client;
+ 	struct regmap *regmap;
+@@ -111,6 +117,8 @@ struct max9295 {
+ 	/* primary serializer properties */
+ 	__u32 def_addr;
+ 	__u32 pst2_ref;
++
++	int ir_type_value;
+ };
+ 
+ static struct max9295 *prim_priv__;
+@@ -478,7 +486,7 @@ module_param(max9295_dynamic_update, bool, 0664);
+ MODULE_PARM_DESC(max9295_dynamic_update, "Update max9295 settings dynamically");
+ 
+ 
+-static char *max9295_setting_verison = "1.0.0.6";
++static char *max9295_setting_verison = "1.0.0.7";
+ module_param(max9295_setting_verison, charp, 0444);
+ MODULE_PARM_DESC(max9295_setting_verison, "Print max9295 setting version");
+ 
+@@ -491,13 +499,22 @@ static struct reg_pair map_cmu_regulator[] = {
+ 	{0x0302, 0x10}, // lllIncrease CMU regulator voltage
+ };
+ 
+-static struct reg_pair map_pipe_opt[] = {
++static struct reg_pair map_pipe_y8_opt[] = {
+ 	{0x0002, 0xF3}, // # Enable all pipes
+ 
+ 	{0x0331, 0x11}, // Write 0x33 for 4 lanes
+ 	{0x0308, 0x6F}, // All pipes pull clock from port B
+ 	{0x0311, 0xF0}, // All pipes pull data from port B
+-	{0x0312, 0x07}, // Double 8-bit data on pipe X, Y, Z
++	{0x0312, 0x0F}, // Double 8-bit data on pipe X, Y, Z & U
++};
++
++static struct reg_pair map_pipe_y12i_opt[] = {
++	{0x0002, 0xF3}, // # Enable all pipes
++
++	{0x0331, 0x11}, // Write 0x33 for 4 lanes
++	{0x0308, 0x6F}, // All pipes pull clock from port B
++	{0x0311, 0xF0}, // All pipes pull data from port B
++	{0x0312, 0x0B}, // Double 8-bit data on pipe X, Y & U
+ };
+ 
+ static struct reg_pair map_pipe_x_control[] = {
+@@ -520,7 +537,7 @@ static struct reg_pair map_pipe_y_control[] = {
+ 	{0x010A, 0x0E}, // LIM_HEART Pipe Y: Disabled
+ };
+ 
+-static struct reg_pair map_pipe_z_control[] = {
++static struct reg_pair map_pipe_z_y8_y8i_control[] = {
+ 	/* addr, val */
+ 	{0x0318, 0x6A}, // Pipe Z pulls Y8 (DT 0x2A)
+ 	{0x0319, 0x72}, // Pipe Z pulls Y8I (DT 0x32)
+@@ -530,11 +547,20 @@ static struct reg_pair map_pipe_z_control[] = {
+ 	{0x0112, 0x0E}, // LIM_HEART Pipe Z: Disabled
+ };
+ 
++static struct reg_pair map_pipe_z_y12i_control[] = {
++	/* addr, val */
++	{0x0318, 0x64}, // Pipe Z pulls Y12I (DT 0x24)
++	{0x030D, 0x04}, // Pipe Z pulls VC2
++	{0x030E, 0x00},
++	{0x0112, 0x0E}, // LIM_HEART Pipe Z: Disabled
++};
++
+ static struct reg_pair map_pipe_u_control[] = {
+ 	/* addr, val */
+-	{0x031A, 0x64}, // Pipe U pulls Y12I (DT 0x24)
+-	{0x030F, 0x04}, // Pipe U pulls VC2
++	{0x031A, 0x6A}, // Pipe U pulls IMU (DT 0x2A)
++	{0x030F, 0x08}, // Pipe U pulls VC3
+ 	{0x0310, 0x00},
++	{0x031F, 0x30}, // BPP = 16 in pipe U
+ 
+ 	{0x0315, 0xD2}, // Enable independent VC's
+ 	{0x011A, 0x0E}, // LIM_HEART Pipe U: Disabled
+@@ -580,13 +606,14 @@ static int max9295_set_registers(struct device *dev, struct reg_pair *map,
+ static int max9295_init_settings(struct device *dev)
+ {
+ 	int err = 0;
++	struct max9295 *priv = dev_get_drvdata(dev);
+ 
+ 	// Set CMU
+ 	err = max9295_set_registers(dev, map_cmu_regulator,
+ 				    ARRAY_SIZE(map_cmu_regulator));
+ 	// Init control
+-	err |= max9295_set_registers(dev, map_pipe_opt,
+-				     ARRAY_SIZE(map_pipe_opt));
++	err |= max9295_set_registers(dev, map_pipe_y8_opt,
++				     ARRAY_SIZE(map_pipe_y8_opt));
+ 
+ 	// Pipe X
+ 	err |= max9295_set_registers(dev, map_pipe_x_control,
+@@ -595,8 +622,8 @@ static int max9295_init_settings(struct device *dev)
+ 	err |= max9295_set_registers(dev, map_pipe_y_control,
+ 				     ARRAY_SIZE(map_pipe_x_control));
+ 	// Pipe Z
+-	err |= max9295_set_registers(dev, map_pipe_z_control,
+-				     ARRAY_SIZE(map_pipe_z_control));
++	err |= max9295_set_registers(dev, map_pipe_z_y8_y8i_control,
++				     ARRAY_SIZE(map_pipe_z_y8_y8i_control));
+ 	// Pipe U
+ 	err |= max9295_set_registers(dev, map_pipe_u_control,
+ 				     ARRAY_SIZE(map_pipe_u_control));
+@@ -611,6 +638,7 @@ static int max9295_init_settings(struct device *dev)
+ 	if (err == 0) {
+ 		dev_info(dev, "%s done\n", __func__);
+ 		init_done = true;
++		priv->ir_type_value = Y8_Y8I;
+ 	} else {
+ 		dev_err(dev, "%s, failed to init settings \n", __func__);
+ 	}
+@@ -627,9 +655,9 @@ static int max9295_check_status(struct device *dev)
+ 
+ 	mutex_lock(&priv->lock);
+ 
+-	for (j = 0; j < ARRAY_SIZE(map_pipe_opt); j++) {
++	for (j = 0; j < ARRAY_SIZE(map_pipe_y8_opt); j++) {
+ 		val = 0;
+-		err = regmap_read(priv->regmap, map_pipe_opt[j].addr, &val);
++		err = regmap_read(priv->regmap, map_pipe_y8_opt[j].addr, &val);
+ 
+ 		dev_info(dev,
+ 			"%s:i2c read, err %x, cmu value %x\n",
+@@ -644,6 +672,7 @@ static int max9295_check_status(struct device *dev)
+ int max9295_update_pipe(struct device *dev, int sensor_type, int data_type)
+ {
+ 	int err = 0;
++	struct max9295 *priv;
+ 
+ 	if (!probe_done)
+ 		return 0;
+@@ -660,6 +689,71 @@ int max9295_update_pipe(struct device *dev, int sensor_type, int data_type)
+ 		max9295_check_status(dev);
+ 	}
+ 
++	priv = dev_get_drvdata(dev);
++	if ((sensor_type == IR_SENSOR) && (priv->ir_type_value != Y8_Y8I) &&
++	    (data_type == 0x2A || data_type == 0x32)) {
++		// Set CMU
++		err = max9295_set_registers(dev, map_cmu_regulator,
++					    ARRAY_SIZE(map_cmu_regulator));
++		// Init control
++		err |= max9295_set_registers(dev, map_pipe_y8_opt,
++					     ARRAY_SIZE(map_pipe_y8_opt));
++
++		// Pipe X
++		err |= max9295_set_registers(dev, map_pipe_x_control,
++					     ARRAY_SIZE(map_pipe_x_control));
++		// Pipe Y
++		err |= max9295_set_registers(dev, map_pipe_y_control,
++					     ARRAY_SIZE(map_pipe_x_control));
++		// Pipe Z
++		err |= max9295_set_registers(dev, map_pipe_z_y8_y8i_control,
++					     ARRAY_SIZE(map_pipe_z_y8_y8i_control));
++		// Pipe U
++		err |= max9295_set_registers(dev, map_pipe_u_control,
++					     ARRAY_SIZE(map_pipe_u_control));
++
++		// Trigger Depth
++		err |= max9295_set_registers(dev, map_depth_trigger,
++					     ARRAY_SIZE(map_depth_trigger));
++		// Trigger RGB
++		err |= max9295_set_registers(dev, map_rgb_trigger,
++					     ARRAY_SIZE(map_rgb_trigger));
++
++		if (err == 0)
++			priv->ir_type_value = Y8_Y8I;
++	} else if ((sensor_type == IR_SENSOR) && (priv->ir_type_value != Y12I) &&
++	           (data_type == 0x24)) {
++		// Set CMU
++		err = max9295_set_registers(dev, map_cmu_regulator,
++					    ARRAY_SIZE(map_cmu_regulator));
++		// Init control
++		err |= max9295_set_registers(dev, map_pipe_y12i_opt,
++					     ARRAY_SIZE(map_pipe_y12i_opt));
++
++		// Pipe X
++		err |= max9295_set_registers(dev, map_pipe_x_control,
++					     ARRAY_SIZE(map_pipe_x_control));
++		// Pipe Y
++		err |= max9295_set_registers(dev, map_pipe_y_control,
++					     ARRAY_SIZE(map_pipe_x_control));
++		// Pipe Z
++		err |= max9295_set_registers(dev, map_pipe_z_y12i_control,
++					     ARRAY_SIZE(map_pipe_z_y12i_control));
++		// Pipe U
++		err |= max9295_set_registers(dev, map_pipe_u_control,
++					     ARRAY_SIZE(map_pipe_u_control));
++
++		// Trigger Depth
++		err |= max9295_set_registers(dev, map_depth_trigger,
++					     ARRAY_SIZE(map_depth_trigger));
++		// Trigger RGB
++		err |= max9295_set_registers(dev, map_rgb_trigger,
++					     ARRAY_SIZE(map_rgb_trigger));
++
++		if (err == 0)
++			priv->ir_type_value = Y12I;
++	}
++
+ 	return err;
+ }
+ EXPORT_SYMBOL(max9295_update_pipe);
+@@ -703,6 +797,7 @@ static int max9295_probe(struct i2c_client *client,
+ 
+ 	dev_set_drvdata(&client->dev, priv);
+ 
++	priv->ir_type_value = Y_NONE;
+ 	max9295_init_settings(&client->dev);
+ 	probe_done = true;
+ 
+diff --git a/drivers/media/i2c/max9296.c b/drivers/media/i2c/max9296.c
+index 8b52d8726..66bfecfce 100644
+--- a/drivers/media/i2c/max9296.c
++++ b/drivers/media/i2c/max9296.c
+@@ -104,6 +104,12 @@ struct pipe_ctx {
+ 	u32 st_id_sel;
+ };
+ 
++enum ir_type {
++	Y_NONE = 0,
++	Y8_Y8I,
++	Y12I,
++};
++
+ struct max9296 {
+ 	struct i2c_client *i2c_client;
+ 	struct regmap *regmap;
+@@ -124,6 +130,8 @@ struct max9296 {
+ 	int reset_gpio;
+ 	int pw_ref;
+ 	struct regulator *vdd_cam_1v2;
++
++	int ir_type_value;
+ };
+ 
+ static int max9296_write_reg(struct device *dev,
+@@ -785,7 +793,7 @@ module_param(max9296_dynamic_update, bool, 0664);
+ MODULE_PARM_DESC(max9296_dynamic_update, "Update max9296 settings dynamically");
+ 
+ 
+-static char *max9296_setting_verison = "1.0.0.6";
++static char *max9296_setting_verison = "1.0.0.7";
+ module_param(max9296_setting_verison, charp, 0444);
+ MODULE_PARM_DESC(max9296_setting_verison, "Print max9296 setting version");
+ 
+@@ -802,11 +810,10 @@ static struct reg_pair map_pipe_opt[] = {
+ 
+ 	{0x044A, 0x50}, // 4 lanes on port A, write 0x50 for 2 lanes
+ 	{0x0320, 0x2F}, // 1500Mbps/lane on port A
+-	{0x031C, 0x00}, // Do not un-double 8bpp (Un-double 8bpp data)
+-	{0x031F, 0x00}, // Do not un-double 8bpp
++//	{0x031C, 0x00}, // Do not un-double 8bpp (Un-double 8bpp data)
++//	{0x031F, 0x00}, // Do not un-double 8bpp
+ 	{0x0473, 0x10}, // 0x02: ALT_MEM_MAP8, 0x10: ALT2_MEM_MAP8
+ 	// VC2 VS will come from pipe Z, not needed for pipe U
+-	{0x0239, 0x39}, // Force VS low in pipe U
+ };
+ 
+ static struct reg_pair map_pipe_x_control[] = {
+@@ -843,10 +850,10 @@ static struct reg_pair map_pipe_y_control[] = {
+ 	{0x0112, 0x23}, // pipe Y
+ };
+ 
+-static struct reg_pair map_pipe_z_control[] = {
++static struct reg_pair map_pipe_z_y8_y8i_control[] = {
+ 	/* addr, val */
+ 	{0x048B, 0x0F}, // Enable 4 mappings for Pipe Z
+-	{0x048D, 0xAA}, // Map Y8 VC1
++	{0x048D, 0xAA}, // Map Y8 VC2
+ 	{0x048E, 0xAA},
+ 	{0x048F, 0x80}, // Map frame start  VC2
+ 	{0x0490, 0x80},
+@@ -860,13 +867,31 @@ static struct reg_pair map_pipe_z_control[] = {
+ 	{0x0124, 0x23}, // pipe Z
+ };
+ 
++static struct reg_pair map_pipe_z_y12i_control[] = {
++	/* addr, val */
++	{0x048B, 0x07}, // Enable 3 mappings for Pipe Z
++	{0x048D, 0xA4}, // Map Y12I VC2
++	{0x048E, 0xA4},
++	{0x048F, 0x80}, // Map frame start  VC2
++	{0x0490, 0x80},
++	{0x0491, 0x81}, // Map frame end  VC2
++	{0x0492, 0x81},
++	{0x04AD, 0x15}, // Map to PHY1 (master for port A)
++
++	// SEQ_MISS_EN: Disabled / DIS_PKT_DET: Disabled
++	{0x0124, 0x23}, // pipe Z
++};
++
+ static struct reg_pair map_pipe_u_control[] = {
+ 	/* addr, val */
+-	// VC2 FS/FE will come from pipe Z, not needed in pipe U
+-	{0x04CB, 0x01}, // Enable 1 mappings for Pipe U
+-	{0x04CD, 0xA4}, // Map Y12I VC2
+-	{0x04CE, 0xA4},
+-	{0x04ED, 0x01}, // Map to PHY1 (master for port A)
++	{0x04CB, 0x07}, // Enable 3 mappings for Pipe U
++	{0x04CD, 0xEA}, // Map IMUI VC3
++	{0x04CE, 0xEA},
++	{0x04CF, 0xC0}, // Map frame start  VC3
++	{0x04D0, 0xC0},
++	{0x04D1, 0xC1}, // Map frame end  VC3
++	{0x04D2, 0xC1},
++	{0x04ED, 0x15}, // Map to PHY1 (master for port A)
+ 
+ 	// SEQ_MISS_EN: Disabled / DIS_PKT_DET: Disabled
+ 	{0x0136, 0x23}, // pipe U
+@@ -910,6 +935,7 @@ static int max9296_set_registers(struct device *dev, struct reg_pair *map,
+ static int max9296_init_settings(struct device *dev)
+ {
+ 	int err = 0;
++	struct max9296 *priv = dev_get_drvdata(dev);
+ 
+ 	// Set CMU
+ 	err = max9296_set_registers(dev, map_cmu_regulator,
+@@ -925,8 +951,8 @@ static int max9296_init_settings(struct device *dev)
+ 	err |= max9296_set_registers(dev, map_pipe_y_control,
+ 				     ARRAY_SIZE(map_pipe_x_control));
+ 	// Pipe Z
+-	err |= max9296_set_registers(dev, map_pipe_z_control,
+-				     ARRAY_SIZE(map_pipe_z_control));
++	err |= max9296_set_registers(dev, map_pipe_z_y8_y8i_control,
++				     ARRAY_SIZE(map_pipe_z_y8_y8i_control));
+ 	// Pipe U
+ 	err |= max9296_set_registers(dev, map_pipe_u_control,
+ 				     ARRAY_SIZE(map_pipe_u_control));
+@@ -941,6 +967,7 @@ static int max9296_init_settings(struct device *dev)
+ 	if (err == 0) {
+ 		dev_info(dev, "%s done\n", __func__);
+ 		init_done = true;
++		priv->ir_type_value = Y8_Y8I;
+ 	} else {
+ 		dev_err(dev, "%s, failed to init settings \n", __func__);
+ 	}
+@@ -972,6 +999,7 @@ static int max9296_check_status(struct device *dev)
+ int max9296_update_pipe(struct device *dev, int sensor_type, int data_type)
+ {
+ 	int err = 0;
++	struct max9296 *priv;
+ 
+ 	if (!probe_done)
+ 		return 0;
+@@ -988,6 +1016,71 @@ int max9296_update_pipe(struct device *dev, int sensor_type, int data_type)
+ 		max9296_check_status(dev);
+ 	}
+ 
++	priv = dev_get_drvdata(dev);
++	if ((sensor_type == IR_SENSOR) && (priv->ir_type_value != Y8_Y8I) &&
++            (data_type == 0x2A || data_type == 0x32)) {
++		// Set CMU
++		err = max9296_set_registers(dev, map_cmu_regulator,
++					    ARRAY_SIZE(map_cmu_regulator));
++		// Init control
++		err |= max9296_set_registers(dev, map_pipe_opt,
++					     ARRAY_SIZE(map_pipe_opt));
++
++		// Pipe X
++		err |= max9296_set_registers(dev, map_pipe_x_control,
++					     ARRAY_SIZE(map_pipe_x_control));
++		// Pipe Y
++		err |= max9296_set_registers(dev, map_pipe_y_control,
++					     ARRAY_SIZE(map_pipe_x_control));
++		// Pipe Z
++		err |= max9296_set_registers(dev, map_pipe_z_y8_y8i_control,
++					     ARRAY_SIZE(map_pipe_z_y8_y8i_control));
++		// Pipe U
++		err |= max9296_set_registers(dev, map_pipe_u_control,
++					     ARRAY_SIZE(map_pipe_u_control));
++
++		// Trigger Depth
++		err |= max9296_set_registers(dev, map_depth_trigger,
++					     ARRAY_SIZE(map_depth_trigger));
++		// Trigger RGB
++		err |= max9296_set_registers(dev, map_rgb_trigger,
++					     ARRAY_SIZE(map_rgb_trigger));
++
++		if (err == 0)
++			priv->ir_type_value = Y8_Y8I;
++	} else if ((sensor_type == IR_SENSOR) && (priv->ir_type_value != Y12I) &&
++		   (data_type == 0x24)) {
++		// Set CMU
++		err = max9296_set_registers(dev, map_cmu_regulator,
++					    ARRAY_SIZE(map_cmu_regulator));
++		// Init control
++		err |= max9296_set_registers(dev, map_pipe_opt,
++					     ARRAY_SIZE(map_pipe_opt));
++
++		// Pipe X
++		err |= max9296_set_registers(dev, map_pipe_x_control,
++					     ARRAY_SIZE(map_pipe_x_control));
++		// Pipe Y
++		err |= max9296_set_registers(dev, map_pipe_y_control,
++					     ARRAY_SIZE(map_pipe_x_control));
++		// Pipe Z
++		err |= max9296_set_registers(dev, map_pipe_z_y12i_control,
++					     ARRAY_SIZE(map_pipe_z_y12i_control));
++		// Pipe U
++		err |= max9296_set_registers(dev, map_pipe_u_control,
++					     ARRAY_SIZE(map_pipe_u_control));
++
++		// Trigger Depth
++		err |= max9296_set_registers(dev, map_depth_trigger,
++					     ARRAY_SIZE(map_depth_trigger));
++		// Trigger RGB
++		err |= max9296_set_registers(dev, map_rgb_trigger,
++					     ARRAY_SIZE(map_rgb_trigger));
++
++		if (err == 0)
++			priv->ir_type_value = Y12I;
++	}
++
+ 	return err;
+ }
+ EXPORT_SYMBOL(max9296_update_pipe);
+@@ -1107,6 +1200,7 @@ static int max9296_probe(struct i2c_client *client,
+ 
+ 	dev_set_drvdata(&client->dev, priv);
+ 
++	priv->ir_type_value = Y_NONE;
+ 	max9296_init_settings(&client->dev);
+ 	probe_done = true;
+ 
+-- 
+2.17.1
+


### PR DESCRIPTION
1, Upgrade SerDes version to 1.0.0.7;

2, Add max9296_dynamic_update to control dynamic update;
    Disable dynamically switching:
    echo 0 > /sys/module/max9296/parameters/max9296_dynamic_update
    Enable dynamically switching:
    echo 0 > /sys/module/max9296/parameters/max9296_dynamic_update

3, Add max9295_dynamic_update to control dynamic update;
    Disable dynamically switching:
    echo 0 > /sys/module/max9295/parameters/max9295_dynamic_update
    Enable dynamically switching:
    echo 1 > /sys/module/max9295/parameters/max9295_dynamic_update

4, Add max9295_setting_verison to show SerDes version;
    cat /sys/module/max9295/parameters/max9295_setting_verison

5, Add max9296_setting_verison to show SerDes version.
    cat /sys/module/max9296/parameters/max9296_setting_verison

Signed-off-by: Qingwu Zhang <qingwu.zhang@intel.com>