### PR TITLE
DSO-18280 - possible regression solution

### DIFF
--- a/kernel/nvidia/0063-DSO-18280-possible-solution.patch
+++ b/kernel/nvidia/0063-DSO-18280-possible-solution.patch
@@ -1,0 +1,51 @@
+From 5e57607cf3ddd8ba555e4e2038155c6e4598fac5 Mon Sep 17 00:00:00 2001
+From: Dmitry Perchanov <dmitry.perchanov@intel.com>
+Date: Wed, 15 Jun 2022 14:03:55 +0300
+Subject: [PATCH] get back PR83 sleep WA to prevent regression - add delay
+ before start streaming - add delay before stop streaming - notify fw by
+ sending stop stream op in case of error
+
+Signed-off-by: Dmitry Perchanov <dmitry.perchanov@intel.com>
+---
+ drivers/media/i2c/d4xx.c | 11 +++++++++++
+ 1 file changed, 11 insertions(+)
+
+diff --git a/drivers/media/i2c/d4xx.c b/drivers/media/i2c/d4xx.c
+index 72de809..bbcda89 100644
+--- a/drivers/media/i2c/d4xx.c
++++ b/drivers/media/i2c/d4xx.c
+@@ -2606,6 +2606,10 @@ static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on)
+ 		ret = ds5_configure(state);
+ 		if (ret)
+ 			goto restore_s_state;
++		/* TODO
++		 * WA to prevent simultaneous multi-stream starting failure sometimes.
++		 * This should be replaced by a proper fix in cam fw later. */
++		msleep_range(100 + 10 * stream_id);
+ 
+ 		ret = ds5_write(state, DS5_START_STOP_STREAM,
+ 				DS5_STREAM_START | stream_id);
+@@ -2626,6 +2630,9 @@ static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on)
+ 		if (DS5_START_MAX_COUNT == i) {
+ 			dev_err(&state->client->dev,
+ 				"start streaming failed, exit on timeout\n");
++			/* notify fw */
++			ret = ds5_write(state, DS5_START_STOP_STREAM,
++					DS5_STREAM_STOP | stream_id);
+ 			ret = -EAGAIN;
+ 			goto restore_s_state;
+ 		} else {
+@@ -2633,6 +2640,10 @@ static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on)
+ 				i * DS5_START_POLL_TIME);
+ 		}
+ 	} else {
++		/* TODO
++		 * WA to prevent simultaneous multi-stream starting failure sometimes.
++		 * This should be replaced by a proper fix in cam fw later. */
++		msleep_range(100 + 10 * stream_id);
+ 		ret = ds5_write(state, DS5_START_STOP_STREAM,
+ 				DS5_STREAM_STOP | stream_id);
+ 		if (ret < 0)
+-- 
+2.17.1
+


### PR DESCRIPTION
This commit addressing following tickets:
 - DSO-18280 - possible solution
	https://rsjira.intel.com/browse/DSO-18280
	[D457][Hard Failure] Depth and IR Sensor Fails to start after several thousand iterations of Random Mix Stability

This PR is bundled with #112, d4xx version 1.0.1.11
This resolution was introduced in past d4xx version 1.0.1.5 PR #83
kernel/nvidia/0042-Add-sleep-hack-back-to-prevent-regression.patch
https://github.com/IntelRealSense/perc_hw_ds5u_android-jetson_tx2/pull/83

and removed in PR #104
kernel/nvidia/0056-Bump-to-version-1.0.1.8.patch
https://github.com/IntelRealSense/perc_hw_ds5u_android-jetson_tx2/pull/104

Latest test shows +10k tests passing, failure on ~20k.

Signed-off-by: Dmitry Perchanov <dmitry.perchanov@intel.com>