### PR TITLE
Docker build environment

### DIFF
--- a/docker/Dockerfile.build
+++ b/docker/Dockerfile.build
@@ -1,0 +1,28 @@
+FROM local/d4xx-env as base
+ARG GIT_REPO_ROOT
+WORKDIR /build/Linux_for_Tegra/source/public
+RUN mkdir -p /src/perc_hw_ds5u_android-jetson_tx2
+
+COPY ./ /src/perc_hw_ds5u_android-jetson_tx2/
+
+### Apply D457 patches and build the kernel image, dtb and D457 driver.
+# get and apply our patches
+RUN \
+if [ -d /src/perc_hw_ds5u_android-jetson_tx2/.git ]; \
+ then \
+  git clone /src/perc_hw_ds5u_android-jetson_tx2 perc_hw_ds5u_android-jetson_tx2; \
+ else \
+  git clone https://github.com/IntelRealSense/perc_hw_ds5u_android-jetson_tx2.git; \
+ fi
+
+WORKDIR perc_hw_ds5u_android-jetson_tx2
+
+# or, if using direct download method
+RUN ./apply_patches_ext.sh ..
+
+# build kernel, dtb and D457 driver
+RUN ./build_all.sh
+RUN XZ_OPT='-T0 -2' tar -cJf  modules.tar.xz -C images/modules .
+
+LABEL version="0.0.1"
+MAINTAINER "dmitry.perchanov@intel.com"

