### PR TITLE
d4xx: fix dfu release warning

### DIFF
--- a/kernel/realsense/d4xx.c
+++ b/kernel/realsense/d4xx.c
@@ -5049,10 +5049,11 @@ static int ds5_dfu_device_release(struct inode *inode, struct file *file)
 #endif
 	/* Verify communication */
 	do {
-		msleep_range(100);
 		ret = ds5_read(state, DS5_FW_VERSION, &state->fw_version);
+		if (ret)
+			msleep_range(10);
 	} while (retry-- && ret != 0 );
-	if (!ret) {
+	if (ret) {
 		dev_warn(&state->client->dev,
 			"%s(): no communication with d4xx\n", __func__);
 		return ret;


### PR DESCRIPTION
Excessive Warning message of "no communication with d4xx" and App startup delay

https://elixir.bootlin.com/linux/latest/source/drivers/base/regmap/regmap.c#L2850
```
/**
 * regmap_raw_read() - Read raw data from the device
 *
 * @map: Register map to read from
 * @reg: First register to be read from
 * @val: Pointer to store read value
 * @val_len: Size of data to read
 *
 * A value of zero will be returned on success, a negative errno will
 * be returned in error cases.
 */
```
Tracked-by: [RSDSO-19607]

Reported-by: Yusheng Hsu <yusheng.hsu@intel.com>