### PR TITLE
Changed imu framerates and resolution

### DIFF
--- a/kernel/nvidia/0051-Set-correct-resolution-and-framerates-for-imu.patch
+++ b/kernel/nvidia/0051-Set-correct-resolution-and-framerates-for-imu.patch
@@ -1,0 +1,61 @@
+From 9f926deec1a3ed99b05a47da9bc86ea7d1888e6a Mon Sep 17 00:00:00 2001
+From: Shikun Ding <shikun.ding@intel.com>
+Date: Tue, 19 Apr 2022 13:32:16 +0800
+Subject: [PATCH] Set correct resolution and framerates for imu
+
+Set available framerates of imu to 100, 200 and 400.
+
+To make imu work:
+Reversed the width and height value for imu in d4xx driver while
+the width:height should be set to 32:1 in bytes.
+Removed the limitation on minimum value of frame height by replacing
+TEGRA_MIN_HEIGHT with value 1.
+
+Signed-off-by: Shikun Ding <shikun.ding@intel.com>
+---
+ drivers/media/i2c/d4xx.c                         | 4 ++--
+ drivers/media/platform/tegra/camera/vi/channel.c | 6 +++++-
+ 2 files changed, 7 insertions(+), 3 deletions(-)
+
+diff --git a/drivers/media/i2c/d4xx.c b/drivers/media/i2c/d4xx.c
+index 449639888..f4aaaa268 100644
+--- a/drivers/media/i2c/d4xx.c
++++ b/drivers/media/i2c/d4xx.c
+@@ -511,7 +511,7 @@ static const u16 ds5_framerate_to_60[] = {5, 15, 30, 60};
+ static const u16 ds5_framerate_to_90[] = {5, 15, 30, 60, 90};
+ static const u16 ds5_framerate_100[] = {100};
+ static const u16 ds5_framerate_90[] = {90};
+-static const u16 ds5_imu_framerates[] = {5, 10, 15, 30, 60, 90};
++static const u16 ds5_imu_framerates[] = {100, 200, 400};
+ 
+ static const struct ds5_resolution d43x_depth_sizes[] = {
+ 	{
+@@ -701,7 +701,7 @@ static const struct ds5_resolution d46x_calibration_sizes[] = {
+ static const struct ds5_resolution ds5_size_imu[] = {
+ 	{
+ 	.width =  32,
+-	.height = 32,
++	.height = 1,
+ 	.framerates = ds5_imu_framerates,
+ 	.n_framerates = ARRAY_SIZE(ds5_imu_framerates),
+ 	},
+diff --git a/drivers/media/platform/tegra/camera/vi/channel.c b/drivers/media/platform/tegra/camera/vi/channel.c
+index 63b120aa8..2b42ff257 100644
+--- a/drivers/media/platform/tegra/camera/vi/channel.c
++++ b/drivers/media/platform/tegra/camera/vi/channel.c
+@@ -195,7 +195,11 @@ static void tegra_channel_fmt_align(struct tegra_channel *chan,
+ 	 * different. Aligned width also may force a sensor mode change other
+ 	 * than the requested one
+ 	 */
+-	*height = clamp(*height, TEGRA_MIN_HEIGHT, TEGRA_MAX_HEIGHT);
++	/* For D4XX IMU, the total size of one frame is 32 while the width:height
++	 * should be set to 32:1. Therefore, ignored the clamping on height here by
++	 * replacing TEGRA_MIN_HEIGHT with 1U ((unsigned int) 1).
++	 */
++	*height = clamp(*height, 1U /*TEGRA_MIN_HEIGHT*/, TEGRA_MAX_HEIGHT);
+ 
+ 	/* Clamp the requested bytes per line value. If the maximum bytes per
+ 	 * line value is zero, the module doesn't support user configurable line
+-- 
+2.17.1
+


### PR DESCRIPTION
Set available framerates of imu to 100, 200 and 400

To make imu work:
1. Reversed the width and height value for imu in d4xx driver while the width:height should be set to 32:1 in bytes.
2. Removed the limitation on minimum value of frame height by replacing the minimum macro to 1.