### PR TITLE
DSO-18070: vi5: reset channel when crc error

### DIFF
--- a/kernel/nvidia/0068-DSO-18070-vi5-reset-channel-when-fault.patch
+++ b/kernel/nvidia/0068-DSO-18070-vi5-reset-channel-when-fault.patch
@@ -1,0 +1,32 @@
+From 1d7e8ff798c89d27790c9da87a6de54aa9974811 Mon Sep 17 00:00:00 2001
+From: Dmitry Perchanov <dmitry.perchanov@intel.com>
+Date: Sun, 3 Jul 2022 14:14:47 +0300
+Subject: [PATCH] vi5: reset channel when fault
+
+---
+ drivers/media/platform/tegra/camera/vi/vi5_fops.c | 9 ++++++++-
+ 1 file changed, 8 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/media/platform/tegra/camera/vi/vi5_fops.c b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
+index 9d043a9..5c14e1e 100644
+--- a/drivers/media/platform/tegra/camera/vi/vi5_fops.c
++++ b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
+@@ -454,7 +454,14 @@ static void vi5_capture_dequeue(struct tegra_channel *chan,
+ 				chan->queue_error = true;
+ 				dev_err(vi->dev, "uncorr_err: flags %d, err_data %d\n",
+ 					descr->status.flags, descr->status.err_data);
+-			} else {
++			} else if (descr->status.flags
++					& CAPTURE_STATUS_FLAG_ERROR_CSIMUX_FRAME_CSI_FAULT) {
++				/* reset channel */
++				dev_err(vi->dev, "uncorr_err: CSI FAULT flags %d, err_data %d\n",
++					descr->status.flags, descr->status.err_data);
++				goto uncorr_err;
++			}
++			else {
+ 				dev_warn(vi->dev,
+ 					"corr_err: discarding frame %d, flags: %d, "
+ 					"err_data %d\n",
+-- 
+2.17.1
+


### PR DESCRIPTION
Reset vi5 channel when flag FRAME_CSI_FAULT is set
This resolves channel timeout of 2500s on first corrupted frame with CRC error

Reference ticket: DSO-18070
https://rsjira.intel.com/browse/DSO-18070

Signed-off-by: Dmitry Perchanov <dmitry.perchanov@intel.com>