### PR TITLE
SerDes: Don't update registers if init failed

### DIFF
--- a/kernel/nvidia/0050-SerDes-Don-t-update-registers-if-init-failed.patch
+++ b/kernel/nvidia/0050-SerDes-Don-t-update-registers-if-init-failed.patch
@@ -1,0 +1,150 @@
+From 30090aa71bb9fa78a29580eeda21d99f0a5348e3 Mon Sep 17 00:00:00 2001
+From: Qingwu Zhang <qingwu.zhang@intel.com>
+Date: Tue, 29 Mar 2022 15:39:20 +0800
+Subject: [PATCH] SerDes: Don't update registers if init failed
+
+On some platforms, there isn't SerDes device.
+Then don't want to update SerDes settings dynamically.
+
+Signed-off-by: Qingwu Zhang <qingwu.zhang@intel.com>
+---
+ drivers/media/i2c/max9295.c | 38 ++++++++++---------------------------
+ drivers/media/i2c/max9296.c | 35 +++++++++-------------------------
+ 2 files changed, 19 insertions(+), 54 deletions(-)
+
+diff --git a/drivers/media/i2c/max9295.c b/drivers/media/i2c/max9295.c
+index 9beb8a53b..b2d9bbdc3 100644
+--- a/drivers/media/i2c/max9295.c
++++ b/drivers/media/i2c/max9295.c
+@@ -639,36 +639,11 @@ static int max9295_init_settings(struct device *dev)
+ 		dev_info(dev, "%s done\n", __func__);
+ 		init_done = true;
+ 		priv->ir_type_value = Y8_Y8I;
+-	} else {
+-		dev_err(dev, "%s, failed to init settings \n", __func__);
+ 	}
+ 
+ 	return err;
+ }
+ 
+-static int max9295_check_status(struct device *dev)
+-{
+-	u32 val = 0;
+-	struct max9295 *priv = dev_get_drvdata(dev);
+-	int err;
+-	u32 j = 0;
+-
+-	mutex_lock(&priv->lock);
+-
+-	for (j = 0; j < ARRAY_SIZE(map_pipe_y8_opt); j++) {
+-		val = 0;
+-		err = regmap_read(priv->regmap, map_pipe_y8_opt[j].addr, &val);
+-
+-		dev_info(dev,
+-			"%s:i2c read, err %x, cmu value %x\n",
+-			__func__, err, val);
+-	};
+-
+-	mutex_unlock(&priv->lock);
+-
+-	return 0;
+-}
+-
+ #define Y8_DATA_TYPE 0x2A
+ #define Y8I_DATA_TYPE 0x1E
+ #define Y12I_DATA_TYPE 0X24
+@@ -688,8 +663,8 @@ int max9295_update_pipe(struct device *dev, int sensor_type, int data_type)
+ 	dev_info(dev, "%s st %d, dt %d \n", __func__, sensor_type, data_type);
+ 
+ 	if (!init_done) {
+-		err = max9295_init_settings(dev);
+-		max9295_check_status(dev);
++		dev_info(dev, "%s, SerDes device may not exist", __func__);
++		return 0;
+ 	}
+ 
+ 	priv = dev_get_drvdata(dev);
+@@ -917,7 +892,14 @@ static int max9295_probe(struct i2c_client *client,
+ 			 __func__, err);
+ #endif /* CONFIG_SYSFS */
+ 
+-	max9295_init_settings(&client->dev);
++	/* don't break probe stage */
++	err = max9295_init_settings(&client->dev);
++	if (err) {
++		dev_warn(&client->dev, "%s, failed to init settings \n",
++			 __func__);
++		err = 0;
++	}
++
+ 	probe_done = true;
+ 
+ 	/* dev communication gets validated when GMSL link setup is done */
+diff --git a/drivers/media/i2c/max9296.c b/drivers/media/i2c/max9296.c
+index 627ce6256..5c554e430 100644
+--- a/drivers/media/i2c/max9296.c
++++ b/drivers/media/i2c/max9296.c
+@@ -968,34 +968,11 @@ static int max9296_init_settings(struct device *dev)
+ 		dev_info(dev, "%s done\n", __func__);
+ 		init_done = true;
+ 		priv->ir_type_value = Y8_Y8I;
+-	} else {
+-		dev_err(dev, "%s, failed to init settings \n", __func__);
+ 	}
+ 
+ 	return err;
+ }
+ 
+-static int max9296_check_status(struct device *dev)
+-{
+-	u32 val = 0;
+-	struct max9296 *priv = dev_get_drvdata(dev);
+-	int err;
+-	u32 j = 0;
+-
+-	mutex_lock(&priv->lock);
+-
+-	for (j = 0; j < ARRAY_SIZE(map_pipe_opt); j++) {
+-		val = 0;
+-		err = regmap_read(priv->regmap, map_pipe_opt[j].addr, &val);
+-		dev_info(dev,
+-			"%s:i2c read, err %x, cmu value %x\n",
+-			__func__, err, val);
+-	};
+-
+-	mutex_unlock(&priv->lock);
+-	return 0;
+-}
+-
+ #define Y8_DATA_TYPE 0x2A
+ #define Y8I_DATA_TYPE 0x1E
+ #define Y12I_DATA_TYPE 0X24
+@@ -1015,8 +992,8 @@ int max9296_update_pipe(struct device *dev, int sensor_type, int data_type)
+ 	dev_info(dev, "%s st %d, dt %d \n", __func__, sensor_type, data_type);
+ 
+ 	if (!init_done) {
+-		err = max9296_init_settings(dev);
+-		max9296_check_status(dev);
++		dev_info(dev, "%s, SerDes device may not exist", __func__);
++		return 0;
+ 	}
+ 
+ 	priv = dev_get_drvdata(dev);
+@@ -1320,7 +1297,13 @@ static int max9296_probe(struct i2c_client *client,
+ 			 __func__, err);
+ #endif /* CONFIG_SYSFS */
+ 
+-	max9296_init_settings(&client->dev);
++	/* don't break probe stage */
++	err = max9296_init_settings(&client->dev);
++	if (err) {
++		dev_warn(&client->dev, "%s, failed to init settings \n",
++			 __func__);
++		err = 0;
++	}
+ 
+ 	probe_done = true;
+ 
+-- 
+2.17.1
+


### PR DESCRIPTION
On some platforms, there isn't SerDes device.
Then don't want to update SerDes settings dynamically.

Signed-off-by: Qingwu Zhang <qingwu.zhang@intel.com>