### PR TITLE
DSO-18345 [D457][LRS] Massive Sequential frame drops on start

### DIFF
--- a/kernel/nvidia/0071-DSO-18345-reset-vi5-on-error.patch
+++ b/kernel/nvidia/0071-DSO-18345-reset-vi5-on-error.patch
@@ -1,0 +1,43 @@
+From e0e8f0cc84a9ff821ea54e502932f25facdcc1c4 Mon Sep 17 00:00:00 2001
+From: Dmitry Perchanov <dmitry.perchanov@intel.com>
+Date: Wed, 10 Aug 2022 10:34:44 +0300
+Subject: [PATCH] vi5 reset channel to prevent timeout vi5 channel causing
+ channel timeout after recoverable error with data matches 20200h pattern
+ running multiple channels from one process
+
+Signed-off-by: Dmitry Perchanov <dmitry.perchanov@intel.com>
+---
+ drivers/media/platform/tegra/camera/vi/vi5_fops.c | 10 ++++++++--
+ 1 file changed, 8 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/media/platform/tegra/camera/vi/vi5_fops.c b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
+index 5c14e1e..bac8783 100644
+--- a/drivers/media/platform/tegra/camera/vi/vi5_fops.c
++++ b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
+@@ -365,7 +365,7 @@ static void vi5_release_buffer(struct tegra_channel *chan,
+ 		/*FIXME: define 236 68 bytes metadata*/
+ 		vb2_set_plane_payload(evb, 0, 68);
+ 		evb->timestamp = vbuf->vb2_buf.timestamp;
+-		vb2_buffer_done(evb, VB2_BUF_STATE_DONE);
++		vb2_buffer_done(evb, buf->vb2_state);
+ 	}
+ }
+ 
+@@ -468,7 +468,13 @@ static void vi5_capture_dequeue(struct tegra_channel *chan,
+ 					descr->status.frame_id, descr->status.flags,
+ 					descr->status.err_data);
+ 				buf->vb2_state = VB2_BUF_STATE_REQUEUEING;
+-				goto done;
++			/* D457: err_data 131072 (20000h) & 512 (200h) leading to channel
++			 * timeout. This happens when first frame is corrupted - no md
++			 * and less lines than requested. Channel reset time is 6ms */
++				if (descr->status.err_data & 0x20200)
++					goto uncorr_err;
++				else
++					goto done;
+ 			}
+ 		} else if (!vi_port) {
+ 			gang_prev_frame_id = descr->status.frame_id;
+-- 
+2.37.1
+


### PR DESCRIPTION
vi5 reset channel to prevent high cpu

vi5 channel timeout after recoverable error with data matches 20200h pattern (err_data 131072, 512)
causing channel timeout running multiple channels from one process

- Addressing:
      [DSO-18310](https://rsjira.intel.com/browse/DSO-18310) [D457][LRS][Pipe] First frame delay When streaming Pipe is always 3-6 seconds
  [DSO-18106](https://rsjira.intel.com/browse/DSO-18106) [D457]: Massive Color frame drops (over 30 frames) while stream
  [DSO-18345](https://rsjira.intel.com/browse/DSO-18345) [D457][LRS] Massive Sequential frame drops on start
    

- Follow-Up:
  [LRS-480](https://rsjira.intel.com/browse/LRS-480) [D457] LibRS Linux backend ignores driver error on video buffers retrieval

Signed-off-by: Dmitry Perchanov <dmitry.perchanov@intel.com>