### PR TITLE
Fixed depth not work without set_fmt invoked early

### DIFF
--- a/kernel/nvidia/0044-Fixed-depth-not-work-without-set_fmt-invoked-early.patch
+++ b/kernel/nvidia/0044-Fixed-depth-not-work-without-set_fmt-invoked-early.patch
@@ -1,0 +1,50 @@
+From ed4644c6d63935bbdf5b43edaf6d6436c8f76506 Mon Sep 17 00:00:00 2001
+From: Shikun Ding <shikun.ding@intel.com>
+Date: Tue, 15 Mar 2022 15:43:52 +0800
+Subject: [PATCH] Fixed depth not work without set_fmt invoked early
+
+When camera powered on and initialized, using v4l2_ctl command
+without formats set option to start streaming will be pending, while
+getting the message 'no camera reply from camera processor' in
+kernel space.
+
+The reason is state->mux.last_set is pointing to state->motion_t.sensor
+, the wrong sensor for streaming depth channel, in ds5_mux_init().
+ds5_mux_s_stream() will be invoked after streaming on. The
+'sensor->streaming' flag for depth in ds5_configure will not be
+set, further skipping the writing 0x1e to override reg. But the override
+reg may have the default value, not 0x1e, set by firmware after camera
+boots. Then streaming depth will fail.
+
+To fix this, just set state->mux.last_set to correct streaming sersor
+on ds5_mux_init stage.
+
+Signed-off-by: Shikun Ding <shikun.ding@intel.com>
+---
+ drivers/media/i2c/d4xx.c | 8 ++++++--
+ 1 file changed, 6 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/media/i2c/d4xx.c b/drivers/media/i2c/d4xx.c
+index 65a889808..363cd2fa0 100644
+--- a/drivers/media/i2c/d4xx.c
++++ b/drivers/media/i2c/d4xx.c
+@@ -2777,10 +2777,14 @@ static int ds5_mux_init(struct i2c_client *c, struct ds5 *state)
+ 	if (ret < 0)
+ 		goto e_entity;
+ 
+-	if (state->is_rgb)
++	if (state->is_depth)
++		state->mux.last_set = &state->depth.sensor;
++	else if (state->is_rgb)
+ 		state->mux.last_set = &state->rgb.sensor;
+-	else
++	else if (state->is_y8)
+ 		state->mux.last_set = &state->motion_t.sensor;
++	else
++		state->mux.last_set = &state->imu.sensor;
+ 
+ #ifdef CONFIG_TEGRA_CAMERA_PLATFORM
+ 	state->mux.sd.dev = &c->dev;
+-- 
+2.17.1
+


### PR DESCRIPTION
__Issue__:
When camera powered on and initialized, using v4l2_ctl command without formats set option to start streaming will be pending, while getting the message 'no camera reply from camera processor' in kernel space.

__Reproduce__:
   - Shut down the max9296 board and power on
    
   - Run following command to stream depth
    ```
    v4l2-ctl -d /dev/video0 --stream-mmap=3 --stream-count=5
    ```
   From dmesg, got  that:

  ![image](https://user-images.githubusercontent.com/89249282/158317771-59a56277-0e82-4e71-92d4-5c220185b5a9.png)

  The root cause is state->mux.last_set is pointing to state->motion_t.sensor , the wrong sensor for streaming depth channel, in ds5_mux_init(). ds5_mux_s_stream() will be invoked after streaming on. The 'sensor->streaming' flag for depth in ds5_configure will not be set, further skipping the writing 0x1e to override reg. But the override reg may have the default value, not 0x1e, set by firmware after camera boots. Then streaming depth will fail.
  
One way to avoid getting this issue is to calling set_fmt to configure the format before streaming.  The set_fmt will change the tate->mux.last_set to an correct sensor. 
```
v4l2-ctl -d /dev/video0 --set-fmt-video=width=1280,height=720 --stream-mmap=3 --stream-count=5
```

Or apply this patch to fix completely. In this patch, just set state->mux.last_set to correct streaming sersor on ds5_mux_init stage.