### PR TITLE
Undo update pipe optimization

### DIFF
--- a/kernel/nvidia/0066-Fix-toggle-issue-from-Y12I-to-Y8.patch
+++ b/kernel/nvidia/0066-Fix-toggle-issue-from-Y12I-to-Y8.patch
@@ -1,0 +1,39 @@
+From 43e105db463a78cff61409028c74c3175456574c Mon Sep 17 00:00:00 2001
+From: Junze Wu <junze.wu@intel.com>
+Date: Mon, 27 Jun 2022 15:53:15 +0800
+Subject: [PATCH] Fix toggle issue from Y12I to Y8
+
+* Add back setting map_pipe_opt registers in max9296_update_pipe()
+
+Signed-off-by: Junze Wu <junze.wu@intel.com>
+---
+ drivers/media/i2c/max9296.c | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/drivers/media/i2c/max9296.c b/drivers/media/i2c/max9296.c
+index 87da4d7bd..dfc419426 100644
+--- a/drivers/media/i2c/max9296.c
++++ b/drivers/media/i2c/max9296.c
+@@ -1004,6 +1004,9 @@ int max9296_update_pipe(struct device *dev, int sensor_type, u32 fourcc)
+ 	priv = dev_get_drvdata(dev);
+ 	if ((priv->ir_type_value != Y8_Y8I) &&
+ 	    (fourcc == V4L2_PIX_FMT_GREY || fourcc == V4L2_PIX_FMT_Y8I)) {
++		// Init control
++		err |= max9296_set_registers(dev, map_pipe_opt,
++					     ARRAY_SIZE(map_pipe_opt));
+ 		// Pipe Z
+ 		err = max9296_set_registers(dev, map_pipe_z_y8_y8i_control,
+ 					ARRAY_SIZE(map_pipe_z_y8_y8i_control));
+@@ -1011,6 +1014,9 @@ int max9296_update_pipe(struct device *dev, int sensor_type, u32 fourcc)
+ 			priv->ir_type_value = Y8_Y8I;
+ 	} else if ((priv->ir_type_value != Y12I) &&
+ 		   (fourcc == V4L2_PIX_FMT_Y12I)) {
++		// Init control
++		err |= max9296_set_registers(dev, map_pipe_opt,
++					     ARRAY_SIZE(map_pipe_opt));
+ 		// Pipe Z
+ 		err = max9296_set_registers(dev, map_pipe_z_y12i_control,
+ 					ARRAY_SIZE(map_pipe_z_y12i_control));
+-- 
+2.25.1
+


### PR DESCRIPTION
* Fixes DSO-18308 Y8/Y12I toggle issue in realsense-viewer (switching Y12i->Y8 should work properly now)
* Undo the optimizations introduced in #105 when updating pipes 