--- a/docker/Dockerfile.env
+++ b/docker/Dockerfile.env
@@ -1,0 +1,30 @@
+ARG BASE_IMAGE=ubuntu:18.04 
+
+FROM $BASE_IMAGE as d4xx-build-env
+
+RUN mkdir /src
+COPY ./ /src
+
+### Stage 1 - add/remove packages ###
+RUN set -eux; apt update \
+		&& apt install -y gcc-aarch64-linux-gnu \ 
+		build-essential bc xxd wget git kmod \
+		&& apt -y clean \
+		&& rm -rf /var/lib/apt/lists/*
+
+# direct download method
+RUN mkdir /build
+
+WORKDIR /build
+RUN \
+if [ -f /src/public_sources.tbz2 ]; then \
+  cp /src/public_sources.tbz2 .;\
+else \
+  wget -q https://developer.nvidia.com/embedded/l4t/r32_release_v7.1/sources/t186/public_sources.tbz2; \
+fi
+RUN tar xjf public_sources.tbz2
+WORKDIR /build/Linux_for_Tegra/source/public
+RUN tar xjf kernel_src.tbz2
+
+LABEL version="0.0.1"
+MAINTAINER "dmitry.perchanov@intel.com"

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,0 +1,70 @@
+RM := rm -rf
+PKG := d4xx-build
+PKGENV := d4xx-env
+REPO := local
+PWD := $(shell pwd)
+BUILD_DATE := $(shell date +"%Y-%m-%-d-%H-%M-%S")
+BUILD_DEST := ${PWD}/out/${BUILD_DATE}
+VERSION := $(shell grep 'LABEL version' Dockerfile.env | awk -F'=' '{print $$2}' | tr -d '\"')
+
+GIT_REPO_TAG := $(shell git describe --abbrev=0 --tags 2>/dev/null)
+GIT_REPO_ROOT := $(shell git rev-parse --show-toplevel 2>/dev/null)
+
+ifeq ($(GIT_REPO_TAG), )
+	GIT_REPO_TAG := latest
+endif
+
+ifeq ($(GIT_REPO_ROOT), )
+	GIT_REPO_ROOT := ./
+endif
+
+all: env build
+docker: env
+
+env:
+	docker build -t $(REPO)/$(PKGENV):$(VERSION) -f Dockerfile.env ./
+	docker tag $(REPO)/$(PKGENV):$(VERSION) $(REPO)/$(PKGENV):latest
+
+build:
+	docker build -t $(REPO)/$(PKG):$(VERSION) \
+		--build-arg GIT_REPO_ROOT=$(GIT_REPO_ROOT) \
+		-f Dockerfile.build $(GIT_REPO_ROOT)
+	mkdir -p ${BUILD_DEST}
+	docker run --rm -it -v ${BUILD_DEST}:/out/ \
+	$(REPO)/$(PKG):$(VERSION) \
+	/bin/bash -c 'cp images/arch/arm64/boot/Image \
+		images/drivers/media/i2c/d4xx.ko \
+		images/arch/arm64/boot/dts/tegra194-p2888-0001-p2822-0000.dtb \
+		modules.tar.xz /out/; \
+		chown -R --reference=/out /out'
+
+push:
+
+tag:
+	docker tag $(REPO)$(PKG):$(VERSION) $(REPO)/$(PKG):latest
+
+pack:
+	docker save -o ./$(PKG)_$(VERSION).tar $(REPO)/$(PKG):$(VERSION)
+	gzip -vf $(PKG)_$(VERSION).tar
+	echo "Use on target: 'docker load -i $(PKG)_$(VERSION).tar'"
+
+run:
+	docker run --rm -it $(REPO)/$(PKG):$(VERSION)
+
+clean-out:
+	${RM} out/* 
+
+clean-env:
+	docker rmi $(REPO)/$(PKGENV):latest $(REPO)/$(PKGENV):$(VERSION)
+
+clean-build:
+	docker rmi $(REPO)/$(PKG):$(VERSION)
+
+clean: clean-env clean-build clean-out
+	-@echo ' '
+
+clean-all: clean
+	
+.PHONY: all clean
+.SECONDARY:
+

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,47 @@
+# D457 MIPI on Jetson AGX Xavier
+This section provides Docker Container build environment for Jetson platform
+Usage
+- Create build environment container and build project
+
+	`make`
+
+- Create build environment container
+
+	`make env`
+
+- Build project
+
+	`make build`
+
+- Clean all containers
+
+	`make clean`
+
+
+Output resources will be created in `out/Y-m-d-H-M-S/` directory
+- kernel image `Image`
+- dtb `tegra194-p2888-0001-p2822-0000.dtb`
+- Modules `modules.tar.xz`
+- D457 driver (also included in modules) `d4xx.ko`
+
+[Install kernel and D457 driver to Jetson AGX Xavier](perc_hw_ds5u_android-jetson_tx2#install-kernel-and-d457-driver-to-jetson-agx-xavier)
+
+Build procedure follows [Direct Download](perc_hw_ds5u_android-jetson_tx2#build-kernel-dtb-and-d457-driver) steps. 
+
+The sources can be cached, you can put `public_sources.tbz2` to this directory
+so it will be not download from 
+[https://developer.nvidia.com/embedded/l4t/r32_release_v7.1/sources/t186/public_sources.tbz2](https://developer.nvidia.com/embedded/l4t/r32_release_v7.1/sources/t186/public_sources.tbz2)
+
+## Docker Containers setup on Ubuntu
+
+[Official guide](https://docs.docker.com/engine/install/ubuntu/)
+
+Short steps
+
+`sudo apt install docker.io`
+
+`sudo usermod -aG docker $USER`
+
+## License
+This project is licensed under the [Apache License, Version 2.0](LICENSE).
+Copyright 2022 Intel Corporation


### PR DESCRIPTION
Usage
- Create build environment container and build project

	`make`

- Create build environment container

	`make env`

- Build project

	`make build`

- Clean all containers

	`make clean`

Output resources will be created in `out/Y-m-d-H-M-S/` directory
- kernel image `Image`
- dtb `tegra194-p2888-0001-p2822-0000.dtb`
- Modules `modules.tar.xz`
- D457 driver (also included in modules) `d4xx.ko`

Signed-off-by: Dmitry Perchanov <dmitry.perchanov@intel.com>