### PR TITLE
Change write only controls to be volatile

### DIFF
--- a/kernel/nvidia/0061-Change-write-only-controls-to-be-volatile.patch
+++ b/kernel/nvidia/0061-Change-write-only-controls-to-be-volatile.patch
@@ -1,0 +1,328 @@
+From c82bff4377d6a70fe03ca0b10e17fe6c38eba5e6 Mon Sep 17 00:00:00 2001
+From: Dmitry Perchanov <dmitry.perchanov@intel.com>
+Date: Wed, 1 Jun 2022 12:09:01 +0300
+Subject: [PATCH] Change write only controls to be volatile and not cached Add
+ sysfs attributes to read/write raw registers Change exposure default width
+ and settings
+
+---
+ drivers/media/i2c/d4xx.c | 211 +++++++++++++++++++++++++++++++++++++--
+ 1 file changed, 204 insertions(+), 7 deletions(-)
+
+diff --git a/drivers/media/i2c/d4xx.c b/drivers/media/i2c/d4xx.c
+index 1a26ee9..cf7c1e8 100644
+--- a/drivers/media/i2c/d4xx.c
++++ b/drivers/media/i2c/d4xx.c
+@@ -123,9 +123,9 @@
+ 
+ #define MIPI_LANE_RATE			1000
+ 
+-#define MAX_DEPTH_EXP			2000
++#define MAX_DEPTH_EXP			200000
+ #define MAX_RGB_EXP			10000
+-#define DEF_DEPTH_EXP			330
++#define DEF_DEPTH_EXP			33000
+ #define DEF_RGB_EXP			1660
+ 
+ /* Currently both depth and IR use VC 0 */
+@@ -1267,8 +1267,6 @@ static int ds5_hw_set_exposure(struct ds5 *state, u32 base, s32 val)
+ 	 *	Color: 1 is 100 us
+ 	 *	Depth: 1 is 1 us
+ 	 */
+-	if (!state->is_rgb)
+-		val *= 100;
+ 
+ 	ret = ds5_write(state, base | DS5_MANUAL_EXPOSURE_MSB, (u16)(val >> 16));
+ 	if (!ret)
+@@ -1639,8 +1637,59 @@ static int ds5_g_volatile_ctrl(struct v4l2_ctrl *ctrl)
+ 	unsigned int i;
+ 	u32 data;
+ 	int ret = 0;
++	u16 base = (state->is_rgb) ? DS5_RGB_CONTROL_BASE : DS5_DEPTH_CONTROL_BASE;
++	u16 reg;
++
++	dev_dbg(&state->client->dev, "%s(): ctrl: %s \n",
++		__func__, ctrl->name);
+ 
+ 	switch (ctrl->id) {
++
++	case V4L2_CID_ANALOGUE_GAIN:
++		if (state->is_imu)
++			return -EINVAL;
++		ret = ds5_read(state, base | DS5_MANUAL_GAIN, ctrl->p_new.p_u16);
++		break;
++
++	case V4L2_CID_EXPOSURE_AUTO:
++		if (state->is_imu)
++			return -EINVAL;
++		ds5_read(state, base | DS5_AUTO_EXPOSURE_MODE, &reg);
++		*ctrl->p_new.p_u16 = reg;
++		/* see ds5_hw_set_auto_exposure */
++		if (!state->is_rgb) {
++			if (reg == 1)
++				*ctrl->p_new.p_u16 = V4L2_EXPOSURE_APERTURE_PRIORITY;
++			else if (reg == 0)
++				*ctrl->p_new.p_u16 = V4L2_EXPOSURE_MANUAL;
++		}
++
++		if (state->is_rgb && reg == 8)
++			*ctrl->p_new.p_u16 = V4L2_EXPOSURE_APERTURE_PRIORITY;
++
++		break;
++
++	case V4L2_CID_EXPOSURE_ABSOLUTE:
++		if (state->is_imu)
++			return -EINVAL;
++		/* see ds5_hw_set_exposure */
++		ds5_read(state, base | DS5_MANUAL_EXPOSURE_MSB, &reg);
++		data = ((u32)reg << 16) & 0xffff0000;
++		ds5_read(state, base | DS5_MANUAL_EXPOSURE_LSB, &reg);
++		data |= reg;
++		*ctrl->p_new.p_u32 = data;
++		break;
++
++	case DS5_CAMERA_CID_LASER_POWER:
++		if (!state->is_rgb)
++			ds5_read(state, base | DS5_LASER_POWER, ctrl->p_new.p_u16);
++		break;
++
++	case DS5_CAMERA_CID_MANUAL_LASER_POWER:
++		if (!state->is_rgb)
++			ds5_read(state, base | DS5_MANUAL_LASER_POWER, ctrl->p_new.p_u16);
++		break;
++
+ 	case DS5_CAMERA_CID_LOG:
+ 		// TODO: wrap HWMonitor command
+ 		//       1. prepare and send command
+@@ -1692,6 +1741,8 @@ static int ds5_g_volatile_ctrl(struct v4l2_ctrl *ctrl)
+ 		ret = ds5_get_calibration_data(state, COEF_CALIBRATION_ID,ctrl->p_new.p_u8, 512);
+ 		break;
+ 	case DS5_CAMERA_CID_FW_VERSION:
++		ret = ds5_read(state, DS5_FW_VERSION, &state->fw_version);
++		ret = ds5_read(state, DS5_FW_BUILD, &state->fw_build);
+ 		*ctrl->p_new.p_u32 = state->fw_version << 16;
+ 		*ctrl->p_new.p_u32 |= state->fw_build;
+ 		break;
+@@ -1751,6 +1802,7 @@ static const struct v4l2_ctrl_config ds5_ctrl_laser_power = {
+ 	.max = 1,
+ 	.step = 1,
+ 	.def = 1,
++	.flags = V4L2_CTRL_FLAG_VOLATILE | V4L2_CTRL_FLAG_EXECUTE_ON_WRITE,
+ };
+ 
+ static const struct v4l2_ctrl_config ds5_ctrl_manual_laser_power = {
+@@ -1762,6 +1814,7 @@ static const struct v4l2_ctrl_config ds5_ctrl_manual_laser_power = {
+ 	.max = 360,
+ 	.step = 30,
+ 	.def = 150,
++	.flags = V4L2_CTRL_FLAG_VOLATILE | V4L2_CTRL_FLAG_EXECUTE_ON_WRITE,
+ };
+ 
+ static const struct v4l2_ctrl_config ds5_ctrl_fw_version = {
+@@ -1985,6 +2038,10 @@ static int ds5_ctrl_init(struct ds5 *state)
+ 						0, 128, 1, 64);
+ 	}
+ 
++	if (ctrls->gain)
++		ctrls->gain->flags =
++				V4L2_CTRL_FLAG_VOLATILE | V4L2_CTRL_FLAG_EXECUTE_ON_WRITE;
++
+ 	ctrls->auto_exp = v4l2_ctrl_new_std_menu(hdl, ops,
+ 				V4L2_CID_EXPOSURE_AUTO,
+ 				V4L2_EXPOSURE_APERTURE_PRIORITY,
+@@ -1992,7 +2049,11 @@ static int ds5_ctrl_init(struct ds5 *state)
+ 				  (1 << V4L2_EXPOSURE_APERTURE_PRIORITY)),
+ 				V4L2_EXPOSURE_APERTURE_PRIORITY);
+ 
+-	/* Exposure time: V4L2_CID_EXPOSURE_ABSOLUTE unit: 100 us. */
++	if (ctrls->auto_exp)
++		ctrls->auto_exp->flags |=
++				V4L2_CTRL_FLAG_VOLATILE | V4L2_CTRL_FLAG_EXECUTE_ON_WRITE;
++
++	/* Exposure time: V4L2_CID_EXPOSURE_ABSOLUTE default unit: 100 us. */
+ 	if (state->is_depth || state->is_y8) {
+ 		ctrls->exposure = v4l2_ctrl_new_std(hdl, ops,
+ 					V4L2_CID_EXPOSURE_ABSOLUTE,
+@@ -2003,6 +2064,13 @@ static int ds5_ctrl_init(struct ds5 *state)
+ 					1, MAX_RGB_EXP, 1, DEF_RGB_EXP);
+ 	}
+ 
++	if (ctrls->exposure) {
++		ctrls->exposure->flags |=
++				V4L2_CTRL_FLAG_VOLATILE | V4L2_CTRL_FLAG_EXECUTE_ON_WRITE;
++		/* override default int type to u32 to match SKU & UVC */
++		ctrls->exposure->type = V4L2_CTRL_TYPE_U32;
++	}
++
+ 	if (hdl->error) {
+ 		v4l2_err(sd, "error creating controls (%d)\n", hdl->error);
+ 		ret = hdl->error;
+@@ -3366,6 +3434,129 @@ static int ds5_chrdev_remove(struct ds5 *state)
+ 	return 0;
+ }
+ 
++/* SYSFS attributes */
++
++static ssize_t ds5_fw_ver_show(struct device *dev,
++		struct device_attribute *attr, char *buf)
++{
++	struct i2c_client *c = to_i2c_client(dev);
++	struct ds5 *state = container_of(i2c_get_clientdata(c),
++			struct ds5, mux.sd.subdev);
++
++	const char *sensor_name[] = {"unknown", "RGB", "DEPTH", "Y8", "IMU"};
++	int sensor_id = state->is_rgb * 1 + state->is_depth * 2 + \
++			state->is_y8 * 3 + state->is_imu * 4;
++
++	ds5_read(state, DS5_FW_VERSION, &state->fw_version);
++	ds5_read(state, DS5_FW_BUILD, &state->fw_build);
++
++	return sprintf(buf, "D4XX Sensor: %s, Version: %d.%d.%d.%d\n",
++			sensor_name[sensor_id],
++			(state->fw_version >> 8) & 0xff, state->fw_version & 0xff,
++			(state->fw_build >> 8) & 0xff, state->fw_build & 0xff);
++}
++
++static DEVICE_ATTR_RO(ds5_fw_ver);
++
++/* Derive 'device_attribute' structure for a read register's attribute */
++struct dev_ds5_reg_attribute {
++	struct device_attribute attr;
++	u16 reg;	// register
++	u8  valid;	// validity of above data
++};
++
++/** Read DS5 register.
++ * ds5_read_reg_show will actually read register from ds5 while
++ * ds5_read_reg_store will store register to read
++ * Example:
++ * echo -n "0xc03c" >ds5_read_reg
++ * Read register result:
++ * cat ds5_read_reg
++ * Expected:
++ * reg:0xc93c, result:0x11
++ */
++static ssize_t ds5_read_reg_show(struct device *dev,
++		struct device_attribute *attr, char *buf)
++{
++	u16 rbuf;
++	int n;
++	struct i2c_client *c = to_i2c_client(dev);
++	struct ds5 *state = container_of(i2c_get_clientdata(c),
++			struct ds5, mux.sd.subdev);
++	struct dev_ds5_reg_attribute *ds5_rw_attr = container_of(attr,
++			struct dev_ds5_reg_attribute, attr);
++	if (ds5_rw_attr->valid != 1)
++		return -EINVAL;
++	ds5_read(state, ds5_rw_attr->reg, &rbuf);
++
++	n = sprintf(buf, "register:0x%4x, value:0x%02x\n", ds5_rw_attr->reg, rbuf);
++
++	return n;
++}
++
++/** Read DS5 register - Store  reg to attr struct pointer
++ * ds5_read_reg_show will actually read register from ds5 while
++ * ds5_read_reg_store will store module, offset and length
++ */
++static ssize_t ds5_read_reg_store(struct device *dev,
++		struct device_attribute *attr, const char *buf, size_t count)
++{
++	struct dev_ds5_reg_attribute *ds5_rw_attr = container_of(attr,
++			struct dev_ds5_reg_attribute, attr);
++	int rc = -1;
++	u32 reg;
++	ds5_rw_attr->valid = 0;
++	/* Decode input */
++	rc = sscanf(buf, "0x%04x", &reg);
++	if (rc != 1)
++		return -EINVAL;
++	ds5_rw_attr->reg = reg;
++	ds5_rw_attr->valid = 1;
++	return count;
++}
++
++#define DS5_RW_REG_ATTR(_name) \
++		struct dev_ds5_reg_attribute dev_attr_##_name = { \
++				__ATTR(_name,  S_IRUGO | S_IWUSR, \
++						ds5_read_reg_show, ds5_read_reg_store), \
++						0, 0 }
++
++static DS5_RW_REG_ATTR(ds5_read_reg);
++
++static ssize_t ds5_write_reg_store(struct device *dev,
++		struct device_attribute *attr, const char *buf, size_t count)
++{
++	struct i2c_client *c = to_i2c_client(dev);
++	struct ds5 *state = container_of(i2c_get_clientdata(c),
++			struct ds5, mux.sd.subdev);
++
++	int rc = -1;
++	u32 reg, w_val = 0;
++	u16 val = -1;
++	/* Decode input */
++	rc = sscanf(buf, "0x%04x 0x%04x", &reg, &w_val);
++	if (rc != 2)
++		return -EINVAL;
++	val = w_val & 0xffff;
++	mutex_lock(&state->lock);
++	ds5_write(state, reg, val);
++	mutex_unlock(&state->lock);
++	return count;
++}
++
++static DEVICE_ATTR_WO(ds5_write_reg);
++
++static struct attribute *ds5_attributes[] = {
++		&dev_attr_ds5_fw_ver.attr,
++		&dev_attr_ds5_read_reg.attr.attr,
++		&dev_attr_ds5_write_reg.attr,
++		NULL
++};
++
++static const struct attribute_group ds5_attr_group = {
++	.attrs = ds5_attributes,
++};
++
+ static int ds5_probe(struct i2c_client *c, const struct i2c_device_id *id)
+ {
+ 	struct ds5 *state = devm_kzalloc(&c->dev, sizeof(*state), GFP_KERNEL);
+@@ -3442,7 +3633,7 @@ static int ds5_probe(struct i2c_client *c, const struct i2c_device_id *id)
+ 	ret = ds5_v4l_init(c, state);
+ 	if (ret < 0)
+ 		goto e_chardev;
+-	/* Override I2C drvdata */
++	/* DONOT!! Override I2C drvdata */
+ //	i2c_set_clientdata(c, state);
+ 
+ /*	regulators? clocks?
+@@ -3453,6 +3644,10 @@ static int ds5_probe(struct i2c_client *c, const struct i2c_device_id *id)
+ 		goto err;
+ 	}
+ */
++	/* Custom sysfs attributes */
++	/* create the sysfs file group */
++	err = sysfs_create_group(&state->client->dev.kobj, &ds5_attr_group);
++
+ 	return 0;
+ 
+ e_chardev:
+@@ -3471,6 +3666,7 @@ static int ds5_remove(struct i2c_client *c)
+ 	if (state->vcc)
+ 		regulator_disable(state->vcc);
+ //	gpio_free(state->pwdn_gpio);
++	sysfs_remove_group(&c->dev.kobj, &ds5_attr_group);
+ 	ds5_chrdev_remove(state);
+ 	if (state->dfu_dev.dfu_state_flag != DS5_DFU_RECOVERY)
+ 		ds5_mux_remove(state);
+@@ -3506,5 +3702,6 @@ MODULE_AUTHOR( "Guennadi Liakhovetski <guennadi.liakhovetski@intel.com>,\n\
+ 				Qingwu Zhang <qingwu.zhang@intel.com>,\n\
+ 				Evgeni Raikhel <evgeni.raikhel@intel.com>,\n\
+ 				Shikun Ding <shikun.ding@intel.com>");
++MODULE_AUTHOR("Dmitry Perchanov <dmitry.perchanov@intel.com>");
+ MODULE_LICENSE("GPL v2");
+-MODULE_VERSION("1.0.1.9");
++MODULE_VERSION("1.0.1.10");
+-- 
+2.17.1
+


### PR DESCRIPTION
Add sysfs attributes to read/write raw registers
Change exposure default width and settings for IR/Depth

This commit addressing following tickets:
 - DSO-18275
	https://rsjira.intel.com/browse/DSO-18275
	[D457][HW RESET] options don't return to default value after performing HW RESET

 - DSO-18293
	https://rsjira.intel.com/browse/DSO-18293
	[D457][LRS] Depth/IR Exposure steps are different than other SKUs, 1-2000 instead of 1-200,000

 - DSO-18180
	https://rsjira.intel.com/browse/DSO-18180
	[D457] After upgrading the camera FW, using DFU, the FW version remains the same, until restarting the host

Signed-off-by: Dmitry Perchanov <dmitry.perchanov@intel.com>