### PR TITLE
V4L2 controls fixup

### DIFF
--- a/kernel/nvidia/0055-V4L2-controls-fixup.patch
+++ b/kernel/nvidia/0055-V4L2-controls-fixup.patch
@@ -1,0 +1,187 @@
+From 36c88ea6ef89a2cdc0d4f0c11ce189787d5848b5 Mon Sep 17 00:00:00 2001
+From: Xin Zhang <xin.x.zhang@intel.com>
+Date: Tue, 19 Apr 2022 10:37:30 +0800
+Subject: [PATCH] V4L2 controls fixup
+
+- No laser controls for color sensor;
+- Set control values to their default when initialization;
+- Follow doc, default manual laser power value changed from 240 to 150;
+- No any control for IMU.
+
+Signed-off-by: Xin Zhang <xin.x.zhang@intel.com>
+---
+ drivers/media/i2c/d4xx.c | 85 +++++++++++++++++++++++-----------------
+ 1 file changed, 49 insertions(+), 36 deletions(-)
+
+diff --git a/drivers/media/i2c/d4xx.c b/drivers/media/i2c/d4xx.c
+index f4cec3a27..c496bc8d0 100644
+--- a/drivers/media/i2c/d4xx.c
++++ b/drivers/media/i2c/d4xx.c
+@@ -1220,7 +1220,7 @@ static const struct v4l2_subdev_ops ds5_imu_subdev_ops = {
+ 	.video = &ds5_sensor_video_ops,
+ };
+ 
+-static int ds5_hw_set_auto_exposure(struct ds5 *state, u32 base, u32 val)
++static int ds5_hw_set_auto_exposure(struct ds5 *state, u32 base, s32 val)
+ {
+ 	if (val != V4L2_EXPOSURE_APERTURE_PRIORITY &&
+ 	    val != V4L2_EXPOSURE_MANUAL)
+@@ -1243,7 +1243,7 @@ static int ds5_hw_set_auto_exposure(struct ds5 *state, u32 base, u32 val)
+ 			val = 0;
+ 	}
+ 
+-	return ds5_write(state, base | DS5_AUTO_EXPOSURE_MODE, val);
++	return ds5_write(state, base | DS5_AUTO_EXPOSURE_MODE, (u16)val);
+ }
+ 
+ /*
+@@ -1251,29 +1251,29 @@ static int ds5_hw_set_auto_exposure(struct ds5 *state, u32 base, u32 val)
+  * Depth/Y8: between 100 and 200000 (200ms)
+  * Color: between 100 and 1000000 (1s)
+  */
+-static int ds5_hw_set_exposure(struct ds5 *state, u32 base, u32 val)
++static int ds5_hw_set_exposure(struct ds5 *state, u32 base, s32 val)
+ {
+ 	int ret;
+ 
+-       if (val < 1)
+-               val = 1;
+-       if ((state->is_depth || state->is_y8) && val > MAX_DEPTH_EXP)
+-               val = MAX_DEPTH_EXP;
+-       if (state->is_rgb && val > MAX_RGB_EXP)
+-               val = MAX_RGB_EXP;
++	if (val < 1)
++		val = 1;
++	if ((state->is_depth || state->is_y8) && val > MAX_DEPTH_EXP)
++		val = MAX_DEPTH_EXP;
++	if (state->is_rgb && val > MAX_RGB_EXP)
++		val = MAX_RGB_EXP;
+ 
+ 	/*
+ 	 * Color and depth uses different unit:
+ 	 *	Color: 1 is 100 us
+ 	 *	Depth: 1 is 1 us
+ 	 */
+-       if (!state->is_rgb)
++	if (!state->is_rgb)
+ 		val *= 100;
+ 
+-	ret = ds5_write(state, base | DS5_MANUAL_EXPOSURE_MSB, val >> 16);
++	ret = ds5_write(state, base | DS5_MANUAL_EXPOSURE_MSB, (u16)(val >> 16));
+ 	if (!ret)
+ 		ret = ds5_write(state, base | DS5_MANUAL_EXPOSURE_LSB,
+-				val & 0xffff);
++				(u16)(val & 0xffff));
+ 
+ 	return ret;
+ }
+@@ -1377,13 +1377,13 @@ static int ds5_s_ctrl(struct v4l2_ctrl *ctrl)
+ 	struct ds5 *state = container_of(ctrl->handler, struct ds5,
+ 					 ctrls.handler);
+ 	struct v4l2_subdev *sd = &state->mux.sd.subdev;
+-	int ret = -EINVAL;
++	int ret = 0;
+ 	u16 base = DS5_DEPTH_CONTROL_BASE;
+ 
+ 	if (state->is_rgb)
+ 		base = DS5_RGB_CONTROL_BASE;
+ 	else if (state->is_imu)
+-		return ret;
++		return -EINVAL;
+ 
+ 	v4l2_dbg(1, 1, sd, "ctrl: %s, value: %d\n", ctrl->name, ctrl->val);
+ 
+@@ -1761,7 +1761,7 @@ static const struct v4l2_ctrl_config ds5_ctrl_manual_laser_power = {
+ 	.min = 0,
+ 	.max = 360,
+ 	.step = 30,
+-	.def = 240,
++	.def = 150,
+ };
+ 
+ static const struct v4l2_ctrl_config ds5_ctrl_fw_version = {
+@@ -1956,31 +1956,23 @@ static int ds5_ctrl_init(struct ds5 *state)
+ 	struct v4l2_subdev *sd = &state->mux.sd.subdev;
+ 	int ret;
+ 
++	if (state->is_imu)
++		return 0;
++
+ 	ret = v4l2_ctrl_handler_init(hdl, DS5_N_CONTROLS);
+ 	if (ret < 0) {
+ 		v4l2_err(sd, "cannot init ctrl handler (%d)\n", ret);
+ 		return ret;
+ 	}
+ 
+-	ctrls->log = v4l2_ctrl_new_custom(hdl, &ds5_ctrl_log, NULL);
+-	ctrls->fw_version = v4l2_ctrl_new_custom(hdl, &ds5_ctrl_fw_version, NULL);
+-	ctrls->gvd = v4l2_ctrl_new_custom(hdl, &ds5_ctrl_gvd, NULL);
+-	ctrls->get_depth_calib = v4l2_ctrl_new_custom(hdl, &ds5_ctrl_get_depth_calib, NULL);
+-	ctrls->set_depth_calib = v4l2_ctrl_new_custom(hdl, &ds5_ctrl_set_depth_calib, NULL);
+-	ctrls->get_coeff_calib = v4l2_ctrl_new_custom(hdl, &ds5_ctrl_get_coeff_calib, NULL);
+-	ctrls->set_coeff_calib = v4l2_ctrl_new_custom(hdl, &ds5_ctrl_set_coeff_calib, NULL);
+-	ctrls->ae_roi_get = v4l2_ctrl_new_custom(hdl, &ds5_ctrl_ae_roi_get, NULL);
+-	ctrls->ae_roi_set = v4l2_ctrl_new_custom(hdl, &ds5_ctrl_ae_roi_set, NULL);
+-	ctrls->ae_setpoint_get = v4l2_ctrl_new_custom(hdl, &ds5_ctrl_ae_setpoint_get, NULL);
+-	ctrls->ae_setpoint_set = v4l2_ctrl_new_custom(hdl, &ds5_ctrl_ae_setpoint_set, NULL);
+-	ctrls->erb = v4l2_ctrl_new_custom(hdl, &ds5_ctrl_erb, NULL);
+-	ctrls->ewb = v4l2_ctrl_new_custom(hdl, &ds5_ctrl_ewb, NULL);
+-	ctrls->hwmc = v4l2_ctrl_new_custom(hdl, &ds5_ctrl_hwmc, NULL);
+-
+-	// TODO: wait for decision from FW if to replace with one control
+-	//       should report as cluster?
+-	ctrls->laser_power = v4l2_ctrl_new_custom(hdl, &ds5_ctrl_laser_power, NULL);
+-	ctrls->manual_laser_power = v4l2_ctrl_new_custom(hdl, &ds5_ctrl_manual_laser_power, NULL);
++	if (state->is_depth || state->is_y8) {
++		ctrls->laser_power = v4l2_ctrl_new_custom(hdl,
++						&ds5_ctrl_laser_power,
++						NULL);
++		ctrls->manual_laser_power = v4l2_ctrl_new_custom(hdl,
++						&ds5_ctrl_manual_laser_power,
++						NULL);
++	}
+ 
+ 	/* Total gain */
+ 	if (state->is_depth || state->is_y8) {
+@@ -2018,7 +2010,29 @@ static int ds5_ctrl_init(struct ds5 *state)
+ 		return ret;
+ 	}
+ 
+-	// TODO: consider invoking v4l2_ctrl_handler_setup(hdl);
++	ret = v4l2_ctrl_handler_setup(hdl);
++	if (ret < 0) {
++		dev_err(&state->client->dev,
++			"failed to set default values for controls\n");
++		v4l2_ctrl_handler_free(hdl);
++		return ret;
++	}
++
++	// Add these after v4l2_ctrl_handler_setup so they won't be set up
++	ctrls->log = v4l2_ctrl_new_custom(hdl, &ds5_ctrl_log, NULL);
++	ctrls->fw_version = v4l2_ctrl_new_custom(hdl, &ds5_ctrl_fw_version, NULL);
++	ctrls->gvd = v4l2_ctrl_new_custom(hdl, &ds5_ctrl_gvd, NULL);
++	ctrls->get_depth_calib = v4l2_ctrl_new_custom(hdl, &ds5_ctrl_get_depth_calib, NULL);
++	ctrls->set_depth_calib = v4l2_ctrl_new_custom(hdl, &ds5_ctrl_set_depth_calib, NULL);
++	ctrls->get_coeff_calib = v4l2_ctrl_new_custom(hdl, &ds5_ctrl_get_coeff_calib, NULL);
++	ctrls->set_coeff_calib = v4l2_ctrl_new_custom(hdl, &ds5_ctrl_set_coeff_calib, NULL);
++	ctrls->ae_roi_get = v4l2_ctrl_new_custom(hdl, &ds5_ctrl_ae_roi_get, NULL);
++	ctrls->ae_roi_set = v4l2_ctrl_new_custom(hdl, &ds5_ctrl_ae_roi_set, NULL);
++	ctrls->ae_setpoint_get = v4l2_ctrl_new_custom(hdl, &ds5_ctrl_ae_setpoint_get, NULL);
++	ctrls->ae_setpoint_set = v4l2_ctrl_new_custom(hdl, &ds5_ctrl_ae_setpoint_set, NULL);
++	ctrls->erb = v4l2_ctrl_new_custom(hdl, &ds5_ctrl_erb, NULL);
++	ctrls->ewb = v4l2_ctrl_new_custom(hdl, &ds5_ctrl_ewb, NULL);
++	ctrls->hwmc = v4l2_ctrl_new_custom(hdl, &ds5_ctrl_hwmc, NULL);
+ 
+ 	state->mux.sd.subdev.ctrl_handler = hdl;
+ 
+@@ -2772,7 +2786,6 @@ static int ds5_mux_init(struct i2c_client *c, struct ds5 *state)
+ 	if (ret < 0)
+ 		return ret;
+ 
+-	// FIXME: this is most likely different for depth and motion detection
+ 	ret = ds5_ctrl_init(state);
+ 	if (ret < 0)
+ 		goto e_entity;
+-- 
+2.17.1
+


### PR DESCRIPTION
- No laser controls for color sensor;
- Set control values to their default when initialization;
- Follow doc, default manual laser power value changed from 240 to 150;
- No any control for IMU.

--------------------

The issue that this PR tries to solve:
- When D457 first power up, some values reading from FW are not the same as their default values in doc
  - Color sensor's `exposure_time_absolute` is 0, though in document min is 1 and default is 1660. (maybe because `auto_exposure` is on so this is irrelevant, though depth sensor's `exposure_time_absolute` is at the default 330 and `auto_exposure` is on too)
  - Color sensor's `analogue_gain` is 0, not the default 64.
  - Manual laser power value is 150, not default 240.
- Without power off, the control values will be consistent from boot to boot, so if the user changed some control value once, and at next boot the v4l2 interface will still show the default value, not the real value in FW.