### PR TITLE
Aligned preferred stride on 64-byte boundary in vi driver

### DIFF
--- a/kernel/nvidia/0057-Aligned-preferred-stride-on-64-byte-boundary.patch
+++ b/kernel/nvidia/0057-Aligned-preferred-stride-on-64-byte-boundary.patch
@@ -1,0 +1,26 @@
+From ef05f7f8286d4b27fde2d55269e6bb885663679f Mon Sep 17 00:00:00 2001
+From: Shikun Ding <shikun.ding@intel.com>
+Date: Wed, 27 Apr 2022 10:02:44 +0800
+Subject: [PATCH] Aligned preferred stride on 64-byte boundary
+
+Signed-off-by: Shikun Ding <shikun.ding@intel.com>
+---
+ include/media/tegra_camera_core.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/include/media/tegra_camera_core.h b/include/media/tegra_camera_core.h
+index 421c22491..1f57648f7 100644
+--- a/include/media/tegra_camera_core.h
++++ b/include/media/tegra_camera_core.h
+@@ -23,7 +23,7 @@
+ /* Width alignment */
+ #define TEGRA_WIDTH_ALIGNMENT	1
+ /* Stride alignment */
+-#define TEGRA_STRIDE_ALIGNMENT	1
++#define TEGRA_STRIDE_ALIGNMENT	64
+ /* Height alignment */
+ #define TEGRA_HEIGHT_ALIGNMENT	1
+ /* Size alignment */
+-- 
+2.17.1
+

--- a/utilities/streamApp/camera_sub_system/include/CSSTypes.h
+++ b/utilities/streamApp/camera_sub_system/include/CSSTypes.h
@@ -123,7 +123,7 @@ struct Format {
 
     uint32_t calc64BytesAlignedStride(void)
     {
-        uint32_t bytesperline = ((width / 64) + ((width % 64) ? 1 : 0)) * 64;
+        uint32_t bytesperline = width;
 
         if (v4l2Format == V4L2_PIX_FMT_YUYV ||
             v4l2Format == V4L2_PIX_FMT_Z16 ||
@@ -132,7 +132,7 @@ struct Format {
         else if (v4l2Format == V4L2_PIX_FMT_Y12I)
             bytesperline *= 4;
 
-        return bytesperline;
+        return ((bytesperline / 64) + ((bytesperline % 64) ? 1 : 0)) * 64;
     }
 
     uint32_t calcBytesPerFrame(void)


### PR DESCRIPTION
This patch is to align the chan->preferred_stride on 64-byte boundary in vi driver. Then v4l2-ctl or other application on user space won't need to do 64 bytes alignment in manual anymore.


Before:
```
# enable dump debug log of file channel.c
$ echo -n 'file channel.c +p' | sudo tee /sys/kernel/debug/dynamic_debug/control

$ v4l2-ctl -d /dev/video0 --set-fmt-video=width=848,height=480,pixelformat="Z16 "
$ dmesg | tail -n 1
[ 1506.149215] video4linux video0: tegra_channel_update_format: Resolution= 848x480 bytesperline=1696


Userspace:
$ v4l2-ctl -d /dev/video0 --set-fmt-video=width=848,height=480 --stream-mmap --stream-count=10 --verbose
VIDIOC_QUERYCAP: ok
VIDIOC_G_FMT: ok
VIDIOC_S_FMT: ok
Format Video Capture:
        Width/Height      : 848/480
        Pixel Format      : 'Z16 '
        Field             : None
        Bytes per Line    : 1696
        Size Image        : 814080
        Colorspace        : sRGB
        Transfer Function : Default (maps to sRGB)
        YCbCr/HSV Encoding: Default (maps to ITU-R 601)
        Quantization      : Default (maps to Full Range)
        Flags             :
VIDIOC_REQBUFS: ok
VIDIOC_QUERYBUF: ok
VIDIOC_QBUF: ok
VIDIOC_QUERYBUF: ok
VIDIOC_QBUF: ok
VIDIOC_QUERYBUF: ok
VIDIOC_QBUF: ok
VIDIOC_QUERYBUF: ok
VIDIOC_QBUF: ok
VIDIOC_STREAMON: ok
        Index    : 1
        Type     : Video Capture
        Flags    : mapped
        Field    : None
        Sequence : 1
        Length   : 814080
        Bytesused: 814080
        Timestamp: 5251.822975s (Monotonic, End-of-Frame)
```

After:
```
$ v4l2-ctl -d /dev/video0 --set-fmt-video=width=848,height=480,pixelformat="Z16 "
$ dmesg | tail -n 1
[  139.456458] video4linux video0: tegra_channel_update_format: Resolution= 848x480 aligned bytesperline=1728


$ v4l2-ctl -d /dev/video0 --set-fmt-video=width=424,height=240,pixelformat="Z16 "
$ dmesg | tail -n 1
[  217.157838] video4linux video0: tegra_channel_update_format: Resolution= 424x240 aligned bytesperline=896


Userspace:
$ v4l2-ctl -d /dev/video0 --set-fmt-video=width=848,height=480 --stream-mmap --stream-count=10 --verbose
VIDIOC_QUERYCAP: ok
VIDIOC_G_FMT: ok
VIDIOC_S_FMT: ok
Format Video Capture:
        Width/Height : 848/480
        Pixel Format : 'Z16 '
        Field : None
        Bytes per Line : 1728
        Size Image : 829440
        Colorspace : sRGB
        Transfer Function : Default (maps to sRGB)
        YCbCr/HSV Encoding: Default (maps to ITU-R 601)
        Quantization : Default (maps to Full Range)
        Flags             :
VIDIOC_REQBUFS: ok
VIDIOC_QUERYBUF: ok
VIDIOC_QBUF: ok
VIDIOC_QUERYBUF: ok
VIDIOC_QBUF: ok
VIDIOC_QUERYBUF: ok
VIDIOC_QBUF: ok
VIDIOC_QUERYBUF: ok
VIDIOC_QBUF: ok
VIDIOC_STREAMON: ok
        Index    : 1
        Type     : Video Capture
        Flags    : mapped
        Field    : None
        Sequence : 1
        Length   : 829440
        Bytesused: 829440
        Timestamp: 5252.022800s (Monotonic, End-of-Frame)
```