### PR TITLE
Updated AE_SETPOINT_GET control's range

### DIFF
--- a/kernel/realsense/d4xx.c
+++ b/kernel/realsense/d4xx.c
@@ -2703,6 +2703,8 @@ static const struct v4l2_ctrl_config ds5_ctrl_ae_setpoint_get = {
 	.name = "ae setpoint get",
 	.type = V4L2_CTRL_TYPE_INTEGER,
 	.flags = V4L2_CTRL_FLAG_VOLATILE | V4L2_CTRL_FLAG_READ_ONLY,
+	.min = 0,
+	.max = 4095,
 	.step = 1,
 };
 


### PR DESCRIPTION
[Tracked by LRS-1164]

`v4l2-compliance` tool is failing while testing this control as there is no range set.