### PR TITLE
jp6: enable kernel HID_SENSOR to support USB HID

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,8 @@ Copy them to the right places:
 ```
 scp -r images/6.0/rootfs/boot/tegra234-camera-d4xx-overlay.dtbo nvidia@10.0.0.116:~/
 scp -r images/6.0/rootfs/lib/modules/5.15.122-tegra/extra nvidia@10.0.0.116:~/
+# Kernel Image with SENSOR_HID support for RealSense USB cameras with IMU
+scp -r images/6.0/rootfs/boot/Image nvidia@10.0.0.116:~/
 ```
 
 on target:
@@ -144,6 +146,9 @@ sudo cp ~/tegra234-camera-d4xx-overlay.dtbo /boot/
 # backup:
 sudo tar -cjf /lib/modules/$(uname -r)/modules_$(uname -r)_extra.tar.bz2 /lib/modules/$(uname -r)/extra
 sudo cp -r ~/extra /lib/modules/$(uname -r)/
+# backup kernel (better to have additional boot entry in extlinux.conf)
+sudo cp /boot/Image /boot/Image.orig
+sudo cp Image /boot/Image
 ```
 
 Enable d4xx overlay:

--- a/kernel/kernel-jammy-src/6.0/0001-kernel-enable-HID_SENSOR.patch
+++ b/kernel/kernel-jammy-src/6.0/0001-kernel-enable-HID_SENSOR.patch
@@ -1,0 +1,48 @@
+From 8abf5719599328104b1eb0c6cbc5f9526f106adc Mon Sep 17 00:00:00 2001
+From: Dmitry Perchanov <dmitry.perchanov@intel.com>
+Date: Tue, 5 Mar 2024 16:42:02 +0200
+Subject: [PATCH] kernel: enable HID_SENSOR
+
+Signed-off-by: Dmitry Perchanov <dmitry.perchanov@intel.com>
+---
+ arch/arm64/configs/defconfig | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/arch/arm64/configs/defconfig b/arch/arm64/configs/defconfig
+index dc016a3a18a8..8ed5714a17fc 100644
+--- a/arch/arm64/configs/defconfig
++++ b/arch/arm64/configs/defconfig
+@@ -849,7 +849,12 @@ CONFIG_SND_SOC_LPASS_WSA_MACRO=m
+ CONFIG_SND_SOC_LPASS_VA_MACRO=m
+ CONFIG_SND_SIMPLE_CARD=m
+ CONFIG_SND_AUDIO_GRAPH_CARD=m
++CONFIG_HID=y
++CONFIG_HIDRAW=y
++CONFIG_HID_GENERIC=y
+ CONFIG_HID_MULTITOUCH=m
++CONFIG_HID_SENSOR_HUB=y
++CONFIG_USB_HID=y
+ CONFIG_I2C_HID_ACPI=m
+ CONFIG_I2C_HID_OF=m
+ CONFIG_USB=y
+@@ -1131,6 +1136,7 @@ CONFIG_EXTCON_USB_GPIO=y
+ CONFIG_EXTCON_USBC_CROS_EC=y
+ CONFIG_RENESAS_RPCIF=m
+ CONFIG_IIO=y
++CONFIG_HID_SENSOR_ACCEL_3D=y
+ CONFIG_EXYNOS_ADC=y
+ CONFIG_MAX9611=m
+ CONFIG_QCOM_SPMI_VADC=m
+@@ -1138,6 +1144,9 @@ CONFIG_QCOM_SPMI_ADC5=m
+ CONFIG_ROCKCHIP_SARADC=m
+ CONFIG_IIO_CROS_EC_SENSORS_CORE=m
+ CONFIG_IIO_CROS_EC_SENSORS=m
++CONFIG_HID_SENSOR_IIO_COMMON=y
++CONFIG_HID_SENSOR_IIO_TRIGGER=y
++CONFIG_HID_SENSOR_GYRO_3D=y
+ CONFIG_IIO_ST_LSM6DSX=m
+ CONFIG_IIO_CROS_EC_LIGHT_PROX=m
+ CONFIG_SENSORS_ISL29018=m
+-- 
+2.34.1
+


### PR DESCRIPTION
Tracked-by: [RSDSO-19608] [D457] [JP6] enable IIO-HID in kernel

IIO-HID is disabled by default for jetson jetpack 6.0
JetPack 4.6.1:
```
administrator@rsjetson20:~$ gzip -d < /proc/config.gz | grep HIDRAW
CONFIG_HIDRAW=y
administrator@rsjetson20:~$ gzip -d < /proc/config.gz | grep HID_SENSOR
CONFIG_HID_SENSOR_HUB=m
CONFIG_HID_SENSOR_CUSTOM_SENSOR=m
CONFIG_HID_SENSOR_ACCEL_3D=m
CONFIG_HID_SENSOR_IIO_COMMON=m
CONFIG_HID_SENSOR_IIO_TRIGGER=m
CONFIG_HID_SENSOR_GYRO_3D=m
```
Jetpack 6.0:
```
root@ubuntu:/home/nvidia# gzip -d < /proc/config.gz | grep HIDRAW
CONFIG_HIDRAW is not set
root@ubuntu:/home/nvidia# gzip -d < /proc/config.gz | grep HID_SENSOR
CONFIG_HID_SENSOR_HUB is not set
```
Issue:
```
[ 3772.623042] hid-generic 0003:8086:0B5C.0004: device has no listeners, quitting
```
rs-enumerate-devices does not detect cameras with imu - d455, d435i
