### PR TITLE
Porting stride alignment patch from JP 5.0.2 to 5.1.2 & 6.0

### DIFF
--- a/kernel/nvidia/5.1.2/0001-Porting-driver-patches-to-jetpack-5.1.2.patch
+++ b/kernel/nvidia/5.1.2/0001-Porting-driver-patches-to-jetpack-5.1.2.patch
@@ -1530,6 +1530,15 @@ diff --git a/include/media/tegra_camera_core.h b/include/media/tegra_camera_core
 index 788cf77dc..421c22491 100644
 --- a/include/media/tegra_camera_core.h
 +++ b/include/media/tegra_camera_core.h
+@@ -23,7 +23,7 @@
+ /* Width alignment */
+ #define TEGRA_WIDTH_ALIGNMENT	1
+ /* Stride alignment */
+-#define TEGRA_STRIDE_ALIGNMENT	1
++#define TEGRA_STRIDE_ALIGNMENT	64
+ /* Height alignment */
+ #define TEGRA_HEIGHT_ALIGNMENT	1
+ /* Size alignment */
 @@ -37,6 +37,8 @@
  #define TEGRA_IMAGE_FORMAT_DEF	32
  

--- a/nvidia-oot/6.0/0001-Porting-nvidia-driver-patches-to-jetpack-6.0.patch
+++ b/nvidia-oot/6.0/0001-Porting-nvidia-driver-patches-to-jetpack-6.0.patch
@@ -1224,6 +1224,15 @@ diff --git a/include/media/tegra_camera_core.h b/include/media/tegra_camera_core
 index e6d9a2b1..38634b77 100644
 --- a/include/media/tegra_camera_core.h
 +++ b/include/media/tegra_camera_core.h
+@@ -18,7 +18,7 @@
+ /* Width alignment */
+ #define TEGRA_WIDTH_ALIGNMENT	1
+ /* Stride alignment */
+-#define TEGRA_STRIDE_ALIGNMENT	1
++#define TEGRA_STRIDE_ALIGNMENT	64
+ /* Height alignment */
+ #define TEGRA_HEIGHT_ALIGNMENT	1
+ /* Size alignment */
 @@ -32,6 +32,8 @@
  #define TEGRA_IMAGE_FORMAT_DEF	32
  


### PR DESCRIPTION
Tracked by RSDSO-19734

Fixing broken images from Depth, IR and Color at 848x480 and 424x240.