### PR TITLE
DSO-18308 LibRealSense fix for toggling IR y8 y12

### DIFF
--- a/kernel/nvidia/0069-DSO-18308-lrs-y8-12-reset-delay.patch
+++ b/kernel/nvidia/0069-DSO-18308-lrs-y8-12-reset-delay.patch
@@ -1,0 +1,43 @@
+From 90855b3a4d61e65a3ab0391e90663743a3d4c6af Mon Sep 17 00:00:00 2001
+From: Dmitry Perchanov <dmitry.perchanov@intel.com>
+Date: Mon, 25 Jul 2022 17:42:44 +0300
+Subject: [PATCH] max9296 set delay after reset
+
+---
+ drivers/media/i2c/max9296.c | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/media/i2c/max9296.c b/drivers/media/i2c/max9296.c
+index dfc4194..c97ad6b 100644
+--- a/drivers/media/i2c/max9296.c
++++ b/drivers/media/i2c/max9296.c
+@@ -982,7 +982,7 @@ int max9296_update_pipe(struct device *dev, int sensor_type, u32 fourcc)
+ {
+ 	int err = 0;
+ 	struct max9296 *priv;
+-
++	const int reset_sleep = 5;
+ 	if (!probe_done)
+ 		return 0;
+ 
+@@ -1007,6 +1007,8 @@ int max9296_update_pipe(struct device *dev, int sensor_type, u32 fourcc)
+ 		// Init control
+ 		err |= max9296_set_registers(dev, map_pipe_opt,
+ 					     ARRAY_SIZE(map_pipe_opt));
++		/* needed to settle serdes line after reset */
++		usleep_range(reset_sleep * 1000, reset_sleep * 1000 + 500);
+ 		// Pipe Z
+ 		err = max9296_set_registers(dev, map_pipe_z_y8_y8i_control,
+ 					ARRAY_SIZE(map_pipe_z_y8_y8i_control));
+@@ -1017,6 +1019,8 @@ int max9296_update_pipe(struct device *dev, int sensor_type, u32 fourcc)
+ 		// Init control
+ 		err |= max9296_set_registers(dev, map_pipe_opt,
+ 					     ARRAY_SIZE(map_pipe_opt));
++		/* needed to settle serdes line after reset */
++		usleep_range(reset_sleep * 1000, reset_sleep * 1000 + 500);
+ 		// Pipe Z
+ 		err = max9296_set_registers(dev, map_pipe_z_y12i_control,
+ 					ARRAY_SIZE(map_pipe_z_y12i_control));
+-- 
+2.37.1
+


### PR DESCRIPTION
- max9296 added delay of 5ms after channel One-shot reset in update pipe,
  resolving I2C communication error as SerDes stalled

Signed-off-by: Dmitry Perchanov <dmitry.perchanov@intel.com>