### PR TITLE
DSO-18280: revert delay for constant deviation

### DIFF
--- a/kernel/nvidia/0065-DSO-18280-revert-wa-stable-deviation.patch
+++ b/kernel/nvidia/0065-DSO-18280-revert-wa-stable-deviation.patch
@@ -1,0 +1,44 @@
+From 51dc0f89cb53c9058f9acd599edd77a263e541f0 Mon Sep 17 00:00:00 2001
+From: Dmitry Perchanov <dmitry.perchanov@intel.com>
+Date: Thu, 16 Jun 2022 14:05:09 +0300
+Subject: [PATCH] DSO-18280 - revert WA
+
+Signed-off-by: Dmitry Perchanov <dmitry.perchanov@intel.com>
+---
+ drivers/media/i2c/d4xx.c | 9 +++++----
+ 1 file changed, 5 insertions(+), 4 deletions(-)
+
+diff --git a/drivers/media/i2c/d4xx.c b/drivers/media/i2c/d4xx.c
+index d45ea7f..a84fc05 100644
+--- a/drivers/media/i2c/d4xx.c
++++ b/drivers/media/i2c/d4xx.c
+@@ -2607,10 +2607,10 @@ static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on)
+ 		ret = ds5_configure(state);
+ 		if (ret)
+ 			goto restore_s_state;
+-		/* TODO
++		/* TODO do not apply this to current QS, improve regression deviation
+ 		 * WA to prevent simultaneous multi-stream starting failure sometimes.
+ 		 * This should be replaced by a proper fix in cam fw later. */
+-		msleep_range(100 + 10 * stream_id);
++		/* msleep_range(100 + 10 * stream_id); */
+ 
+ 		ret = ds5_write(state, DS5_START_STOP_STREAM,
+ 				DS5_STREAM_START | stream_id);
+@@ -2641,10 +2641,11 @@ static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on)
+ 				i * DS5_START_POLL_TIME);
+ 		}
+ 	} else {
+-		/* TODO
++		/* TODO do not apply this to current QS, improve regression deviation
+ 		 * WA to prevent simultaneous multi-stream starting failure sometimes.
+ 		 * This should be replaced by a proper fix in cam fw later. */
+-		msleep_range(100 + 10 * stream_id);
++		/* msleep_range(100 + 10 * stream_id); */
++
+ 		ret = ds5_write(state, DS5_START_STOP_STREAM,
+ 				DS5_STREAM_STOP | stream_id);
+ 		if (ret < 0)
+-- 
+2.17.1
+


### PR DESCRIPTION
This patch will revert #113 removing delay in start/stop stream.
Decision was taked for on going QS to not apply such work-around as solution,
thus getting better deviation in regression tests.
- Ticket addressed:
https://rsjira.intel.com/browse/DSO-18280
[D457][Hard Failure] Depth and IR Sensor Fails to start after several thousand iterations of Random Mix Stability

Signed-off-by: Dmitry Perchanov <dmitry.perchanov@intel.com>