### PR TITLE
d4xx: hwmc return success on ioctl

### DIFF
--- a/kernel/realsense/d4xx.c
+++ b/kernel/realsense/d4xx.c
@@ -2514,8 +2514,10 @@ static int ds5_g_volatile_ctrl(struct v4l2_ctrl *ctrl)
 			u16 dataLen = 0;
 			u16 bufLen = ctrl->dims[0];
 			ret = ds5_get_hwmc(state, data,	bufLen, &dataLen);
-			if (ret)
+			if (ret) {
+				ret = 0; // LRS doesn't expect to get errors with HWMC
 				break;
+			}
 			/* This is needed for librealsense, to align there code with UVC,
 		 	 * last word is length - 4 bytes header length */
 			dataLen -= 4;


### PR DESCRIPTION
LRS expects success on hwmc ioctl call.

[Error] /tmp/sandbox/src/librealsense-exception.h:52 - xioctl(VIDIOC_G_EXT_CTRLS) failed Last Error: Bad message