### PR TITLE
Add missing git checkout step to readme

### DIFF
--- a/README_JP6.md
+++ b/README_JP6.md
@@ -43,6 +43,7 @@ sudo apt-get install -y build-essential bc wget flex bison curl libssl-dev xxd
 ```
 git clone https://github.com/IntelRealSense/realsense_mipi_platform_driver.git
 cd realsense_mipi_platform_driver
+git checkout dev
 ./setup_workspace.sh 6.0
 ./apply_patches.sh apply 6.0
 ./build_all.sh 6.0

--- a/README_JP6.md
+++ b/README_JP6.md
@@ -33,7 +33,7 @@ sudo apt-get install -y build-essential bc wget flex bison curl libssl-dev xxd
 ```
 ## Build NVIDIA® kernel drivers, dtb and D457 driver - cross compile x86-64
 
-1. Clone [realsense_mipi_platform_driver](https://github.com/IntelRealSense/realsense_mipi_platform_driver.git) repo.
+1. Clone [realsense_mipi_platform_driver](https://github.com/IntelRealSense/realsense_mipi_platform_driver.git) repo and switch to the `dev` branch.
 2. The developers can set up build environment, ARM64 compiler, kernel sources and NVIDIA's Jetson git repositories by using the setup script.
 3. Apply patches for kernel drivers, nvidia-oot module and tegra devicetree.
 4. Build cross-compile project on host (Build PC).


### PR DESCRIPTION
The instructions for JP6 in the dev branch omit a git checkout step. 