### PR TITLE
[PATCH] Fix Y12I streaming error handling in vi5_capture_dequeue

### DIFF
--- a/nvidia-oot/6.0/0003-Fix-y12i-calibration-stream.patch
+++ b/nvidia-oot/6.0/0003-Fix-y12i-calibration-stream.patch
@@ -7,8 +7,8 @@ index 7d07ccd7..c64dcc38 100644
  	vb->vb2_buf.timestamp = descr->status.sof_timestamp;
  
 -	if (frame_err)
-+	/* TODO: Remove Y12I frame_err workaround once Y12I hardware/firmware reports
-+	 * frame_err correctly (no false positives during Y12I streaming).
++	/* TODO: Remove Y12I frame_err workaround once Y12I is fixed
++	 * Currently there is a black-bar at the bottom of the frame.
 +	 */
 +	if (frame_err && chan->fmtinfo->fourcc != V4L2_PIX_FMT_Y12I)
  		buf->vb2_state = VB2_BUF_STATE_ERROR;


### PR DESCRIPTION
Improve error handling for Y12I streaming by refining the condition that sets the buffer state to error. This change addresses the specific handling of frame errors for Y12I format.