### PR TITLE
Optimized framerates setting and interfaces

### DIFF
--- a/kernel/nvidia/0047-Optimized-framerates-setting-and-interfaces.patch
+++ b/kernel/nvidia/0047-Optimized-framerates-setting-and-interfaces.patch
@@ -1,0 +1,107 @@
+From 13419292a0ea01aa4b707798404016ec4ef592cf Mon Sep 17 00:00:00 2001
+From: Shikun Ding <shikun.ding@intel.com>
+Date: Thu, 17 Mar 2022 13:44:15 +0800
+Subject: [PATCH] Optimized framerates setting and interfaces
+
+Extended the ds5_size_imu array by appending more fixed number
+Used state->mux.last_set to instead of selection on which sensor
+to get/set
+Set default fps of each sensor to 30, more commonly used for SD
+and HD streams
+
+Signed-off-by: Shikun Ding <shikun.ding@intel.com>
+---
+ drivers/media/i2c/d4xx.c | 36 ++++++++++++++++++------------------
+ 1 file changed, 18 insertions(+), 18 deletions(-)
+
+diff --git a/drivers/media/i2c/d4xx.c b/drivers/media/i2c/d4xx.c
+index 363cd2fa0..b006c8628 100644
+--- a/drivers/media/i2c/d4xx.c
++++ b/drivers/media/i2c/d4xx.c
+@@ -511,7 +511,7 @@ static const u16 ds5_framerate_to_60[] = {5, 15, 30, 60};
+ static const u16 ds5_framerate_to_90[] = {5, 15, 30, 60, 90};
+ static const u16 ds5_framerate_100[] = {100};
+ static const u16 ds5_framerate_90[] = {90};
+-static const u16 ds5_imu_framerates[] = {5, 90};
++static const u16 ds5_imu_framerates[] = {5, 10, 15, 30, 60, 90};
+ 
+ static const struct ds5_resolution d43x_depth_sizes[] = {
+ 	{
+@@ -819,6 +819,7 @@ static void ds5_sensor_format_init(struct ds5_sensor *sensor)
+ {
+ 	const struct ds5_format *fmt;
+ 	struct v4l2_mbus_framefmt *ffmt;
++	unsigned int i;
+ 
+ 	if (sensor->config.format)
+ 		return;
+@@ -836,6 +837,13 @@ static void ds5_sensor_format_init(struct ds5_sensor *sensor)
+ 
+ 	sensor->config.format = fmt;
+ 	sensor->config.resolution = fmt->resolutions;
++	/* Set default framerate to 30, or to 1st one if not supported */
++	for (i = 0; i < fmt->resolutions->n_framerates;i++) {
++		if (fmt->resolutions->framerates[i] == ds5_framerate_30 /* fps */) {
++			sensor->config.framerate = ds5_framerate_30;
++			return;
++		}
++	}
+ 	sensor->config.framerate = fmt->resolutions->framerates[0];
+ }
+ 
+@@ -2425,19 +2433,18 @@ static int ds5_mux_g_frame_interval(struct v4l2_subdev *sd,
+ 				    struct v4l2_subdev_frame_interval *fi)
+ {
+ 	struct ds5 *state = container_of(sd, struct ds5, mux.sd.subdev);
+-	struct ds5_sensor *depth = &state->depth.sensor;
+-	struct ds5_sensor *rgb = &state->rgb.sensor;
++	struct ds5_sensor *sensor = NULL;
+ 
+ 	if (NULL == sd || NULL == fi)
+ 		return -EINVAL;
+ 
+-	dev_info(sd->dev, "%s(): %s %d\n", __func__, sd->name, fi->pad);
++	sensor = state->mux.last_set;
+ 
+ 	fi->interval.numerator = 1;
+-	if(state->is_rgb)
+-		fi->interval.denominator = rgb->config.framerate;
+-	else
+-		fi->interval.denominator = depth->config.framerate;
++	fi->interval.denominator = sensor->config.framerate;
++
++	dev_info(sd->dev, "%s(): %s %u\n", __func__, sd->name,
++		 fi->interval.denominator);
+ 
+ 	return 0;
+ }
+@@ -2466,16 +2473,7 @@ static int ds5_mux_s_frame_interval(struct v4l2_subdev *sd,
+ 	if (NULL == sd || NULL == fi || fi->interval.numerator == 0)
+ 		return -EINVAL;
+ 
+-	dev_info(sd->dev, "%s(): %s %d\n", __func__, sd->name, fi->pad);
+-
+-	if(state->is_rgb)
+-		sensor = &state->rgb.sensor;
+-	if (state->is_depth)
+-		sensor = &state->depth.sensor;
+-	if (state->is_y8)
+-		sensor = &state->motion_t.sensor;
+-	if (state->is_imu)
+-		sensor = &state->imu.sensor;
++	sensor = state->mux.last_set;
+ 
+ 	framerate = fi->interval.denominator / fi->interval.numerator;
+ 	framerate = __ds5_probe_framerate(sensor->config.resolution, framerate);
+@@ -2483,6 +2481,8 @@ static int ds5_mux_s_frame_interval(struct v4l2_subdev *sd,
+ 	fi->interval.numerator = 1;
+ 	fi->interval.denominator = framerate;
+ 
++	dev_info(sd->dev, "%s(): %s %u\n", __func__, sd->name, framerate);
++
+ 	return 0;
+ }
+ 
+-- 
+2.17.1
+


### PR DESCRIPTION
1. Extended the ds5_size_imu array by appending more fixed number
   Framerate to IMU can be set one of  {5, 10, 15, 30, 60, 90} with 32x32 resolution.

1. Used state->mux.last_set to instead of selection on which sensor to get/set.
    Removed some useless codes.

1. Set default fps of each sensor to 30, more commonly used for SD  and HD streams