### PR TITLE
DSO-18310: d4xx: stderr is stall on printk

### DIFF
--- a/kernel/nvidia/0062-DSO-18310-d4xx-stderr-stall-on-printk.patch
+++ b/kernel/nvidia/0062-DSO-18310-d4xx-stderr-stall-on-printk.patch
@@ -1,0 +1,76 @@
+From 1ae2536788a3a506a58f3459a37aec494fd34caa Mon Sep 17 00:00:00 2001
+From: Dmitry Perchanov <dmitry.perchanov@intel.com>
+Date: Mon, 13 Jun 2022 13:07:44 +0300
+Subject: [PATCH] d4xx: stderr is unbuffered causing stall on printk
+
+---
+ drivers/media/i2c/d4xx.c | 14 +++++++-------
+ 1 file changed, 7 insertions(+), 7 deletions(-)
+
+diff --git a/drivers/media/i2c/d4xx.c b/drivers/media/i2c/d4xx.c
+index cf7c1e8..72de809 100644
+--- a/drivers/media/i2c/d4xx.c
++++ b/drivers/media/i2c/d4xx.c
+@@ -1334,7 +1334,7 @@ static int ds5_send_hwmc(struct ds5 *state, u16 cmdLen, struct hwm_cmd *cmd,
+ 				return -EAGAIN;
+ 		}
+ 
+-		dev_err(&state->client->dev, "%s(): HWMC read len: %d\n",
++		dev_info(&state->client->dev, "%s(): HWMC read len: %d\n",
+ 					__func__, *dataLen);
+ 		// First 4 bytes of cmd->Data after read will include opcode
+ 		ds5_raw_read_with_check(state, 0x4900, cmd->Data, *dataLen);
+@@ -1455,7 +1455,7 @@ static int ds5_s_ctrl(struct v4l2_ctrl *ctrl)
+ 	case DS5_CAMERA_CID_AE_SETPOINT_SET: {
+ 		struct hwm_cmd *ae_setpoint_cmd;
+ 		if (ctrl->p_new.p_s32) {
+-			dev_err(&state->client->dev, "%s():0x%x \n", __func__,
++			dev_info(&state->client->dev, "%s():0x%x \n", __func__,
+ 					*(ctrl->p_new.p_s32));
+ 			ae_setpoint_cmd = devm_kzalloc(&state->client->dev, sizeof(struct hwm_cmd) + 4, GFP_KERNEL);
+ 			memcpy(ae_setpoint_cmd, &set_ae_setpoint, sizeof (set_ae_setpoint));
+@@ -1476,7 +1476,7 @@ static int ds5_s_ctrl(struct v4l2_ctrl *ctrl)
+ 			size = *(ctrl->p_new.p_u8 + 2) << 8;
+ 			size |= *(ctrl->p_new.p_u8 + 3);
+ 
+-			dev_err(&state->client->dev, "%s(): offset %x, size: %x\n",
++			dev_info(&state->client->dev, "%s(): offset %x, size: %x\n",
+ 							__func__, offset, size);
+ 
+ 
+@@ -1518,7 +1518,7 @@ static int ds5_s_ctrl(struct v4l2_ctrl *ctrl)
+ 			size = *((u8*)ctrl->p_new.p_u8 + 2) << 8;
+ 			size |= *((u8*)ctrl->p_new.p_u8 + 3);
+ 
+-			dev_err(&state->client->dev, "%s():0x%x 0x%x 0x%x 0x%x\n", __func__,
++			dev_info(&state->client->dev, "%s():0x%x 0x%x 0x%x 0x%x\n", __func__,
+ 					*((u8*)ctrl->p_new.p_u8),
+ 					*((u8*)ctrl->p_new.p_u8 + 1),
+ 					*((u8*)ctrl->p_new.p_u8 + 2),
+@@ -1549,7 +1549,7 @@ static int ds5_s_ctrl(struct v4l2_ctrl *ctrl)
+ 
+ 			size = *((u8*)ctrl->p_new.p_u8 + 1) << 8;
+ 			size |= *((u8*)ctrl->p_new.p_u8 + 0);
+-			dev_err(&state->client->dev, "%s(): HWMC size %d\n", __func__, size);
++			dev_info(&state->client->dev, "%s(): HWMC size %d\n", __func__, size);
+ 			ret = ds5_send_hwmc(state, size + 4, (struct hwm_cmd *)ctrl->p_new.p_u8, true, &dataLen);
+ 		}
+ 		break;
+@@ -2340,7 +2340,7 @@ static int ds5_mux_enum_frame_interval(struct v4l2_subdev *sd,
+ 
+ 	tmp.pad = 0;
+ 
+-	dev_err(state->depth.sensor.sd.dev, "%s(): pad %d code %x width %d height %d\n", __func__,
++	dev_info(state->depth.sensor.sd.dev, "%s(): pad %d code %x width %d height %d\n", __func__,
+ 				pad, tmp.code, tmp.width, tmp.height);
+ 
+ 	if (state->is_depth)
+@@ -3704,4 +3704,4 @@ MODULE_AUTHOR( "Guennadi Liakhovetski <guennadi.liakhovetski@intel.com>,\n\
+ 				Shikun Ding <shikun.ding@intel.com>");
+ MODULE_AUTHOR("Dmitry Perchanov <dmitry.perchanov@intel.com>");
+ MODULE_LICENSE("GPL v2");
+-MODULE_VERSION("1.0.1.10");
++MODULE_VERSION("1.0.1.11");
+-- 
+2.17.1
+


### PR DESCRIPTION
Change dev_err with dev_info where no error cause as
stderr is unbuffered causing stall on printk
The printk results in I2C call taking 8000usec to run vs 40usec when the printk is replaced with info-level log

- [x] Bump d4xx version to 1.0.1.11

This commit addressing following ticket:

- 	DSO-18310
	https://rsjira.intel.com/browse/DSO-18310
	[D457][LRS][Pipe] First frame delay When streaming Pipe is always 3-6 seconds

Signed-off-by: Dmitry Perchanov dmitry.perchanov@intel.com