### PR TITLE
SerDes: Correct DT for Y8I

### DIFF
--- a/kernel/nvidia/0044-SerDes-Correct-DT-for-Y8I.patch
+++ b/kernel/nvidia/0044-SerDes-Correct-DT-for-Y8I.patch
@@ -1,0 +1,81 @@
+From 3c6d9798545c39869745253bbba4d470a4cc22b1 Mon Sep 17 00:00:00 2001
+From: Qingwu Zhang <qingwu.zhang@intel.com>
+Date: Tue, 15 Mar 2022 09:12:07 +0800
+Subject: [PATCH] SerDes: Correct DT for Y8I
+
+Y8I data type was changed to 1E, and it should be
+changed in switching function as well.
+
+Signed-off-by: Qingwu Zhang <qingwu.zhang@intel.com>
+---
+ drivers/media/i2c/max9295.c | 7 +++++--
+ drivers/media/i2c/max9296.c | 7 +++++--
+ 2 files changed, 10 insertions(+), 4 deletions(-)
+
+diff --git a/drivers/media/i2c/max9295.c b/drivers/media/i2c/max9295.c
+index aaf5e990d..fc2f4ebe0 100644
+--- a/drivers/media/i2c/max9295.c
++++ b/drivers/media/i2c/max9295.c
+@@ -669,6 +669,9 @@ static int max9295_check_status(struct device *dev)
+ 	return 0;
+ }
+ 
++#define Y8_DATA_TYPE 0x2A
++#define Y8I_DATA_TYPE 0x1E
++#define Y12I_DATA_TYPE 0X24
+ int max9295_update_pipe(struct device *dev, int sensor_type, int data_type)
+ {
+ 	int err = 0;
+@@ -691,7 +694,7 @@ int max9295_update_pipe(struct device *dev, int sensor_type, int data_type)
+ 
+ 	priv = dev_get_drvdata(dev);
+ 	if ((sensor_type == IR_SENSOR) && (priv->ir_type_value != Y8_Y8I) &&
+-	    (data_type == 0x2A || data_type == 0x32)) {
++	    (data_type == Y8_DATA_TYPE || data_type == Y8I_DATA_TYPE)) {
+ 		// Set CMU
+ 		err = max9295_set_registers(dev, map_cmu_regulator,
+ 					    ARRAY_SIZE(map_cmu_regulator));
+@@ -722,7 +725,7 @@ int max9295_update_pipe(struct device *dev, int sensor_type, int data_type)
+ 		if (err == 0)
+ 			priv->ir_type_value = Y8_Y8I;
+ 	} else if ((sensor_type == IR_SENSOR) && (priv->ir_type_value != Y12I) &&
+-	           (data_type == 0x24)) {
++	           (data_type == Y12I_DATA_TYPE)) {
+ 		// Set CMU
+ 		err = max9295_set_registers(dev, map_cmu_regulator,
+ 					    ARRAY_SIZE(map_cmu_regulator));
+diff --git a/drivers/media/i2c/max9296.c b/drivers/media/i2c/max9296.c
+index 9d209f1bc..cca3a51a2 100644
+--- a/drivers/media/i2c/max9296.c
++++ b/drivers/media/i2c/max9296.c
+@@ -996,6 +996,9 @@ static int max9296_check_status(struct device *dev)
+ 	return 0;
+ }
+ 
++#define Y8_DATA_TYPE 0x2A
++#define Y8I_DATA_TYPE 0x1E
++#define Y12I_DATA_TYPE 0X24
+ int max9296_update_pipe(struct device *dev, int sensor_type, int data_type)
+ {
+ 	int err = 0;
+@@ -1018,7 +1021,7 @@ int max9296_update_pipe(struct device *dev, int sensor_type, int data_type)
+ 
+ 	priv = dev_get_drvdata(dev);
+ 	if ((sensor_type == IR_SENSOR) && (priv->ir_type_value != Y8_Y8I) &&
+-            (data_type == 0x2A || data_type == 0x32)) {
++            (data_type == Y8_DATA_TYPE || data_type == Y8I_DATA_TYPE)) {
+ 		// Set CMU
+ 		err = max9296_set_registers(dev, map_cmu_regulator,
+ 					    ARRAY_SIZE(map_cmu_regulator));
+@@ -1049,7 +1052,7 @@ int max9296_update_pipe(struct device *dev, int sensor_type, int data_type)
+ 		if (err == 0)
+ 			priv->ir_type_value = Y8_Y8I;
+ 	} else if ((sensor_type == IR_SENSOR) && (priv->ir_type_value != Y12I) &&
+-		   (data_type == 0x24)) {
++		   (data_type == Y12I_DATA_TYPE)) {
+ 		// Set CMU
+ 		err = max9296_set_registers(dev, map_cmu_regulator,
+ 					    ARRAY_SIZE(map_cmu_regulator));
+-- 
+2.17.1
+


### PR DESCRIPTION
Y8I data type was changed to 1E, and it should be
changed in switching function as well.

Signed-off-by: Qingwu Zhang <qingwu.zhang@intel.com>