### PR TITLE
nvidia-vi5: prevent high cpu usage.

### DIFF
--- a/kernel/nvidia/4.6.1/0078-nvidia-vi5-prevent-high-cpu-usage.patch
+++ b/kernel/nvidia/4.6.1/0078-nvidia-vi5-prevent-high-cpu-usage.patch
@@ -1,0 +1,32 @@
+From 6611c1c40470c0b8387c4639e936d480fd073591 Mon Sep 17 00:00:00 2001
+From: Dmitry Perchanov <dmitry.perchanov@intel.com>
+Date: Wed, 28 Feb 2024 18:06:23 +0200
+Subject: [PATCH] nvidia-vi5: prevent high cpu usage.
+
+Error 262144 (40000h) cause high cpu usage.
+
+Tracked-by: <LRS-1019>
+
+Signed-off-by: Dmitry Perchanov <dmitry.perchanov@intel.com>
+---
+ drivers/media/platform/tegra/camera/vi/vi5_fops.c | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/media/platform/tegra/camera/vi/vi5_fops.c b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
+index 97b7d9f35..6d6e1777e 100644
+--- a/drivers/media/platform/tegra/camera/vi/vi5_fops.c
++++ b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
+@@ -553,7 +553,9 @@ static void vi5_capture_dequeue(struct tegra_channel *chan,
+ 
+ 			/* D457: err_data 131072 (20000h) & 512 (200h) leading to channel
+ 			 * timeout. This happens when first frame is corrupted - no md
+-			 * and less lines than requested. Channel reset time is 6ms */
++			 * and less lines than requested.
++			 * Error 262144 (40000h) cause high cpu usage.
++			 * Channel reset time is 6ms */
+ 				if (descr->status.err_data & 0x20200) {
+ 					spin_lock_irqsave(&chan->capture_state_lock, flags);
+ 					chan->capture_state = CAPTURE_ERROR;
+-- 
+2.34.1
+

--- a/kernel/nvidia/5.0.2/0013-nvidia-vi5-prevent-high-cpu-usage.patch
+++ b/kernel/nvidia/5.0.2/0013-nvidia-vi5-prevent-high-cpu-usage.patch
@@ -1,0 +1,34 @@
+From 41f58778cef047b1465ab54f67967b3b297184ab Mon Sep 17 00:00:00 2001
+From: Dmitry Perchanov <dmitry.perchanov@intel.com>
+Date: Wed, 28 Feb 2024 17:51:09 +0200
+Subject: [PATCH] nvidia-vi5: prevent high cpu usage.
+
+Error 262144 (40000h) cause high cpu usage.
+
+Tracked-by: <LRS-1019>
+
+Signed-off-by: Dmitry Perchanov <dmitry.perchanov@intel.com>
+---
+ drivers/media/platform/tegra/camera/vi/vi5_fops.c | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/media/platform/tegra/camera/vi/vi5_fops.c b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
+index af790b60d..afaf3d742 100644
+--- a/drivers/media/platform/tegra/camera/vi/vi5_fops.c
++++ b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
+@@ -604,8 +604,10 @@ static void vi5_capture_dequeue(struct tegra_channel *chan,
+ #endif
+ 				/* D457: err_data 131072 (20000h) & 512 (200h) leading to channel
+ 				* timeout. This happens when first frame is corrupted - no md
+-				* and less lines than requested. Channel reset time is 6ms */
+-				if (descr->status.err_data & 0x20200) {
++				* and less lines than requested.
++				* Error 262144 (40000h) cause high cpu usage.
++				* Channel reset time is 6ms */
++				if (descr->status.err_data & 0x60200) {
+ 					spin_lock_irqsave(&chan->capture_state_lock, flags);
+ 					chan->capture_state = CAPTURE_ERROR;
+ 					spin_unlock_irqrestore(&chan->capture_state_lock, flags);
+-- 
+2.34.1
+

--- a/kernel/nvidia/5.1.2/0002-nvidia-vi5-prevent-high-cpu-usage.patch
+++ b/kernel/nvidia/5.1.2/0002-nvidia-vi5-prevent-high-cpu-usage.patch
@@ -1,0 +1,34 @@
+From 1e8fba2868bf843a7b56cf5df7e544bdc028c8f9 Mon Sep 17 00:00:00 2001
+From: Dmitry Perchanov <dmitry.perchanov@intel.com>
+Date: Wed, 28 Feb 2024 17:56:21 +0200
+Subject: [PATCH] nvidia-vi5: prevent high cpu usage.
+
+Error 262144 (40000h) cause high cpu usage.
+
+Tracked-by: <LRS-1019>
+
+Signed-off-by: Dmitry Perchanov <dmitry.perchanov@intel.com>
+---
+ drivers/media/platform/tegra/camera/vi/vi5_fops.c | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/media/platform/tegra/camera/vi/vi5_fops.c b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
+index 042a80e51..8ba911c4d 100644
+--- a/drivers/media/platform/tegra/camera/vi/vi5_fops.c
++++ b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
+@@ -655,8 +655,10 @@ static void vi5_capture_dequeue(struct tegra_channel *chan,
+ #endif
+ 				/* D457: err_data 131072 (20000h) & 512 (200h) leading to channel
+ 				* timeout. This happens when first frame is corrupted - no md
+-				* and less lines than requested. Channel reset time is 6ms */
+-				if (descr->status.err_data & 0x20200) {
++				* and less lines than requested.
++				* Error 262144 (40000h) cause high cpu usage.
++				* Channel reset time is 6ms */
++				if (descr->status.err_data & 0x60200) {
+ 					spin_lock_irqsave(&chan->capture_state_lock, flags);
+ 					chan->capture_state = CAPTURE_ERROR;
+ 					spin_unlock_irqrestore(&chan->capture_state_lock, flags);
+-- 
+2.34.1
+


### PR DESCRIPTION
Error 262144 (40000h) cause high cpu usage.

Tracked-by: <LRS-1019>