### PR TITLE
Add sleep hack back to prevent regression

### DIFF
--- a/kernel/nvidia/0043-Add-sleep-hack-back-to-prevent-regression.patch
+++ b/kernel/nvidia/0043-Add-sleep-hack-back-to-prevent-regression.patch
@@ -1,0 +1,56 @@
+From 5c32ef84c6196a0abff19987a5fc2a203e111d6d Mon Sep 17 00:00:00 2001
+From: Xin Zhang <xin.x.zhang@intel.com>
+Date: Mon, 14 Mar 2022 18:21:34 +0800
+Subject: [PATCH] Add sleep hack back to prevent regression
+
+The sleep was removed in 68996dfb040f8e8654399107e7189ee1861ff05e.
+There's report of regression of simultaneous multi-stream starting
+failure sometimes. Add it back for now, this sould be properly fixed
+later.
+
+Signed-off-by: Xin Zhang <xin.x.zhang@intel.com>
+---
+ drivers/media/i2c/d4xx.c | 16 +++++++++++++++-
+ 1 file changed, 15 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/media/i2c/d4xx.c b/drivers/media/i2c/d4xx.c
+index 37ebd0a4c..65a889808 100644
+--- a/drivers/media/i2c/d4xx.c
++++ b/drivers/media/i2c/d4xx.c
+@@ -2525,6 +2525,13 @@ static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on)
+ 		if (ret)
+ 			goto restore_s_state;
+ 
++		/*
++		 * TODO
++		 * Hack to prevent simultaneous multi-stream starting failure
++		 * sometimes. This should be replaced by a proper fix later.
++		 */
++		msleep_range(100);
++
+ 		ret = ds5_write(state, DS5_START_STOP_STREAM,
+ 				DS5_STREAM_START | stream_id);
+ 		if (ret < 0)
+@@ -2551,6 +2558,13 @@ static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on)
+ 				i * DS5_START_POLL_TIME);
+ 		}
+ 	} else {
++		/*
++		 * TODO
++		 * Hack to prevent simultaneous multi-stream starting failure
++		 * sometimes. This should be replaced by a proper fix later.
++		 */
++		msleep_range(100);
++
+ 		ret = ds5_write(state, DS5_START_STOP_STREAM,
+ 				DS5_STREAM_STOP | stream_id);
+ 		if (ret < 0)
+@@ -3482,4 +3496,4 @@ MODULE_AUTHOR( "Guennadi Liakhovetski <guennadi.liakhovetski@intel.com>,\n\
+ 				Alexander Gantman <alexander.gantman@intel.com>,\n\
+ 				Emil Jahshan <emil.jahshan@intel.com>");
+ MODULE_LICENSE("GPL v2");
+-MODULE_VERSION("1.0.1.4");
++MODULE_VERSION("1.0.1.5");
+-- 
+2.17.1
+


### PR DESCRIPTION
The sleep was removed in 68996dfb040f8e8654399107e7189ee1861ff05e.
There's report of regression of simultaneous multi-stream starting
failure sometimes. Add it back for now, this should be properly fixed
later.

Signed-off-by: Xin Zhang <xin.x.zhang@intel.com>

Unless time is limited, we'd better find the root cause and fix it. This sleep doesn't seem 100% safe to fix the problem anyway.