### PR TITLE
DSO-18375 d4xx change parent I2C bus clock rate to fast, 400000 Hz

### DIFF
--- a/kernel/nvidia/0070-DSO-18375-d4xx-dfu-i2c-bus-clk-fast.patch
+++ b/kernel/nvidia/0070-DSO-18375-d4xx-dfu-i2c-bus-clk-fast.patch
@@ -1,0 +1,146 @@
+From 44f91413c93ffb952f9505404471561f123108c6 Mon Sep 17 00:00:00 2001
+From: Dmitry Perchanov <dmitry.perchanov@intel.com>
+Date: Wed, 27 Jul 2022 15:33:01 +0300
+Subject: [PATCH] d4xx: change dfu i2c bus clk to 400k
+
+Signed-off-by: Dmitry Perchanov <dmitry.perchanov@intel.com>
+---
+ drivers/media/i2c/d4xx.c | 55 ++++++++++++++++++++++++++++++++--------
+ 1 file changed, 45 insertions(+), 10 deletions(-)
+
+diff --git a/drivers/media/i2c/d4xx.c b/drivers/media/i2c/d4xx.c
+index 7d5a319..98789a6 100644
+--- a/drivers/media/i2c/d4xx.c
++++ b/drivers/media/i2c/d4xx.c
+@@ -156,6 +156,11 @@ enum ds5_mux_pad {
+ /* DFU definition section */
+ #define DFU_MAGIC_NUMBER "/0x01/0x02/0x03/0x04"
+ #define DFU_BLOCK_SIZE 1024
++
++#define DFU_I2C_STANDARD_MODE		100000
++#define DFU_I2C_FAST_MODE			400000
++#define DFU_I2C_BUS_CLK_RATE		DFU_I2C_FAST_MODE
++
+ #define ds5_read_with_check(state, addr, val) {\
+ 	if (ds5_read(state, addr, val))	\
+ 		return -EINVAL;}
+@@ -368,6 +373,7 @@ struct ds5_dfu_dev {
+ 	unsigned char *dfu_msg;
+ 	u16 msg_write_once;
+ 	unsigned char init_v4l_f;
++	u32 bus_clk_rate;
+ };
+ 
+ enum {
+@@ -3173,7 +3179,7 @@ static int ds5_dfu_detach(struct ds5 *state)
+ };
+ 
+ /* When a process reads from our device, this gets called. */
+-static ssize_t device_read(struct file *flip, char __user *buffer, size_t len, loff_t *offset)
++static ssize_t ds5_dfu_device_read(struct file *flip, char __user *buffer, size_t len, loff_t *offset)
+ {
+ 	struct ds5 *state = flip->private_data;
+ 	u16 fw_ver;
+@@ -3198,7 +3204,7 @@ e_dfu_read_failed:
+ 	return ret;
+ };
+ 
+-static ssize_t device_write(struct file *flip, const char __user *buffer, size_t len, loff_t *offset)
++static ssize_t ds5_dfu_device_write(struct file *flip, const char __user *buffer, size_t len, loff_t *offset)
+ {
+ 	struct ds5 *state = flip->private_data;
+ 	int ret = 0;
+@@ -3277,9 +3283,11 @@ dfu_write_error:
+ 	return ret;
+ };
+ 
+-static int device_open(struct inode *inode, struct file *file)
++static int ds5_dfu_device_open(struct inode *inode, struct file *file)
+ {
+ 	struct ds5 *state = container_of(inode->i_cdev, struct ds5, dfu_dev.ds5_cdev);
++	struct i2c_adapter *parent = i2c_parent_is_i2c_adapter(
++			state->client->adapter);
+ 
+ 	if (state->dfu_dev.device_open_count)
+ 		return -EBUSY;
+@@ -3288,6 +3296,19 @@ static int device_open(struct inode *inode, struct file *file)
+ 		state->dfu_dev.dfu_state_flag = DS5_DFU_OPEN;
+ 	state->dfu_dev.dfu_msg = devm_kzalloc(&state->client->dev, DFU_BLOCK_SIZE, GFP_KERNEL);
+ 	file->private_data = state;
++
++	/* get i2c controller and set dfu bus clock rate */
++	while (parent && i2c_parent_is_i2c_adapter(parent))
++		parent = i2c_parent_is_i2c_adapter(state->client->adapter);
++
++	dev_info(&state->client->dev, "%s(): i2c-%d bus_clk = %d, set %d\n",
++			__func__,
++			i2c_adapter_id(parent),
++			i2c_get_adapter_bus_clk_rate(parent),
++			DFU_I2C_BUS_CLK_RATE);
++
++	state->dfu_dev.bus_clk_rate = i2c_get_adapter_bus_clk_rate(parent);
++	i2c_set_adapter_bus_clk_rate(parent, DFU_I2C_BUS_CLK_RATE);
+ 	return 0;
+ };
+ 
+@@ -3354,9 +3375,11 @@ e_depth:
+ 	return ret;
+ }
+ 
+-static int device_release(struct inode *inode, struct file *file)
++static int ds5_dfu_device_release(struct inode *inode, struct file *file)
+ {
+ 	struct ds5 *state = container_of(inode->i_cdev, struct ds5, dfu_dev.ds5_cdev);
++	struct i2c_adapter *parent = i2c_parent_is_i2c_adapter(
++			state->client->adapter);
+ 
+ 	state->dfu_dev.device_open_count--;
+ 	if (state->dfu_dev.dfu_state_flag  != DS5_DFU_RECOVERY)
+@@ -3367,15 +3390,26 @@ static int device_release(struct inode *inode, struct file *file)
+ 	if (state->dfu_dev.dfu_msg)
+ 		devm_kfree(&state->client->dev, state->dfu_dev.dfu_msg);
+ 	state->dfu_dev.dfu_msg = NULL;
++
++	/* get i2c controller and restore bus clock rate */
++	while (parent && i2c_parent_is_i2c_adapter(parent))
++		parent = i2c_parent_is_i2c_adapter(state->client->adapter);
++
++	dev_info(&state->client->dev, "%s(): i2c-%d bus_clk %d, restore to %d\n",
++			__func__, i2c_adapter_id(parent),
++			i2c_get_adapter_bus_clk_rate(parent),
++			state->dfu_dev.bus_clk_rate);
++
++	i2c_set_adapter_bus_clk_rate(parent, state->dfu_dev.bus_clk_rate);
+ 	return 0;
+ };
+ 
+ static const struct file_operations ds5_device_file_ops = {
+ 	.owner  = THIS_MODULE,
+-	.read = &device_read,
+-	.write = &device_write,
+-	.open = &device_open,
+-	.release = &device_release
++	.read = &ds5_dfu_device_read,
++	.write = &ds5_dfu_device_write,
++	.open = &ds5_dfu_device_open,
++	.release = &ds5_dfu_device_release
+ };
+ 
+ struct class* g_ds5_class;
+@@ -3679,10 +3713,11 @@ static int ds5_remove(struct i2c_client *c)
+ 	if (state->vcc)
+ 		regulator_disable(state->vcc);
+ //	gpio_free(state->pwdn_gpio);
+-	sysfs_remove_group(&c->dev.kobj, &ds5_attr_group);
+ 	ds5_chrdev_remove(state);
+-	if (state->dfu_dev.dfu_state_flag != DS5_DFU_RECOVERY)
++	if (state->dfu_dev.dfu_state_flag != DS5_DFU_RECOVERY) {
++		sysfs_remove_group(&c->dev.kobj, &ds5_attr_group);
+ 		ds5_mux_remove(state);
++	}
+ 	return 0;
+ }
+ 
+-- 
+2.37.1
+


### PR DESCRIPTION
- While DFU device opens, the bus clock rate will be saved and restored by DFU device close.
  Change clock rate to FAST mode, 400000Hz, while in DFU mode.
- Addressing https://rsjira.intel.com/browse/DSO-18375
  [D457] DFU I2C bus clock speed
- fixed unload d4xx driver in dfu state

Signed-off-by: Dmitry Perchanov <dmitry.perchanov@intel.com>