### PR TITLE
 Fix HWM command round-trip time

### DIFF
--- a/kernel/nvidia/0064-DSO-18343-Refine-sending-HWM-command-and-remove-unne.patch
+++ b/kernel/nvidia/0064-DSO-18343-Refine-sending-HWM-command-and-remove-unne.patch
@@ -1,0 +1,45 @@
+From 7b012868e895e405222dfbde6f3d7637ba8c1026 Mon Sep 17 00:00:00 2001
+From: Evgeni Raikhel <evgeni.raikhel@intel.com>
+Date: Tue, 14 Jun 2022 15:26:01 +0300
+Subject: [PATCH] DSO-18343: Refine sending HWM command and remove unnecessary
+ waits. Sending HWM I2C command unconditionally invoked 50msec sleep due to
+ bug in code, resulting in delays and frame drops imposed on the application
+ layer. This commits fixes this issue, and additionally refines the retry
+ mechanism to reduce the anticipated overhead when a temporal failure occurs
+
+---
+ drivers/media/i2c/d4xx.c | 9 +++++----
+ 1 file changed, 5 insertions(+), 4 deletions(-)
+
+diff --git a/drivers/media/i2c/d4xx.c b/drivers/media/i2c/d4xx.c
+index 72de80988..a49a264e8 100644
+--- a/drivers/media/i2c/d4xx.c
++++ b/drivers/media/i2c/d4xx.c
+@@ -1305,8 +1305,9 @@ static int ds5_send_hwmc(struct ds5 *state, u16 cmdLen, struct hwm_cmd *cmd,
+ {
+ 	int ret = 0;
+ 	u16 status = 2;
+-	int retries = 20;
++	int retries = 100;
+ 	int errorCode;
++	int iter = retries;
+ 
+ 	dev_info(&state->client->dev, "%s(): HWMC header: 0x%x, magic: 0x%x, opcode: 0x%x, param1: %d, param2: %d, param3: %d, param4: %d\n",
+ 			__func__, cmd->header, cmd->magic_word, cmd->opcode, cmd->param1, cmd->param2, cmd->param3, cmd->param4);
+@@ -1315,10 +1316,10 @@ static int ds5_send_hwmc(struct ds5 *state, u16 cmdLen, struct hwm_cmd *cmd,
+ 
+ 	ds5_write_with_check(state, 0x490C, 0x01); /* execute cmd */
+ 	do {
+-		if (retries != 5)
+-			msleep_range(50);
++		if (iter != retries)
++			msleep_range(10);
+ 		ret = ds5_read(state, 0x4904, &status);
+-	} while (retries-- && status != 0);
++	} while (iter-- && status != 0);
+ 
+ 	if (ret || status != 0) {
+ 		ds5_raw_read(state, 0x4900, &errorCode, 4);
+-- 
+2.17.1
+


### PR DESCRIPTION
Sending HWM I2C command was unconditionally calling for 50msec sleep due to incorrect loop implementation
This commits also refines the i2c retry mechanism to reduce the anticipated overhead when a temporal failure occurs.
Tracked on: DSO-18343.