### PR TITLE
Fix build issues when using direct kernel download method

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,22 +22,22 @@ Or download Jetson Linux source code tarball from [JetPack 5.0.2 BSP sources](ht
 
 ```
 # JetPack 5.0.2
-mkdir l4t-gcc/5.0.2
+mkdir -p l4t-gcc/5.0.2
 cd ./l4t-gcc/5.0.2
 wget https://developer.nvidia.com/embedded/jetson-linux/bootlin-toolchain-gcc-93 -O aarch64--glibc--stable-final.tar.gz
 tar xf aarch64--glibc--stable-final.tar.gz
-cd ..
+cd ../..
 wget https://developer.nvidia.com/embedded/l4t/r35_release_v1.0/sources/public_sources.tbz2
 tar xjf public_sources.tbz2
 cd Linux_for_Tegra/source/public
 tar xjf kernel_src.tbz2
 
 # or JetPack 4.6.1
-mkdir l4t-gcc/4.6.1
+mkdir -p l4t-gcc/4.6.1
 cd ./l4t-gcc/4.6.1
 wget http://releases.linaro.org/components/toolchain/binaries/7.3-2018.05/aarch64-linux-gnu/gcc-linaro-7.3.1-2018.05-x86_64_aarch64-linux-gnu.tar.xz
 tar xf gcc-linaro-7.3.1-2018.05-x86_64_aarch64-linux-gnu.tar.xz --strip-components 1
-cd ..
+cd ../..
 wget https://developer.nvidia.com/embedded/l4t/r32_release_v7.1/sources/t186/public_sources.tbz2
 tar xjf public_sources.tbz2
 cd Linux_for_Tegra/source/public

--- a/apply_patches_ext.sh
+++ b/apply_patches_ext.sh
@@ -27,5 +27,5 @@ apply_external_patches $1 $KERNEL_DIR
 apply_external_patches $1 hardware/nvidia/platform/t19x/galen/kernel-dts
 
 if [[ $JETPACK_VERSION =~ 5.* ]]; then
-    cp $DEVDIR/d4xx.c $DEVDIR/sources_$JETPACK_VERSION/kernel/nvidia/drivers/media/i2c/
+    cp $DEVDIR/d4xx.c $DEVDIR/$1/kernel/nvidia/drivers/media/i2c/
 fi

--- a/build_all.sh
+++ b/build_all.sh
@@ -12,8 +12,9 @@ export DEVDIR=$(cd `dirname $0` && pwd)
 
 . $DEVDIR/scripts/setup-common "$1"
 
-if [[ -z "$2" ]]; then
-    SRCS="$DEVDIR/sources_$JETPACK_VERSION"
+SRCS="$DEVDIR/sources_$JETPACK_VERSION"
+if [[ -n "$2" ]]; then
+    SRCS="$2"
 fi
 
 if [[ "$JETPACK_VERSION" == "5.0.2" ]]; then


### PR DESCRIPTION
* When download kernel source directly without using setup_workspace.sh script, the sources_$JETPACK_VERSION directory is absent for apply_patches_ext.sh, and instead should be ./Linux_for_tegra/source/public, which is supplied via the source_dir parameter ($1)
* Added default value for $SRCS, which is not set in build_all.sh if source dir parameter is missing
* Updated README

Signed-off-by: Junze Wu <junze.wu@intel.com>