### PR TITLE
SerDes: Dump registers with sysfs

### DIFF
--- a/kernel/nvidia/0048-SerDes-Dump-registers-with-sysfs.patch
+++ b/kernel/nvidia/0048-SerDes-Dump-registers-with-sysfs.patch
@@ -1,0 +1,367 @@
+From 78c54d09b09c1683c23c1ac1c1fc0a26efc64c42 Mon Sep 17 00:00:00 2001
+From: Qingwu Zhang <qingwu.zhang@intel.com>
+Date: Mon, 28 Mar 2022 14:40:32 +0800
+Subject: [PATCH] SerDes: Dump registers with sysfs
+
+Dump max9295 settings:
+/sys/bus/i2c/drivers/max9295/30-0040/register_dump
+Dump max9296 settings:
+/sys/bus/i2c/drivers/max9296/30-0048/register_dump
+
+Signed-off-by: Qingwu Zhang <qingwu.zhang@intel.com>
+---
+ drivers/media/i2c/max9295.c | 127 ++++++++++++++++++++++++++++++++++-
+ drivers/media/i2c/max9296.c | 128 +++++++++++++++++++++++++++++++++++-
+ 2 files changed, 249 insertions(+), 6 deletions(-)
+
+diff --git a/drivers/media/i2c/max9295.c b/drivers/media/i2c/max9295.c
+index fc2f4ebe0..9beb8a53b 100644
+--- a/drivers/media/i2c/max9295.c
++++ b/drivers/media/i2c/max9295.c
+@@ -620,7 +620,7 @@ static int max9295_init_settings(struct device *dev)
+ 				     ARRAY_SIZE(map_pipe_x_control));
+ 	// Pipe Y
+ 	err |= max9295_set_registers(dev, map_pipe_y_control,
+-				     ARRAY_SIZE(map_pipe_x_control));
++				     ARRAY_SIZE(map_pipe_y_control));
+ 	// Pipe Z
+ 	err |= max9295_set_registers(dev, map_pipe_z_y8_y8i_control,
+ 				     ARRAY_SIZE(map_pipe_z_y8_y8i_control));
+@@ -707,7 +707,7 @@ int max9295_update_pipe(struct device *dev, int sensor_type, int data_type)
+ 					     ARRAY_SIZE(map_pipe_x_control));
+ 		// Pipe Y
+ 		err |= max9295_set_registers(dev, map_pipe_y_control,
+-					     ARRAY_SIZE(map_pipe_x_control));
++					     ARRAY_SIZE(map_pipe_y_control));
+ 		// Pipe Z
+ 		err |= max9295_set_registers(dev, map_pipe_z_y8_y8i_control,
+ 					     ARRAY_SIZE(map_pipe_z_y8_y8i_control));
+@@ -738,7 +738,7 @@ int max9295_update_pipe(struct device *dev, int sensor_type, int data_type)
+ 					     ARRAY_SIZE(map_pipe_x_control));
+ 		// Pipe Y
+ 		err |= max9295_set_registers(dev, map_pipe_y_control,
+-					     ARRAY_SIZE(map_pipe_x_control));
++					     ARRAY_SIZE(map_pipe_y_control));
+ 		// Pipe Z
+ 		err |= max9295_set_registers(dev, map_pipe_z_y12i_control,
+ 					     ARRAY_SIZE(map_pipe_z_y12i_control));
+@@ -761,6 +761,114 @@ int max9295_update_pipe(struct device *dev, int sensor_type, int data_type)
+ }
+ EXPORT_SYMBOL(max9295_update_pipe);
+ 
++static int max9295_get_dump(struct device *dev, char *data_addr,
++			    struct reg_pair *pair, u32 pair_size)
++{
++	struct max9295 *priv = dev_get_drvdata(dev);
++	int err;
++	u32 val = 0;
++	char *addr = data_addr;
++	int data_size = 0;
++	int cnt = 0;
++	u32 j = 0;
++
++	mutex_lock(&priv->lock);
++
++	for (j = 0; j < pair_size; j++) {
++		val = 0;
++		err = regmap_read(priv->regmap, pair[j].addr, &val);
++
++		if (!err) {
++			cnt = snprintf(addr, 100 - data_size, "0x%04x:0x%x\n",
++				       pair[j].addr, val);
++			addr += cnt;
++			data_size += cnt;
++			dev_info(dev,
++				"%s:i2c read, addr 0x%x, value %x\n",
++				__func__, pair[j].addr, val);
++		} else {
++			dev_warn(dev,
++				"%s:i2c read, err %x, addr 0x%x, value %x\n",
++				__func__, err, pair[j].addr, val);
++		}
++	};
++
++	mutex_unlock(&priv->lock);
++
++	return data_size;
++}
++
++#ifdef CONFIG_SYSFS
++
++static ssize_t max9295_dev_dump_show(struct device *dev,
++				     struct device_attribute *attr, char *buf)
++{
++	char *data_addr = buf;
++	int data_size = 0;
++	int count = 0;
++
++	if (!buf)
++		return -ENOMEM;
++
++	data_size = max9295_get_dump(dev, data_addr, map_cmu_regulator,
++				     ARRAY_SIZE(map_cmu_regulator));
++	count += data_size;
++	data_addr += data_size;
++
++	data_size = max9295_get_dump(dev, data_addr, map_pipe_y8_opt,
++				     ARRAY_SIZE(map_pipe_y8_opt));
++	count += data_size;
++	data_addr += data_size;
++
++	data_size = max9295_get_dump(dev, data_addr, map_pipe_x_control,
++				     ARRAY_SIZE(map_pipe_x_control));
++	count += data_size;
++	data_addr += data_size;
++
++	data_size = max9295_get_dump(dev, data_addr, map_pipe_y_control,
++				     ARRAY_SIZE(map_pipe_y_control));
++	count += data_size;
++	data_addr += data_size;
++
++	data_size = max9295_get_dump(dev, data_addr, map_pipe_z_y8_y8i_control,
++				     ARRAY_SIZE(map_pipe_z_y8_y8i_control));
++	count += data_size;
++	data_addr += data_size;
++
++	data_size = max9295_get_dump(dev, data_addr, map_pipe_u_control,
++				     ARRAY_SIZE(map_pipe_u_control));
++	count += data_size;
++	data_addr += data_size;
++
++	data_size = max9295_get_dump(dev, data_addr, map_depth_trigger,
++				     ARRAY_SIZE(map_depth_trigger));
++	count += data_size;
++	data_addr += data_size;
++
++	data_size = max9295_get_dump(dev, data_addr, map_rgb_trigger,
++				     ARRAY_SIZE(map_rgb_trigger));
++	count += data_size;
++	data_addr += data_size;
++	*data_addr = '0';
++
++	dev_info(dev, "%s, buf %p, count %d, \n", __func__, buf, count);
++
++	return count;
++}
++
++static DEVICE_ATTR(register_dump, 0444, max9295_dev_dump_show, NULL);
++
++static struct attribute *max9295_attributes[] = {
++	&dev_attr_register_dump.attr,
++	NULL
++};
++
++static const struct attribute_group max9295_attr_group = {
++	.attrs = max9295_attributes,
++};
++
++#endif /* CONFIG_SYSFS */
++
+ static int max9295_probe(struct i2c_client *client,
+ 				const struct i2c_device_id *id)
+ {
+@@ -801,6 +909,14 @@ static int max9295_probe(struct i2c_client *client,
+ 	dev_set_drvdata(&client->dev, priv);
+ 
+ 	priv->ir_type_value = Y_NONE;
++
++#ifdef CONFIG_SYSFS
++	err = sysfs_create_group(&client->dev.kobj, &max9295_attr_group);
++	if (err)
++		dev_warn(&client->dev, "%s, failed to create sysfs, err %d",
++			 __func__, err);
++#endif /* CONFIG_SYSFS */
++
+ 	max9295_init_settings(&client->dev);
+ 	probe_done = true;
+ 
+@@ -816,6 +932,11 @@ static int max9295_remove(struct i2c_client *client)
+ 
+ 	if (client != NULL) {
+ 		priv = dev_get_drvdata(&client->dev);
++
++#ifdef CONFIG_SYSFS
++		sysfs_remove_group(&client->dev.kobj, &max9295_attr_group);
++#endif /* CONFIG_SYSFS */
++
+ 		mutex_destroy(&priv->lock);
+ 		i2c_unregister_device(client);
+ 		client = NULL;
+diff --git a/drivers/media/i2c/max9296.c b/drivers/media/i2c/max9296.c
+index cca3a51a2..627ce6256 100644
+--- a/drivers/media/i2c/max9296.c
++++ b/drivers/media/i2c/max9296.c
+@@ -949,7 +949,7 @@ static int max9296_init_settings(struct device *dev)
+ 				     ARRAY_SIZE(map_pipe_x_control));
+ 	// Pipe Y
+ 	err |= max9296_set_registers(dev, map_pipe_y_control,
+-				     ARRAY_SIZE(map_pipe_x_control));
++				     ARRAY_SIZE(map_pipe_y_control));
+ 	// Pipe Z
+ 	err |= max9296_set_registers(dev, map_pipe_z_y8_y8i_control,
+ 				     ARRAY_SIZE(map_pipe_z_y8_y8i_control));
+@@ -1034,7 +1034,7 @@ int max9296_update_pipe(struct device *dev, int sensor_type, int data_type)
+ 					     ARRAY_SIZE(map_pipe_x_control));
+ 		// Pipe Y
+ 		err |= max9296_set_registers(dev, map_pipe_y_control,
+-					     ARRAY_SIZE(map_pipe_x_control));
++					     ARRAY_SIZE(map_pipe_y_control));
+ 		// Pipe Z
+ 		err |= max9296_set_registers(dev, map_pipe_z_y8_y8i_control,
+ 					     ARRAY_SIZE(map_pipe_z_y8_y8i_control));
+@@ -1065,7 +1065,7 @@ int max9296_update_pipe(struct device *dev, int sensor_type, int data_type)
+ 					     ARRAY_SIZE(map_pipe_x_control));
+ 		// Pipe Y
+ 		err |= max9296_set_registers(dev, map_pipe_y_control,
+-					     ARRAY_SIZE(map_pipe_x_control));
++					     ARRAY_SIZE(map_pipe_y_control));
+ 		// Pipe Z
+ 		err |= max9296_set_registers(dev, map_pipe_z_y12i_control,
+ 					     ARRAY_SIZE(map_pipe_z_y12i_control));
+@@ -1088,6 +1088,114 @@ int max9296_update_pipe(struct device *dev, int sensor_type, int data_type)
+ }
+ EXPORT_SYMBOL(max9296_update_pipe);
+ 
++static int max9296_get_dump(struct device *dev, char *data_addr,
++			    struct reg_pair *pair, u32 pair_size)
++{
++	struct max9296 *priv = dev_get_drvdata(dev);
++	int err;
++	u32 val = 0;
++	char *addr = data_addr;
++	int data_size = 0;
++	int cnt = 0;
++	u32 j = 0;
++
++	mutex_lock(&priv->lock);
++
++	for (j = 0; j < pair_size; j++) {
++		val = 0;
++		err = regmap_read(priv->regmap, pair[j].addr, &val);
++
++		if (!err) {
++			cnt = snprintf(addr, PAGE_SIZE, "0x%04x:0x%x\n",
++				       pair[j].addr, val);
++			addr += cnt;
++			data_size += cnt;
++			dev_info(dev,
++				"%s:i2c read, addr 0x%x, value %x\n",
++				__func__, pair[j].addr, val);
++		} else {
++			dev_warn(dev,
++				"%s:i2c read, err %x, addr 0x%x, value %x\n",
++				__func__, err, pair[j].addr, val);
++		}
++	};
++
++	mutex_unlock(&priv->lock);
++
++	return data_size;
++}
++
++#ifdef CONFIG_SYSFS
++
++static ssize_t max9296_dev_dump_show(struct device *dev,
++				     struct device_attribute *attr, char *buf)
++{
++	char *data_addr = buf;
++	int data_size = 0;
++	int count = 0;
++
++	if (!buf)
++		return -ENOMEM;
++
++	data_size = max9296_get_dump(dev, data_addr, map_cmu_regulator,
++				     ARRAY_SIZE(map_cmu_regulator));
++	count += data_size;
++	data_addr += data_size;
++
++	data_size = max9296_get_dump(dev, data_addr, map_pipe_opt,
++				     ARRAY_SIZE(map_pipe_opt));
++	count += data_size;
++	data_addr += data_size;
++
++	data_size = max9296_get_dump(dev, data_addr, map_pipe_x_control,
++				     ARRAY_SIZE(map_pipe_x_control));
++	count += data_size;
++	data_addr += data_size;
++
++	data_size = max9296_get_dump(dev, data_addr, map_pipe_y_control,
++				     ARRAY_SIZE(map_pipe_y_control));
++	count += data_size;
++	data_addr += data_size;
++
++	data_size = max9296_get_dump(dev, data_addr, map_pipe_z_y8_y8i_control,
++				     ARRAY_SIZE(map_pipe_z_y8_y8i_control));
++	count += data_size;
++	data_addr += data_size;
++
++	data_size = max9296_get_dump(dev, data_addr, map_pipe_u_control,
++				     ARRAY_SIZE(map_pipe_u_control));
++	count += data_size;
++	data_addr += data_size;
++
++	data_size = max9296_get_dump(dev, data_addr, map_depth_trigger,
++				     ARRAY_SIZE(map_depth_trigger));
++	count += data_size;
++	data_addr += data_size;
++
++	data_size = max9296_get_dump(dev, data_addr, map_rgb_trigger,
++				     ARRAY_SIZE(map_rgb_trigger));
++	count += data_size;
++	data_addr += data_size;
++	*data_addr = '0';
++
++	dev_info(dev, "%s, buf %p, count %d, \n", __func__, buf, count);
++
++	return count;
++}
++
++static DEVICE_ATTR(register_dump, 0444, max9296_dev_dump_show, NULL);
++
++static struct attribute *max9296_attributes[] = {
++	&dev_attr_register_dump.attr,
++	NULL
++};
++
++static const struct attribute_group max9296_attr_group = {
++	.attrs = max9296_attributes,
++};
++
++#endif /* CONFIG_SYSFS */
++
+ const struct of_device_id max9296_of_match[] = {
+ 	{ .compatible = "nvidia,max9296", },
+ 	{ },
+@@ -1204,7 +1312,16 @@ static int max9296_probe(struct i2c_client *client,
+ 	dev_set_drvdata(&client->dev, priv);
+ 
+ 	priv->ir_type_value = Y_NONE;
++
++#ifdef CONFIG_SYSFS
++	err = sysfs_create_group(&client->dev.kobj, &max9296_attr_group);
++	if (err)
++		dev_warn(&client->dev, "%s, failed to create sysfs, err %d",
++			 __func__, err);
++#endif /* CONFIG_SYSFS */
++
+ 	max9296_init_settings(&client->dev);
++
+ 	probe_done = true;
+ 
+ 	/* dev communication gets validated when GMSL link setup is done */
+@@ -1220,6 +1337,11 @@ static int max9296_remove(struct i2c_client *client)
+ 
+ 	if (client != NULL) {
+ 		priv = dev_get_drvdata(&client->dev);
++
++#ifdef CONFIG_SYSFS
++		sysfs_remove_group(&client->dev.kobj, &max9296_attr_group);
++#endif /* CONFIG_SYSFS */
++
+ 		mutex_destroy(&priv->lock);
+ 		i2c_unregister_device(client);
+ 		client = NULL;
+-- 
+2.17.1
+


### PR DESCRIPTION
Dump max9295 settings:
/sys/bus/i2c/drivers/max9295/30-0040/register_dump
Dump max9296 settings:
/sys/bus/i2c/drivers/max9296/30-0048/register_dump

Signed-off-by: Qingwu Zhang <qingwu.zhang@intel.com>