### PR TITLE
JP6 d4xx integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # D457 MIPI on Jetson AGX Xavier
 The RealSense MIPI platform driver enables the user to control and stream RealSense 3D MIPI cameras.
 The system shall include:
-* Jetson platform (Currently Supported JetPack versions are: 5.0.2, 4.6.1)
+* Jetson platform (Currently Supported JetPack versions are: 6.0, 5.1.2, 5.0.2, 4.6.1)
 * RealSense De-Serialize board (https://store.intelrealsense.com/buy-intel-realsense-des457.html)
 * RS MIPI camera (e.g. https://store.intelrealsense.com/buy-intel-realsense-depth-camera-d457.html)
 
@@ -25,9 +25,26 @@ The developers can set up the source code with NVIDIA's Jetson git repositories 
 ./setup_workspace.sh [JetPack_version]
 ```
 
-Or download Jetson Linux source code tarball from [JetPack 5.1.2 BSP sources](https://developer.nvidia.com/downloads/embedded/l4t/r35_release_v4.1/sources/public_sources.tbz2), [JetPack 5.0.2 BSP sources](https://developer.nvidia.com/embedded/l4t/r35_release_v1.0/sources/public_sources.tbz2), [JetPack 4.6.1 BSP sources](https://developer.nvidia.com/embedded/l4t/r32_release_v7.1/sources/t186/public_sources.tbz2).
+Or download Jetson Linux source code tarball from 
+- [JetPack 6.0-DP BSP sources](https://developer.nvidia.com/downloads/embedded/l4t/r36_release_v2.0/sources/public_sources.tbz2)
+- [JetPack 5.1.2 BSP sources](https://developer.nvidia.com/downloads/embedded/l4t/r35_release_v4.1/sources/public_sources.tbz2) 
+- [JetPack 5.0.2 BSP sources](https://developer.nvidia.com/embedded/l4t/r35_release_v1.0/sources/public_sources.tbz2) 
+- [JetPack 4.6.1 BSP sources](https://developer.nvidia.com/embedded/l4t/r32_release_v7.1/sources/t186/public_sources.tbz2)
 
 ```
+# JetPack 6.0
+mkdir -p l4t-gcc/6.0
+cd ./l4t-gcc/6.0
+wget https://developer.nvidia.com/downloads/embedded/l4t/r36_release_v2.0/toolchain/aarch64--glibc--stable-2022.08-1.tar.bz2 -O aarch64--glibc--stable-final.tar.bz2
+tar xf aarch64--glibc--stable-final.tar.bz2 --strip-components 1
+cd ../..
+wget https://developer.nvidia.com/downloads/embedded/l4t/r36_release_v2.0/sources/public_sources.tbz2
+tar xjf public_sources.tbz2
+cd Linux_for_Tegra/source
+tar xjf kernel_src.tbz2
+tar xjf kernel_oot_modules_src.tbz2
+tar xjf nvidia_kernel_display_driver_source.tbz2
+
 # JetPack 5.1.2
 mkdir -p l4t-gcc/5.1.2
 cd ./l4t-gcc/5.1.2
@@ -43,14 +60,14 @@ tar xjf kernel_src.tbz2
 mkdir -p l4t-gcc/5.0.2
 cd ./l4t-gcc/5.0.2
 wget https://developer.nvidia.com/embedded/jetson-linux/bootlin-toolchain-gcc-93 -O aarch64--glibc--stable-final.tar.gz
-tar xf aarch64--glibc--stable-final.tar.gz
+tar xf aarch64--glibc--stable-final.tar.gz --strip-components 1
 cd ../..
 wget https://developer.nvidia.com/embedded/l4t/r35_release_v1.0/sources/public_sources.tbz2
 tar xjf public_sources.tbz2
 cd Linux_for_Tegra/source/public
 tar xjf kernel_src.tbz2
 
-# or JetPack 4.6.1
+# JetPack 4.6.1
 mkdir -p l4t-gcc/4.6.1
 cd ./l4t-gcc/4.6.1
 wget http://releases.linaro.org/components/toolchain/binaries/7.3-2018.05/aarch64-linux-gnu/gcc-linaro-7.3.1-2018.05-x86_64_aarch64-linux-gnu.tar.xz
@@ -70,6 +87,8 @@ Apply D457 patches and build the kernel image, dtb and D457 driver.
 
 # or, if using direct download method
 # ./apply_patches_ext.sh [--one-cam | --dual-cam] ./Linux_for_tegra/source/public [JetPack_version]
+# for JP6.0, source path is ./Linux_for_tegra/source :
+# ./apply_patches_ext.sh ./Linux_for_tegra/source 6.0
 
 Note: The `--one-cam` and `--dual-cam` option applies only for JetPack 5.0.2,
 compatible with adapter: https://store.intelrealsense.com/buy-intel-realsense-des457.html.
@@ -91,6 +110,62 @@ sudo apt install build-essential bc flex bison
 
 Debian packages will be generated in `images` folder.
 
+## Install kernel and D457 driver to Jetson Orin
+<details>
+<summary>JP6.0 build results</summary>
+
+- kernel image (not modified): `images/6.0/rootfs/boot/Image`
+- dtb overlay: `images/6.0/rootfs/boot/tegra234-camera-d4xx-overlay.dtbo`
+- oot modules: `images/6.0/rootfs/lib/modules/5.15.122-tegra/extra`
+
+Following steps required:
+
+1.	Copy entire directory “images/6.0/rootfs/lib/modules/5.15.122-tegra/extra/” from host to “/lib/modules/5.15.122-tegra/extra/” on Orin
+2.	Copy “tegra234-camera-d4xx-overlay.dtbo” from host to “/boot/tegra234-camera-d4xx-overlay.dtbo” on Orin
+3.	Run  $ sudo /opt/nvidia/jetson-io/jetson-io.py
+    1.	Configure Jetson AGX CSI Connector
+    2.	Configure for compatible hardware
+    3.	Jetson RealSense Camera D457
+    4.	$ sudo depmod
+    5.	$ echo "d4xx" | sudo tee /etc/modules-load.d/d4xx.conf
+4.	Reboot
+
+Copy them to the right places:
+
+```
+# scp -r images/6.0/rootfs/boot/Image nvidia@10.0.0.116:~/
+scp -r images/6.0/rootfs/boot/tegra234-camera-d4xx-overlay.dtbo nvidia@10.0.0.116:~/
+scp -r images/6.0/rootfs/lib/modules/5.15.122-tegra/extra nvidia@10.0.0.116:~/
+```
+
+on target:
+
+```
+# sudo cp ~/Image /boot/
+sudo cp ~/tegra234-camera-d4xx-overlay.dtbo /boot/
+# backup:
+sudo cp -r /lib/modules/$(uname -r)/extra /lib/modules/$(uname -r)/extra.orig
+sudo cp -r ~/extra /lib/modules/$(uname -r)/
+```
+
+Enable d4xx overlay:
+
+`sudo /opt/nvidia/jetson-io/jetson-io.py`
+
+1.	Configure Jetson AGX CSI Connector
+2.	Configure for compatible hardware
+3.	Jetson RealSense Camera D457
+
+Enable d4xx autoload:
+
+`echo "d4xx" | sudo tee /etc/modules-load.d/d4xx.conf`
+
+`sudo depmod`
+
+---
+
+</details>
+
 ## Install kernel and D457 driver to Jetson AGX Xavier
 
 1. Install the kernel and modules
@@ -101,7 +176,8 @@ Copy the Debian package `linux-image-5.10.104-d457_5.10.104-d457-1_arm64.deb` to
 
 1.2 If building with `build_all.sh`
 
-The necessary files are at
+The necessary files are:
+
 - kernel image `images/<JetPack_version>/arch/arm64/boot/Image`
 - dtb `images/<JetPack_version>/arch/arm64/boot/dts/nvidia/tegra194-p2888-0001-p2822-0000.dtb`, or `images/4.6.1/arch/arm64/boot/dts/tegra194-p2888-0001-p2822-0000.dtb` for JetPack 4.6.1.
 - D457 driver `images/<JetPack_version>/drivers/media/i2c/d4xx.ko`

--- a/README.md
+++ b/README.md
@@ -120,20 +120,19 @@ Debian packages will be generated in `images` folder.
 
 Following steps required:
 
-1.	Copy entire directory “images/6.0/rootfs/lib/modules/5.15.122-tegra/extra/” from host to “/lib/modules/5.15.122-tegra/extra/” on Orin
-2.	Copy “tegra234-camera-d4xx-overlay.dtbo” from host to “/boot/tegra234-camera-d4xx-overlay.dtbo” on Orin
-3.	Run  $ sudo /opt/nvidia/jetson-io/jetson-io.py
+1.	Copy entire directory `images/6.0/rootfs/lib/modules/5.15.122-tegra/extra/` from host to `/lib/modules/5.15.122-tegra/extra/` on Orin
+2.	Copy `tegra234-camera-d4xx-overlay.dtbo` from host to `/boot/tegra234-camera-d4xx-overlay.dtbo` on Orin
+3.	Run  $ `sudo /opt/nvidia/jetson-io/jetson-io.py`
     1.	Configure Jetson AGX CSI Connector
     2.	Configure for compatible hardware
     3.	Jetson RealSense Camera D457
-    4.	$ sudo depmod
-    5.	$ echo "d4xx" | sudo tee /etc/modules-load.d/d4xx.conf
+    4.	$ `sudo depmod`
+    5.	$ `echo "d4xx" | sudo tee /etc/modules-load.d/d4xx.conf`
 4.	Reboot
 
 Copy them to the right places:
 
 ```
-# scp -r images/6.0/rootfs/boot/Image nvidia@10.0.0.116:~/
 scp -r images/6.0/rootfs/boot/tegra234-camera-d4xx-overlay.dtbo nvidia@10.0.0.116:~/
 scp -r images/6.0/rootfs/lib/modules/5.15.122-tegra/extra nvidia@10.0.0.116:~/
 ```
@@ -141,21 +140,31 @@ scp -r images/6.0/rootfs/lib/modules/5.15.122-tegra/extra nvidia@10.0.0.116:~/
 on target:
 
 ```
-# sudo cp ~/Image /boot/
 sudo cp ~/tegra234-camera-d4xx-overlay.dtbo /boot/
 # backup:
-sudo cp -r /lib/modules/$(uname -r)/extra /lib/modules/$(uname -r)/extra.orig
+sudo tar -cjf /lib/modules/$(uname -r)/modules_$(uname -r)_extra.tar.bz2 /lib/modules/$(uname -r)/extra
 sudo cp -r ~/extra /lib/modules/$(uname -r)/
 ```
 
 Enable d4xx overlay:
 
+With Jetson-IO tool:
 `sudo /opt/nvidia/jetson-io/jetson-io.py`
 
 1.	Configure Jetson AGX CSI Connector
 2.	Configure for compatible hardware
 3.	Jetson RealSense Camera D457
 
+With command line
+
+`sudo /opt/nvidia/jetson-io/config-by-hardware.py -n 2="Jetson RealSense Camera D457"`
+
+Expected:
+```
+nvidia@ubuntu:~$ sudo /opt/nvidia/jetson-io/config-by-hardware.py -n 2="Jetson RealSense Camera D457"
+Configuration saved to /boot/tegra234-camera-d4xx-overlay.dtbo.
+Reboot system to reconfigure.
+```
 Enable d4xx autoload:
 
 `echo "d4xx" | sudo tee /etc/modules-load.d/d4xx.conf`

--- a/apply_patches.sh
+++ b/apply_patches.sh
@@ -52,7 +52,7 @@ apply_external_patches() {
 
 apply_external_patches $1 $D4XX_SRC_DST
 
-if [[ $(ls -A ${KERNEL_DIR}/${JETPACK_VERSION}) ]]; then
+if [ -d ${KERNEL_DIR}/${JETPACK_VERSION} ]; then
     apply_external_patches $1 $KERNEL_DIR
 fi
 

--- a/apply_patches.sh
+++ b/apply_patches.sh
@@ -31,7 +31,11 @@ cd "$DEVDIR"
 if [[ "$JETPACK_VERSION" == "4.6.1" ]]; then
     JP5_D4XX_DTSI="tegra194-camera-d4xx.dtsi"
 fi
-
+if [[ "$JETPACK_VERSION" == "6.0" ]]; then
+    D4XX_SRC_DST=nvidia-oot
+else
+    D4XX_SRC_DST=kernel/nvidia
+fi
 # NVIDIA SDK Manager's JetPack 4.6.1 source_sync.sh doesn't set the right folder name, it mismatches with the direct tar
 # package source code. Correct the folder name.
 if [ -d sources_$JETPACK_VERSION/hardware/nvidia/platform/t19x/galen-industrial-dts ]; then
@@ -46,13 +50,26 @@ apply_external_patches() {
     fi
 }
 
-apply_external_patches $1 kernel/nvidia
-apply_external_patches $1 $KERNEL_DIR
-apply_external_patches $1 hardware/nvidia/platform/t19x/galen/kernel-dts
+apply_external_patches $1 $D4XX_SRC_DST
+
+if [[ $(ls -A ${KERNEL_DIR}/${JETPACK_VERSION}) ]]; then
+    apply_external_patches $1 $KERNEL_DIR
+fi
+
+if [[ "$JETPACK_VERSION" == "6.0" ]]; then
+    apply_external_patches $1 hardware/nvidia/t23x/nv-public
+else
+    apply_external_patches $1 hardware/nvidia/platform/t19x/galen/kernel-dts
+fi
 
 if [ $1 = 'apply' ]; then
-    cp $DEVDIR/kernel/realsense/d4xx.c $DEVDIR/sources_$JETPACK_VERSION/kernel/nvidia/drivers/media/i2c/
-    cp $DEVDIR/hardware/realsense/$JP5_D4XX_DTSI $DEVDIR/sources_$JETPACK_VERSION/hardware/nvidia/platform/t19x/galen/kernel-dts/common/tegra194-camera-d4xx.dtsi
+    cp $DEVDIR/kernel/realsense/d4xx.c $DEVDIR/sources_$JETPACK_VERSION/${D4XX_SRC_DST}/drivers/media/i2c/
+    if [[ "$JETPACK_VERSION" == "6.0" ]]; then
+        # jp6 overlay
+        cp $DEVDIR/hardware/realsense/tegra234-camera-d4xx-overlay.dts $DEVDIR/sources_$JETPACK_VERSION/hardware/nvidia/t23x/nv-public/overlay/
+    else
+        cp $DEVDIR/hardware/realsense/$JP5_D4XX_DTSI $DEVDIR/sources_$JETPACK_VERSION/hardware/nvidia/platform/t19x/galen/kernel-dts/common/tegra194-camera-d4xx.dtsi
+    fi
 elif [ $1 = 'reset' ]; then
-    [[ -f $DEVDIR/sources_$JETPACK_VERSION/kernel/nvidia/drivers/media/i2c/d4xx.c ]] && rm $DEVDIR/sources_$JETPACK_VERSION/kernel/nvidia/drivers/media/i2c/d4xx.c
+    [[ -f $DEVDIR/sources_$JETPACK_VERSION/${D4XX_SRC_DST}/drivers/media/i2c/d4xx.c ]] && rm $DEVDIR/sources_$JETPACK_VERSION/${D4XX_SRC_DST}/drivers/media/i2c/d4xx.c
 fi

--- a/build_all.sh
+++ b/build_all.sh
@@ -15,7 +15,7 @@ NPROC=$(nproc)
 
 SRCS="$DEVDIR/sources_$JETPACK_VERSION"
 if [[ -n "$2" ]]; then
-    SRCS="$2"
+    SRCS=$(realpath $2)
 fi
 
 if [[ "$JETPACK_VERSION" == "6.0" ]]; then

--- a/build_all.sh
+++ b/build_all.sh
@@ -9,6 +9,7 @@ if [[ "$1" == "-h" ]]; then
 fi
 
 export DEVDIR=$(cd `dirname $0` && pwd)
+NPROC=$(nproc)
 
 . $DEVDIR/scripts/setup-common "$1"
 
@@ -17,7 +18,9 @@ if [[ -n "$2" ]]; then
     SRCS="$2"
 fi
 
-if [[ "$JETPACK_VERSION" == "5.1.2" ]]; then
+if [[ "$JETPACK_VERSION" == "6.0" ]]; then
+    export CROSS_COMPILE=$DEVDIR/l4t-gcc/$JETPACK_VERSION/bin/aarch64-buildroot-linux-gnu-
+elif [[ "$JETPACK_VERSION" == "5.1.2" ]]; then
     export CROSS_COMPILE=$DEVDIR/l4t-gcc/$JETPACK_VERSION/bin/aarch64-buildroot-linux-gnu-
 elif [[ "$JETPACK_VERSION" == "5.0.2" ]]; then
     export CROSS_COMPILE=$DEVDIR/l4t-gcc/$JETPACK_VERSION/bin/aarch64-buildroot-linux-gnu-
@@ -32,8 +35,28 @@ export KERNEL_MODULES_OUT=$TEGRA_KERNEL_OUT/modules
 # Check if BUILD_NUMBER is set as it will add a postfix to the kernel name "vermagic" (normally it happens on CI who have BUILD_NUMBER defined)
 [[ -n "${BUILD_NUMBER}" ]] && echo "Warning! You have BUILD_NUMBER set to ${BUILD_NUMBER}, This will affect your vermagic"
 
-cd $SRCS/$KERNEL_DIR
+# Build jp6 out-of-tree modules
+# following: 
+# https://docs.nvidia.com/jetson/archives/r36.2/DeveloperGuide/SD/Kernel/KernelCustomization.html#building-the-jetson-linux-kernel
+if [[ "$JETPACK_VERSION" == "6.0" ]]; then
+    cd $SRCS
+    export KERNEL_HEADERS=$SRCS/kernel/kernel-jammy-src
+    ln -sf $TEGRA_KERNEL_OUT $SRCS/out
+    make ARCH=arm64 -C kernel
+    # export KERNEL_HEADERS=$SRCS/out
+    make ARCH=arm64 modules
+    make ARCH=arm64 dtbs
+    mkdir -p $TEGRA_KERNEL_OUT/rootfs/boot/dtb
+    cp $SRCS/nvidia-oot/device-tree/platform/generic-dts/dtbs/tegra234-p3737-0000+p3701-0000-nv.dtb $TEGRA_KERNEL_OUT/rootfs/boot/dtb/
+    cp $SRCS/nvidia-oot/device-tree/platform/generic-dts/dtbs/tegra234-camera-d4xx-overlay.dtbo $TEGRA_KERNEL_OUT/rootfs/boot/
+    export INSTALL_MOD_PATH=$TEGRA_KERNEL_OUT/rootfs/
+    make ARCH=arm64 install -C kernel
+    make ARCH=arm64 modules_install
+else
+#jp4/5
+    cd $SRCS/$KERNEL_DIR
+    make ARCH=arm64 O=$TEGRA_KERNEL_OUT tegra_defconfig
+    make ARCH=arm64 O=$TEGRA_KERNEL_OUT -j$(NPROC)
+    make ARCH=arm64 O=$TEGRA_KERNEL_OUT modules_install INSTALL_MOD_PATH=$KERNEL_MODULES_OUT
+fi
 
-make ARCH=arm64 O=$TEGRA_KERNEL_OUT tegra_defconfig
-make ARCH=arm64 O=$TEGRA_KERNEL_OUT -j`nproc`
-make ARCH=arm64 O=$TEGRA_KERNEL_OUT modules_install INSTALL_MOD_PATH=$KERNEL_MODULES_OUT -j`nproc`

--- a/build_all.sh
+++ b/build_all.sh
@@ -56,7 +56,7 @@ else
 #jp4/5
     cd $SRCS/$KERNEL_DIR
     make ARCH=arm64 O=$TEGRA_KERNEL_OUT tegra_defconfig
-    make ARCH=arm64 O=$TEGRA_KERNEL_OUT -j$(NPROC)
+    make ARCH=arm64 O=$TEGRA_KERNEL_OUT -j${NPROC}
     make ARCH=arm64 O=$TEGRA_KERNEL_OUT modules_install INSTALL_MOD_PATH=$KERNEL_MODULES_OUT
 fi
 

--- a/hardware/nvidia/t23x/nv-public/6.0/0001-overlay-enable-d4xx-camera-for-Orin-jp6.patch
+++ b/hardware/nvidia/t23x/nv-public/6.0/0001-overlay-enable-d4xx-camera-for-Orin-jp6.patch
@@ -1,0 +1,25 @@
+From 91e9bb1de78dbd96dc80d47e1a7c1fd28873e8fa Mon Sep 17 00:00:00 2001
+From: Dmitry Perchanov <dmitry.perchanov@intel.com>
+Date: Mon, 29 Jan 2024 05:52:20 +0200
+Subject: [PATCH] overlay: enable d4xx camera for Orin jp6
+
+Signed-off-by: Dmitry Perchanov <dmitry.perchanov@intel.com>
+---
+ overlay/Makefile | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/overlay/Makefile b/overlay/Makefile
+index b3b0638..ff0cb54 100644
+--- a/overlay/Makefile
++++ b/overlay/Makefile
+@@ -54,6 +54,7 @@ dtbo-y += tegra234-p3737-camera-dual-hawk-ar0234-e3653-overlay.dtbo
+ dtbo-y += tegra234-p3737-camera-imx390-overlay.dtbo
+ dtbo-y += tegra234-p3737-camera-p3762-a00-overlay.dtbo
+ dtbo-y += tegra234-p3740-camera-p3783-a00-overlay.dtbo
++dtbo-y += tegra234-camera-d4xx-overlay.dtbo
+ 
+ 
+ ifneq ($(dtb-y),)
+-- 
+2.34.1
+

--- a/hardware/realsense/tegra234-camera-d4xx-overlay.dts
+++ b/hardware/realsense/tegra234-camera-d4xx-overlay.dts
@@ -1,0 +1,474 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// SPDX-FileCopyrightText: Copyright (c) 2018-2023, INTEL CORPORATION.  All rights reserved.
+
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/clock/tegra234-clock.h>
+#include <dt-bindings/gpio/tegra234-gpio.h>
+#include <dt-bindings/tegra234-p3737-0000+p3701-0000.h>
+
+#define CAM0_RST_L	TEGRA234_MAIN_GPIO(H, 3)
+#define CAMERA_I2C_MUX_BUS(x) (0x1E + x)
+
+/* camera control gpio definitions */
+/ {
+	overlay-name = "Jetson RealSense Camera D457";
+    jetson-header-name = "Jetson AGX CSI Connector";
+    compatible = JETSON_COMPATIBLE;
+
+	fragment@0 {
+		target-path = "/";
+		__overlay__ {
+			tegra-capture-vi {
+				num-channels = <4>;
+				ports {
+					status = "okay";
+					port@0 {
+						status = "okay";
+						d4xx_vi_in0: endpoint {
+							status = "okay";
+							vc-id = <0>;
+							port-index = <0>;
+							bus-width = <2>;
+							remote-endpoint = <&d4xx_csi_out0>;
+						};
+					};
+					port@1 {
+						status = "okay";
+						d4xx_vi_in1: endpoint {
+							status = "okay";
+							vc-id = <1>;
+							port-index = <0>;
+							bus-width = <2>;
+							remote-endpoint = <&d4xx_csi_out1>;
+						};
+					};
+					port@2 {
+						status = "okay";
+						d4xx_vi_in2: endpoint {
+							status = "okay";
+							vc-id = <2>;
+							port-index = <0>;
+							bus-width = <2>;
+							remote-endpoint = <&d4xx_csi_out2>;
+						};
+					};
+					port@3 {
+						status = "okay";
+						d4xx_vi_in3: endpoint {
+							status = "okay";
+							vc-id = <3>;
+							port-index = <0>;
+							bus-width = <2>;
+							remote-endpoint = <&d4xx_csi_out3>;
+						};
+					};
+				};
+			};
+			tegra-camera-platform {
+				modules {
+					status = "okay";
+					module0 {
+						status = "okay";
+						badge = "d4xx_depth";
+						position = "bottomleft";
+						orientation = "1";
+						drivernode0 {
+							status = "okay";
+							/* Declare PCL support driver (classically known as guid)  */
+							pcl_id = "v4l2_sensor";
+							/* Declare the device-tree hierarchy to driver instance */
+							sysfs-device-tree = "/sys/firmware/devicetree/base/bus@0/i2c@3180000/tca9548@72/i2c@0/d4m@1a";
+						};
+					};
+					module1 {
+						status = "okay";
+						badge = "d4xx_rgb";
+						position = "bottomright";
+						orientation = "1";
+						drivernode0 {
+							status = "okay";
+							/* Declare PCL support driver (classically known as guid)  */
+							pcl_id = "v4l2_sensor";
+							/* Declare the device-tree hierarchy to driver instance */
+							sysfs-device-tree = "/sys/firmware/devicetree/base/bus@0/i2c@3180000/tca9548@72/i2c@1/d4m@1a";
+						};
+					};
+					module2 {
+						status = "okay";
+						badge = "d4xx_y8";
+						position = "centerleft";
+						orientation = "1";
+						drivernode0 {
+							status = "okay";
+							/* Declare PCL support driver (classically known as guid)  */
+							pcl_id = "v4l2_sensor";
+							sysfs-device-tree = "/sys/firmware/devicetree/base/bus@0/i2c@3180000/tca9548@72/i2c@2/d4m@1a";
+						};
+					};
+					module3 {
+						status = "okay";
+						badge = "d4xx_imu";
+						position = "centerright";
+						orientation = "1";
+						drivernode0 {
+							status = "okay";
+								/* Declare PCL support driver (classically known as guid)  */
+							pcl_id = "v4l2_sensor";
+							/* Declare the device-tree hierarchy to driver instance */
+							sysfs-device-tree = "/sys/firmware/devicetree/base/bus@0/i2c@3180000/tca9548@72/i2c@3/d4m@1a";
+						};
+					};
+				};
+			};
+			bus@0 {
+				host1x@13e00000 {
+					nvcsi@15a00000 {
+						num-channels = <4>;
+						channel@0 {
+							status = "okay";
+							ports {
+								status = "okay";
+								port@0 {
+									status = "okay";
+									d4xx_csi_in0: endpoint@0 {
+										status = "okay";
+										port-index = <0>;
+										bus-width = <2>;
+										remote-endpoint = <&d4m0_out>;
+									};
+								};
+								port@1 {
+									status = "okay";
+									d4xx_csi_out0: endpoint@1 {
+										status = "okay";
+										remote-endpoint = <&d4xx_vi_in0>;
+									};
+								};
+							};
+						};
+						channel@1 {
+							status = "okay";
+							ports {
+								status = "okay";
+								port@0 {
+									status = "okay";
+									d4xx_csi_in1: endpoint@2 {
+										status = "okay";
+										port-index = <0>;
+										bus-width = <2>;
+										remote-endpoint = <&d4m1_out>;
+									};
+								};
+								port@1 {
+									status = "okay";
+									d4xx_csi_out1: endpoint@3 {
+										status = "okay";
+										remote-endpoint = <&d4xx_vi_in1>;
+									};
+								};
+							};
+						};
+						channel@2 {
+							status = "okay";
+							ports {
+								status = "okay";
+								port@0 {
+									status = "okay";
+									d4xx_csi_in2: endpoint@4 {
+										status = "okay";
+										port-index = <0>;
+										bus-width = <2>;
+										remote-endpoint = <&d4m2_out>;
+									};
+								};
+								port@1 {
+									status = "okay";
+									d4xx_csi_out2: endpoint@5 {
+										status = "okay";
+										remote-endpoint = <&d4xx_vi_in2>;
+									};
+								};
+							};
+						};
+						channel@3 {
+							status = "okay";
+							ports {
+								status = "okay";
+								port@0 {
+									status = "okay";
+									d4xx_csi_in3: endpoint@6 {
+										status = "okay";
+										port-index = <0>;
+										bus-width = <2>;
+										remote-endpoint = <&d4m3_out>;
+									};
+								};
+								port@1 {
+									status = "okay";
+									d4xx_csi_out3: endpoint@7 {
+										status = "okay";
+										remote-endpoint = <&d4xx_vi_in3>;
+									};
+								};
+							};
+						};
+					};
+				};
+				i2c@3180000 {
+					clock-frequency = <100000>;
+					tca9548@72 {
+						status = "okay";
+						reg = <0x72>;
+						compatible = "nxp,pca9548";
+						#address-cells = <1>;
+						#size-cells = <0>;
+						skip_mux_detect = "yes";
+						vcc-supply = <&vdd_1v8_ls>;
+						/*vcc-pullup-supply = <&battery_reg>;*/
+						force_bus_start = <CAMERA_I2C_MUX_BUS(0)>;
+						vcc_lp = "vcc";
+						i2c@0 {
+							reg = <0>;
+							i2c-mux,deselect-on-exit;
+							#address-cells = <1>;
+							#size-cells = <0>;
+
+							dser: max9296@48 {
+								status = "okay";
+								reg = <0x48>;
+								compatible = "maxim,max9296";
+								csi-mode = "2x4";
+								max-src = <1>;
+								reset-gpios = <&gpio CAM0_RST_L GPIO_ACTIVE_HIGH>;
+							};
+
+							ser_prim: max9295_prim@40 {
+								status = "okay";
+								reg = <0x40>;
+								compatible = "maxim,max9295";
+								is-prim-ser;
+							};
+
+							ser_a: max9295_a@42 {
+								status = "okay";
+								compatible = "maxim,max9295";
+								reg = <0x42>;
+								maxim,gmsl-dser-device = <&dser>;
+							};
+
+							d4m0: d4m@1a {
+								status = "okay";
+								def-addr = <0x10>;
+								reg = <0x1a>;
+								compatible = "intel,d4xx";
+								use_sensor_mode_id = "true";
+								vcc-supply = <&vdd_1v8_ls>;
+								cam-type = "Depth";
+								nvidia,gmsl-ser-device = <&ser_a>;
+								nvidia,gmsl-dser-device = <&dser>;
+								ports {
+									#address-cells = <1>;
+									#size-cells = <0>;
+
+									port@0 {
+										reg = <0>;
+										d4m0_out: endpoint {
+											vc-id = <0>;
+											port-index = <0>;
+											bus-width = <2>;
+											remote-endpoint = <&d4xx_csi_in0>;
+										};
+									};
+								};
+								mode0 {
+									pixel_t = "grey_y16";
+									num_lanes = "2";
+									csi_pixel_bit_depth = "16";
+									active_w = "1280";
+									active_h = "720";
+									tegra_sinterface = "serial_a";
+									mclk_khz = "24000";
+									pix_clk_hz = "74250000";
+									line_length = "1280"; /* 2200 */
+									embedded_metadata_height = "1";
+								};
+								gmsl-link {
+									src-csi-port = "b";
+									dst-csi-port = "a";
+									serdes-csi-link = "a";
+									csi-mode = "1x4";
+									st-vc = <0>;
+									vc-id = <0>;
+									num-lanes = <2>;
+								};
+							};
+						};
+
+						i2c@1 {
+							status = "okay";
+							reg = <3>; 	// line 18-19 of the I2C switch
+							i2c-mux,deselect-on-exit;
+							#address-cells = <1>;
+							#size-cells = <0>;
+
+							d4m1: d4m@1a {
+								status = "okay";
+								def-addr = <0x10>;
+								reg = <0x1a>;
+								compatible = "intel,d4xx";
+								use_sensor_mode_id = "true";
+								vcc-supply = <&vdd_1v8_ls>;
+								cam-type = "RGB";
+								nvidia,gmsl-ser-device = <&ser_a>;
+								nvidia,gmsl-dser-device = <&dser>;
+								ports {
+									#address-cells = <1>;
+									#size-cells = <0>;
+
+									port@0 {
+										reg = <0>;
+										d4m1_out: endpoint {
+											port-index = <1>;
+											bus-width = <2>;
+											remote-endpoint = <&d4xx_csi_in1>;
+										};
+									};
+								};
+								mode0 {
+									pixel_t = "grey_y16";
+									num_lanes = "2";
+									csi_pixel_bit_depth = "16";
+									active_w = "1920";
+									active_h = "1080";
+									tegra_sinterface = "serial_e";
+									mclk_khz = "24000";
+									pix_clk_hz = "74250000";
+									line_length = "1280"; /* 2200 */
+									embedded_metadata_height = "1";
+								};
+								gmsl-link {
+									src-csi-port = "b";
+									dst-csi-port = "a";
+									serdes-csi-link = "a";
+									csi-mode = "1x4";
+									st-vc = <0>;
+									vc-id = <1>;
+									num-lanes = <2>;
+								};
+							};
+						};
+						i2c@2 {
+							status = "okay";
+							reg = <4>;	// line 4 of the I2C switch
+							i2c-mux,deselect-on-exit;
+							#address-cells = <1>;
+							#size-cells = <0>;
+
+							d4m2: d4m@1a {
+								status = "okay";
+								def-addr = <0x10>;
+								reg = <0x1a>;
+								compatible = "intel,d4xx";
+								use_sensor_mode_id = "true";
+								vcc-supply = <&vdd_1v8_ls>;
+								cam-type = "Y8";
+								nvidia,gmsl-ser-device = <&ser_a>;
+								nvidia,gmsl-dser-device = <&dser>;
+								ports {
+									#address-cells = <1>;
+									#size-cells = <0>;
+
+									port@0 {
+										reg = <0>;
+										d4m2_out: endpoint {
+											port-index = <2>;
+											bus-width = <2>;
+											remote-endpoint = <&d4xx_csi_in2>;
+										};
+									};
+								};
+								/* mode0: Y8, mode1: depth D16 */
+								mode0 {
+									pixel_t = "grey_y16";
+									num_lanes = "2";
+									csi_pixel_bit_depth = "16";
+									active_w = "1280";
+									active_h = "720";
+									tegra_sinterface = "serial_b";
+									mclk_khz = "24000";
+									pix_clk_hz = "74250000";
+									line_length = "1280"; /* 2200 */
+									embedded_metadata_height = "0";
+								};
+								gmsl-link {
+									src-csi-port = "b";
+									dst-csi-port = "a";
+									serdes-csi-link = "a";
+									csi-mode = "1x4";
+									st-vc = <0>;
+									vc-id = <2>;
+									num-lanes = <2>;
+								};
+							};
+						};
+						i2c@3 {
+							status = "okay";
+							reg = <5>;	// line 4 of the I2C switch
+							i2c-mux,deselect-on-exit;
+							#address-cells = <1>;
+							#size-cells = <0>;
+
+							d4m3: d4m@1a {
+								status = "okay";
+								def-addr = <0x10>;
+								reg = <0x1a>;
+								compatible = "intel,d4xx";
+								use_sensor_mode_id = "true";
+								vcc-supply = <&vdd_1v8_ls>;
+								cam-type = "IMU";
+								nvidia,gmsl-ser-device = <&ser_a>;
+								nvidia,gmsl-dser-device = <&dser>;
+								ports {
+									#address-cells = <1>;
+									#size-cells = <0>;
+
+									port@0 {
+										reg = <0>;
+										d4m3_out: endpoint {
+											port-index = <3>;
+											bus-width = <2>;
+											remote-endpoint = <&d4xx_csi_in3>;
+										};
+									};
+								};
+								mode0 {
+									pixel_t = "grey_y16";
+									num_lanes = "2";
+									csi_pixel_bit_depth = "16";
+									active_w = "640";
+									active_h = "480";
+									tegra_sinterface = "serial_b";
+									mclk_khz = "24000";
+									pix_clk_hz = "74250000";
+									line_length = "1280"; /* 2200 */
+									embedded_metadata_height = "0";
+								};
+								gmsl-link {
+									src-csi-port = "b";
+									dst-csi-port = "a";
+									serdes-csi-link = "a";
+									csi-mode = "1x4";
+									st-vc = <0>;
+									vc-id = <3>;
+									num-lanes = <2>;
+								};
+							};
+						};
+					};
+				};
+			};
+		};
+	};
+};

--- a/kernel/kernel-jammy-src/Makefile
+++ b/kernel/kernel-jammy-src/Makefile
@@ -1,0 +1,94 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
+KERNEL_SRC_DIR ?= kernel-jammy-src
+KERNEL_DEF_CONFIG ?= defconfig
+
+MAKEFILE_DIR := $(abspath $(shell dirname $(lastword $(MAKEFILE_LIST))))
+kernel_source_dir := $(MAKEFILE_DIR)/$(KERNEL_SRC_DIR)
+
+kernel_image := ${kernel_source_dir}/arch/arm64/boot/Image
+
+NPROC ?= $(shell nproc)
+
+# LOCALVERSION : -tegra or -rt-tegra
+version = $(shell grep -q "CONFIG_PREEMPT_RT=y" \
+    ${kernel_source_dir}/arch/arm64/configs/defconfig && echo "-rt-tegra" || echo "-tegra")
+
+.PHONY : kernel install clean help
+
+kernel:
+	@echo   "================================================================================"
+	@echo   "Building $(KERNEL_SRC_DIR) sources"
+	@echo   "================================================================================"
+	$(MAKE) \
+		ARCH=arm64 \
+		-C $(kernel_source_dir) \
+		LOCALVERSION=$(version) \
+		$(KERNEL_DEF_CONFIG)
+
+	$(MAKE) -j $(NPROC) \
+		ARCH=arm64 \
+		-C $(kernel_source_dir) \
+		LOCALVERSION=$(version) \
+		--output-sync=target Image
+
+	$(MAKE) -j $(NPROC) \
+		ARCH=arm64 \
+		-C $(kernel_source_dir) \
+		LOCALVERSION=$(version) \
+		--output-sync=target dtbs
+
+	$(MAKE) -j $(NPROC) \
+		ARCH=arm64 \
+		-C $(kernel_source_dir) \
+		LOCALVERSION=$(version) \
+		--output-sync=target modules
+
+	@echo   "================================================================================"
+	@if [ -f "$(kernel_image)" ] ; then \
+		echo   "Kernel Image: $(kernel_image)"; \
+	else \
+		echo   "Error: Missing kernel image: $(kernel_image)"; \
+        false ; \
+	fi
+	@echo   "Kernel sources compiled successfully."
+	@echo   "================================================================================"
+
+
+install:
+	@echo   "================================================================================"
+	@echo   "Installing $(KERNEL_SRC_DIR) sources"
+	@echo   "================================================================================"
+	install $(kernel_image) $(INSTALL_MOD_PATH)/boot/
+	$(MAKE) \
+		ARCH=arm64 \
+		-C $(kernel_source_dir) \
+		LOCALVERSION=$(version) \
+		INSTALL_MOD_PATH=$(INSTALL_MOD_PATH) \
+		modules_install
+	@echo   "================================================================================"
+	@echo   "Kernel and in-tree modules installed successfully."
+	@echo   "================================================================================"
+
+
+clean:
+	@echo   "================================================================================"
+	@echo   "Cleaning $(KERNEL_SRC_DIR) sources"
+	@echo   "================================================================================"
+	$(MAKE) \
+		ARCH=arm64 \
+		-C $(kernel_source_dir) \
+		mrproper
+	@echo   "================================================================================"
+	@echo   "Kernel and in-tree modules installed successfully."
+	@echo   "================================================================================"
+
+# make help
+help:
+	@echo   "================================================================================"
+	@echo   "Usage:"
+	@echo   "   make or make kernel   # to build kernel"
+	@echo   "   make install          # to install kernel image and in-tree modules"
+	@echo   "   make clean            # to make clean kernel source"
+	@echo   "================================================================================"

--- a/kernel/realsense/d4xx.c
+++ b/kernel/realsense/d4xx.c
@@ -1034,7 +1034,7 @@ static void ds5_sensor_format_init(struct ds5_sensor *sensor)
 
 /* No locking needed for enumeration methods */
 static int ds5_sensor_enum_mbus_code(struct v4l2_subdev *sd,
-#if LINUX_VERSION_CODE <= KERNEL_VERSION(5, 15, 10)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 15, 10)
 				     struct v4l2_subdev_pad_config *cfg,
 #else
 				     struct v4l2_subdev_state *v4l2_state,
@@ -1057,7 +1057,7 @@ static int ds5_sensor_enum_mbus_code(struct v4l2_subdev *sd,
 }
 
 static int ds5_sensor_enum_frame_size(struct v4l2_subdev *sd,
-#if LINUX_VERSION_CODE <= KERNEL_VERSION(5, 15, 10)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 15, 10)
 				     struct v4l2_subdev_pad_config *cfg,
 #else
 				     struct v4l2_subdev_state *v4l2_state,
@@ -1785,7 +1785,7 @@ static int ds5_get_hwmc_status(struct ds5 *state)
 			break;
 
 			default:
-				dev_warn(&state->client->dev,
+				dev_dbg(&state->client->dev,
 					"%s(): HWMC failed, ret: %d, status: %x, error code: %d\n",
 					__func__, ret, status, errorCode);
 				ret = -EBADMSG;
@@ -1811,7 +1811,7 @@ static int ds5_get_hwmc(struct ds5 *state, unsigned char *data,
 	memset(data, 0, cmdDataLen);
 	ret = ds5_get_hwmc_status(state);
 	if (ret) {
-		dev_warn(&state->client->dev,
+		dev_dbg(&state->client->dev,
 			"%s(): HWMC status not clear, ret: %d\n",
 			__func__, ret);
 			return ret;
@@ -3711,7 +3711,6 @@ static int ds5_mux_enum_mbus_code(struct v4l2_subdev *sd,
 	/* Locks internally */
 #if LINUX_VERSION_CODE < KERNEL_VERSION(5, 15, 10)
 	ret = ds5_sensor_enum_mbus_code(remote_sd, cfg, &tmp);
-				     struct v4l2_subdev_pad_config *cfg,
 #else
 	ret = ds5_sensor_enum_mbus_code(remote_sd, v4l2_state, &tmp);
 #endif
@@ -5017,7 +5016,7 @@ static int ds5_dfu_device_release(struct inode *inode, struct file *file)
 {
 	struct ds5 *state = container_of(inode->i_cdev, struct ds5, dfu_dev.ds5_cdev);
 #ifdef CONFIG_TEGRA_CAMERA_PLATFORM
-#if LINUX_VERSION_CODE <= KERNEL_VERSION(5, 15, 10)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 15, 10)
 	struct i2c_adapter *parent = i2c_parent_is_i2c_adapter(
 			state->client->adapter);
 #endif
@@ -5034,7 +5033,7 @@ static int ds5_dfu_device_release(struct inode *inode, struct file *file)
 		devm_kfree(&state->client->dev, state->dfu_dev.dfu_msg);
 	state->dfu_dev.dfu_msg = NULL;
 #ifdef CONFIG_TEGRA_CAMERA_PLATFORM
-#if LINUX_VERSION_CODE <= KERNEL_VERSION(5, 15, 10)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 15, 10)
 	/* get i2c controller and restore bus clock rate */
 	while (parent && i2c_parent_is_i2c_adapter(parent))
 		parent = i2c_parent_is_i2c_adapter(state->client->adapter);
@@ -5050,7 +5049,7 @@ static int ds5_dfu_device_release(struct inode *inode, struct file *file)
 #endif
 	/* Verify communication */
 	do {
-		msleep_range(1);
+		msleep_range(100);
 		ret = ds5_read(state, DS5_FW_VERSION, &state->fw_version);
 	} while (retry-- && ret != 0 );
 	if (!ret) {

--- a/nvidia-oot/6.0/0001-Porting-nvidia-driver-patches-to-jetpack-6.0.patch
+++ b/nvidia-oot/6.0/0001-Porting-nvidia-driver-patches-to-jetpack-6.0.patch
@@ -1,0 +1,1253 @@
+From 205fc8227e5a3a1c0b4781562d599a800a43d85e Mon Sep 17 00:00:00 2001
+From: Dmitry Perchanov <dmitry.perchanov@intel.com>
+Date: Wed, 10 Jan 2024 17:27:18 +0200
+Subject: [PATCH] Porting nvidia driver patches to jetpack 6.0
+
+Signed-off-by: Dmitry Perchanov <dmitry.perchanov@intel.com>
+---
+ drivers/media/i2c/Makefile                    |   3 +
+ drivers/media/i2c/max9295.c                   | 140 ++++++
+ drivers/media/i2c/max9296.c                   | 189 +++++++++
+ .../platform/tegra/camera/sensor_common.c     |   4 +
+ .../media/platform/tegra/camera/vi/channel.c  | 401 +++++++++++++++++-
+ .../media/platform/tegra/camera/vi/graph.c    |  38 +-
+ .../platform/tegra/camera/vi/mc_common.c      |  28 +-
+ .../media/platform/tegra/camera/vi/vi5_fops.c |  36 ++
+ .../platform/tegra/camera/vi/vi5_formats.h    |  30 +-
+ include/media/gmsl-link.h                     |   3 +
+ include/media/max9295.h                       |   4 +
+ include/media/max9296.h                       |   8 +
+ include/media/mc_common.h                     |  22 +
+ include/media/tegra_camera_core.h             |   8 +
+ 14 files changed, 902 insertions(+), 12 deletions(-)
+
+diff --git a/drivers/media/i2c/Makefile b/drivers/media/i2c/Makefile
+index 866fc75b..ab7eb8fa 100644
+--- a/drivers/media/i2c/Makefile
++++ b/drivers/media/i2c/Makefile
+@@ -5,6 +5,9 @@ subdir-ccflags-y += -Werror
+ 
+ obj-m += max9295.o
+ obj-m += max9296.o
++subdir-ccflags-y += -DCONFIG_VIDEO_D4XX_SERDES
++subdir-ccflags-y += -DCONFIG_TEGRA_CAMERA_PLATFORM
++obj-m += d4xx.o
+ ifeq ($(findstring ack_src,$(NV_BUILD_KERNEL_OPTIONS)),)
+ obj-m += max96712.o
+ obj-m += ar1335_common.o
+diff --git a/drivers/media/i2c/max9295.c b/drivers/media/i2c/max9295.c
+index 2f69c355..a9b8ae67 100644
+--- a/drivers/media/i2c/max9295.c
++++ b/drivers/media/i2c/max9295.c
+@@ -463,6 +463,146 @@ static  struct regmap_config max9295_regmap_config = {
+ 	.cache_type = REGCACHE_RBTREE,
+ };
+ 
++struct reg_pair {
++	u16 addr;
++	u8 val;
++};
++
++static int max9295_set_registers(struct device *dev, struct reg_pair *map,
++				 u32 count)
++{
++	int err = 0;
++	u32 j = 0;
++
++	for (j = 0; j < count; j++) {
++		err = max9295_write_reg(dev,
++			map[j].addr, map[j].val);
++		if (err != 0)
++			break;
++	}
++
++	return err;
++}
++
++static int __max9295_set_pipe(struct device *dev, int pipe_id, u8 data_type1,
++			      u8 data_type2, u32 vc_id)
++{
++	int err = 0;
++	u8 bpp = 0x30;
++	static u8 pipe_x_val = 0x0;
++	struct reg_pair map_multi_pipe_en[] = {
++		{0x0315, 0x80},
++	};
++	struct reg_pair map_bpp8dbl[] = {
++		{0x0312, 0x0F},
++	};
++	struct reg_pair map_pipe_control[] = {
++		/* addr, val */
++		{MAX9295_PIPE_X_DT_ADDR, 0x5E}, // Pipe X pulls data_type1
++		{0x0315, 0x52}, // Pipe X pulls data_type2
++		{0x0309, 0x01}, // # Pipe X pulls vc_id
++		{0x030A, 0x00},
++		{0x031C, 0x30}, // BPP in pipe X
++		{0x0102, 0x0E}, // LIM_HEART Pipe X: Disabled
++	};
++
++	if (data_type1 == GMSL_CSI_DT_RAW_8 || data_type1 == GMSL_CSI_DT_EMBED
++	    || data_type2 == GMSL_CSI_DT_RAW_8 || data_type2 == GMSL_CSI_DT_EMBED) {
++		map_bpp8dbl[0].val |= (1 << pipe_id);
++	} else {
++		map_bpp8dbl[0].val &= ~(1 << pipe_id);
++	}
++	err |= max9295_set_registers(dev, map_bpp8dbl, ARRAY_SIZE(map_bpp8dbl));
++
++	if (data_type1 == GMSL_CSI_DT_RGB_888)
++		bpp = 0x18;
++
++	map_pipe_control[0].addr += 0x2 * pipe_id;
++	map_pipe_control[1].addr += 0x2 * pipe_id;
++	map_pipe_control[2].addr += 0x2 * pipe_id;
++	map_pipe_control[3].addr += 0x2 * pipe_id;
++	map_pipe_control[4].addr += 0x1 * pipe_id;
++	map_pipe_control[5].addr += 0x8 * pipe_id;
++
++	map_pipe_control[0].val = 0x40 | data_type1;
++	map_pipe_control[1].val = 0x40 | data_type2;
++	map_pipe_control[2].val = 1 << vc_id;
++	map_pipe_control[3].val = 0x00;
++	map_pipe_control[4].val = bpp;
++	map_pipe_control[5].val = 0x0E;
++
++	if (pipe_id == 0)
++		pipe_x_val = map_pipe_control[1].val;
++
++	err |= max9295_set_registers(dev, map_pipe_control,
++				     ARRAY_SIZE(map_pipe_control));
++
++	map_multi_pipe_en[0].val = 0x80 | pipe_x_val;
++	err |= max9295_set_registers(dev, map_multi_pipe_en,
++				     ARRAY_SIZE(map_multi_pipe_en));
++
++	return err;
++}
++
++int max9295_init_settings(struct device *dev)
++{
++	int err = 0;
++	int i;
++	struct max9295 *priv = dev_get_drvdata(dev);
++
++	struct reg_pair map_pipe_opt[] = {
++		// Enable all pipes
++		{MAX9295_PIPE_EN_ADDR, 0xF3},
++		// Write 0x33 for 4 lanes
++		{MAX9295_MIPI_RX1_ADDR, 0x11},
++		// All pipes pull clock from port B
++		{MAX9295_CSI_PORT_SEL_ADDR, 0x6F},
++		// All pipes pull data from port B
++		{MAX9295_START_PIPE_ADDR, 0xF0},
++	};
++
++	mutex_lock(&priv->lock);
++
++	// Init control
++	err |= max9295_set_registers(dev, map_pipe_opt,
++				     ARRAY_SIZE(map_pipe_opt));
++
++	for (i = 0; i < MAX9295_MAX_PIPES; i++)
++		err |= __max9295_set_pipe(dev, i, GMSL_CSI_DT_YUV422_8,
++					  GMSL_CSI_DT_EMBED, i);
++
++	mutex_unlock(&priv->lock);
++
++	return err;
++}
++EXPORT_SYMBOL(max9295_init_settings);
++
++int max9295_set_pipe(struct device *dev, int pipe_id,
++		     u8 data_type1, u8 data_type2, u32 vc_id)
++{
++	struct max9295 *priv = dev_get_drvdata(dev);
++	int err = 0;
++
++	if (pipe_id > (MAX9295_MAX_PIPES - 1)) {
++		dev_info(dev, "%s, input pipe_id: %d exceed max9295 max pipes\n",
++			 __func__, pipe_id);
++		return -EINVAL;
++	}
++
++	dev_dbg(dev, "%s pipe_id %d, data_type1 %u, data_type2 %u, vc_id %u\n",
++		__func__, pipe_id, data_type1, data_type2, vc_id);
++
++	mutex_lock(&priv->lock);
++
++	err = __max9295_set_pipe(dev, pipe_id, data_type1, data_type2, vc_id);
++
++	mutex_unlock(&priv->lock);
++
++	return err;
++}
++EXPORT_SYMBOL(max9295_set_pipe);
++
++
+ #if KERNEL_VERSION(6, 3, 0) <= LINUX_VERSION_CODE
+ static int max9295_probe(struct i2c_client *client)
+ #else
+diff --git a/drivers/media/i2c/max9296.c b/drivers/media/i2c/max9296.c
+index 0337cb5f..9754acfd 100644
+--- a/drivers/media/i2c/max9296.c
++++ b/drivers/media/i2c/max9296.c
+@@ -32,6 +32,8 @@
+ #define MAX9296_PIPE_X_DST_1_MAP_ADDR 0x410
+ #define MAX9296_PIPE_X_SRC_2_MAP_ADDR 0x411
+ #define MAX9296_PIPE_X_DST_2_MAP_ADDR 0x412
++#define MAX9296_PIPE_X_SRC_3_MAP_ADDR 0x413
++#define MAX9296_PIPE_X_DST_3_MAP_ADDR 0x414
+ 
+ #define MAX9296_PIPE_X_ST_SEL_ADDR 0x50
+ 
+@@ -248,6 +250,9 @@ void max9296_power_off(struct device *dev)
+ 	mutex_lock(&priv->lock);
+ 	priv->pw_ref--;
+ 
++	if (priv->pw_ref < 0)
++		priv->pw_ref = 0;
++
+ 	if (priv->pw_ref == 0) {
+ 		/* enter reset mode: XCLR */
+ 		usleep_range(1, 2);
+@@ -767,6 +772,190 @@ ret:
+ }
+ EXPORT_SYMBOL(max9296_setup_streaming);
+ 
++static int max9296_set_registers(struct device *dev, struct reg_pair *map,
++				 u32 count)
++{
++	int err = 0;
++	u32 j = 0;
++
++	for (j = 0; j < count; j++) {
++		err = max9296_write_reg(dev,
++			map[j].addr, map[j].val);
++		if (err != 0)
++			break;
++	}
++
++	return err;
++}
++
++int max9296_get_available_pipe_id(struct device *dev, int vc_id)
++{
++	int i;
++	int pipe_id = -ENOMEM;
++	struct max9296 *priv = dev_get_drvdata(dev);
++
++	mutex_lock(&priv->lock);
++	for (i = 0; i < MAX9296_MAX_PIPES; i++) {
++		if (i == vc_id && !priv->pipe[i].st_count) {
++			priv->pipe[i].st_count++;
++			pipe_id = i;
++			break;
++		}
++	}
++	mutex_unlock(&priv->lock);
++
++	return pipe_id;
++}
++EXPORT_SYMBOL(max9296_get_available_pipe_id);
++
++int max9296_release_pipe(struct device *dev, int pipe_id)
++{
++	struct max9296 *priv = dev_get_drvdata(dev);
++
++	if (pipe_id < 0 || pipe_id >= MAX9296_MAX_PIPES)
++		return -EINVAL;
++
++	mutex_lock(&priv->lock);
++	priv->pipe[pipe_id].st_count = 0;
++	mutex_unlock(&priv->lock);
++
++	return 0;
++}
++EXPORT_SYMBOL(max9296_release_pipe);
++
++void max9296_reset_oneshot(struct device *dev)
++{
++	struct max9296 *priv = dev_get_drvdata(dev);
++
++	mutex_lock(&priv->lock);
++	if (priv->splitter_enabled) {
++		max9296_write_reg(dev, MAX9296_CTRL0_ADDR, 0x03);
++		max9296_write_reg(dev, MAX9296_CTRL0_ADDR, 0x23);
++	} else {
++		max9296_write_reg(dev, MAX9296_CTRL0_ADDR, 0x31);
++	}
++	/* delay to settle link */
++	msleep(100);
++	mutex_unlock(&priv->lock);
++}
++EXPORT_SYMBOL(max9296_reset_oneshot);
++
++static int __max9296_set_pipe(struct device *dev, int pipe_id, u8 data_type1,
++			      u8 data_type2, u32 vc_id)
++{
++	int err = 0;
++	int i = 0;
++	u8 en_mapping_num = 0x0F;
++	u8 all_mapping_phy = 0x55;
++	struct reg_pair map_pipe_opt[] = {
++		{0x1458, 0x28}, // PHY A Optimization
++		{0x1459, 0x68}, // PHY A Optimization
++		{0x1558, 0x28}, // PHY B Optimization
++		{0x1559, 0x68}, // PHY B Optimization
++		// 4 lanes on port A, write 0x50 for 2 lanes
++		{MAX9296_LANE_CTRL1_ADDR, 0x50},
++		// 1500Mbps/lane on port A
++		{MAX9296_PHY1_CLK_ADDR, 0x2F},
++		// Do not un-double 8bpp (Un-double 8bpp data)
++		//{0x031C, 0x00},
++		// Do not un-double 8bpp
++		//{0x031F, 0x00},
++		// 0x02: ALT_MEM_MAP8, 0x10: ALT2_MEM_MAP8
++		{0x0473, 0x10},
++	};
++	struct reg_pair map_pipe_control[] = {
++		// Enable 4 mappings for Pipe X
++		{MAX9296_TX11_PIPE_X_EN_ADDR, 0x0F},
++		// Map data_type1 on vc_id
++		{MAX9296_PIPE_X_SRC_0_MAP_ADDR, 0x1E},
++		{MAX9296_PIPE_X_DST_0_MAP_ADDR, 0x1E},
++		// Map frame_start on vc_id
++		{MAX9296_PIPE_X_SRC_1_MAP_ADDR, 0x00},
++		{MAX9296_PIPE_X_DST_1_MAP_ADDR, 0x00},
++		// Map frame end on vc_id
++		{MAX9296_PIPE_X_SRC_2_MAP_ADDR, 0x01},
++		{MAX9296_PIPE_X_DST_2_MAP_ADDR, 0x01},
++		// Map data_type2 on vc_id
++		{MAX9296_PIPE_X_SRC_3_MAP_ADDR, 0x12},
++		{MAX9296_PIPE_X_DST_3_MAP_ADDR, 0x12},
++		// All mappings to PHY1 (master for port A)
++		{MAX9296_TX45_PIPE_X_DST_CTRL_ADDR, 0x55},
++		// SEQ_MISS_EN: Disabled / DIS_PKT_DET: Disabled
++		{0x0100, 0x23}, // pipe X
++	};
++
++	for (i = 0; i < 10; i++) {
++		map_pipe_control[i].addr += 0x40 * pipe_id;
++	}
++	map_pipe_control[10].addr += 0x12 * pipe_id;
++
++	if (data_type2 == 0x0) {
++		en_mapping_num = 0x07;
++		all_mapping_phy = 0x15;
++	}
++	map_pipe_control[0].val = en_mapping_num;
++	map_pipe_control[1].val = (vc_id << 6) | data_type1;
++	map_pipe_control[2].val = (vc_id << 6) | data_type1;
++	map_pipe_control[3].val = (vc_id << 6) | 0x00;
++	map_pipe_control[4].val = (vc_id << 6) | 0x00;
++	map_pipe_control[5].val = (vc_id << 6) | 0x01;
++	map_pipe_control[6].val = (vc_id << 6) | 0x01;
++	map_pipe_control[7].val = (vc_id << 6) | data_type2;
++	map_pipe_control[8].val = (vc_id << 6) | data_type2;
++	map_pipe_control[9].val = all_mapping_phy;
++	map_pipe_control[10].val = 0x23;
++
++	err |= max9296_set_registers(dev, map_pipe_control,
++				     ARRAY_SIZE(map_pipe_control));
++
++	err |= max9296_set_registers(dev, map_pipe_opt,
++				     ARRAY_SIZE(map_pipe_opt));
++
++	return err;
++}
++int max9296_init_settings(struct device *dev)
++{
++	int err = 0;
++	int i;
++	struct max9296 *priv = dev_get_drvdata(dev);
++
++	mutex_lock(&priv->lock);
++
++	for (i = 0; i < MAX9296_MAX_PIPES; i++)
++		err |= __max9296_set_pipe(dev, i, GMSL_CSI_DT_YUV422_8,
++					  GMSL_CSI_DT_EMBED, i);
++
++	mutex_unlock(&priv->lock);
++
++	return err;
++}
++EXPORT_SYMBOL(max9296_init_settings);
++
++int max9296_set_pipe(struct device *dev, int pipe_id,
++		     u8 data_type1, u8 data_type2, u32 vc_id)
++{
++	struct max9296 *priv = dev_get_drvdata(dev);
++	int err = 0;
++
++	if (pipe_id > (MAX9296_MAX_PIPES - 1)) {
++		dev_info(dev, "%s, input pipe_id: %d exceed max9296 max pipes\n",
++			 __func__, pipe_id);
++		return -EINVAL;
++	}
++
++	dev_dbg(dev, "%s pipe_id %d, data_type1 %u, data_type2 %u, vc_id %u\n",
++		__func__, pipe_id, data_type1, data_type2, vc_id);
++
++	mutex_lock(&priv->lock);
++
++	err = __max9296_set_pipe(dev, pipe_id, data_type1, data_type2, vc_id);
++
++	mutex_unlock(&priv->lock);
++
++	return err;
++}
++EXPORT_SYMBOL(max9296_set_pipe);
++
+ static const struct of_device_id max9296_of_match[] = {
+ 	{ .compatible = "maxim,max9296", },
+ 	{ },
+diff --git a/drivers/media/platform/tegra/camera/sensor_common.c b/drivers/media/platform/tegra/camera/sensor_common.c
+index 92cc2fdf..69139eee 100644
+--- a/drivers/media/platform/tegra/camera/sensor_common.c
++++ b/drivers/media/platform/tegra/camera/sensor_common.c
+@@ -267,6 +267,10 @@ static int extract_pixel_format(
+ 		*format = V4L2_PIX_FMT_UYVY;
+ 	else if (strncmp(pixel_t, "yuv_vyuy16", size) == 0)
+ 		*format = V4L2_PIX_FMT_VYUY;
++	else if (strncmp(pixel_t, "grey_y8", size) == 0)
++		*format = V4L2_PIX_FMT_GREY;
++	else if (strncmp(pixel_t, "grey_y16", size) == 0)
++		*format = V4L2_PIX_FMT_Y16;
+ 	else {
+ 		pr_err("%s: Need to extend format%s\n", __func__, pixel_t);
+ 		return -EINVAL;
+diff --git a/drivers/media/platform/tegra/camera/vi/channel.c b/drivers/media/platform/tegra/camera/vi/channel.c
+index c4da4119..e2258ce9 100644
+--- a/drivers/media/platform/tegra/camera/vi/channel.c
++++ b/drivers/media/platform/tegra/camera/vi/channel.c
+@@ -203,7 +203,12 @@ static void tegra_channel_fmt_align(struct tegra_channel *chan,
+ 	 * different. Aligned width also may force a sensor mode change other
+ 	 * than the requested one
+ 	 */
+-	*height = clamp(*height, TEGRA_MIN_HEIGHT, TEGRA_MAX_HEIGHT);
++	/* For D4XX IMU, the total size of one frame is 32 while the width:height
++	* should be set to 32:1. Therefore, ignored the clamping on height here by
++	* replacing TEGRA_MIN_HEIGHT with 1U ((unsigned int) 1).
++	*/
++	*height = clamp(*height, 1U /*TEGRA_MIN_HEIGHT*/, TEGRA_MAX_HEIGHT);
++
+ 
+ 	/* Clamp the requested bytes per line value. If the maximum bytes per
+ 	 * line value is zero, the module doesn't support user configurable line
+@@ -1027,7 +1032,8 @@ tegra_channel_querycap(struct file *file, void *fh, struct v4l2_capability *cap)
+ 
+ 	cap->device_caps = V4L2_CAP_VIDEO_CAPTURE | V4L2_CAP_STREAMING;
+ 	cap->device_caps |= V4L2_CAP_EXT_PIX_FORMAT;
+-	cap->capabilities = cap->device_caps | V4L2_CAP_DEVICE_CAPS;
++	cap->capabilities = cap->device_caps | V4L2_CAP_DEVICE_CAPS |
++			V4L2_CAP_META_CAPTURE;
+ 
+ 	strlcpy(cap->driver, "tegra-video", sizeof(cap->driver));
+ 	strlcpy(cap->card, chan->video->name, sizeof(cap->card));
+@@ -2218,6 +2224,62 @@ static long tegra_channel_default_ioctl(struct file *file, void *fh,
+ 	return ret;
+ }
+ 
++static int
++__tegra_channel_get_parm(struct tegra_channel *chan,
++			  struct v4l2_streamparm *a)
++{
++	struct v4l2_subdev *sd = chan->subdev_on_csi;
++	int ret = 0;
++	struct v4l2_subdev_frame_interval interval;
++
++	/* dmipx: fixing G_PARM EINVAL error */
++//	ret = v4l2_subdev_call(sd, video, g_frame_interval, &interval);
++	ret = sd->ops->video->g_frame_interval(sd, &interval);
++
++	a->parm.capture.timeperframe.numerator = interval.interval.numerator;
++	a->parm.capture.timeperframe.denominator = interval.interval.denominator;
++
++	return ret;
++}
++
++static int tegra_channel_get_parm(struct file *file, void *fh, struct v4l2_streamparm *a)
++{
++	struct tegra_channel *chan = video_drvdata(file);
++
++	a->parm.capture.timeperframe.numerator = 1;
++	a->parm.capture.timeperframe.denominator = 12;
++
++	return __tegra_channel_get_parm(chan, a);
++}
++
++static int
++__tegra_channel_set_parm(struct tegra_channel *chan,
++			  struct v4l2_streamparm *a)
++{
++	struct v4l2_subdev *sd = chan->subdev_on_csi;
++	int ret = 0;
++
++	struct v4l2_subdev_frame_interval interval;
++	interval.pad = 1;
++	interval.interval.numerator = a->parm.capture.timeperframe.numerator;
++	interval.interval.denominator = a->parm.capture.timeperframe.denominator;
++
++	ret = v4l2_subdev_call(sd, video, s_frame_interval, &interval);
++	if (ret == -ENOIOCTLCMD)
++			return -ENOTTY;
++
++	return ret;
++}
++static int tegra_channel_set_parm(struct file *file, void *fh, struct v4l2_streamparm *a)
++{
++	struct tegra_channel *chan = video_drvdata(file);
++
++	if (vb2_is_busy(&chan->queue))
++			return -EBUSY;
++
++	return __tegra_channel_set_parm(chan, a);
++}
++
+ static const struct v4l2_ioctl_ops tegra_channel_ioctl_ops = {
+ 	.vidioc_querycap		= tegra_channel_querycap,
+ 	.vidioc_enum_framesizes		= tegra_channel_enum_framesizes,
+@@ -2249,6 +2311,9 @@ static const struct v4l2_ioctl_ops tegra_channel_ioctl_ops = {
+ 	.vidioc_s_input			= tegra_channel_s_input,
+ 	.vidioc_log_status		= tegra_channel_log_status,
+ 	.vidioc_default			= tegra_channel_default_ioctl,
++	.vidioc_g_parm			= tegra_channel_get_parm,
++	.vidioc_s_parm			= tegra_channel_set_parm,
++
+ };
+ 
+ static int tegra_channel_close(struct file *fp);
+@@ -2464,6 +2529,331 @@ static int tegra_channel_csi_init(struct tegra_channel *chan)
+ 	return ret;
+ }
+ 
++static int tegra_metadata_open(struct file *fp)
++{
++	struct video_device *vdev = video_devdata(fp);
++	struct tegra_channel *chan = video_get_drvdata(vdev);
++	int ret;
++
++	mutex_lock(&chan->embedded.lock);
++	ret = v4l2_fh_open(fp);
++	mutex_unlock(&chan->embedded.lock);
++
++	return ret;
++}
++
++static int tegra_metadata_close(struct file *fp)
++{
++	struct video_device *vdev = video_devdata(fp);
++	struct tegra_channel *chan = video_get_drvdata(vdev);
++	int ret = _vb2_fop_release(fp, &chan->embedded.lock);
++
++	return ret;
++}
++
++static const struct v4l2_file_operations tegra_metadata_fops = {
++	.owner          = THIS_MODULE,
++	.unlocked_ioctl = video_ioctl2,
++	.open           = tegra_metadata_open,
++	.release        = tegra_metadata_close,
++	.read           = vb2_fop_read,
++	.poll           = vb2_fop_poll,
++	.mmap           = vb2_fop_mmap,
++};
++
++static int tegra_metadata_querycap(struct file *file, void *fh,
++                                 struct v4l2_capability *cap)
++{
++	struct v4l2_fh *vfh = file->private_data;
++	struct tegra_channel *chan = video_drvdata(file);
++
++	/* FIXME: why do Device Caps show V4L2_CAP_EXT_PIX_FORMAT? */
++	cap->device_caps = V4L2_CAP_META_CAPTURE | V4L2_CAP_STREAMING;
++	cap->capabilities = cap->device_caps | V4L2_CAP_DEVICE_CAPS |
++			V4L2_CAP_EXT_PIX_FORMAT | V4L2_CAP_VIDEO_CAPTURE;
++
++	strlcpy(cap->driver, "tegra-embedded", sizeof(cap->driver));
++	strlcpy(cap->card, vfh->vdev->name, sizeof(cap->card));
++	snprintf(cap->bus_info, sizeof(cap->bus_info), "platform:%s:%u",
++			dev_name(chan->vi->dev), chan->port[0]);
++
++	return 0;
++}
++
++static int tegra_metadata_enum_format(struct file *file, void *fh,
++                                     struct v4l2_fmtdesc *f)
++{
++	if (f->index)
++		return -EINVAL;
++
++	f->pixelformat = V4L2_META_FMT_D4XX;
++	strlcpy(f->description, "D4XX metadata format", sizeof(f->description));
++
++	return 0;
++}
++
++static int tegra_metadata_get_format(struct file *file, void *fh,
++                                    struct v4l2_format *format)
++{
++	struct v4l2_fh *vfh = file->private_data;
++	struct v4l2_meta_format *fmt = &format->fmt.meta;
++
++	if (format->type != vfh->vdev->queue->type)
++		return -EINVAL;
++
++	memset(fmt, 0, sizeof(*fmt));
++
++	fmt->dataformat = V4L2_META_FMT_D4XX;
++	fmt->buffersize = 255;
++
++	return 0;
++}
++static int tegra_metadata_set_format(struct file *file, void *fh,
++                                    struct v4l2_format *format)
++{
++   return 0;
++}
++
++static int tegra_metadata_try_format(struct file *file, void *fh,
++                                    struct v4l2_format *format)
++{
++    return 0;
++}
++static const struct v4l2_ioctl_ops tegra_metadata_ioctl_ops = {
++	.vidioc_querycap                = tegra_metadata_querycap,
++	.vidioc_enum_fmt_meta_cap       = tegra_metadata_enum_format,
++	.vidioc_g_fmt_meta_cap          = tegra_metadata_get_format,
++	.vidioc_s_fmt_meta_cap          = tegra_metadata_set_format,
++	.vidioc_try_fmt_meta_cap        = tegra_metadata_try_format,
++	.vidioc_reqbufs                 = vb2_ioctl_reqbufs,
++	.vidioc_querybuf                = vb2_ioctl_querybuf,
++	.vidioc_qbuf                    = vb2_ioctl_qbuf,
++	.vidioc_dqbuf                   = vb2_ioctl_dqbuf,
++	.vidioc_create_bufs             = vb2_ioctl_create_bufs,
++	.vidioc_expbuf                  = vb2_ioctl_expbuf,
++	.vidioc_streamon                = vb2_ioctl_streamon,
++	.vidioc_streamoff               = vb2_ioctl_streamoff,
++};
++
++static int tegra_metadata_queue_setup(struct vb2_queue *vq,
++                    unsigned int *nbuffers, unsigned int *nplanes,
++                    unsigned int sizes[], struct device *alloc_devs[])
++{
++	struct tegra_channel *chan = vb2_get_drv_priv(vq);
++
++	if (*nplanes) {
++		if (*nplanes != 1)
++			return -EINVAL;
++
++		if (sizes[0] < 255)
++			return -EINVAL;
++
++		return 0;
++	}
++
++	*nplanes = 1;
++	sizes[0] = 255;
++	alloc_devs[0] = chan->vi->dev;
++
++
++	return 0;
++}
++
++static int tegra_metadata_buffer_prepare(struct vb2_buffer *vb)
++{
++	if (vb->num_planes != 1)
++		return -EINVAL;
++
++	if (vb2_plane_size(vb, 0) < 255)
++		return -EINVAL;
++
++	return 0;
++}
++
++static void tegra_metadata_buffer_queue(struct vb2_buffer *vb)
++{
++	struct tegra_channel *chan = vb2_get_drv_priv(vb->vb2_queue);
++
++	spin_lock(&chan->embedded.spin_lock);
++	if (chan->embedded.num_buffers < 16) {
++		chan->embedded.buffers[chan->embedded.head] = vb;
++		chan->embedded.head++;
++		if (chan->embedded.head > 15)
++			chan->embedded.head = chan->embedded.head - 16;
++		chan->embedded.num_buffers++;
++	}
++	spin_unlock(&chan->embedded.spin_lock);
++}
++
++static int tegra_metadata_start_streaming(struct vb2_queue *vq, unsigned int count)
++{
++	return 0;
++}
++
++static void tegra_metadata_stop_streaming(struct vb2_queue *vq)
++{
++	struct tegra_channel *chan = vb2_get_drv_priv(vq);
++	int i = 0;
++
++	spin_lock(&chan->embedded.spin_lock);
++	for (i = 0; i < chan->embedded.num_buffers; i++) {
++		struct vb2_buffer *evb;
++		evb = chan->embedded.buffers[chan->embedded.tail];
++		chan->embedded.buffers[chan->embedded.tail] = NULL;
++		chan->embedded.tail++;
++		if (chan->embedded.tail > 15)
++			chan->embedded.tail = chan->embedded.tail - 16;
++		vb2_buffer_done(evb, VB2_BUF_STATE_ERROR);
++	}
++	spin_unlock(&chan->embedded.spin_lock);
++
++	chan->embedded.head = 0;
++	chan->embedded.tail = 0;;
++	chan->embedded.num_buffers = 0;
++}
++
++static const struct vb2_ops tegra_metadata_qops = {
++	.queue_setup            = tegra_metadata_queue_setup,
++	.buf_prepare            = tegra_metadata_buffer_prepare,
++	.buf_queue              = tegra_metadata_buffer_queue,
++	.wait_prepare           = vb2_ops_wait_prepare,
++	.wait_finish            = vb2_ops_wait_finish,
++	.start_streaming        = tegra_metadata_start_streaming,
++	.stop_streaming         = tegra_metadata_stop_streaming,
++};
++
++int tegra_channel_init_video_embedded(struct tegra_channel *chan)
++{
++	struct video_device *video;
++	struct vb2_queue *queue = &chan->embedded.queue;
++	struct tegra_mc_vi *vi = chan->vi;
++	int ret;
++
++	mutex_init(&chan->embedded.lock);
++	spin_lock_init(&chan->embedded.spin_lock);
++
++	video = chan->embedded.video = video_device_alloc();
++	chan->embedded.pad.flags = MEDIA_PAD_FL_SINK;
++
++	ret = tegra_media_entity_init(&video->entity, 1,
++									&chan->embedded.pad, false, false);
++	if (ret < 0) {
++		video_device_release(video);
++		dev_err(vi->dev, "%s(): metadata entity init: %d\n",
++				__func__, ret);
++		return ret;
++	}
++
++	ret = v4l2_ctrl_handler_init(&chan->embedded.ctrl_handler,
++									MAX_CID_CONTROLS);
++	if (chan->embedded.ctrl_handler.error) {
++		dev_err(&video->dev, "failed to init control handler\n");
++		return ret;
++	}
++
++	video->fops = &tegra_metadata_fops;
++	video->v4l2_dev = &vi->v4l2_dev;
++	video->queue = queue;
++	snprintf(video->name, sizeof(video->name), "%s-metadata-%u",
++			dev_name(vi->dev), chan->port[0]);
++#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 4, 0)
++	video->vfl_type = VFL_TYPE_GRABBER;
++#else
++	video->vfl_type = VFL_TYPE_VIDEO;
++	video->device_caps = V4L2_CAP_META_CAPTURE | V4L2_CAP_STREAMING;
++#endif
++	video->vfl_dir = VFL_DIR_RX;
++	video->release = video_device_release_empty;
++	video->ioctl_ops = &tegra_metadata_ioctl_ops;
++	video->ctrl_handler = &chan->embedded.ctrl_handler;
++	video->lock = &chan->embedded.lock;
++
++	video_set_drvdata(video, chan);
++
++#if defined(CONFIG_VIDEOBUF2_DMA_CONTIG)
++	/* get the buffers queue... */
++	ret = tegra_vb2_dma_init(vi->dev, &chan->embedded.alloc_ctx,
++					SZ_64K, &vi->vb2_dma_alloc_refcnt);
++	if (ret < 0)
++		goto ctx_alloc_error;
++
++#endif
++//#if defined(CONFIG_VIDEOBUF2_DMA_CONTIG)
++	/* get the buffers queue... */
++//     chan->embedded.alloc_ctx = vb2_dma_contig_init_ctx(vi->dev);
++//     if (IS_ERR(chan->embedded.alloc_ctx)) {
++//             dev_err(vi->dev, "%s(): vb2 buffer init: %ld\n", __func__,
++//                     PTR_ERR(chan->embedded.alloc_ctx));
++//             goto ctx_alloc_error;
++//     }
++//#endif
++
++	queue->type = V4L2_BUF_TYPE_META_CAPTURE;
++	queue->io_modes = VB2_MMAP | VB2_DMABUF | VB2_READ | VB2_USERPTR;
++	queue->lock = &chan->embedded.lock;
++	queue->drv_priv = chan;
++	queue->buf_struct_size = sizeof(struct tegra_channel_buffer);
++	queue->ops = &tegra_metadata_qops;
++#if defined(CONFIG_VIDEOBUF2_DMA_CONTIG)
++	queue->mem_ops = &vb2_dma_contig_memops;
++#endif
++	queue->timestamp_flags = V4L2_BUF_FLAG_TIMESTAMP_MONOTONIC |
++			V4L2_BUF_FLAG_TSTAMP_SRC_EOF;
++	ret = vb2_queue_init(queue);
++	if (ret < 0) {
++		dev_err(vi->dev, "%s(): metadata queue initialize: %d\n",
++				__func__, ret);
++		goto vb2_queue_error;
++	}
++
++	return 0;
++
++vb2_queue_error:
++#if defined(CONFIG_VIDEOBUF2_DMA_CONTIG)
++	tegra_vb2_dma_cleanup(vi->dev, chan->embedded.alloc_ctx,
++			&vi->vb2_dma_alloc_refcnt);
++ctx_alloc_error:
++#endif
++	media_entity_cleanup(&video->entity);
++
++	return ret;
++}
++
++int tegra_channel_cleanup_video_embedded(struct tegra_channel *chan)
++{
++	struct video_device *video = chan->embedded.video;
++	struct vb2_queue *queue = &chan->embedded.queue;
++	struct device *vi_unit_dev = tegra_channel_get_vi_unit(chan);
++
++	if (!video)
++		return -EINVAL;
++
++	video_unregister_device(video);
++
++	/* release embedded data buffer */
++	if (chan->emb_buf_size > 0) {
++		dma_free_coherent(vi_unit_dev,
++				chan->emb_buf_size,
++				chan->emb_buf_addr, chan->emb_buf);
++		chan->emb_buf_size = 0;
++		vb2_queue_release(queue);
++#if defined(CONFIG_VIDEOBUF2_DMA_CONTIG)
++		tegra_vb2_dma_cleanup(vi_unit_dev, chan->embedded.alloc_ctx,
++						&chan->vi->vb2_dma_alloc_refcnt);
++#endif
++	}
++
++	v4l2_ctrl_handler_free(&chan->embedded.ctrl_handler);
++
++#if defined(CONFIG_MEDIA_CONTROLLER)
++	media_entity_cleanup(&video->entity);
++#endif
++
++	video_device_release(video);
++
++	return 0;
++}
++
+ int tegra_channel_init_video(struct tegra_channel *chan)
+ {
+ 	struct tegra_mc_vi *vi = chan->vi;
+@@ -2650,6 +3040,13 @@ int tegra_channel_cleanup(struct tegra_channel *chan)
+ 			chan->emb_buf_size,
+ 			chan->emb_buf_addr, chan->emb_buf);
+ 		chan->emb_buf_size = 0;
++		vb2_queue_release(&chan->embedded.queue);
++#if IS_ENABLED(CONFIG_VIDEOBUF2_DMA_CONTIG)
++		tegra_vb2_dma_cleanup(vi_unit_dev, chan->embedded.alloc_ctx,
++			&chan->vi->vb2_dma_alloc_refcnt);
++		//vb2_dma_contig_cleanup_ctx(chan->embedded.alloc_ctx);
++#endif
++		media_entity_cleanup(&chan->embedded.video->entity);
+ 	}
+ 
+ 	tegra_channel_dealloc_buffer_queue(chan);
+diff --git a/drivers/media/platform/tegra/camera/vi/graph.c b/drivers/media/platform/tegra/camera/vi/graph.c
+index dc14fe4e..cea4bda9 100644
+--- a/drivers/media/platform/tegra/camera/vi/graph.c
++++ b/drivers/media/platform/tegra/camera/vi/graph.c
+@@ -290,6 +290,11 @@ static int tegra_vi_graph_notify_complete(struct v4l2_async_notifier *notifier)
+ 	struct tegra_channel *chan =
+ 		container_of(notifier, struct tegra_channel, notifier);
+ 	struct tegra_vi_graph_entity *entity;
++	struct camera_common_data *s_data;
++	struct device_node *node;
++	struct sensor_mode_properties *sensor_mode = NULL;
++	int idx;
++
+ 	int ret;
+ 
+ 	dev_dbg(chan->vi->dev, "notify complete, all subdevs registered\n");
+@@ -323,16 +328,46 @@ static int tegra_vi_graph_notify_complete(struct v4l2_async_notifier *notifier)
+ 	if (ret < 0)
+ 		goto graph_error;
+ 
++	/* Init embedded channel only if embedded is set in DT*/
++	s_data = to_camera_common_data(chan->subdev_on_csi->dev);
++	node = chan->subdev_on_csi->dev->of_node;
++	if (s_data && node) {
++		idx = s_data->mode_prop_idx;
++		if (idx < s_data->sensor_props.num_modes)
++			sensor_mode = &s_data->sensor_props.sensor_modes[idx];
++	}
++
++	if (sensor_mode &&
++		sensor_mode->image_properties.embedded_metadata_height > 0) {
++		ret = tegra_channel_init_video_embedded(chan);
++		if (ret < 0) {
++			dev_err(chan->vi->dev,
++					"failed to initialize embedded channel\n");
++			goto register_embedded_device_error;
++		}
++		ret = video_register_device(chan->embedded.video, VFL_TYPE_VIDEO, -1);
++		if (ret < 0) {
++			dev_err(&chan->video->dev, "failed to register embedded %s: %d\n",
++					chan->embedded.video->name, ret);
++			goto register_embedded_device_error;
++		}
++	}
++
++
+ 	ret = v4l2_device_register_subdev_nodes(&chan->vi->v4l2_dev);
+ 	if (ret < 0) {
+ 		dev_err(chan->vi->dev, "failed to register subdev nodes\n");
+-		goto graph_error;
++		goto register_nodes_error;
+ 	}
+ 
+ 	chan->link_status++;
+ 
+ 	return 0;
+ 
++register_nodes_error:
++	video_unregister_device(chan->embedded.video);
++register_embedded_device_error:
++	tegra_vi_graph_remove_links(chan);
+ graph_error:
+ 	video_unregister_device(chan->video);
+ register_device_error:
+@@ -396,6 +431,7 @@ static void tegra_vi_graph_notify_unbind(struct v4l2_async_notifier *notifier,
+ 
+ 	/* cleanup for complete */
+ 	if (chan->link_status) {
++		tegra_channel_cleanup_video_embedded(chan);
+ 		tegra_vi_graph_remove_links(chan);
+ 		tegra_channel_cleanup_video(chan);
+ 		chan->link_status--;
+diff --git a/drivers/media/platform/tegra/camera/vi/mc_common.c b/drivers/media/platform/tegra/camera/vi/mc_common.c
+index 57c2d61a..57db86d5 100644
+--- a/drivers/media/platform/tegra/camera/vi/mc_common.c
++++ b/drivers/media/platform/tegra/camera/vi/mc_common.c
+@@ -161,6 +161,10 @@ static int vi_parse_dt(struct tegra_mc_vi *vi, struct platform_device *dev)
+ 	struct device_node *port;
+ 	int value = 0xFF;
+ 	int ret = 0;
++	struct device_node *dser_node = NULL;
++	struct i2c_client *dser_i2c = NULL;
++	struct device_node *ser_node = NULL;
++	struct i2c_client *ser_i2c = NULL;
+ 
+ 	err = of_property_read_u32(node, "num-channels", &num_channels);
+ 	if (err) {
+@@ -168,8 +172,30 @@ static int vi_parse_dt(struct tegra_mc_vi *vi, struct platform_device *dev)
+ 			"Failed to find num of channels, set to 0\n");
+ 		num_channels = 0;
+ 	}
+-	vi->num_channels = num_channels;
+ 
++	vi->dser_dev = NULL;
++	dser_node = of_parse_phandle(node, "nvidia,gmsl-dser-device", 0);
++	if (dser_node) {
++		dser_i2c = of_find_i2c_device_by_node(dser_node);
++		of_node_put(dser_node);
++		if (dser_i2c) {
++			dev_info(&dev->dev, "dser_i2c->addr 0x%x", dser_i2c->addr);
++			vi->dser_dev = &dser_i2c->dev;
++		}
++	}
++
++	vi->ser_dev = NULL;
++	ser_node = of_parse_phandle(node, "nvidia,gmsl-ser-device", 0);
++	if (ser_node) {
++		ser_i2c = of_find_i2c_device_by_node(ser_node);
++		of_node_put(ser_node);
++		if (ser_i2c) {
++			dev_info(&dev->dev, "ser_i2c->addr 0x%x", ser_i2c->addr);
++			vi->ser_dev = &ser_i2c->dev;
++		}
++	}
++
++	vi->num_channels = num_channels;
+ 	ports = of_get_child_by_name(node, "ports");
+ 	if (ports == NULL)
+ 		ports = node;
+diff --git a/drivers/media/platform/tegra/camera/vi/vi5_fops.c b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
+index 3d29ee78..22dd202f 100644
+--- a/drivers/media/platform/tegra/camera/vi/vi5_fops.c
++++ b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
+@@ -424,6 +424,39 @@ static void vi5_setup_surface(struct tegra_channel *chan,
+ 		chan->capture_descr_sequence += 1;
+ }
+ 
++static void vi5_release_metadata_buffer(struct tegra_channel *chan,
++	struct vb2_v4l2_buffer *vbuf)
++{
++	struct vb2_buffer *evb = NULL;
++	struct vb2_v4l2_buffer *evbuf;
++	void* frm_buffer;
++
++	spin_lock(&chan->embedded.spin_lock);
++	if (0 < chan->embedded.num_buffers) {
++		evb = chan->embedded.buffers[chan->embedded.tail];
++		chan->embedded.buffers[chan->embedded.tail] = NULL;
++		chan->embedded.tail++;
++		if (chan->embedded.tail > 15)
++			chan->embedded.tail = chan->embedded.tail - 16;
++		chan->embedded.num_buffers--;
++	}
++	spin_unlock(&chan->embedded.spin_lock);
++
++	if (!evb)
++		return;
++
++	frm_buffer = vb2_plane_vaddr(evb, 0);
++	if (!frm_buffer)
++		return;
++
++	memcpy(frm_buffer, chan->emb_buf_addr, 255);
++	evbuf = to_vb2_v4l2_buffer(evb);
++	evbuf->sequence = vbuf->sequence;
++	vb2_set_plane_payload(evb, 0, 68);
++	evb->timestamp = vbuf->vb2_buf.timestamp;
++	vb2_buffer_done(evb, VB2_BUF_STATE_DONE);
++}
++
+ static void vi5_release_buffer(struct tegra_channel *chan,
+ 	struct tegra_channel_buffer *buf)
+ {
+@@ -434,6 +467,9 @@ static void vi5_release_buffer(struct tegra_channel *chan,
+ 	vb2_set_plane_payload(&vbuf->vb2_buf, 0, chan->format.sizeimage);
+ 
+ 	vb2_buffer_done(&vbuf->vb2_buf, buf->vb2_state);
++
++	if (chan->embedded_data_height == 1 && buf->vb2_state == VB2_BUF_STATE_DONE)
++		vi5_release_metadata_buffer(chan, vbuf);
+ }
+ 
+ static void vi5_capture_enqueue(struct tegra_channel *chan,
+diff --git a/drivers/media/platform/tegra/camera/vi/vi5_formats.h b/drivers/media/platform/tegra/camera/vi/vi5_formats.h
+index 1d0c1133..1d375de5 100644
+--- a/drivers/media/platform/tegra/camera/vi/vi5_formats.h
++++ b/drivers/media/platform/tegra/camera/vi/vi5_formats.h
+@@ -82,6 +82,8 @@ static const struct tegra_video_format vi5_video_formats[] = {
+ 	/* RAW 7: TODO */
+ 
+ 	/* RAW 8 */
++	TEGRA_VIDEO_FORMAT(RAW8, 8, Y8_1X8, 1, 1, T_R8,
++				RAW8, GREY, "Greyscale 8"),
+ 	TEGRA_VIDEO_FORMAT(RAW8, 8, SRGGB8_1X8, 1, 1, T_R8,
+ 				RAW8, SRGGB8, "RGRG.. GBGB.."),
+ 	TEGRA_VIDEO_FORMAT(RAW8, 8, SGRBG8_1X8, 1, 1, T_R8,
+@@ -112,22 +114,22 @@ static const struct tegra_video_format vi5_video_formats[] = {
+ 				RAW12, SBGGR12, "BGBG.. GRGR.."),
+ 
+ 	/* RGB888 */
+-	TEGRA_VIDEO_FORMAT(RGB888, 24, RGB888_1X24, 4, 1, T_A8R8G8B8,
+-				RGB888, RGBA32, "RGBA-8-8-8-8"),
++	// TEGRA_VIDEO_FORMAT(RGB888, 24, RGB888_1X24, 4, 1, T_A8R8G8B8,
++	// 			RGB888, RGBA32, "RGBA-8-8-8-8"),
+ 	TEGRA_VIDEO_FORMAT(RGB888, 24, RGB888_1X32_PADHI, 4, 1, T_A8B8G8R8,
+ 				RGB888, RGB32, "RGB-8-8-8-8"),
+ 
+ 	/* YUV422 */
+-	TEGRA_VIDEO_FORMAT(YUV422, 16, UYVY8_1X16, 2, 1, T_U8_Y8__V8_Y8,
+-				YUV422_8, UYVY, "YUV 4:2:2"),
+-	TEGRA_VIDEO_FORMAT(YUV422, 16, VYUY8_1X16, 2, 1, T_V8_Y8__U8_Y8,
+-				YUV422_8, VYUY, "YUV 4:2:2"),
++	// TEGRA_VIDEO_FORMAT(YUV422, 16, UYVY8_1X16, 2, 1, T_U8_Y8__V8_Y8,
++	// 			YUV422_8, UYVY, "YUV 4:2:2"),
++	// TEGRA_VIDEO_FORMAT(YUV422, 16, VYUY8_1X16, 2, 1, T_V8_Y8__U8_Y8,
++	// 			YUV422_8, VYUY, "YUV 4:2:2"),
+ 	TEGRA_VIDEO_FORMAT(YUV422, 16, YUYV8_1X16, 2, 1, T_Y8_U8__Y8_V8,
+ 				YUV422_8, YUYV, "YUV 4:2:2"),
+ 	TEGRA_VIDEO_FORMAT(YUV422, 16, YVYU8_1X16, 2, 1, T_Y8_V8__Y8_U8,
+ 				YUV422_8, YVYU, "YUV 4:2:2"),
+-	TEGRA_VIDEO_FORMAT(YUV422, 16, UYVY8_1X16, 1, 1, T_Y8__V8U8_N422,
+-				YUV422_8, NV16, "NV16"),
++	// TEGRA_VIDEO_FORMAT(YUV422, 16, UYVY8_1X16, 1, 1, T_Y8__V8U8_N422,
++	// 			YUV422_8, NV16, "NV16"),
+ 	TEGRA_VIDEO_FORMAT(YUV422, 16, UYVY8_2X8, 2, 1, T_U8_Y8__V8_Y8,
+ 				YUV422_8, UYVY, "YUV 4:2:2 UYVY"),
+ 	TEGRA_VIDEO_FORMAT(YUV422, 16, VYUY8_2X8, 2, 1, T_V8_Y8__U8_Y8,
+@@ -136,6 +138,18 @@ static const struct tegra_video_format vi5_video_formats[] = {
+ 				YUV422_8, YUYV, "YUV 4:2:2 YUYV"),
+ 	TEGRA_VIDEO_FORMAT(YUV422, 16, YVYU8_2X8, 2, 1, T_Y8_V8__Y8_U8,
+ 				YUV422_8, YVYU, "YUV 4:2:2 YVYU"),
++
++	TEGRA_VIDEO_FORMAT(YUV422, 16, UYVY8_1X16, 2, 1, T_U8_Y8__V8_Y8,
++				YUV422_8, Z16, "Depth 16"),
++	TEGRA_VIDEO_FORMAT(YUV422, 16, VYUY8_1X16, 2, 1, T_V8_Y8__U8_Y8,
++				YUV422_8, Y8I, "Y8I 16"),
++	// TODO: RealSesne calibration format Y12I should be 3-byte,
++	// R[7:3]R[3:0] | L[3:0]R[11:8] | L[11:8]L[7:4]
++	// but, currently, it's 4-byte, one byte is added as alignment
++	// R[7:3]R[3:0] | L[3:0]R[11:8] | L[11:8]L[7:4] | ALIGN[7:0]
++	TEGRA_VIDEO_FORMAT(RGB888, 24, RGB888_1X24, 4, 1, T_A8R8G8B8,
++				RGB888, Y12I, "Y12I 24"),
++
+ };
+ 
+ #endif
+diff --git a/include/media/gmsl-link.h b/include/media/gmsl-link.h
+index ad902d0a..7dce2356 100644
+--- a/include/media/gmsl-link.h
++++ b/include/media/gmsl-link.h
+@@ -40,6 +40,9 @@
+ #define GMSL_CSI_DT_RAW_12 0x2C
+ #define GMSL_CSI_DT_UED_U1 0x30
+ #define GMSL_CSI_DT_EMBED 0x12
++#define GMSL_CSI_DT_YUV422_8 0x1E
++#define GMSL_CSI_DT_RGB_888 0x24
++#define GMSL_CSI_DT_RAW_8 0x2A
+ 
+ #define GMSL_ST_ID_UNUSED 0xFF
+ 
+diff --git a/include/media/max9295.h b/include/media/max9295.h
+index bf801aa2..c576e3e5 100644
+--- a/include/media/max9295.h
++++ b/include/media/max9295.h
+@@ -12,6 +12,7 @@
+ #ifndef __MAX9295_H__
+ #define __MAX9295_H__
+ 
++#include <linux/types.h>
+ #include <media/gmsl-link.h>
+ /**
+  * \defgroup max9295 MAX9295 serializer driver
+@@ -22,6 +23,8 @@
+  * @{
+  */
+ 
++int max9295_set_pipe(struct device *dev, int pipe_id, u8 data_type1,
++		     u8 data_type2, u32 vc_id);
+ 
+ /**
+  * @brief  Powers on a serializer device and performs the I2C overrides
+@@ -82,6 +85,7 @@ int max9295_sdev_unpair(struct device *dev, struct device *s_dev);
+  */
+ int max9295_setup_streaming(struct device *dev);
+ 
++int max9295_init_settings(struct device *dev);
+ /** @} */
+ 
+ #endif  /* __MAX9295_H__ */
+diff --git a/include/media/max9296.h b/include/media/max9296.h
+index 210dbc80..6b4c796e 100644
+--- a/include/media/max9296.h
++++ b/include/media/max9296.h
+@@ -12,6 +12,7 @@
+ #ifndef __MAX9296_H__
+ #define __MAX9296_H__
+ 
++#include <linux/types.h>
+ #include <media/gmsl-link.h>
+ /**
+  * \defgroup max9296 MAX9296 deserializer driver
+@@ -22,6 +23,12 @@
+  * @{
+  */
+ 
++int max9296_get_available_pipe_id(struct device *dev, int vc_id);
++int max9296_set_pipe(struct device *dev, int pipe_id, u8 data_type1,
++		     u8 data_type2, u32 vc_id);
++int max9296_release_pipe(struct device *dev, int pipe_id);
++void max9296_reset_oneshot(struct device *dev);
++
+ /**
+  * Puts a deserializer device in single exclusive link mode, so link-specific
+  * I2C overrides can be performed for sensor and serializer devices.
+@@ -146,6 +153,7 @@ int max9296_power_on(struct device *dev);
+  */
+ void max9296_power_off(struct device *dev);
+ 
++int max9296_init_settings(struct device *dev);
+ /** @} */
+ 
+ #endif  /* __MAX9296_H__ */
+diff --git a/include/media/mc_common.h b/include/media/mc_common.h
+index f10bde3d..63a0ce71 100644
+--- a/include/media/mc_common.h
++++ b/include/media/mc_common.h
+@@ -222,6 +222,23 @@ struct tegra_channel {
+ 	unsigned int embedded_data_width;
+ 	unsigned int embedded_data_height;
+ 
++	struct {
++		struct video_device *video;
++		struct mutex lock;
++		spinlock_t spin_lock;
++		struct vb2_queue queue;
++		/*FIXME: 16 is max queued metadata buffers
++		* define 16
++		*/
++		struct vb2_buffer *buffers[16];
++		unsigned int head;
++		unsigned int tail;
++		unsigned int num_buffers;
++		void *alloc_ctx;
++		struct media_pad pad;
++		struct v4l2_ctrl_handler ctrl_handler;
++	} embedded;
++
+ 	DECLARE_BITMAP(fmts_bitmap, MAX_FORMAT_NUM);
+ 	atomic_t power_on_refcnt;
+ 	struct v4l2_fh *fh;
+@@ -300,6 +317,9 @@ struct tegra_mc_vi {
+ 	unsigned int num_channels;
+ 	unsigned int num_subdevs;
+ 
++	struct device *dser_dev;
++	struct device *ser_dev;
++
+ 	struct tegra_csi_device *csi;
+ 	struct list_head vi_chans;
+ 	struct tegra_channel *tpg_start;
+@@ -396,7 +416,9 @@ struct tegra_channel_buffer *dequeue_inflight(struct tegra_channel *chan);
+ int tegra_channel_set_power(struct tegra_channel *chan, bool on);
+ 
+ int tegra_channel_init_video(struct tegra_channel *chan);
++int tegra_channel_init_video_embedded(struct tegra_channel *chan);
+ int tegra_channel_cleanup_video(struct tegra_channel *chan);
++int tegra_channel_cleanup_video_embedded(struct tegra_channel *chan);
+ 
+ struct tegra_vi_fops {
+ 	int (*vi_power_on)(struct tegra_channel *chan);
+diff --git a/include/media/tegra_camera_core.h b/include/media/tegra_camera_core.h
+index e6d9a2b1..38634b77 100644
+--- a/include/media/tegra_camera_core.h
++++ b/include/media/tegra_camera_core.h
+@@ -32,6 +32,8 @@
+ #define TEGRA_IMAGE_FORMAT_DEF	32
+ 
+ enum tegra_image_dt {
++	TEGRA_IMAGE_DT_EMBEDDED_8 = 18,
++
+ 	TEGRA_IMAGE_DT_YUV420_8 = 24,
+ 	TEGRA_IMAGE_DT_YUV420_10,
+ 
+@@ -51,6 +53,12 @@ enum tegra_image_dt {
+ 	TEGRA_IMAGE_DT_RAW10,
+ 	TEGRA_IMAGE_DT_RAW12,
+ 	TEGRA_IMAGE_DT_RAW14,
++
++	TEGRA_IMAGE_DT_USER_1 = 48,
++	TEGRA_IMAGE_DT_USER_2,
++	TEGRA_IMAGE_DT_USER_3,
++	TEGRA_IMAGE_DT_USER_4,
++
+ };
+ 
+ /* Supported CSI to VI Data Formats */
+-- 
+2.34.1
+

--- a/nvidia-oot/Makefile
+++ b/nvidia-oot/Makefile
@@ -1,0 +1,177 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
+KERNEL_HEADERS ?= /lib/modules/$(shell uname -r)/build
+KERNEL_OUTPUT ?= ${KERNEL_HEADERS}
+
+MAKEFILE_DIR := $(abspath $(shell dirname $(lastword $(MAKEFILE_LIST))))
+NVIDIA_HEADERS ?= ${MAKEFILE_DIR}/out/nvidia-linux-header
+NVIDIA_CONFTEST ?= ${MAKEFILE_DIR}/out/nvidia-conftest
+
+ifneq ($(words $(subst :, ,$(MAKEFILE_DIR))), 1)
+$(error source directory cannot contain spaces or colons)
+endif
+
+NPROC ?= $(shell nproc)
+
+.PHONY : help modules modules_install clean conftest nvidia-headers hwpm nvidia-oot nvgpu
+
+# help is default target!
+help:
+	@echo   "================================================================================"
+	@echo   "Usage:"
+	@echo   "   make modules          # to build NVIDIA OOT and display drivers"
+	@echo   "   make dtbs             # to build NVIDIA DTBs"
+	@echo   "   make modules_install  # to install drivers to the INSTALL_MOD_PATH"
+	@echo   "   make clean            # to make clean driver sources"
+	@echo   "================================================================================"
+
+modules: hwpm nvidia-oot nvgpu nvidia-display
+dtbs: nvidia-dtbs
+modules_install: hwpm nvidia-oot nvgpu nvidia-display-install
+clean: hwpm nvidia-oot nvgpu nvidia-display-clean nvidia-dtbs-clean
+
+
+conftest:
+ifeq ($(MAKECMDGOALS), modules)
+	@echo   "================================================================================"
+	@echo   "make $(MAKECMDGOALS) - conftest ..."
+	@echo   "================================================================================"
+	mkdir -p $(NVIDIA_CONFTEST)/nvidia;
+	cp -av $(MAKEFILE_DIR)/nvidia-oot/scripts/conftest/* $(NVIDIA_CONFTEST)/nvidia/;
+	$(MAKE) ARCH=arm64 \
+		src=$(NVIDIA_CONFTEST)/nvidia obj=$(NVIDIA_CONFTEST)/nvidia \
+		CC=$(CROSS_COMPILE)gcc LD=$(CROSS_COMPILE)ld \
+		NV_KERNEL_SOURCES=$(KERNEL_HEADERS) \
+		NV_KERNEL_OUTPUT=$(KERNEL_OUTPUT) \
+		-f $(NVIDIA_CONFTEST)/nvidia/Makefile
+endif
+
+hwpm: conftest
+	@if [ ! -d "$(MAKEFILE_DIR)/hwpm" ] ; then \
+		echo "Directory hwpm is not found, exiting.."; \
+		false; \
+	fi
+	@echo   "================================================================================"
+	@echo   "make $(MAKECMDGOALS) - hwpm ..."
+	@echo   "================================================================================"
+	$(MAKE) -j $(NPROC) ARCH=arm64 \
+		-C $(KERNEL_HEADERS) \
+		M=$(MAKEFILE_DIR)/hwpm/drivers/tegra/hwpm \
+		CONFIG_TEGRA_OOT_MODULE=m \
+		srctree.hwpm=$(MAKEFILE_DIR)/hwpm \
+		srctree.nvconftest=$(NVIDIA_CONFTEST) \
+		$(MAKECMDGOALS)
+
+nvidia-oot: conftest hwpm
+	@if [ ! -d "$(MAKEFILE_DIR)/nvidia-oot" ] ; then \
+		echo "Directory nvidia-oot is not found, exiting.."; \
+		false; \
+	fi
+	@echo   "================================================================================"
+	@echo   "make $(MAKECMDGOALS) - nvidia-oot ..."
+	@echo   "================================================================================"
+	$(MAKE) -j $(NPROC) ARCH=arm64 \
+		-C $(KERNEL_HEADERS) \
+		M=$(MAKEFILE_DIR)/nvidia-oot \
+		CONFIG_TEGRA_OOT_MODULE=m \
+		srctree.nvidia-oot=$(MAKEFILE_DIR)/nvidia-oot \
+		srctree.hwpm=$(MAKEFILE_DIR)/hwpm \
+		srctree.nvconftest=$(NVIDIA_CONFTEST) \
+		KBUILD_EXTRA_SYMBOLS=$(MAKEFILE_DIR)/hwpm/drivers/tegra/hwpm/Module.symvers \
+		$(MAKECMDGOALS)
+
+nvgpu: conftest nvidia-oot
+	if [ ! -d "$(MAKEFILE_DIR)/nvgpu" ] ; then \
+		echo "Directory nvgpu is not found, exiting.."; \
+		false; \
+	fi
+	@echo   "================================================================================"
+	@echo   "make $(MAKECMDGOALS) - nvgpu ..."
+	@echo   "================================================================================"
+	$(MAKE) -j $(NPROC) ARCH=arm64 \
+		-C $(KERNEL_HEADERS) \
+		M=$(MAKEFILE_DIR)/nvgpu/drivers/gpu/nvgpu \
+		CONFIG_TEGRA_OOT_MODULE=m \
+		srctree.nvidia=$(MAKEFILE_DIR)/nvidia-oot \
+		srctree.nvidia-oot=$(MAKEFILE_DIR)/nvidia-oot \
+		srctree.nvconftest=$(NVIDIA_CONFTEST) \
+		KBUILD_EXTRA_SYMBOLS=$(MAKEFILE_DIR)/nvidia-oot/Module.symvers \
+		$(MAKECMDGOALS)
+
+
+define display-cmd
+	$(MAKE) -j $(NPROC) ARCH=arm64 TARGET_ARCH=aarch64 \
+		-C $(MAKEFILE_DIR)/nvdisplay \
+		LOCALVERSION=$(version) \
+		NV_VERBOSE=0 \
+		KERNELRELEASE="" \
+		SYSSRC=$(NVIDIA_HEADERS) \
+		SYSOUT=$(NVIDIA_HEADERS) \
+		SYSSRCHOST1X=$(MAKEFILE_DIR)/nvidia-oot/drivers/gpu/host1x/include \
+		CC=$(CROSS_COMPILE)gcc \
+		LD=$(CROSS_COMPILE)ld.bfd \
+		AR=$(CROSS_COMPILE)ar \
+		CXX=$(CROSS_COMPILE)g++ \
+		OBJCOPY=$(CROSS_COMPILE)objcopy
+endef
+
+
+nvidia-headers: nvidia-oot
+	mkdir -p $(NVIDIA_HEADERS) && cp -LR $(KERNEL_HEADERS)/* $(NVIDIA_HEADERS) && \
+		cp -LR $(MAKEFILE_DIR)/nvidia-oot/include/* $(NVIDIA_HEADERS)/include/ && \
+		cat $(KERNEL_HEADERS)/Module.symvers $(MAKEFILE_DIR)/nvidia-oot/Module.symvers > \
+		$(NVIDIA_HEADERS)/Module.symvers
+
+
+nvidia-display: nvidia-headers
+	@if [ ! -d "$(MAKEFILE_DIR)/nvdisplay" ] ; then \
+		echo "Directory nvdisplay is not found, exiting.."; \
+		false; \
+	fi
+	@echo   "================================================================================"
+	@echo   "make $(MAKECMDGOALS) - nvidia-display ..."
+	@echo   "================================================================================"
+	$(display-cmd) modules
+	@echo   "================================================================================"
+	@echo   "Display driver compiled successfully."
+	@echo   "================================================================================"
+
+
+nvidia-display-install:
+	@echo   "================================================================================"
+	@echo   "make $(MAKECMDGOALS) - nvidia-display ..."
+	@echo   "================================================================================"
+	$(MAKE) -C $(NVIDIA_HEADERS) \
+		M=$(MAKEFILE_DIR)/nvdisplay/kernel-open modules_install
+
+nvidia-display-clean:
+	@echo   "================================================================================"
+	@echo   "make $(MAKECMDGOALS) - nvidia-display ..."
+	@echo   "================================================================================"
+	if [ -d $(NVIDIA_HEADERS) ]; then \
+		$(display-cmd) clean && \
+		rm -fr $(NVIDIA_HEADERS); \
+	fi
+
+nvidia-dtbs:
+	@echo   "================================================================================"
+	@echo   "make nvidia-dtbs ..."
+	@echo   "================================================================================"
+	TEGRA_TOP=$(MAKEFILE_DIR) \
+	srctree=$(KERNEL_HEADERS) \
+	oottree=$(MAKEFILE_DIR)/nvidia-oot \
+	HOSTCC=gcc \
+	$(MAKE) -f $(MAKEFILE_DIR)/nvidia-oot/scripts/Makefile.build \
+		obj=$(MAKEFILE_DIR)/nvidia-oot/device-tree/platform/generic-dts \
+		dtbs
+	@echo   "================================================================================"
+	@echo   "DTBs compiled successfully."
+	@echo   "================================================================================"
+
+nvidia-dtbs-clean:
+	@echo   "================================================================================"
+	@echo   "make $(MAKECMDGOALS) - nvidia-dtbs ..."
+	@echo   "================================================================================"
+	rm -fr $(MAKEFILE_DIR)/nvidia-oot/device-tree/platform/generic-dts/dtbs
+

--- a/scripts/setup-common
+++ b/scripts/setup-common
@@ -8,7 +8,10 @@ if [[ -z "$1" ]]; then
     JETPACK_VERSION="5.0.2"
 fi
 
-if [[ $JETPACK_VERSION == "5.1.2" ]]; then
+if [[ $JETPACK_VERSION == "6.0" ]]; then
+    L4T_VERSION="jetson_36.2"
+    KERNEL_DIR="kernel/kernel-jammy-src"
+elif [[ $JETPACK_VERSION == "5.1.2" ]]; then
     L4T_VERSION="jetson_35.4.1"
     KERNEL_DIR="kernel/kernel-5.10"
 elif [[ $JETPACK_VERSION == "5.0.2" ]]; then
@@ -18,6 +21,6 @@ elif [[ $JETPACK_VERSION == "4.6.1" ]]; then
     L4T_VERSION="tegra-l4t-r32.7.1"
     KERNEL_DIR="kernel/kernel-4.9"
 else
-    echo "Wrong JetPack version ($JETPACK_VERSION)! Only 5.0.2 and 4.6.1 supported."
+    echo "Wrong JetPack version ($JETPACK_VERSION)! Only 6.0, 5.1.2, 5.0.2 and 4.6.1 supported."
     exit 1
 fi

--- a/scripts/source_sync_6.0.sh
+++ b/scripts/source_sync_6.0.sh
@@ -1,0 +1,344 @@
+#!/bin/bash
+
+# SPDX-FileCopyrightText: Copyright (c) 2012-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+#
+# This script sync's NVIDIA's version of
+# 1. the kernel source
+# from nv-tegra, NVIDIA's public git repository.
+# The script also provides opportunities to the sync to a specific tag
+# so that the binaries shipped with a release can be replicated.
+#
+# Usage:
+# By default it will download all the listed sources
+# ./source_sync.sh
+# Use the -t <TAG> option to provide the TAG to be used to sync all the sources.
+# Use the -k <TAG> option to download only the kernel and device tree repos and optionally sync to TAG
+# For detailed usage information run with -h option.
+#
+
+
+# verify that git is installed
+if  ! which git > /dev/null  ; then
+  echo "ERROR: git is not installed. If your linux distro is 10.04 or later,"
+  echo "git can be installed by 'sudo apt-get install git-core'."
+  exit 1
+fi
+
+# source dir
+LDK_DIR=$(cd `dirname $0` && pwd)
+# script name
+SCRIPT_NAME=`basename $0`
+# info about sources.
+# NOTE: *Add only kernel repos here. Add new repos separately below. Keep related repos together*
+# NOTE: nvethrnetrm.git should be listed after "linux-nv-oot.git" due to nesting of sync path
+SOURCE_INFO="
+k:kernel/kernel-jammy-src:nv-tegra.nvidia.com/3rdparty/canonical/linux-jammy.git:
+k:nvgpu:nv-tegra.nvidia.com/linux-nvgpu.git:
+k:nvidia-oot:nv-tegra.nvidia.com/linux-nv-oot.git:
+k:hwpm:nv-tegra.nvidia.com/linux-hwpm.git:
+k:nvethernetrm:nv-tegra.nvidia.com/kernel/nvethernetrm.git:
+k:hardware/nvidia/t23x/nv-public:nv-tegra.nvidia.com/device/hardware/nvidia/t23x-public-dts.git:
+k:hardware/nvidia/tegra/nv-public:nv-tegra.nvidia.com/device/hardware/nvidia/tegra-public-dts.git:
+k:nvdisplay:nv-tegra.nvidia.com/tegra/kernel-src/nv-kernel-display-driver.git:
+k:dtc-src/1.4.5:nv-tegra.nvidia.com/3rdparty/dtc-src/1.4.5.git:
+o:tegra/argus-cam-libav/argus_cam_libavencoder:nv-tegra.nvidia.com/tegra/argus-cam-libav/argus_cam_libavencoder.git:
+o:tegra/cuda-src/nvsample_cudaprocess:nv-tegra.nvidia.com/tegra/cuda-src/nvsample_cudaprocess.git:
+o:tegra/gfx-src/nv-xconfig:nv-tegra.nvidia.com/tegra/gfx-src/nv-xconfig.git:
+o:tegra/gst-src/gst-egl:nv-tegra.nvidia.com/tegra/gst-src/gst-egl.git:
+o:tegra/gst-src/gst-jpeg:nv-tegra.nvidia.com/tegra/gst-src/gst-jpeg.git:
+o:tegra/gst-src/gst-nvarguscamera:nv-tegra.nvidia.com/tegra/gst-src/gst-nvarguscamera.git:
+o:tegra/gst-src/gst-nvcompositor:nv-tegra.nvidia.com/tegra/gst-src/gst-nvcompositor.git:
+o:tegra/gst-src/gst-nvtee:nv-tegra.nvidia.com/tegra/gst-src/gst-nvtee.git:
+o:tegra/gst-src/gst-nvv4l2camera:nv-tegra.nvidia.com/tegra/gst-src/gst-nvv4l2camera.git:
+o:tegra/gst-src/gst-nvvidconv:nv-tegra.nvidia.com/tegra/gst-src/gst-nvvidconv.git:
+o:tegra/gst-src/gst-nvvideo4linux2:nv-tegra.nvidia.com/tegra/gst-src/gst-nvvideo4linux2.git:
+o:tegra/gst-src/nvgstapps:nv-tegra.nvidia.com/tegra/gst-src/nvgstapps.git:
+o:tegra/gst-src/libgstnvcustomhelper:nv-tegra.nvidia.com/tegra/gst-src/libgstnvcustomhelper.git:
+o:tegra/gst-src/libgstnvdrmvideosink:nv-tegra.nvidia.com/tegra/gst-src/libgstnvdrmvideosink.git:
+o:tegra/gst-src/libgstnvvideosinks:nv-tegra.nvidia.com/tegra/gst-src/libgstnvvideosinks.git:
+o:tegra/v4l2-src/libv4l2_nvargus:nv-tegra.nvidia.com/tegra/v4l2-src/libv4l2_nvargus.git:
+o:tegra/nv-sci-src/nvsci_headers:nv-tegra.nvidia.com/tegra/nv-sci-src/nvsci_headers.git:
+o:tegra/optee-src/atf:nv-tegra.nvidia.com/tegra/optee-src/atf.git:
+o:tegra/optee-src/nv-optee:nv-tegra.nvidia.com/tegra/optee-src/nv-optee.git:
+o:tegra/v4l2-src/v4l2_libs:nv-tegra.nvidia.com/tegra/v4l2-src/v4l2_libs.git:
+"
+
+# exit on error on sync
+EOE=0
+# after processing SOURCE_INFO
+NSOURCES=0
+declare -a SOURCE_INFO_PROCESSED
+# download all?
+DALL=1
+
+function Usages {
+	local ScriptName=$1
+	local LINE
+	local OP
+	local DESC
+	local PROCESSED=()
+	local i
+
+	echo "Use: $1 [options]"
+	echo "Available general options are,"
+	echo "     -h     :     help"
+	echo "     -e     : exit on sync error"
+	echo "     -d [DIR] : root of source is DIR"
+	echo "     -t [TAG] : Git tag that will be used to sync all the sources"
+	echo ""
+	echo "By default, all sources are downloaded."
+	echo "Only specified sources are downloaded, if one or more of the following options are mentioned."
+	echo ""
+	echo "$SOURCE_INFO" | while read LINE; do
+		if [ ! -z "$LINE" ]; then
+			OP=$(echo "$LINE" | cut -f 1 -d ':')
+			DESC=$(echo "$LINE" | cut -f 2 -d ':')
+			if [[ ! " ${PROCESSED[@]} " =~ " ${OP} " ]]; then
+				echo "     -${OP} [TAG]: Download $DESC source and optionally sync to TAG"
+				PROCESSED+=("${OP}")
+			else
+				echo "           and download $DESC source and sync to the same TAG"
+			fi
+		fi
+	done
+	echo ""
+}
+
+function ProcessSwitch {
+	local SWITCH="$1"
+	local TAG="$2"
+	local i
+	local found=0
+
+	for ((i=0; i < NSOURCES; i++)); do
+		local OP=$(echo "${SOURCE_INFO_PROCESSED[i]}" | cut -f 1 -d ':')
+		if [ "-${OP}" == "$SWITCH" ]; then
+			SOURCE_INFO_PROCESSED[i]="${SOURCE_INFO_PROCESSED[i]}${TAG}:y"
+			DALL=0
+			found=1
+		fi
+	done
+
+	if [ "$found" == 1 ]; then
+		return 0
+	fi
+
+	echo "Terminating... wrong switch: ${SWITCH}" >&2
+	Usages "$SCRIPT_NAME"
+	exit 1
+}
+
+function UpdateTags {
+	local SWITCH="$1"
+	local TAG="$2"
+	local i
+
+	for ((i=0; i < NSOURCES; i++)); do
+		local OP=$(echo "${SOURCE_INFO_PROCESSED[i]}" | cut -f 1 -d ':')
+		if [ "${OP}" == "$SWITCH" ]; then
+			SOURCE_INFO_PROCESSED[i]=$(echo "${SOURCE_INFO_PROCESSED[i]}" \
+				| awk -F: -v OFS=: -v var="${TAG}" '{$4=var; print}')
+		fi
+	done
+}
+
+function DownloadAndSync {
+	local WHAT_SOURCE="$1"
+	local LDK_SOURCE_DIR="$2"
+	local REPO_URL="$3"
+	local TAG="$4"
+	local OPT="$5"
+	local RET=0
+
+	if [ -d "${LDK_SOURCE_DIR}" ]; then
+		echo "Directory for $WHAT, ${LDK_SOURCE_DIR}, already exists!"
+		pushd "${LDK_SOURCE_DIR}" > /dev/null
+		git status 2>&1 >/dev/null
+		if [ $? -ne 0 ]; then
+			echo "But the directory is not a git repository -- clean it up first"
+			echo ""
+			echo ""
+			popd > /dev/null
+			return 1
+		fi
+		git fetch --all 2>&1 >/dev/null
+		popd > /dev/null
+	else
+		echo "Downloading default $WHAT source..."
+
+		git clone "$REPO_URL" -n ${LDK_SOURCE_DIR} 2>&1 >/dev/null
+		if [ $? -ne 0 ]; then
+			echo "$2 source sync failed!"
+			echo ""
+			echo ""
+			return 1
+		fi
+
+		echo "The default $WHAT source is downloaded in: ${LDK_SOURCE_DIR}"
+	fi
+
+	if [ -z "$TAG" ]; then
+		echo "Please enter a tag to sync $2 source to"
+		echo -n "(enter nothing to skip): "
+		read TAG
+		TAG=$(echo $TAG)
+		UpdateTags $OPT $TAG
+	fi
+
+	if [ ! -z "$TAG" ]; then
+		pushd ${LDK_SOURCE_DIR} > /dev/null
+		git tag -l 2>/dev/null | grep -q -P "^$TAG\$"
+		if [ $? -eq 0 ]; then
+			echo "Syncing up with tag $TAG..."
+			git checkout -b mybranch_$(date +%Y-%m-%d-%s) $TAG
+			echo "$2 source sync'ed to tag $TAG successfully!"
+		else
+			echo "Couldn't find tag $TAG"
+			echo "$2 source sync to tag $TAG failed!"
+			RET=1
+		fi
+		popd > /dev/null
+	fi
+	echo ""
+	echo ""
+
+	return "$RET"
+}
+
+# prepare processing ....
+GETOPT=":ehd:t:"
+
+OIFS="$IFS"
+IFS=$(echo -en "\n\b")
+SOURCE_INFO_PROCESSED=($(echo "$SOURCE_INFO"))
+IFS="$OIFS"
+NSOURCES=${#SOURCE_INFO_PROCESSED[*]}
+
+for ((i=0; i < NSOURCES; i++)); do
+	OP=$(echo "${SOURCE_INFO_PROCESSED[i]}" | cut -f 1 -d ':')
+	GETOPT="${GETOPT}${OP}:"
+done
+
+# parse the command line first
+while getopts "$GETOPT" opt; do
+	case $opt in
+		d)
+			case $OPTARG in
+				-[A-Za-z]*)
+					Usages "$SCRIPT_NAME"
+					exit 1
+					;;
+				*)
+					LDK_DIR="$OPTARG"
+					;;
+			esac
+			;;
+		e)
+			EOE=1
+			;;
+		h)
+			Usages "$SCRIPT_NAME"
+			exit 1
+			;;
+		t)
+			TAG="$OPTARG"
+			PROCESSED=()
+			for ((i=0; i < NSOURCES; i++)); do
+				OP=$(echo "${SOURCE_INFO_PROCESSED[i]}" | cut -f 1 -d ':')
+				if [[ ! " ${PROCESSED[@]} " =~ " ${OP} " ]]; then
+					UpdateTags $OP $TAG
+					PROCESSED+=("${OP}")
+				fi
+			done
+			;;
+		[A-Za-z])
+			case $OPTARG in
+				-[A-Za-z]*)
+					eval arg=\$$((OPTIND-1))
+					case $arg in
+						-[A-Za-Z]-*)
+							Usages "$SCRIPT_NAME"
+							exit 1
+							;;
+						*)
+							ProcessSwitch "-$opt" ""
+							OPTIND=$((OPTIND-1))
+							;;
+					esac
+					;;
+				*)
+					ProcessSwitch "-$opt" "$OPTARG"
+					;;
+			esac
+			;;
+		:)
+			case $OPTARG in
+				#required arguments
+				d)
+					Usages "$SCRIPT_NAME"
+					exit 1
+					;;
+				#optional arguments
+				[A-Za-z])
+					ProcessSwitch "-$OPTARG" ""
+					;;
+			esac
+			;;
+		\?)
+			echo "Terminating... wrong switch: $@" >&2
+			Usages "$SCRIPT_NAME"
+			exit 1
+			;;
+	esac
+done
+shift $((OPTIND-1))
+
+GRET=0
+for ((i=0; i < NSOURCES; i++)); do
+	OPT=$(echo "${SOURCE_INFO_PROCESSED[i]}" | cut -f 1 -d ':')
+	WHAT=$(echo "${SOURCE_INFO_PROCESSED[i]}" | cut -f 2 -d ':')
+	REPO=$(echo "${SOURCE_INFO_PROCESSED[i]}" | cut -f 3 -d ':')
+	TAG=$(echo "${SOURCE_INFO_PROCESSED[i]}" | cut -f 4 -d ':')
+	DNLOAD=$(echo "${SOURCE_INFO_PROCESSED[i]}" | cut -f 5 -d ':')
+
+	if [ $DALL -eq 1 -o "x${DNLOAD}" == "xy" ]; then
+		DownloadAndSync "$WHAT" "${LDK_DIR}/${WHAT}" "git://${REPO}" "${TAG}" "${OPT}"
+		tRET=$?
+		let GRET=GRET+tRET
+		if [ $tRET -ne 0 -a $EOE -eq 1 ]; then
+			exit $tRET
+		fi
+	fi
+done
+
+ln -sf ../../../../../../nvethernetrm ${LDK_DIR}/nvidia-oot/drivers/net/ethernet/nvidia/nvethernet/nvethernetrm
+
+exit $GRET

--- a/setup_workspace.sh
+++ b/setup_workspace.sh
@@ -66,3 +66,10 @@ if [[ "$JETPACK_VERSION" == "6.0" ]]; then
     cp ./nvidia-oot/Makefile ./sources_$JETPACK_VERSION/
     cp ./kernel/kernel-jammy-src/Makefile ./sources_$JETPACK_VERSION/kernel
 fi
+
+# remove BUILD_NUMBER env dependency kernel vermagic
+if [[ "${JETPACK_VERSION}" == "4.6.1" ]]; then
+    sed -i s/'UTS_RELEASE=\$(KERNELRELEASE)-ab\$(BUILD_NUMBER)'/'UTS_RELEASE=\$(KERNELRELEASE)'/g ./sources_$JETPACK_VERSION/kernel/kernel-4.9/Makefile
+    sed -i 's/the-space :=/E =/g' ./sources_$JETPACK_VERSION/kernel/kernel-4.9/scripts/Kbuild.include
+    sed -i 's/the-space += /the-space = \$E \$E/g' ./sources_$JETPACK_VERSION/kernel/kernel-4.9/scripts/Kbuild.include
+fi

--- a/setup_workspace.sh
+++ b/setup_workspace.sh
@@ -26,7 +26,7 @@ function DisplayNvidiaLicense {
 if [[ "$1" == "-h" ]]; then
     echo "setup_workspace.sh [JetPack_version]"
     echo "setup_workspace.sh -h"
-    echo "JetPack_version can be 4.6.1, 5.0.2, 5.1.2"
+    echo "JetPack_version can be 4.6.1, 5.0.2, 5.1.2, 6.0"
     exit 1
 fi
 
@@ -42,7 +42,10 @@ DisplayNvidiaLicense ""
 if [[ ! -d "$DEVDIR/l4t-gcc/$JETPACK_VERSION/bin/" ]]; then
     mkdir -p $DEVDIR/l4t-gcc/$JETPACK_VERSION
     cd $DEVDIR/l4t-gcc/$JETPACK_VERSION
-    if [[ "$JETPACK_VERSION" == "5.1.2" ]]; then
+    if [[ "$JETPACK_VERSION" == "6.0" ]]; then
+        wget https://developer.nvidia.com/downloads/embedded/l4t/r36_release_v2.0/toolchain/aarch64--glibc--stable-2022.08-1.tar.bz2 -O aarch64--glibc--stable-final.tar.bz2
+        tar xf aarch64--glibc--stable-final.tar.bz2 --strip-components 1
+    elif [[ "$JETPACK_VERSION" == "5.1.2" ]]; then
         wget https://developer.nvidia.com/embedded/jetson-linux/bootlin-toolchain-gcc-93 -O aarch64--glibc--stable-final.tar.gz
         tar xf aarch64--glibc--stable-final.tar.gz
     elif [[ "$JETPACK_VERSION" == "5.0.2" ]]; then
@@ -58,3 +61,8 @@ fi
 cd $DEVDIR
 ./scripts/source_sync_$JETPACK_VERSION.sh -t $L4T_VERSION -d sources_$JETPACK_VERSION
 
+# copy Makefile for jp6
+if [[ "$JETPACK_VERSION" == "6.0" ]]; then
+    cp ./nvidia-oot/Makefile ./sources_$JETPACK_VERSION/
+    cp ./kernel/kernel-jammy-src/Makefile ./sources_$JETPACK_VERSION/kernel
+fi


### PR DESCRIPTION
jp6: base build scripts

d4xx: add modern kernel support

gmsl: parse open firmware gmsl nodes as maxim or nvidia.

dtb: jetson orin d4xx overlay

dtb: enable jp6 build d4xx overlay

build scripts support for jp6

nvidia-oot: compile out of kernel tree

apply patches only if there is patches