### PR TITLE
d4xx: Fix crash issue after failed to initialize HW

### DIFF
--- a/kernel/nvidia/0046-d4xx-Fix-crash-issue-after-failed-to-initialize-HW.patch
+++ b/kernel/nvidia/0046-d4xx-Fix-crash-issue-after-failed-to-initialize-HW.patch
@@ -1,0 +1,55 @@
+From 8cdfb2e4572af4cc8a35032e26c1901b653c10d5 Mon Sep 17 00:00:00 2001
+From: Qingwu Zhang <qingwu.zhang@intel.com>
+Date: Thu, 17 Mar 2022 10:52:07 +0800
+Subject: [PATCH] d4xx: Fix crash issue after failed to initialize HW
+
+[   78.550393] [<ffffff8008b1b924>] v4l2_async_unregister_subdev+0xbc/0xe0
+[   78.556803] [<ffffff80011a52ac>] ds5_v4l_init+0x544/0x730 [d4xx]
+[   78.562135] [<ffffff80011a572c>] ds5_probe+0x294/0x528 [d4xx]
+[   78.567733] [<ffffff8008ae3b64>] i2c_device_probe+0x144/0x258
+[   78.573063] [<ffffff800877f910>] driver_probe_device+0x298/0x448
+
+Signed-off-by: Qingwu Zhang <qingwu.zhang@intel.com>
+---
+ drivers/media/i2c/d4xx.c | 12 ++++++++----
+ 1 file changed, 8 insertions(+), 4 deletions(-)
+
+diff --git a/drivers/media/i2c/d4xx.c b/drivers/media/i2c/d4xx.c
+index 65a889808..701da2884 100644
+--- a/drivers/media/i2c/d4xx.c
++++ b/drivers/media/i2c/d4xx.c
+@@ -3233,15 +3233,15 @@ static int ds5_v4l_init(struct i2c_client *c,struct ds5 *state)
+ 
+ 	ret = ds5_rgb_init(c, state);
+ 	if (ret < 0)
+-		goto e_rgb;
++		goto e_motion_t;
+ 
+ 	ret = ds5_imu_init(c, state);
+ 	if (ret < 0)
+-		goto e_imu;
++		goto e_rgb;
+ 
+ 	ret = ds5_mux_init(c, state);
+ 	if (ret < 0)
+-		goto e_motion_t;
++		goto e_imu;
+ 
+ 	ret = ds5_hw_init(c, state);
+ 	if (ret < 0)
+@@ -3253,7 +3253,11 @@ static int ds5_v4l_init(struct i2c_client *c,struct ds5 *state)
+ 
+ 	return 0;
+ e_mux:
+-	ds5_mux_remove(state);
++#ifdef CONFIG_TEGRA_CAMERA_PLATFORM
++	camera_common_cleanup(&state->mux.sd);
++#endif
++	v4l2_ctrl_handler_free(state->mux.sd.subdev.ctrl_handler);
++	media_entity_cleanup(&state->mux.sd.subdev.entity);
+ e_imu:
+ 	media_entity_cleanup(&state->imu.sensor.sd.entity);
+ e_rgb:
+-- 
+2.17.1
+


### PR DESCRIPTION
1, Fix crash issue after failed to initialize HW;
2, Rename PR 0044 --> 0045.

Signed-off-by: Qingwu Zhang <qingwu.zhang@intel.com>