### PR TITLE
Metadata related fixes

### DIFF
--- a/hardware/nvidia/platform/t19x/galen/kernel-dts/0009-Set-each-sensor-s-active_w-in-dts-just-enough-for-me.patch
+++ b/hardware/nvidia/platform/t19x/galen/kernel-dts/0009-Set-each-sensor-s-active_w-in-dts-just-enough-for-me.patch
@@ -1,0 +1,61 @@
+From 827ec9b711dcd491391ad12e0184bcb17b9d8ec8 Mon Sep 17 00:00:00 2001
+From: Xin Zhang <xin.x.zhang@intel.com>
+Date: Wed, 30 Mar 2022 19:14:16 +0800
+Subject: [PATCH] Set each sensor's active_w in dts just enough for metadata
+
+Signed-off-by: Xin Zhang <xin.x.zhang@intel.com>
+---
+ common/tegra194-camera-d4xx.dtsi | 16 ++++++++--------
+ 1 file changed, 8 insertions(+), 8 deletions(-)
+
+diff --git a/common/tegra194-camera-d4xx.dtsi b/common/tegra194-camera-d4xx.dtsi
+index 009e0ee..0b33d06 100644
+--- a/common/tegra194-camera-d4xx.dtsi
++++ b/common/tegra194-camera-d4xx.dtsi
+@@ -83,8 +83,8 @@
+ 					mode0 {
+ 						pixel_t = "grey_y16";
+ 						num_lanes = "2";
+-						active_w = "1280";
+-						active_h = "720";
++						active_w = "128";
++						active_h = "0";
+ 						tegra_sinterface = "serial_a";
+ 						mclk_khz = "24000";
+ 						/*pix_clk_hz = "148500000";*/ /* for 2 streams? */
+@@ -137,8 +137,8 @@
+ 						pixel_t = "grey_y8";
+ 
+ 						num_lanes = "2";
+-						active_w = "1920";
+-						active_h = "1080";
++						active_w = "128";
++						active_h = "0";
+ 						tegra_sinterface = "serial_e";
+ 						mclk_khz = "24000";
+ 						/*pix_clk_hz = "148500000";*/ /* for 2 streams? */
+@@ -191,8 +191,8 @@
+ 					mode0 {
+ 						pixel_t = "grey_y8";
+ 						num_lanes = "2";
+-						active_w = "1280";
+-						active_h = "720";
++						active_w = "128";
++						active_h = "0";
+ 						tegra_sinterface = "serial_b";
+ 						mclk_khz = "24000";
+ 						/*pix_clk_hz = "148500000";*/ /* for 2 streams? */
+@@ -245,8 +245,8 @@
+ 					mode0 {
+ 						pixel_t = "grey_y8";
+ 						num_lanes = "2";
+-						active_w = "640";
+-						active_h = "480";
++						active_w = "128";
++						active_h = "0";
+ 						tegra_sinterface = "serial_b";
+ 						mclk_khz = "24000";
+ 						/*pix_clk_hz = "148500000";*/ /* for 2 streams? */
+-- 
+2.17.1
+

--- a/kernel/nvidia/0057-Metadata-related-fixes.patch
+++ b/kernel/nvidia/0057-Metadata-related-fixes.patch
@@ -1,0 +1,595 @@
+From 53df76cec4998a21622da2ba1da5315b02e9ba1f Mon Sep 17 00:00:00 2001
+From: Xin Zhang <xin.x.zhang@intel.com>
+Date: Mon, 14 Mar 2022 11:15:27 +0800
+Subject: [PATCH] Metadata related fixes
+
+- Make metadata buffer smaller so copy on it could waste less CPU;
+- IR channel changed from 2 SerDes configs (Y8_Y8I, Y12I) to 3 configs
+  (Y8, Y8I, Y12I), and Y8/Y8I configs enabled metadata datatype, the 2
+  datatypes per channel limitation is still respected while we could
+  have metadata on IR Y8 and Y8I;
+- Enable metadata for IR, /dev/video5 will be IR metadata node;
+- Y12I doesn't have metadata, the metadata node /dev/video5 will output
+  no data when the format is set to Y12I.
+- Metadata related code refactoring in MC/VI driver: cleanup, move
+  related code into one place, get config from dt instead of hardcode.
+
+Signed-off-by: Xin Zhang <xin.x.zhang@intel.com>
+Signed-off-by: Shikun Ding <shikun.ding@intel.com>
+---
+ drivers/media/i2c/max9295.c                   | 73 ++++++++++++----
+ drivers/media/i2c/max9296.c                   | 79 ++++++++++++++---
+ .../media/platform/tegra/camera/vi/channel.c  | 12 +--
+ .../media/platform/tegra/camera/vi/graph.c    | 53 ++++++++----
+ .../media/platform/tegra/camera/vi/vi5_fops.c | 85 +++++++++++--------
+ include/media/mc_common.h                     |  1 +
+ 6 files changed, 209 insertions(+), 94 deletions(-)
+
+diff --git a/drivers/media/i2c/max9295.c b/drivers/media/i2c/max9295.c
+index 1ddb0d3e6..29bdabbbc 100644
+--- a/drivers/media/i2c/max9295.c
++++ b/drivers/media/i2c/max9295.c
+@@ -105,7 +105,8 @@ struct max9295_client_ctx {
+ 
+ enum ir_type {
+ 	Y_NONE = 0,
+-	Y8_Y8I,
++	Y8,
++	Y8I,
+ 	Y12I,
+ };
+ 
+@@ -537,10 +538,20 @@ static struct reg_pair map_pipe_y_control[] = {
+ 	{0x010A, 0x0E}, // LIM_HEART Pipe Y: Disabled
+ };
+ 
+-static struct reg_pair map_pipe_z_y8_y8i_control[] = {
++static struct reg_pair map_pipe_z_y8_control[] = {
+ 	/* addr, val */
+ 	{0x0318, 0x6A}, // Pipe Z pulls Y8 (DT 0x2A)
+-	{0x0319, 0x5E}, // Pipe Z pulls Y8I (DT 0x1E)
++	{0x0319, 0x52}, // Pipe Z pulls EMB8 (DT 0x12)
++	{0x030D, 0x04}, // Pipe Z pulls VC2
++	{0x030E, 0x00},
++	{0x031E, 0x30}, // BPP = 16 in pipe Z
++	{0x0112, 0x0E}, // LIM_HEART Pipe Z: Disabled
++};
++
++static struct reg_pair map_pipe_z_y8i_control[] = {
++	/* addr, val */
++	{0x0318, 0x5E}, // Pipe Z pulls Y8I (DT 0x1E)
++	{0x0319, 0x52}, // Pipe Z pulls EMB8 (DT 0x12)
+ 	{0x030D, 0x04}, // Pipe Z pulls VC2
+ 	{0x030E, 0x00},
+ 	{0x031E, 0x30}, // BPP = 16 in pipe Z
+@@ -550,10 +561,11 @@ static struct reg_pair map_pipe_z_y8_y8i_control[] = {
+ static struct reg_pair map_pipe_z_y12i_control[] = {
+ 	/* addr, val */
+ 	{0x0318, 0x64}, // Pipe Z pulls Y12I (DT 0x24)
++	{0x0319, 0x00}, // Reset to clean EMB8 setting for Y8/Y8I configs
+ 	{0x030D, 0x04}, // Pipe Z pulls VC2
+ 	{0x030E, 0x00},
+-	/* Reset reg 0x031E since it's very likely to modified in Y8/Y8I
+-	 * before run Y12I. For Y12I, this reg not required to be set.
++	/* Reset reg 0x031E since it's very likely to be modified in Y8/Y8I
++	 * before run Y12I. For Y12I, this reg is not required to be set.
+ 	 */
+ 	{0x031E, 0x18},
+ 	{0x0112, 0x0E}, // LIM_HEART Pipe Z: Disabled
+@@ -626,8 +638,8 @@ static int max9295_init_settings(struct device *dev)
+ 	err |= max9295_set_registers(dev, map_pipe_y_control,
+ 				     ARRAY_SIZE(map_pipe_y_control));
+ 	// Pipe Z
+-	err |= max9295_set_registers(dev, map_pipe_z_y8_y8i_control,
+-				     ARRAY_SIZE(map_pipe_z_y8_y8i_control));
++	err |= max9295_set_registers(dev, map_pipe_z_y8_control,
++				     ARRAY_SIZE(map_pipe_z_y8_control));
+ 	// Pipe U
+ 	err |= max9295_set_registers(dev, map_pipe_u_control,
+ 				     ARRAY_SIZE(map_pipe_u_control));
+@@ -642,7 +654,7 @@ static int max9295_init_settings(struct device *dev)
+ 	if (err == 0) {
+ 		dev_info(dev, "%s done\n", __func__);
+ 		init_done = true;
+-		priv->ir_type_value = Y8_Y8I;
++		priv->ir_type_value = Y8;
+ 	}
+ 
+ 	return err;
+@@ -672,8 +684,39 @@ int max9295_update_pipe(struct device *dev, int sensor_type, int data_type)
+ 	}
+ 
+ 	priv = dev_get_drvdata(dev);
+-	if ((sensor_type == IR_SENSOR) && (priv->ir_type_value != Y8_Y8I) &&
+-	    (data_type == Y8_DATA_TYPE || data_type == Y8I_DATA_TYPE)) {
++	if ((sensor_type == IR_SENSOR) && (priv->ir_type_value != Y8) &&
++	    (data_type == Y8_DATA_TYPE)) {
++		// Set CMU
++		err = max9295_set_registers(dev, map_cmu_regulator,
++					    ARRAY_SIZE(map_cmu_regulator));
++		// Init control
++		err |= max9295_set_registers(dev, map_pipe_y8_opt,
++					     ARRAY_SIZE(map_pipe_y8_opt));
++
++		// Pipe X
++		err |= max9295_set_registers(dev, map_pipe_x_control,
++					     ARRAY_SIZE(map_pipe_x_control));
++		// Pipe Y
++		err |= max9295_set_registers(dev, map_pipe_y_control,
++					     ARRAY_SIZE(map_pipe_y_control));
++		// Pipe Z
++		err |= max9295_set_registers(dev, map_pipe_z_y8_control,
++					     ARRAY_SIZE(map_pipe_z_y8_control));
++		// Pipe U
++		err |= max9295_set_registers(dev, map_pipe_u_control,
++					     ARRAY_SIZE(map_pipe_u_control));
++
++		// Trigger Depth
++		err |= max9295_set_registers(dev, map_depth_trigger,
++					     ARRAY_SIZE(map_depth_trigger));
++		// Trigger RGB
++		err |= max9295_set_registers(dev, map_rgb_trigger,
++					     ARRAY_SIZE(map_rgb_trigger));
++
++		if (err == 0)
++			priv->ir_type_value = Y8;
++	} else if ((sensor_type == IR_SENSOR) && (priv->ir_type_value != Y8I) &&
++	    (data_type == Y8I_DATA_TYPE)) {
+ 		// Set CMU
+ 		err = max9295_set_registers(dev, map_cmu_regulator,
+ 					    ARRAY_SIZE(map_cmu_regulator));
+@@ -688,8 +731,8 @@ int max9295_update_pipe(struct device *dev, int sensor_type, int data_type)
+ 		err |= max9295_set_registers(dev, map_pipe_y_control,
+ 					     ARRAY_SIZE(map_pipe_y_control));
+ 		// Pipe Z
+-		err |= max9295_set_registers(dev, map_pipe_z_y8_y8i_control,
+-					     ARRAY_SIZE(map_pipe_z_y8_y8i_control));
++		err |= max9295_set_registers(dev, map_pipe_z_y8i_control,
++					     ARRAY_SIZE(map_pipe_z_y8i_control));
+ 		// Pipe U
+ 		err |= max9295_set_registers(dev, map_pipe_u_control,
+ 					     ARRAY_SIZE(map_pipe_u_control));
+@@ -702,7 +745,7 @@ int max9295_update_pipe(struct device *dev, int sensor_type, int data_type)
+ 					     ARRAY_SIZE(map_rgb_trigger));
+ 
+ 		if (err == 0)
+-			priv->ir_type_value = Y8_Y8I;
++			priv->ir_type_value = Y8I;
+ 	} else if ((sensor_type == IR_SENSOR) && (priv->ir_type_value != Y12I) &&
+ 	           (data_type == Y12I_DATA_TYPE)) {
+ 		// Set CMU
+@@ -809,8 +852,8 @@ static ssize_t max9295_dev_dump_show(struct device *dev,
+ 	count += data_size;
+ 	data_addr += data_size;
+ 
+-	data_size = max9295_get_dump(dev, data_addr, map_pipe_z_y8_y8i_control,
+-				     ARRAY_SIZE(map_pipe_z_y8_y8i_control));
++	data_size = max9295_get_dump(dev, data_addr, map_pipe_z_y8_control,
++				     ARRAY_SIZE(map_pipe_z_y8_control));
+ 	count += data_size;
+ 	data_addr += data_size;
+ 
+diff --git a/drivers/media/i2c/max9296.c b/drivers/media/i2c/max9296.c
+index adc26c732..4dc571394 100644
+--- a/drivers/media/i2c/max9296.c
++++ b/drivers/media/i2c/max9296.c
+@@ -106,7 +106,8 @@ struct pipe_ctx {
+ 
+ enum ir_type {
+ 	Y_NONE = 0,
+-	Y8_Y8I,
++	Y8,
++	Y8I,
+ 	Y12I,
+ };
+ 
+@@ -850,7 +851,7 @@ static struct reg_pair map_pipe_y_control[] = {
+ 	{0x0112, 0x23}, // pipe Y
+ };
+ 
+-static struct reg_pair map_pipe_z_y8_y8i_control[] = {
++static struct reg_pair map_pipe_z_y8_control[] = {
+ 	/* addr, val */
+ 	{0x048B, 0x0F}, // Enable 4 mappings for Pipe Z
+ 	{0x048D, 0xAA}, // Map Y8 VC2
+@@ -859,8 +860,25 @@ static struct reg_pair map_pipe_z_y8_y8i_control[] = {
+ 	{0x0490, 0x80},
+ 	{0x0491, 0x81}, // Map frame end  VC2
+ 	{0x0492, 0x81},
+-	{0x0493, 0x9E}, // Map Y8I, VC2
+-	{0x0494, 0x9E},
++	{0x0493, 0x92}, // Map EMB8, VC2
++	{0x0494, 0x92},
++	{0x04AD, 0x55}, // Map to PHY1 (master for port A)
++
++	// SEQ_MISS_EN: Disabled / DIS_PKT_DET: Disabled
++	{0x0124, 0x23}, // pipe Z
++};
++
++static struct reg_pair map_pipe_z_y8i_control[] = {
++	/* addr, val */
++	{0x048B, 0x0F}, // Enable 4 mappings for Pipe Z
++	{0x048D, 0x9E}, // Map Y8I VC2
++	{0x048E, 0x9E},
++	{0x048F, 0x80}, // Map frame start  VC2
++	{0x0490, 0x80},
++	{0x0491, 0x81}, // Map frame end  VC2
++	{0x0492, 0x81},
++	{0x0493, 0x92}, // Map EMB8, VC2
++	{0x0494, 0x92},
+ 	{0x04AD, 0x55}, // Map to PHY1 (master for port A)
+ 
+ 	// SEQ_MISS_EN: Disabled / DIS_PKT_DET: Disabled
+@@ -876,6 +894,8 @@ static struct reg_pair map_pipe_z_y12i_control[] = {
+ 	{0x0490, 0x80},
+ 	{0x0491, 0x81}, // Map frame end  VC2
+ 	{0x0492, 0x81},
++	{0x0493, 0x00}, // Reset to unmap EMB8, VC2
++	{0x0494, 0x00},
+ 	{0x04AD, 0x15}, // Map to PHY1 (master for port A)
+ 
+ 	// SEQ_MISS_EN: Disabled / DIS_PKT_DET: Disabled
+@@ -951,8 +971,8 @@ static int max9296_init_settings(struct device *dev)
+ 	err |= max9296_set_registers(dev, map_pipe_y_control,
+ 				     ARRAY_SIZE(map_pipe_y_control));
+ 	// Pipe Z
+-	err |= max9296_set_registers(dev, map_pipe_z_y8_y8i_control,
+-				     ARRAY_SIZE(map_pipe_z_y8_y8i_control));
++	err |= max9296_set_registers(dev, map_pipe_z_y8_control,
++				     ARRAY_SIZE(map_pipe_z_y8_control));
+ 	// Pipe U
+ 	err |= max9296_set_registers(dev, map_pipe_u_control,
+ 				     ARRAY_SIZE(map_pipe_u_control));
+@@ -967,7 +987,7 @@ static int max9296_init_settings(struct device *dev)
+ 	if (err == 0) {
+ 		dev_info(dev, "%s done\n", __func__);
+ 		init_done = true;
+-		priv->ir_type_value = Y8_Y8I;
++		priv->ir_type_value = Y8;
+ 	}
+ 
+ 	return err;
+@@ -997,8 +1017,39 @@ int max9296_update_pipe(struct device *dev, int sensor_type, int data_type)
+ 	}
+ 
+ 	priv = dev_get_drvdata(dev);
+-	if ((sensor_type == IR_SENSOR) && (priv->ir_type_value != Y8_Y8I) &&
+-            (data_type == Y8_DATA_TYPE || data_type == Y8I_DATA_TYPE)) {
++	if ((sensor_type == IR_SENSOR) && (priv->ir_type_value != Y8) &&
++            (data_type == Y8_DATA_TYPE)) {
++		// Set CMU
++		err = max9296_set_registers(dev, map_cmu_regulator,
++					    ARRAY_SIZE(map_cmu_regulator));
++		// Init control
++		err |= max9296_set_registers(dev, map_pipe_opt,
++					     ARRAY_SIZE(map_pipe_opt));
++
++		// Pipe X
++		err |= max9296_set_registers(dev, map_pipe_x_control,
++					     ARRAY_SIZE(map_pipe_x_control));
++		// Pipe Y
++		err |= max9296_set_registers(dev, map_pipe_y_control,
++					     ARRAY_SIZE(map_pipe_y_control));
++		// Pipe Z
++		err |= max9296_set_registers(dev, map_pipe_z_y8_control,
++					     ARRAY_SIZE(map_pipe_z_y8_control));
++		// Pipe U
++		err |= max9296_set_registers(dev, map_pipe_u_control,
++					     ARRAY_SIZE(map_pipe_u_control));
++
++		// Trigger Depth
++		err |= max9296_set_registers(dev, map_depth_trigger,
++					     ARRAY_SIZE(map_depth_trigger));
++		// Trigger RGB
++		err |= max9296_set_registers(dev, map_rgb_trigger,
++					     ARRAY_SIZE(map_rgb_trigger));
++
++		if (err == 0)
++			priv->ir_type_value = Y8;
++	} else if ((sensor_type == IR_SENSOR) && (priv->ir_type_value != Y8I) &&
++            (data_type == Y8I_DATA_TYPE)) {
+ 		// Set CMU
+ 		err = max9296_set_registers(dev, map_cmu_regulator,
+ 					    ARRAY_SIZE(map_cmu_regulator));
+@@ -1013,8 +1064,8 @@ int max9296_update_pipe(struct device *dev, int sensor_type, int data_type)
+ 		err |= max9296_set_registers(dev, map_pipe_y_control,
+ 					     ARRAY_SIZE(map_pipe_y_control));
+ 		// Pipe Z
+-		err |= max9296_set_registers(dev, map_pipe_z_y8_y8i_control,
+-					     ARRAY_SIZE(map_pipe_z_y8_y8i_control));
++		err |= max9296_set_registers(dev, map_pipe_z_y8i_control,
++					     ARRAY_SIZE(map_pipe_z_y8i_control));
+ 		// Pipe U
+ 		err |= max9296_set_registers(dev, map_pipe_u_control,
+ 					     ARRAY_SIZE(map_pipe_u_control));
+@@ -1027,7 +1078,7 @@ int max9296_update_pipe(struct device *dev, int sensor_type, int data_type)
+ 					     ARRAY_SIZE(map_rgb_trigger));
+ 
+ 		if (err == 0)
+-			priv->ir_type_value = Y8_Y8I;
++			priv->ir_type_value = Y8I;
+ 	} else if ((sensor_type == IR_SENSOR) && (priv->ir_type_value != Y12I) &&
+ 		   (data_type == Y12I_DATA_TYPE)) {
+ 		// Set CMU
+@@ -1134,8 +1185,8 @@ static ssize_t max9296_dev_dump_show(struct device *dev,
+ 	count += data_size;
+ 	data_addr += data_size;
+ 
+-	data_size = max9296_get_dump(dev, data_addr, map_pipe_z_y8_y8i_control,
+-				     ARRAY_SIZE(map_pipe_z_y8_y8i_control));
++	data_size = max9296_get_dump(dev, data_addr, map_pipe_z_y8_control,
++				     ARRAY_SIZE(map_pipe_z_y8_control));
+ 	count += data_size;
+ 	data_addr += data_size;
+ 
+diff --git a/drivers/media/platform/tegra/camera/vi/channel.c b/drivers/media/platform/tegra/camera/vi/channel.c
+index 2b42ff257..499ec37d0 100644
+--- a/drivers/media/platform/tegra/camera/vi/channel.c
++++ b/drivers/media/platform/tegra/camera/vi/channel.c
+@@ -2543,7 +2543,7 @@ static const struct vb2_ops tegra_metadata_qops = {
+ 	.stop_streaming		= tegra_metadata_stop_streaming,
+ };
+ 
+-static int tegra_channel_video_init_embedded(struct tegra_channel *chan)
++int tegra_channel_init_video_embedded(struct tegra_channel *chan)
+ {
+ 	struct video_device *video = &chan->embedded.video;
+ 	struct vb2_queue *queue = &chan->embedded.queue;
+@@ -2759,16 +2759,6 @@ int tegra_channel_init(struct tegra_channel *chan)
+ 		goto deskew_ctx_err;
+ 	}
+ 
+-	/*FIXME: init embedded channel only if embedded is set in DT*/
+-	/*if (chan->embedded.height) {*/
+-	if (chan->id == 0 || chan->id == 1) {
+-		ret =tegra_channel_video_init_embedded(chan);
+-		if (ret < 0)
+-			dev_err(chan->vi->dev, "failed to initialize embedded channel\n");
+-			/*FIXME: should we fail channel init?*/
+-	}
+-	/*}*/
+-
+ 	chan->init_done = true;
+ 
+ 	return 0;
+diff --git a/drivers/media/platform/tegra/camera/vi/graph.c b/drivers/media/platform/tegra/camera/vi/graph.c
+index 6544f884f..08f21c8bf 100644
+--- a/drivers/media/platform/tegra/camera/vi/graph.c
++++ b/drivers/media/platform/tegra/camera/vi/graph.c
+@@ -369,8 +369,11 @@ static int tegra_vi_graph_notify_complete(struct v4l2_async_notifier *notifier)
+ 	struct tegra_channel *chan =
+ 		container_of(notifier, struct tegra_channel, notifier);
+ 	struct tegra_vi_graph_entity *entity;
++	struct camera_common_data *s_data;
++	struct device_node *node;
++	struct sensor_mode_properties *sensor_mode = NULL;
++	int idx;
+ 	int ret;
+-	int emb_ret;
+ 
+ 	dev_err(chan->vi->dev, "notify complete, all subdevs registered\n");
+ 
+@@ -389,45 +392,61 @@ static int tegra_vi_graph_notify_complete(struct v4l2_async_notifier *notifier)
+ 		goto register_device_error;
+ 	}
+ 
+-	if (chan->id == 0 || chan->id == 1) {
+-		emb_ret = video_register_device(&chan->embedded.video,
+-				VFL_TYPE_GRABBER, -1);
+-		if (emb_ret < 0) {
+-			dev_err(&chan->video->dev, "%s(): register embedded %s: %d\n",
+-				__func__, chan->embedded.video.name, emb_ret);
+-			goto register_embedded_device_error;
+-		}
+-		dev_err(&chan->video->dev, "%s(): register embedded %s: %d\n",
+-					__func__, chan->embedded.video.name, emb_ret);
+-	}
+-
+ 	/* Create links for every entity. */
+ 	list_for_each_entry(entity, &chan->entities, list) {
+ 		if (entity->entity != NULL) {
+ 			ret = tegra_vi_graph_build_one(chan, entity);
+ 			if (ret < 0)
+-				goto graph_error;
++				goto link_error;
+ 		}
+ 	}
+ 
+ 	/* Create links for channels */
+ 	ret = tegra_vi_graph_build_links(chan);
+ 	if (ret < 0)
+-		goto graph_error;
++		goto link_error;
++
++	s_data = to_camera_common_data(chan->subdev_on_csi->dev);
++	node = chan->subdev_on_csi->dev->of_node;
++	if (s_data && node) {
++		idx = s_data->mode_prop_idx;
++		if (idx < s_data->sensor_props.num_modes)
++			sensor_mode = &s_data->sensor_props.sensor_modes[idx];
++	}
++
++	if (sensor_mode &&
++	    sensor_mode->image_properties.embedded_metadata_height > 0) {
++		ret = tegra_channel_init_video_embedded(chan);
++		if (ret < 0) {
++			dev_err(chan->vi->dev,
++				"failed to initialize embedded channel\n");
++			goto register_embedded_device_error;
++		}
++
++		ret = video_register_device(&chan->embedded.video,
++				VFL_TYPE_GRABBER, -1);
++		if (ret < 0) {
++			dev_err(&chan->video->dev, "failed to register embedded %s: %d\n",
++				chan->embedded.video.name, ret);
++			goto register_embedded_device_error;
++		}
++	}
+ 
+ 	ret = v4l2_device_register_subdev_nodes(&chan->vi->v4l2_dev);
+ 	if (ret < 0) {
+ 		dev_err(chan->vi->dev, "failed to register subdev nodes\n");
+-		goto graph_error;
++		goto register_nodes_error;
+ 	}
+ 
+ 	chan->link_status++;
+ 
+ 	return 0;
+ 
+-graph_error:
++register_nodes_error:
+ 	video_unregister_device(&chan->embedded.video);
+ register_embedded_device_error:
++	tegra_vi_graph_remove_links(chan);
++link_error:
+ 	video_unregister_device(chan->video);
+ register_device_error:
+ 	video_device_release(chan->video);
+diff --git a/drivers/media/platform/tegra/camera/vi/vi5_fops.c b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
+index 0e2fe065b..662cd3b74 100644
+--- a/drivers/media/platform/tegra/camera/vi/vi5_fops.c
++++ b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
+@@ -310,7 +310,7 @@ static void vi5_setup_surface(struct tegra_channel *chan,
+ 
+ 	if (chan->embedded.height > 0) {
+ 		desc->ch_cfg.embdata_enable = 1;
+-		desc->ch_cfg.frame.embed_x = chan->embedded.width * BPP_MEM;
++		desc->ch_cfg.frame.embed_x = chan->embedded.width;
+ 		desc->ch_cfg.frame.embed_y = chan->embedded.height;
+ 
+ 		desc_memoryinfo->surface[VI_ATOMP_SURFACE_EMBEDDED].base_address
+@@ -319,54 +319,59 @@ static void vi5_setup_surface(struct tegra_channel *chan,
+ 			= desc->ch_cfg.frame.embed_x * desc->ch_cfg.frame.embed_y;
+ 
+ 		desc->ch_cfg.atomp.surface_stride[VI_ATOMP_SURFACE_EMBEDDED]
+-			= chan->embedded.width * BPP_MEM;
++			= chan->embedded.width;
+ 	}
+ 
+ 	chan->capture_descr_sequence += 1;
+ }
+ 
++static void vi5_release_metadata_buffer(struct tegra_channel *chan,
++	struct vb2_v4l2_buffer *vbuf)
++{
++	struct vb2_buffer *evb = NULL;
++	struct vb2_v4l2_buffer *evbuf;
++	void* frm_buffer;
++
++	spin_lock(&chan->embedded.spin_lock);
++	if (0 < chan->embedded.num_buffers) {
++		evb = chan->embedded.buffers[chan->embedded.tail];
++		chan->embedded.buffers[chan->embedded.tail] = NULL;
++		chan->embedded.tail++;
++		if (chan->embedded.tail > 15)
++			chan->embedded.tail = chan->embedded.tail - 16;
++		chan->embedded.num_buffers--;
++	}
++	spin_unlock(&chan->embedded.spin_lock);
++
++	if (!evb)
++		return;
++
++	frm_buffer = vb2_plane_vaddr(evb, 0);
++	if (!frm_buffer)
++		return;
++
++	memcpy(frm_buffer, chan->vi->emb_buf_addr[chan->id], chan->embedded.width);
++	evbuf = to_vb2_v4l2_buffer(evb);
++	evbuf->sequence = vbuf->sequence;
++	vb2_set_plane_payload(evb, 0, chan->embedded.width);
++	evb->timestamp = vbuf->vb2_buf.timestamp;
++	vb2_buffer_done(evb, VB2_BUF_STATE_DONE);
++}
++
+ static void vi5_release_buffer(struct tegra_channel *chan,
+ 	struct tegra_channel_buffer *buf)
+ {
+ 	struct vb2_v4l2_buffer *vbuf = &buf->buf;
+-	struct vb2_buffer *evb;
+-	struct vb2_v4l2_buffer *evbuf;
+ 
+ 	vbuf->sequence = chan->sequence++;
+ 	vbuf->field = V4L2_FIELD_NONE;
+ 	vb2_set_plane_payload(&vbuf->vb2_buf, 0, chan->format.sizeimage);
+ 
+-	evb = NULL;
+-	if ((chan->embedded.height == 1)) {
+-		void* frm_buffer;
+-		spin_lock(&chan->embedded.spin_lock);
+-		if (0 < chan->embedded.num_buffers ){
+-			evb = chan->embedded.buffers[chan->embedded.tail];
+-			chan->embedded.buffers[chan->embedded.tail] = NULL;
+-			chan->embedded.tail++;
+-			if (chan->embedded.tail > 15)
+-				chan->embedded.tail = chan->embedded.tail - 16;
+-			chan->embedded.num_buffers--;
+-		}
+-		spin_unlock(&chan->embedded.spin_lock);
+-
+-		if(evb) {
+-			frm_buffer = vb2_plane_vaddr(evb, 0);
+-			if(frm_buffer != NULL) {
+-				memcpy(frm_buffer,chan->vi->emb_buf_addr[chan->id], 256);
+-			}
+-		}
+-	}
+-
+ 	vb2_buffer_done(&vbuf->vb2_buf, buf->vb2_state);
+-	if (chan->embedded.height == 1 && evb) {
+-		evbuf = to_vb2_v4l2_buffer(evb);
+-		evbuf->sequence = vbuf->sequence;
+-		/*FIXME: define 236*/
+-		vb2_set_plane_payload(evb, 0, 236);
+-		evb->timestamp = vbuf->vb2_buf.timestamp;
+-		vb2_buffer_done(evb, VB2_BUF_STATE_DONE);
+-	}
++
++	if (chan->embedded.height == 1 &&
++	    buf->vb2_state == VB2_BUF_STATE_DONE)
++		vi5_release_metadata_buffer(chan, vbuf);
+ }
+ 
+ static void vi5_capture_enqueue(struct tegra_channel *chan,
+@@ -780,15 +785,21 @@ static int vi5_channel_start_streaming(struct vb2_queue *vq, u32 count)
+ 						chan->embedded.height =
+ 							sensor_mode->image_properties.\
+ 							embedded_metadata_height;
+-						if (chan->id != 0 && chan->id != 1)
++						/*
++						 * IR channel Y12I format stream
++						 * doesn't have metadata, it must
++						 * be disabled otherwise it will
++						 * cause stream errors
++						 */
++						if (chan->id == 2 &&
++						    chan->fmtinfo->fourcc == V4L2_PIX_FMT_Y12I)
+ 							chan->embedded.height = 0;
+ 						/* rounding up to page size */
+ 						emb_buf_size =
+ 							round_up(chan->\
+ 							embedded.width *
+ 								chan->\
+-								embedded.height *
+-								BPP_MEM,
++								embedded.height,
+ 								PAGE_SIZE);
+ 					}
+ 				}
+diff --git a/include/media/mc_common.h b/include/media/mc_common.h
+index acfdadbe5..fd166593b 100644
+--- a/include/media/mc_common.h
++++ b/include/media/mc_common.h
+@@ -421,6 +421,7 @@ struct tegra_channel_buffer *dequeue_inflight(struct tegra_channel *chan);
+ int tegra_channel_set_power(struct tegra_channel *chan, bool on);
+ 
+ int tegra_channel_init_video(struct tegra_channel *chan);
++int tegra_channel_init_video_embedded(struct tegra_channel *chan);
+ int tegra_channel_cleanup_video(struct tegra_channel *chan);
+ 
+ struct tegra_vi_fops {
+-- 
+2.17.1
+


### PR DESCRIPTION
This PR contains the following:
- Make metadata buffer smaller so copy on it could waste less CPU;
- IR channel changed from 2 SerDes configs (Y8_Y8I, Y12I) to 3 configs
  (Y8, Y8I, Y12I), and Y8/Y8I configs enabled metadata datatype, the 2
  datatypes per channel limitation is still respected while we could
  have metadata on IR Y8 and Y8I;
- Enable metadata for IR, /dev/video5 will be IR metadata node;
- Y12I doesn't have metadata, the metadata node /dev/video5 will output
  no data when the format is set to Y12I.
- Metadata related code refactoring in MC/VI driver: cleanup, move
  related code into one place, get config from dt instead of hardcode.

Tested IR Y8 & Y8I metatdata with validation code https://github.com/jubransh/v4l_val_infra (modified myself, because currently IR metadata is disabled and the bpp for Y8I is wrong), and I see the metadata dumped.