### PR TITLE
Allow refresh serdes configs during runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,20 +77,31 @@ sudo depmod
 After rebooting Jetson, the D457 driver should work.
 
 ## Available directives on max9295/max9296 register setting
+
 - Dump registers
-    ```
-    cat /sys/bus/i2c/drivers/max9295/30-0040/register_dump
-    cat /sys/bus/i2c/drivers/max9296/30-0048/register_dump
-    ```
+```
+cat /sys/bus/i2c/drivers/max9295/30-0040/register_dump
+cat /sys/bus/i2c/drivers/max9296/30-0048/register_dump
+```
+
 - Dump setting version
-    ```
-    cat /sys/module/max9295/parameters/max9295_setting_verison
-    cat /sys/module/max9296/parameters/max9296_setting_verison
-   ```
+
+```
+cat /sys/module/max9295/parameters/max9295_setting_verison
+cat /sys/module/max9296/parameters/max9296_setting_verison
+```
 
 - Disable updating setting dynamically (updating setting manually by running script).
   **0** means disable updating setting dynamically, while **1** means enable updating setting dynamically.
-    ```
-    echo 0 | sudo tee /sys/module/max9295/parameters/max9295_dynamic_update
-    echo 0 | sudo tee /sys/module/max9296/parameters/max9296_dynamic_update
-    ```
+
+```
+echo 0 | sudo tee /sys/module/max9295/parameters/max9295_dynamic_update
+echo 0 | sudo tee /sys/module/max9296/parameters/max9296_dynamic_update
+```
+
+- Refresh max9295/max9295 register values, this is used for forcely set serdes setting when necessary
+
+```
+echo 1 | sudo tee /sys/bus/i2c/drivers/max9295/30-0040/refresh_setting
+echo 1 | sudo tee /sys/bus/i2c/drivers/max9296/30-0048/refresh_setting
+```

