### PR TITLE
Rectify Metadata size in the NVCSI driver and its internal allocation…

### DIFF
--- a/build_all.sh
+++ b/build_all.sh
@@ -12,4 +12,4 @@ export KERNEL_MODULES_OUT=$TEGRA_KERNEL_OUT/modules
 cd $DEVDIR/../kernel/kernel-4.9
 make ARCH=arm64 O=$TEGRA_KERNEL_OUT tegra_defconfig
 make ARCH=arm64 O=$TEGRA_KERNEL_OUT -j`nproc`
-make ARCH=arm64 O=$TEGRA_KERNEL_OUT modules_install INSTALL_MOD_PATH=$KERNEL_MODULES_OUT
+make ARCH=arm64 O=$TEGRA_KERNEL_OUT modules_install INSTALL_MOD_PATH=$KERNEL_MODULES_OUT -j`nproc`

--- a/kernel/nvidia/0057-rectify-embedded-metadata-buffer-size-to-255-to-real.patch
+++ b/kernel/nvidia/0057-rectify-embedded-metadata-buffer-size-to-255-to-real.patch
@@ -1,0 +1,91 @@
+From 239637e0f35ca35cd1910bd58a99dab9980a2863 Mon Sep 17 00:00:00 2001
+From: Evgeni Raikhel <evgeni.raikhel@intel.com>
+Date: Wed, 18 May 2022 13:20:21 +0300
+Subject: [PATCH] rectify embedded  metadata buffer size to 255 to realign with
+ UVC spec
+
+---
+ drivers/media/i2c/d4xx.c                          | 3 ++-
+ drivers/media/platform/tegra/camera/vi/channel.c  | 8 ++++----
+ drivers/media/platform/tegra/camera/vi/vi5_fops.c | 6 +++---
+ 3 files changed, 9 insertions(+), 8 deletions(-)
+
+diff --git a/drivers/media/i2c/d4xx.c b/drivers/media/i2c/d4xx.c
+index f256756d2..1a26ee97a 100644
+--- a/drivers/media/i2c/d4xx.c
++++ b/drivers/media/i2c/d4xx.c
+@@ -3504,6 +3504,7 @@ MODULE_AUTHOR( "Guennadi Liakhovetski <guennadi.liakhovetski@intel.com>,\n\
+ 				Emil Jahshan <emil.jahshan@intel.com>,\n\
+ 				Xin Zhang <xin.x.zhang@intel.com>,\n\
+ 				Qingwu Zhang <qingwu.zhang@intel.com>,\n\
++				Evgeni Raikhel <evgeni.raikhel@intel.com>,\n\
+ 				Shikun Ding <shikun.ding@intel.com>");
+ MODULE_LICENSE("GPL v2");
+-MODULE_VERSION("1.0.1.8");
++MODULE_VERSION("1.0.1.9");
+diff --git a/drivers/media/platform/tegra/camera/vi/channel.c b/drivers/media/platform/tegra/camera/vi/channel.c
+index 2b42ff257..b5bf8c7b0 100644
+--- a/drivers/media/platform/tegra/camera/vi/channel.c
++++ b/drivers/media/platform/tegra/camera/vi/channel.c
+@@ -2423,7 +2423,7 @@ static int tegra_metadata_get_format(struct file *file, void *fh,
+ 	memset(fmt, 0, sizeof(*fmt));
+ 
+ 	fmt->dataformat = V4L2_META_FMT_D4XX_CSI2;
+-	fmt->buffersize = 256;
++	fmt->buffersize = 255;
+ 
+ 	return 0;
+ }
+@@ -2466,14 +2466,14 @@ static int tegra_metadata_queue_setup(struct vb2_queue *vq,
+ 		if (*nplanes != 1)
+ 			return -EINVAL;
+ 
+-		if (sizes[0] < 256)
++		if (sizes[0] < 255)
+ 			return -EINVAL;
+ 
+ 		return 0;
+ 	}
+ 
+ 	*nplanes = 1;
+-	sizes[0] = 256;
++	sizes[0] = 255;
+ 	alloc_devs[0] = chan->vi->dev;
+ 
+ 
+@@ -2485,7 +2485,7 @@ static int tegra_metadata_buffer_prepare(struct vb2_buffer *vb)
+ 	if (vb->num_planes != 1)
+ 		return -EINVAL;
+ 
+-	if (vb2_plane_size(vb, 0) < 256)
++	if (vb2_plane_size(vb, 0) < 255)
+ 		return -EINVAL;
+ 
+ 	return 0;
+diff --git a/drivers/media/platform/tegra/camera/vi/vi5_fops.c b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
+index 0e2fe065b..9d043a9c8 100644
+--- a/drivers/media/platform/tegra/camera/vi/vi5_fops.c
++++ b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
+@@ -353,7 +353,7 @@ static void vi5_release_buffer(struct tegra_channel *chan,
+ 		if(evb) {
+ 			frm_buffer = vb2_plane_vaddr(evb, 0);
+ 			if(frm_buffer != NULL) {
+-				memcpy(frm_buffer,chan->vi->emb_buf_addr[chan->id], 256);
++				memcpy(frm_buffer,chan->vi->emb_buf_addr[chan->id], 255);
+ 			}
+ 		}
+ 	}
+@@ -362,8 +362,8 @@ static void vi5_release_buffer(struct tegra_channel *chan,
+ 	if (chan->embedded.height == 1 && evb) {
+ 		evbuf = to_vb2_v4l2_buffer(evb);
+ 		evbuf->sequence = vbuf->sequence;
+-		/*FIXME: define 236*/
+-		vb2_set_plane_payload(evb, 0, 236);
++		/*FIXME: define 236 68 bytes metadata*/
++		vb2_set_plane_payload(evb, 0, 68);
+ 		evb->timestamp = vbuf->vb2_buf.timestamp;
+ 		vb2_buffer_done(evb, VB2_BUF_STATE_DONE);
+ 	}
+-- 
+2.17.1
+


### PR DESCRIPTION
The internal buffer max size is set to be 255 instead of 256 bytes. The insonsistency was producing segfault when using mmap files to enquie/dequeu kernel buffers.
The actual size temporally aligned to 68 bytes as required by MIPI metadata.
Bumping the version to 1.0.1.9.
Tracked on : DSO-18197