--- a/kernel/nvidia/0057-Allow-refresh-serdes-configs-during-runtime.patch
+++ b/kernel/nvidia/0057-Allow-refresh-serdes-configs-during-runtime.patch
@@ -1,0 +1,518 @@
+From 10e153f2440324e145e51e3212687cd68b92e75f Mon Sep 17 00:00:00 2001
+From: Xin Zhang <xin.x.zhang@intel.com>
+Date: Tue, 17 May 2022 19:34:15 +0800
+Subject: [PATCH] Allow refresh serdes configs during runtime
+
+- Add 2 attrs to refresh max9295/max9296 configs anytime by user.
+- When switching formats of IR stream, do not refresh all the serdes
+  settings, so other streaming streams won't be interrupted. Only the
+  necessary addresses are set now.
+
+Signed-off-by: Xin Zhang <xin.x.zhang@intel.com>
+---
+ drivers/media/i2c/max9295.c                   | 128 ++++++++----------
+ drivers/media/i2c/max9296.c                   | 106 ++++++---------
+ .../media/platform/tegra/camera/vi/channel.c  |  14 +-
+ include/media/max9295.h                       |   3 +-
+ include/media/max9296.h                       |   3 +-
+ 5 files changed, 104 insertions(+), 150 deletions(-)
+
+diff --git a/drivers/media/i2c/max9295.c b/drivers/media/i2c/max9295.c
+index 1ddb0d3e6..a65f3d464 100644
+--- a/drivers/media/i2c/max9295.c
++++ b/drivers/media/i2c/max9295.c
+@@ -104,7 +104,6 @@ struct max9295_client_ctx {
+ };
+ 
+ enum ir_type {
+-	Y_NONE = 0,
+ 	Y8_Y8I,
+ 	Y12I,
+ };
+@@ -496,24 +495,22 @@ struct reg_pair {
+ };
+ 
+ static struct reg_pair map_cmu_regulator[] = {
+-	{0x0302, 0x10}, // lllIncrease CMU regulator voltage
++	{0x0302, 0x10}, // Increase CMU regulator voltage
+ };
+ 
+-static struct reg_pair map_pipe_y8_opt[] = {
++static struct reg_pair map_pipe_opt[] = {
+ 	{0x0002, 0xF3}, // # Enable all pipes
+ 
+ 	{0x0331, 0x11}, // Write 0x33 for 4 lanes
+ 	{0x0308, 0x6F}, // All pipes pull clock from port B
+ 	{0x0311, 0xF0}, // All pipes pull data from port B
++};
++
++static struct reg_pair map_pipe_y8_opt[] = {
+ 	{0x0312, 0x0F}, // Double 8-bit data on pipe X, Y, Z & U
+ };
+ 
+ static struct reg_pair map_pipe_y12i_opt[] = {
+-	{0x0002, 0xF3}, // # Enable all pipes
+-
+-	{0x0331, 0x11}, // Write 0x33 for 4 lanes
+-	{0x0308, 0x6F}, // All pipes pull clock from port B
+-	{0x0311, 0xF0}, // All pipes pull data from port B
+ 	{0x0312, 0x0B}, // Double 8-bit data on pipe X, Y & U
+ };
+ 
+@@ -550,10 +547,11 @@ static struct reg_pair map_pipe_z_y8_y8i_control[] = {
+ static struct reg_pair map_pipe_z_y12i_control[] = {
+ 	/* addr, val */
+ 	{0x0318, 0x64}, // Pipe Z pulls Y12I (DT 0x24)
++	{0x0319, 0x00}, // Reset to clean setting of Y8/Y8I configs
+ 	{0x030D, 0x04}, // Pipe Z pulls VC2
+ 	{0x030E, 0x00},
+-	/* Reset reg 0x031E since it's very likely to modified in Y8/Y8I
+-	 * before run Y12I. For Y12I, this reg not required to be set.
++	/* Reset reg 0x031E since it's very likely to be modified in Y8/Y8I
++	 * before running Y12I. For Y12I, this reg is not required to be set.
+ 	 */
+ 	{0x031E, 0x18},
+ 	{0x0112, 0x0E}, // LIM_HEART Pipe Z: Disabled
+@@ -616,6 +614,8 @@ static int max9295_init_settings(struct device *dev)
+ 	err = max9295_set_registers(dev, map_cmu_regulator,
+ 				    ARRAY_SIZE(map_cmu_regulator));
+ 	// Init control
++	err |= max9295_set_registers(dev, map_pipe_opt,
++				     ARRAY_SIZE(map_pipe_opt));
+ 	err |= max9295_set_registers(dev, map_pipe_y8_opt,
+ 				     ARRAY_SIZE(map_pipe_y8_opt));
+ 
+@@ -626,8 +626,13 @@ static int max9295_init_settings(struct device *dev)
+ 	err |= max9295_set_registers(dev, map_pipe_y_control,
+ 				     ARRAY_SIZE(map_pipe_y_control));
+ 	// Pipe Z
+-	err |= max9295_set_registers(dev, map_pipe_z_y8_y8i_control,
++	if (priv->ir_type_value == Y8_Y8I)
++		err |= max9295_set_registers(dev, map_pipe_z_y8_y8i_control,
+ 				     ARRAY_SIZE(map_pipe_z_y8_y8i_control));
++	else
++		err |= max9295_set_registers(dev, map_pipe_z_y12i_control,
++				     ARRAY_SIZE(map_pipe_z_y12i_control));
++
+ 	// Pipe U
+ 	err |= max9295_set_registers(dev, map_pipe_u_control,
+ 				     ARRAY_SIZE(map_pipe_u_control));
+@@ -642,16 +647,12 @@ static int max9295_init_settings(struct device *dev)
+ 	if (err == 0) {
+ 		dev_info(dev, "%s done\n", __func__);
+ 		init_done = true;
+-		priv->ir_type_value = Y8_Y8I;
+ 	}
+ 
+ 	return err;
+ }
+ 
+-#define Y8_DATA_TYPE 0x2A
+-#define Y8I_DATA_TYPE 0x1E
+-#define Y12I_DATA_TYPE 0X24
+-int max9295_update_pipe(struct device *dev, int sensor_type, int data_type)
++int max9295_update_pipe(struct device *dev, int sensor_type, u32 fourcc)
+ {
+ 	int err = 0;
+ 	struct max9295 *priv;
+@@ -660,78 +661,39 @@ int max9295_update_pipe(struct device *dev, int sensor_type, int data_type)
+ 		return 0;
+ 
+ 	if (!max9295_dynamic_update) {
+-		dev_info(dev, "%s, don't update dynamically", __func__);
++		dev_info(dev, "%s, don't update dynamically\n", __func__);
+ 		return 0;
+ 	}
+ 
+-	dev_info(dev, "%s st %d, dt %d \n", __func__, sensor_type, data_type);
++	dev_info(dev, "%s st %d, fourcc %u\n", __func__, sensor_type, fourcc);
+ 
+ 	if (!init_done) {
+-		dev_info(dev, "%s, SerDes device may not exist", __func__);
++		dev_info(dev, "%s, SerDes device may not exist\n", __func__);
+ 		return 0;
+ 	}
+ 
++	if (sensor_type != IR_SENSOR)
++		return 0;
++
+ 	priv = dev_get_drvdata(dev);
+-	if ((sensor_type == IR_SENSOR) && (priv->ir_type_value != Y8_Y8I) &&
+-	    (data_type == Y8_DATA_TYPE || data_type == Y8I_DATA_TYPE)) {
+-		// Set CMU
+-		err = max9295_set_registers(dev, map_cmu_regulator,
+-					    ARRAY_SIZE(map_cmu_regulator));
++	if ((priv->ir_type_value != Y8_Y8I) &&
++	    (fourcc == V4L2_PIX_FMT_GREY || fourcc == V4L2_PIX_FMT_Y8I)) {
+ 		// Init control
+-		err |= max9295_set_registers(dev, map_pipe_y8_opt,
+-					     ARRAY_SIZE(map_pipe_y8_opt));
+-
+-		// Pipe X
+-		err |= max9295_set_registers(dev, map_pipe_x_control,
+-					     ARRAY_SIZE(map_pipe_x_control));
+-		// Pipe Y
+-		err |= max9295_set_registers(dev, map_pipe_y_control,
+-					     ARRAY_SIZE(map_pipe_y_control));
++		err = max9295_set_registers(dev, map_pipe_y8_opt,
++					ARRAY_SIZE(map_pipe_y8_opt));
+ 		// Pipe Z
+ 		err |= max9295_set_registers(dev, map_pipe_z_y8_y8i_control,
+-					     ARRAY_SIZE(map_pipe_z_y8_y8i_control));
+-		// Pipe U
+-		err |= max9295_set_registers(dev, map_pipe_u_control,
+-					     ARRAY_SIZE(map_pipe_u_control));
+-
+-		// Trigger Depth
+-		err |= max9295_set_registers(dev, map_depth_trigger,
+-					     ARRAY_SIZE(map_depth_trigger));
+-		// Trigger RGB
+-		err |= max9295_set_registers(dev, map_rgb_trigger,
+-					     ARRAY_SIZE(map_rgb_trigger));
+-
++					ARRAY_SIZE(map_pipe_z_y8_y8i_control));
+ 		if (err == 0)
+ 			priv->ir_type_value = Y8_Y8I;
+-	} else if ((sensor_type == IR_SENSOR) && (priv->ir_type_value != Y12I) &&
+-	           (data_type == Y12I_DATA_TYPE)) {
+-		// Set CMU
+-		err = max9295_set_registers(dev, map_cmu_regulator,
+-					    ARRAY_SIZE(map_cmu_regulator));
++	} else if ((priv->ir_type_value != Y12I) &&
++		   (fourcc == V4L2_PIX_FMT_Y12I)) {
+ 		// Init control
+-		err |= max9295_set_registers(dev, map_pipe_y12i_opt,
+-					     ARRAY_SIZE(map_pipe_y12i_opt));
+-
+-		// Pipe X
+-		err |= max9295_set_registers(dev, map_pipe_x_control,
+-					     ARRAY_SIZE(map_pipe_x_control));
+-		// Pipe Y
+-		err |= max9295_set_registers(dev, map_pipe_y_control,
+-					     ARRAY_SIZE(map_pipe_y_control));
++		err = max9295_set_registers(dev, map_pipe_y12i_opt,
++					ARRAY_SIZE(map_pipe_y12i_opt));
+ 		// Pipe Z
+ 		err |= max9295_set_registers(dev, map_pipe_z_y12i_control,
+-					     ARRAY_SIZE(map_pipe_z_y12i_control));
+-		// Pipe U
+-		err |= max9295_set_registers(dev, map_pipe_u_control,
+-					     ARRAY_SIZE(map_pipe_u_control));
+-
+-		// Trigger Depth
+-		err |= max9295_set_registers(dev, map_depth_trigger,
+-					     ARRAY_SIZE(map_depth_trigger));
+-		// Trigger RGB
+-		err |= max9295_set_registers(dev, map_rgb_trigger,
+-					     ARRAY_SIZE(map_rgb_trigger));
+-
++					ARRAY_SIZE(map_pipe_z_y12i_control));
+ 		if (err == 0)
+ 			priv->ir_type_value = Y12I;
+ 	}
+@@ -794,6 +756,11 @@ static ssize_t max9295_dev_dump_show(struct device *dev,
+ 	count += data_size;
+ 	data_addr += data_size;
+ 
++	data_size = max9295_get_dump(dev, data_addr, map_pipe_opt,
++				     ARRAY_SIZE(map_pipe_opt));
++	count += data_size;
++	data_addr += data_size;
++
+ 	data_size = max9295_get_dump(dev, data_addr, map_pipe_y8_opt,
+ 				     ARRAY_SIZE(map_pipe_y8_opt));
+ 	count += data_size;
+@@ -837,8 +804,23 @@ static ssize_t max9295_dev_dump_show(struct device *dev,
+ 
+ static DEVICE_ATTR(register_dump, 0444, max9295_dev_dump_show, NULL);
+ 
++static ssize_t refresh_setting_store(struct device *dev,
++				     struct device_attribute *attr,
++				     const char *buf, size_t count)
++{
++	int ret;
++
++	ret = max9295_init_settings(dev);
++	if (ret)
++		return ret;
++
++	return count;
++}
++static DEVICE_ATTR_WO(refresh_setting);
++
+ static struct attribute *max9295_attributes[] = {
+ 	&dev_attr_register_dump.attr,
++	&dev_attr_refresh_setting.attr,
+ 	NULL
+ };
+ 
+@@ -887,12 +869,12 @@ static int max9295_probe(struct i2c_client *client,
+ 
+ 	dev_set_drvdata(&client->dev, priv);
+ 
+-	priv->ir_type_value = Y_NONE;
++	priv->ir_type_value = Y8_Y8I;
+ 
+ #ifdef CONFIG_SYSFS
+ 	err = sysfs_create_group(&client->dev.kobj, &max9295_attr_group);
+ 	if (err)
+-		dev_warn(&client->dev, "%s, failed to create sysfs, err %d",
++		dev_warn(&client->dev, "%s, failed to create sysfs, err %d\n",
+ 			 __func__, err);
+ #endif /* CONFIG_SYSFS */
+ 
+diff --git a/drivers/media/i2c/max9296.c b/drivers/media/i2c/max9296.c
+index adc26c732..87da4d7bd 100644
+--- a/drivers/media/i2c/max9296.c
++++ b/drivers/media/i2c/max9296.c
+@@ -105,7 +105,6 @@ struct pipe_ctx {
+ };
+ 
+ enum ir_type {
+-	Y_NONE = 0,
+ 	Y8_Y8I,
+ 	Y12I,
+ };
+@@ -876,6 +875,8 @@ static struct reg_pair map_pipe_z_y12i_control[] = {
+ 	{0x0490, 0x80},
+ 	{0x0491, 0x81}, // Map frame end  VC2
+ 	{0x0492, 0x81},
++	{0x0493, 0x00}, // Reset to unmap EMB8, VC2
++	{0x0494, 0x00},
+ 	{0x04AD, 0x15}, // Map to PHY1 (master for port A)
+ 
+ 	// SEQ_MISS_EN: Disabled / DIS_PKT_DET: Disabled
+@@ -951,8 +952,13 @@ static int max9296_init_settings(struct device *dev)
+ 	err |= max9296_set_registers(dev, map_pipe_y_control,
+ 				     ARRAY_SIZE(map_pipe_y_control));
+ 	// Pipe Z
+-	err |= max9296_set_registers(dev, map_pipe_z_y8_y8i_control,
++	if (priv->ir_type_value == Y8_Y8I)
++		err |= max9296_set_registers(dev, map_pipe_z_y8_y8i_control,
+ 				     ARRAY_SIZE(map_pipe_z_y8_y8i_control));
++	else
++		err |= max9296_set_registers(dev, map_pipe_z_y12i_control,
++				     ARRAY_SIZE(map_pipe_z_y12i_control));
++
+ 	// Pipe U
+ 	err |= max9296_set_registers(dev, map_pipe_u_control,
+ 				     ARRAY_SIZE(map_pipe_u_control));
+@@ -967,16 +973,12 @@ static int max9296_init_settings(struct device *dev)
+ 	if (err == 0) {
+ 		dev_info(dev, "%s done\n", __func__);
+ 		init_done = true;
+-		priv->ir_type_value = Y8_Y8I;
+ 	}
+ 
+ 	return err;
+ }
+ 
+-#define Y8_DATA_TYPE 0x2A
+-#define Y8I_DATA_TYPE 0x1E
+-#define Y12I_DATA_TYPE 0X24
+-int max9296_update_pipe(struct device *dev, int sensor_type, int data_type)
++int max9296_update_pipe(struct device *dev, int sensor_type, u32 fourcc)
+ {
+ 	int err = 0;
+ 	struct max9296 *priv;
+@@ -985,78 +987,33 @@ int max9296_update_pipe(struct device *dev, int sensor_type, int data_type)
+ 		return 0;
+ 
+ 	if (!max9296_dynamic_update) {
+-		dev_info(dev, "%s, don't update dynamically", __func__);
++		dev_info(dev, "%s, don't update dynamically\n", __func__);
+ 		return 0;
+ 	}
+ 
+-	dev_info(dev, "%s st %d, dt %d \n", __func__, sensor_type, data_type);
++	dev_info(dev, "%s st %d, fourcc %u\n", __func__, sensor_type, fourcc);
+ 
+ 	if (!init_done) {
+-		dev_info(dev, "%s, SerDes device may not exist", __func__);
++		dev_info(dev, "%s, SerDes device may not exist\n", __func__);
+ 		return 0;
+ 	}
+ 
++	if (sensor_type != IR_SENSOR)
++		return 0;
++
+ 	priv = dev_get_drvdata(dev);
+-	if ((sensor_type == IR_SENSOR) && (priv->ir_type_value != Y8_Y8I) &&
+-            (data_type == Y8_DATA_TYPE || data_type == Y8I_DATA_TYPE)) {
+-		// Set CMU
+-		err = max9296_set_registers(dev, map_cmu_regulator,
+-					    ARRAY_SIZE(map_cmu_regulator));
+-		// Init control
+-		err |= max9296_set_registers(dev, map_pipe_opt,
+-					     ARRAY_SIZE(map_pipe_opt));
+-
+-		// Pipe X
+-		err |= max9296_set_registers(dev, map_pipe_x_control,
+-					     ARRAY_SIZE(map_pipe_x_control));
+-		// Pipe Y
+-		err |= max9296_set_registers(dev, map_pipe_y_control,
+-					     ARRAY_SIZE(map_pipe_y_control));
++	if ((priv->ir_type_value != Y8_Y8I) &&
++	    (fourcc == V4L2_PIX_FMT_GREY || fourcc == V4L2_PIX_FMT_Y8I)) {
+ 		// Pipe Z
+-		err |= max9296_set_registers(dev, map_pipe_z_y8_y8i_control,
+-					     ARRAY_SIZE(map_pipe_z_y8_y8i_control));
+-		// Pipe U
+-		err |= max9296_set_registers(dev, map_pipe_u_control,
+-					     ARRAY_SIZE(map_pipe_u_control));
+-
+-		// Trigger Depth
+-		err |= max9296_set_registers(dev, map_depth_trigger,
+-					     ARRAY_SIZE(map_depth_trigger));
+-		// Trigger RGB
+-		err |= max9296_set_registers(dev, map_rgb_trigger,
+-					     ARRAY_SIZE(map_rgb_trigger));
+-
++		err = max9296_set_registers(dev, map_pipe_z_y8_y8i_control,
++					ARRAY_SIZE(map_pipe_z_y8_y8i_control));
+ 		if (err == 0)
+ 			priv->ir_type_value = Y8_Y8I;
+-	} else if ((sensor_type == IR_SENSOR) && (priv->ir_type_value != Y12I) &&
+-		   (data_type == Y12I_DATA_TYPE)) {
+-		// Set CMU
+-		err = max9296_set_registers(dev, map_cmu_regulator,
+-					    ARRAY_SIZE(map_cmu_regulator));
+-		// Init control
+-		err |= max9296_set_registers(dev, map_pipe_opt,
+-					     ARRAY_SIZE(map_pipe_opt));
+-
+-		// Pipe X
+-		err |= max9296_set_registers(dev, map_pipe_x_control,
+-					     ARRAY_SIZE(map_pipe_x_control));
+-		// Pipe Y
+-		err |= max9296_set_registers(dev, map_pipe_y_control,
+-					     ARRAY_SIZE(map_pipe_y_control));
++	} else if ((priv->ir_type_value != Y12I) &&
++		   (fourcc == V4L2_PIX_FMT_Y12I)) {
+ 		// Pipe Z
+-		err |= max9296_set_registers(dev, map_pipe_z_y12i_control,
+-					     ARRAY_SIZE(map_pipe_z_y12i_control));
+-		// Pipe U
+-		err |= max9296_set_registers(dev, map_pipe_u_control,
+-					     ARRAY_SIZE(map_pipe_u_control));
+-
+-		// Trigger Depth
+-		err |= max9296_set_registers(dev, map_depth_trigger,
+-					     ARRAY_SIZE(map_depth_trigger));
+-		// Trigger RGB
+-		err |= max9296_set_registers(dev, map_rgb_trigger,
+-					     ARRAY_SIZE(map_rgb_trigger));
+-
++		err = max9296_set_registers(dev, map_pipe_z_y12i_control,
++					ARRAY_SIZE(map_pipe_z_y12i_control));
+ 		if (err == 0)
+ 			priv->ir_type_value = Y12I;
+ 	}
+@@ -1162,8 +1119,23 @@ static ssize_t max9296_dev_dump_show(struct device *dev,
+ 
+ static DEVICE_ATTR(register_dump, 0444, max9296_dev_dump_show, NULL);
+ 
++static ssize_t refresh_setting_store(struct device *dev,
++				     struct device_attribute *attr,
++				     const char *buf, size_t count)
++{
++	int ret;
++
++	ret = max9296_init_settings(dev);
++	if (ret)
++		return ret;
++
++	return count;
++}
++static DEVICE_ATTR_WO(refresh_setting);
++
+ static struct attribute *max9296_attributes[] = {
+ 	&dev_attr_register_dump.attr,
++	&dev_attr_refresh_setting.attr,
+ 	NULL
+ };
+ 
+@@ -1288,7 +1260,7 @@ static int max9296_probe(struct i2c_client *client,
+ 
+ 	dev_set_drvdata(&client->dev, priv);
+ 
+-	priv->ir_type_value = Y_NONE;
++	priv->ir_type_value = Y8_Y8I;
+ 
+ #ifdef CONFIG_SYSFS
+ 	err = sysfs_create_group(&client->dev.kobj, &max9296_attr_group);
+diff --git a/drivers/media/platform/tegra/camera/vi/channel.c b/drivers/media/platform/tegra/camera/vi/channel.c
+index 2b42ff257..5ca7b39a2 100644
+--- a/drivers/media/platform/tegra/camera/vi/channel.c
++++ b/drivers/media/platform/tegra/camera/vi/channel.c
+@@ -1967,19 +1967,17 @@ __tegra_channel_set_format(struct tegra_channel *chan,
+ 
+ 	vfmt = tegra_core_get_format_by_fourcc(chan, pix->pixelformat);
+ 
+-	if (vi->dser_dev) {
+-		ret = max9296_update_pipe(vi->dser_dev, chan->id, vfmt->img_dt);
+-
+-		dev_info(vi->dser_dev, "%s, chan id %d, data_type %x\n",
++	if (vi->ser_dev) {
++		ret = max9295_update_pipe(vi->ser_dev, chan->id, vfmt->fourcc);
++		dev_info(vi->ser_dev, "%s, chan id %d, data_type %x\n",
+ 			 __func__, chan->id, vfmt->img_dt);
+ 		if (ret < 0)
+ 			return ret;
+ 	}
+ 
+-	if (vi->ser_dev) {
+-		ret = max9295_update_pipe(vi->ser_dev, chan->id, vfmt->img_dt);
+-
+-		dev_info(vi->ser_dev, "%s, chan id %d, data_type %x\n",
++	if (vi->dser_dev) {
++		ret = max9296_update_pipe(vi->dser_dev, chan->id, vfmt->fourcc);
++		dev_info(vi->dser_dev, "%s, chan id %d, data_type %x\n",
+ 			 __func__, chan->id, vfmt->img_dt);
+ 		if (ret < 0)
+ 			return ret;
+diff --git a/include/media/max9295.h b/include/media/max9295.h
+index 1d15a5457..d25f43fc0 100644
+--- a/include/media/max9295.h
++++ b/include/media/max9295.h
+@@ -25,6 +25,7 @@
+ #ifndef __MAX9295_H__
+ #define __MAX9295_H__
+ 
++#include <linux/types.h>
+ #include <media/gmsl-link.h>
+ /**
+  * \defgroup max9295 MAX9295 serializer driver
+@@ -35,7 +36,7 @@
+  * @{
+  */
+ 
+-int max9295_update_pipe(struct device *dev, int sensor_type, int data_type);
++int max9295_update_pipe(struct device *dev, int sensor_type, u32 fourcc);
+ 
+ /**
+  * @brief  Powers on a serializer device and performs the I2C overrides
+diff --git a/include/media/max9296.h b/include/media/max9296.h
+index e05780ec9..69ada8a5e 100644
+--- a/include/media/max9296.h
++++ b/include/media/max9296.h
+@@ -25,6 +25,7 @@
+ #ifndef __MAX9296_H__
+ #define __MAX9296_H__
+ 
++#include <linux/types.h>
+ #include <media/gmsl-link.h>
+ /**
+  * \defgroup max9296 MAX9296 deserializer driver
+@@ -35,7 +36,7 @@
+  * @{
+  */
+ 
+-int max9296_update_pipe(struct device *dev, int sensor_type, int data_type);
++int max9296_update_pipe(struct device *dev, int sensor_type, u32 fourcc);
+ 
+ /**
+  * Puts a deserializer device in single exclusive link mode, so link-specific
+-- 
+2.17.1
+


### PR DESCRIPTION
- Add 2 attrs to refresh max9295/max9296 configs anytime by user.
- When switching formats of IR stream, do not refresh all the serdes
  settings, so other streaming streams won't be interrupted. Only the
  necessary addresses are set now.

Test steps for using the new attributes:

1. Boot the board and use D457 as usual;
2. Power off the max9296 board then power on, to lose all settings of max9295/9296;
3. Run commands below.
```
echo 1 | sudo tee /sys/bus/i2c/drivers/max9295/30-0040/refresh_setting
echo 1 | sudo tee /sys/bus/i2c/drivers/max9296/30-0048/refresh_setting
```
4. Start streams of D457 as usual, still works. IR stream format will still be the last used one, matching the v4l2 node format.

And when switching formats of IR stream, the serdes settings being changed are reduced to only the necessary ones. So now if another stream is streaming, it won't be interrupted (on current master, the streaming could be seen stopped for 1 or 2 seconds then go on again), with the new changes the other stream won't be affected.