### PR TITLE
Add support for JetPack 6.2.1 and update Nvidia sources handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 # D457 MIPI on NVIDIA® Jetson AGX Xavier™ and AGX Orin™
 The RealSense™ MIPI platform driver enables the user to control and stream RealSense™ 3D MIPI cameras.
 The system shall include:
-* NVIDIA® Jetson platform (Currently Supported JetPack versions are: 6.2, 6.1, 6.0, 5.1.2, 5.0.2, 4.6.1)
+* NVIDIA® Jetson platform (Currently Supported JetPack versions are: 6.2.1, 6.2, 6.1, 6.0, 5.1.2, 5.0.2, 4.6.1)
 * RealSense De-Serialize board (https://store.intelrealsense.com/buy-intel-realsense-des457.html)
 * NVIDIA® Jetson AGX Orin™ Passive adapter board from [Leopard Imaging LI-JTX1-SUB-ADPT](https://leopardimaging.com/product/accessories/adapters-carrier-boards/for-nvidia-jetson/li-jtx1-sub-adpt/)
 * RS MIPI camera (e.g. https://store.intelrealsense.com/buy-intel-realsense-depth-camera-d457.html)

--- a/README_JP6.2.md
+++ b/README_JP6.2.md
@@ -4,6 +4,7 @@
 The RealSense™ MIPI platform driver enables the user to control and stream RealSense™ 3D MIPI cameras.
 The system shall include:
 * NVIDIA® Jetson™ platform Supported JetPack versions are:
+    - [6.2.1 production release](https://developer.nvidia.com/embedded/jetpack-sdk-621)
     - [6.2 production release](https://developer.nvidia.com/embedded/jetpack-sdk-62)
     - [6.1 production release](https://developer.nvidia.com/embedded/jetpack-sdk-61)
     - [6.0 production release](https://developer.nvidia.com/embedded/jetpack-sdk-60)

--- a/apply_patches.sh
+++ b/apply_patches.sh
@@ -53,6 +53,12 @@ if [[ "$ACTION" == reset && -d "sources_$SOURCES_VERSION/hardware/nvidia/platfor
     rm -rfv "sources_$SOURCES_VERSION/hardware/nvidia/platform/t19x/galen-industrial" > /dev/null
 fi
 
+# Create nvethernetrm symlink for JP 6.x (moved from source_sync_6.x.sh)
+# JP 5.x handles nvethernetrm differently (full path clone, not a symlink)
+if [[ "$ACTION" == reset ]] && [[ "$JETPACK_VERSION" =~ ^6\. ]]; then
+    ln -sf ../../../../../../nvethernetrm "sources_$SOURCES_VERSION/nvidia-oot/drivers/net/ethernet/nvidia/nvethernet/nvethernetrm"
+fi
+
 apply_external_patches() {
     git -C "sources_$SOURCES_VERSION/$3" status > /dev/null
     if [[ "$1" == 'apply' ]]; then
@@ -62,6 +68,9 @@ apply_external_patches() {
         fi
         ls -Ld "${PWD}/$3/$2"
         ls -Lw1 "${PWD}/$3/$2"
+        # Store the original commit hash before applying patches
+        ORIGINAL_COMMIT=$(git -C "sources_$SOURCES_VERSION/$3" rev-parse HEAD)
+        echo "$ORIGINAL_COMMIT" > "sources_$SOURCES_VERSION/$3/.realsense_patch_base"
         git -C "sources_$SOURCES_VERSION/$3" apply "${PWD}/$3/$2"/*
     elif [ "$1" = "reset" ]; then
         if ! git -C "sources_$SOURCES_VERSION/$3" diff --quiet || ! git -C "sources_$SOURCES_VERSION/$3" diff --cached --quiet; then
@@ -69,7 +78,14 @@ apply_external_patches() {
             [[ "$confirm" != "y" && "$confirm" != "Y" ]] && exit 1
         fi
         echo -n "$(ls -d "sources_$SOURCES_VERSION/$3"): "
-        git -C "sources_$SOURCES_VERSION/$3" reset --hard $4
+        # Reset to original commit if .realsense_patch_base exists, otherwise use L4T_VERSION
+        if [[ -f "sources_$SOURCES_VERSION/$3/.realsense_patch_base" ]]; then
+            RESET_TARGET=$(cat "sources_$SOURCES_VERSION/$3/.realsense_patch_base")
+            git -C "sources_$SOURCES_VERSION/$3" reset --hard "$RESET_TARGET"
+            rm -f "sources_$SOURCES_VERSION/$3/.realsense_patch_base"
+        else
+            git -C "sources_$SOURCES_VERSION/$3" reset --hard $4
+        fi
     fi
 }
 
@@ -90,5 +106,42 @@ if [[ "$ACTION" = "apply" ]]; then
         cp hardware/realsense/tegra234-camera-d4xx-overlay*.dts "sources_$SOURCES_VERSION/hardware/nvidia/t23x/nv-public/overlay/"
     else
         cp "hardware/realsense/${JP5_D4XX_DTSI}" "sources_$SOURCES_VERSION/hardware/nvidia/platform/t19x/galen/kernel-dts/common/tegra194-camera-d4xx.dtsi"
+    fi
+    
+    # Stage all modified files after patching
+    git -C "sources_$SOURCES_VERSION/$D4XX_SRC_DST" add -A
+    [[ -d "sources_$SOURCES_VERSION/$KERNEL_DIR" ]] && git -C "sources_$SOURCES_VERSION/$KERNEL_DIR" add -A
+    if [[ -d "sources_$SOURCES_VERSION/hardware/nvidia/t23x/nv-public" ]]; then
+        git -C "sources_$SOURCES_VERSION/hardware/nvidia/t23x/nv-public" add -A
+    elif [[ -d "sources_$SOURCES_VERSION/hardware/nvidia/platform/t19x/galen/kernel-dts" ]]; then
+        git -C "sources_$SOURCES_VERSION/hardware/nvidia/platform/t19x/galen/kernel-dts" add -A
+    fi
+    
+    # Get author identity from root repo
+    GIT_AUTHOR_NAME=$(git config user.name)
+    GIT_AUTHOR_EMAIL=$(git config user.email)
+    
+    # Update local git identity for subrepos
+    git -C "sources_$SOURCES_VERSION/$D4XX_SRC_DST" config user.name "$GIT_AUTHOR_NAME"
+    git -C "sources_$SOURCES_VERSION/$D4XX_SRC_DST" config user.email "$GIT_AUTHOR_EMAIL"
+    if [[ -d "sources_$SOURCES_VERSION/$KERNEL_DIR" ]]; then
+        git -C "sources_$SOURCES_VERSION/$KERNEL_DIR" config user.name "$GIT_AUTHOR_NAME"
+        git -C "sources_$SOURCES_VERSION/$KERNEL_DIR" config user.email "$GIT_AUTHOR_EMAIL"
+    fi
+    if [[ -d "sources_$SOURCES_VERSION/hardware/nvidia/platform/t19x/galen/kernel-dts" ]]; then
+        git -C "sources_$SOURCES_VERSION/hardware/nvidia/platform/t19x/galen/kernel-dts" config user.name "$GIT_AUTHOR_NAME"
+        git -C "sources_$SOURCES_VERSION/hardware/nvidia/platform/t19x/galen/kernel-dts" config user.email "$GIT_AUTHOR_EMAIL"
+    elif [[ -d "sources_$SOURCES_VERSION/hardware/nvidia/t23x/nv-public" ]]; then
+        git -C "sources_$SOURCES_VERSION/hardware/nvidia/t23x/nv-public" config user.name "$GIT_AUTHOR_NAME"
+        git -C "sources_$SOURCES_VERSION/hardware/nvidia/t23x/nv-public" config user.email "$GIT_AUTHOR_EMAIL"
+    fi
+
+    # Commit all staged files
+    git -C "sources_$SOURCES_VERSION/$D4XX_SRC_DST" commit -m "RS patched" || true
+    [[ -d "sources_$SOURCES_VERSION/$KERNEL_DIR" ]] && git -C "sources_$SOURCES_VERSION/$KERNEL_DIR" commit -m "RS patched" || true
+    if [[ -d "sources_$SOURCES_VERSION/hardware/nvidia/t23x/nv-public" ]]; then
+        git -C "sources_$SOURCES_VERSION/hardware/nvidia/t23x/nv-public" commit -m "RS patched" || true
+    elif [[ -d "sources_$SOURCES_VERSION/hardware/nvidia/platform/t19x/galen/kernel-dts" ]]; then
+        git -C "sources_$SOURCES_VERSION/hardware/nvidia/platform/t19x/galen/kernel-dts" commit -m "RS patched" || true
     fi
 fi

--- a/build_all.sh
+++ b/build_all.sh
@@ -3,16 +3,31 @@
 set -e
 
 if [[ $# < 1 || "$1" == "-h" ]]; then
-    echo "build_all.sh [--dev-dbg] JetPack_version [JetPack_Linux_source]"
+    echo "build_all.sh [--clean] [--dev-dbg] JetPack_version [JetPack_Linux_source]"
     echo "build_all.sh -h"
     exit 1
 fi
 
+CLEAN=0
 DEVDBG=0
-if [[ "$1" == "--dev-dbg" ]]; then
-    DEVDBG=1
-    shift
-fi
+
+# Parse optional flags
+while [[ "$1" == --* ]]; do
+    case "$1" in
+        --clean)
+            CLEAN=1
+            shift
+            ;;
+        --dev-dbg)
+            DEVDBG=1
+            shift
+            ;;
+        *)
+            echo "Unknown option: $1"
+            exit 1
+            ;;
+    esac
+done
 
 export DEVDIR=$(cd `dirname $0` && pwd)
 NPROC=$(nproc)
@@ -40,6 +55,14 @@ fi
 
 export LOCALVERSION=-tegra
 export TEGRA_KERNEL_OUT="$DEVDIR/images/$1"
+
+# Clean if requested
+if [[ $CLEAN == 1 ]]; then
+    echo "Cleaning build artifacts for $1..."
+    rm -rf $TEGRA_KERNEL_OUT
+    rm -rf $SRCS/out
+fi
+
 mkdir -p $TEGRA_KERNEL_OUT
 export KERNEL_MODULES_OUT=$TEGRA_KERNEL_OUT/modules
 
@@ -87,16 +110,16 @@ if [[ "$JETPACK_VERSION" == "6.x" ]]; then
     KERNELVERSION=$(cat $KERNEL_HEADERS/include/config/kernel.release)
     KERNEL_MODULES_OUT=$INSTALL_MOD_PATH/lib/modules/${KERNELVERSION}
     mkdir -p $KERNEL_MODULES_OUT/extra
-    cp $KERNEL_MODULES_OUT/kernel/drivers/iio/buffer/kfifo_buf.ko $KERNEL_MODULES_OUT/extra/
-    cp $KERNEL_MODULES_OUT/kernel/drivers/iio/buffer/industrialio-triggered-buffer.ko $KERNEL_MODULES_OUT/extra/
-    cp $KERNEL_MODULES_OUT/kernel/drivers/iio/common/hid-sensors/hid-sensor-iio-common.ko $KERNEL_MODULES_OUT/extra/
-    cp $KERNEL_MODULES_OUT/kernel/drivers/hid/hid-sensor-hub.ko $KERNEL_MODULES_OUT/extra/
-    cp $KERNEL_MODULES_OUT/kernel/drivers/iio/accel/hid-sensor-accel-3d.ko $KERNEL_MODULES_OUT/extra/
-    cp $KERNEL_MODULES_OUT/kernel/drivers/iio/gyro/hid-sensor-gyro-3d.ko $KERNEL_MODULES_OUT/extra/
-    cp $KERNEL_MODULES_OUT/kernel/drivers/iio/common/hid-sensors/hid-sensor-trigger.ko $KERNEL_MODULES_OUT/extra/
+    cp $KERNEL_MODULES_OUT/kernel/drivers/iio/buffer/kfifo_buf.ko $KERNEL_MODULES_OUT/extra/ || true
+    cp $KERNEL_MODULES_OUT/kernel/drivers/iio/buffer/industrialio-triggered-buffer.ko $KERNEL_MODULES_OUT/extra/ || true
+    cp $KERNEL_MODULES_OUT/kernel/drivers/iio/common/hid-sensors/hid-sensor-iio-common.ko $KERNEL_MODULES_OUT/extra/ || true
+    cp $KERNEL_MODULES_OUT/kernel/drivers/hid/hid-sensor-hub.ko $KERNEL_MODULES_OUT/extra/ || true
+    cp $KERNEL_MODULES_OUT/kernel/drivers/iio/accel/hid-sensor-accel-3d.ko $KERNEL_MODULES_OUT/extra/ || true
+    cp $KERNEL_MODULES_OUT/kernel/drivers/iio/gyro/hid-sensor-gyro-3d.ko $KERNEL_MODULES_OUT/extra/ || true
+    cp $KERNEL_MODULES_OUT/kernel/drivers/iio/common/hid-sensors/hid-sensor-trigger.ko $KERNEL_MODULES_OUT/extra/ || true
     # RealSense cameras support
-    cp $KERNEL_MODULES_OUT/kernel/drivers/media/usb/uvc/uvcvideo.ko $KERNEL_MODULES_OUT/extra/
-    cp $KERNEL_MODULES_OUT/kernel/drivers/media/v4l2-core/videodev.ko $KERNEL_MODULES_OUT/extra/
+    cp $KERNEL_MODULES_OUT/kernel/drivers/media/usb/uvc/uvcvideo.ko $KERNEL_MODULES_OUT/extra/ || true
+    cp $KERNEL_MODULES_OUT/kernel/drivers/media/v4l2-core/videodev.ko $KERNEL_MODULES_OUT/extra/ || true
 else
 #jp4/5
     cd $SRCS/$KERNEL_DIR

--- a/kernel/kernel-jammy-src/6.2.1/0001-kernel-enable-HID_SENSOR-without-USB-impact.patch
+++ b/kernel/kernel-jammy-src/6.2.1/0001-kernel-enable-HID_SENSOR-without-USB-impact.patch
@@ -1,0 +1,47 @@
+From a28c524638e88665f3757002703a7add3e95643b Mon Sep 17 00:00:00 2001
+From: ejgoldik <ehud.joseph.goldik@intel.com>
+Date: Sun, 8 Jun 2025 11:08:56 +0300
+Subject: [PATCH] kernel: enable HID_SENSOR without USB impact
+
+Signed-off-by: Ehud J. Goldik <ehud.joseph.goldik@intel.com>
+---
+ arch/arm64/configs/defconfig | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/arch/arm64/configs/defconfig b/arch/arm64/configs/defconfig
+index 57e2a364e..8fffc0a60 100644
+--- a/arch/arm64/configs/defconfig
++++ b/arch/arm64/configs/defconfig
+@@ -862,9 +862,11 @@ CONFIG_SND_SOC_LPASS_WSA_MACRO=m
+ CONFIG_SND_SOC_LPASS_VA_MACRO=m
+ CONFIG_SND_SIMPLE_CARD=m
+ CONFIG_SND_AUDIO_GRAPH_CARD=m
++CONFIG_HID=m
+ CONFIG_HIDRAW=y
+ CONFIG_UHID=m
+ CONFIG_HID_MULTITOUCH=m
++CONFIG_HID_SENSOR_HUB=m
+ CONFIG_I2C_HID_ACPI=m
+ CONFIG_I2C_HID_OF=m
+ CONFIG_USB=y
+@@ -1148,6 +1150,7 @@ CONFIG_EXTCON_USB_GPIO=y
+ CONFIG_EXTCON_USBC_CROS_EC=y
+ CONFIG_RENESAS_RPCIF=m
+ CONFIG_IIO=y
++CONFIG_HID_SENSOR_ACCEL_3D=m
+ CONFIG_BMI088_ACCEL=m
+ CONFIG_EXYNOS_ADC=y
+ CONFIG_MAX9611=m
+@@ -1155,6 +1158,9 @@ CONFIG_QCOM_SPMI_ADC5=m
+ CONFIG_ROCKCHIP_SARADC=m
+ CONFIG_IIO_CROS_EC_SENSORS_CORE=m
+ CONFIG_IIO_CROS_EC_SENSORS=m
++CONFIG_HID_SENSOR_IIO_COMMON=m
++CONFIG_HID_SENSOR_IIO_TRIGGER=m
++CONFIG_HID_SENSOR_GYRO_3D=m
+ CONFIG_BMG160=m
+ CONFIG_IIO_ST_LSM6DSX=m
+ CONFIG_IIO_CROS_EC_LIGHT_PROX=m
+-- 
+2.43.0
+

--- a/kernel/kernel-jammy-src/6.2.1/0002-realsense-camera-formats-jammy-master.patch
+++ b/kernel/kernel-jammy-src/6.2.1/0002-realsense-camera-formats-jammy-master.patch
@@ -1,0 +1,198 @@
+From a82c166d13d5ad2b1837e68123f5e25ea81c458e Mon Sep 17 00:00:00 2001
+From: Dmitry Perchanov <dmitry.perchanov@intel.com>
+Date: Thu, 1 Sep 2022 18:14:43 +0300
+Subject: [PATCH] Streaming formats for Ubuntu 22.04 (jammy). Kernel 5.15
+
+Author: Yu MENG <yu1.meng@intel.com>
+
+Signed-off-by: Dmitry Perchanov <dmitry.perchanov@intel.com>
+---
+ drivers/media/usb/uvc/uvc_driver.c   | 57 ++++++++++++++++++++++++++++
+ drivers/media/usb/uvc/uvcvideo.h     | 34 +++++++++++++++++
+ drivers/media/v4l2-core/v4l2-ioctl.c |  9 +++++
+ include/uapi/linux/videodev2.h       |  9 +++++
+ 4 files changed, 109 insertions(+)
+
+diff --git a/drivers/media/usb/uvc/uvc_driver.c b/drivers/media/usb/uvc/uvc_driver.c
+index 9a791d8ef200..205d524128da 100644
+--- a/drivers/media/usb/uvc/uvc_driver.c
++++ b/drivers/media/usb/uvc/uvc_driver.c
+@@ -165,6 +165,11 @@ static struct uvc_format_desc uvc_fmts[] = {
+ 		.guid		= UVC_GUID_FORMAT_Y12I,
+ 		.fcc		= V4L2_PIX_FMT_Y12I,
+ 	},
++	{
++		.name		= "Greyscale 16 L/R (Y16I)",
++		.guid		= UVC_GUID_FORMAT_Y16I,
++		.fcc		= V4L2_PIX_FMT_Y16I,
++	},
+ 	{
+ 		.name		= "Depth data 16-bit (Z16)",
+ 		.guid		= UVC_GUID_FORMAT_Z16,
+@@ -220,6 +225,58 @@ static struct uvc_format_desc uvc_fmts[] = {
+ 		.guid		= UVC_GUID_FORMAT_HEVC,
+ 		.fcc		= V4L2_PIX_FMT_HEVC,
+ 	},
++	{
++		.name		= "Depth data 16-bit (D16)",
++		.guid		= UVC_GUID_FORMAT_D16,
++		.fcc		= V4L2_PIX_FMT_Z16,
++	},
++	{
++		.name		= "Packed raw data 10-bit",
++		.guid		= UVC_GUID_FORMAT_W10,
++		.fcc		= V4L2_PIX_FMT_W10,
++	},
++	{
++		.name		= "Confidence data (C   )",
++		.guid		= UVC_GUID_FORMAT_CONFIDENCE_MAP,
++		.fcc		= V4L2_PIX_FMT_CONFIDENCE_MAP,
++	},
++	/* FishEye 8-bit monochrome */
++	{
++		.name		= "Raw data 8-bit (RAW8)",
++		.guid		= UVC_GUID_FORMAT_RAW8,
++		.fcc		= V4L2_PIX_FMT_GREY,
++	},
++	/* Legacy formats for backward-compatibility*/
++	{
++		.name		= "Raw data 16-bit (RW16)",
++		.guid		= UVC_GUID_FORMAT_RW16,
++		.fcc		= V4L2_PIX_FMT_RW16,
++	},
++	{
++		.name		= "16-bit Bayer BGBG/GRGR",
++		.guid		= UVC_GUID_FORMAT_BAYER16,
++		.fcc		= V4L2_PIX_FMT_SBGGR16,
++	},
++	{
++		.name		= "Z16 Huffman Compression",
++		.guid		= UVC_GUID_FORMAT_Z16H,
++		.fcc		= V4L2_PIX_FMT_Z16H,
++	},
++	{
++		.name		= "Frame Grabber (FG  )",
++		.guid		= UVC_GUID_FORMAT_FG,
++		.fcc		= V4L2_PIX_FMT_FG,
++	},
++	{
++		.name		= "SR300 Depth/Confidence (INZC)",
++		.guid		= UVC_GUID_FORMAT_INZC,
++		.fcc		= V4L2_PIX_FMT_INZC,
++	},
++	{
++		.name		= "Relative IR (PAIR)",
++		.guid		= UVC_GUID_FORMAT_PAIR,
++		.fcc		= V4L2_PIX_FMT_PAIR,
++	},
+ };
+ 
+ /* ------------------------------------------------------------------------
+diff --git a/drivers/media/usb/uvc/uvcvideo.h b/drivers/media/usb/uvc/uvcvideo.h
+index c3ea6a53869f..3a551e3fa262 100644
+--- a/drivers/media/usb/uvc/uvcvideo.h
++++ b/drivers/media/usb/uvc/uvcvideo.h
+@@ -145,6 +145,9 @@
+ #define UVC_GUID_FORMAT_Y12I \
+ 	{ 'Y',  '1',  '2',  'I', 0x00, 0x00, 0x10, 0x00, \
+ 	 0x80, 0x00, 0x00, 0xaa, 0x00, 0x38, 0x9b, 0x71}
++#define UVC_GUID_FORMAT_Y16I \
++	{ 'Y',  '1',  '6',  'I', 0x00, 0x00, 0x10, 0x00, \
++	 0x80, 0x00, 0x00, 0xaa, 0x00, 0x38, 0x9b, 0x71}
+ #define UVC_GUID_FORMAT_Z16 \
+ 	{ 'Z',  '1',  '6',  ' ', 0x00, 0x00, 0x10, 0x00, \
+ 	 0x80, 0x00, 0x00, 0xaa, 0x00, 0x38, 0x9b, 0x71}
+@@ -175,6 +178,37 @@
+ 	{ 'H',  'E',  'V',  'C', 0x00, 0x00, 0x10, 0x00, \
+ 	 0x80, 0x00, 0x00, 0xaa, 0x00, 0x38, 0x9b, 0x71}
+ 
++	#define UVC_GUID_FORMAT_D16 \
++	{ 'P', 0x00,  0x00,  0x00, 0x00, 0x00, 0x10, 0x00, \
++		0x80, 0x00, 0x00, 0xaa, 0x00, 0x38, 0x9b, 0x71}
++	#define UVC_GUID_FORMAT_W10 \
++	{ 'W',  '1',  '0',  ' ', 0x00, 0x00, 0x10, 0x00, \
++		0x80, 0x00, 0x00, 0xaa, 0x00, 0x38, 0x9b, 0x71}
++	#define UVC_GUID_FORMAT_RAW8 \
++	{ 'R',  'A',  'W',  '8', 0x66, 0x1a, 0x42, 0xa2, \
++		0x90, 0x65, 0xd0, 0x18, 0x14, 0xa8, 0xef, 0x8a}
++	#define UVC_GUID_FORMAT_CONFIDENCE_MAP \
++	{ 'C',  ' ',  ' ',  ' ', 0x00, 0x00, 0x10, 0x00, \
++		0x80, 0x00, 0x00, 0xaa, 0x00, 0x38, 0x9b, 0x71}
++	/* Legacy formats */
++	#define UVC_GUID_FORMAT_RW16 \
++	{ 'R',  'W',  '1',  '6', 0x00, 0x00, 0x10, 0x00, \
++		0x80, 0x00, 0x00, 0xaa, 0x00, 0x38, 0x9b, 0x71}
++	#define UVC_GUID_FORMAT_BAYER16 \
++	{ 'R',  'W',  '1',  '6', 0x66, 0x1a, 0x42, 0xa2, \
++		0x90, 0x65, 0xd0, 0x18, 0x14, 0xa8, 0xef, 0x8a}
++	#define UVC_GUID_FORMAT_Z16H \
++	{ 'Z',  '1',  '6',  'H', 0x00, 0x00, 0x10, 0x00, \
++	 0x80, 0x00, 0x00, 0xaa, 0x00, 0x38, 0x9b, 0x71}
++	#define UVC_GUID_FORMAT_FG \
++	{ 'F',  'G',  ' ',  ' ', 0x00, 0x00, 0x10, 0x00, \
++	0x80, 0x00, 0x00, 0xaa, 0x00, 0x38, 0x9b, 0x71}
++	#define UVC_GUID_FORMAT_INZC \
++	{ 'I',  'N',  'Z',  'C', 0x02, 0xb6, 0x0f, 0x48, \
++	0x97, 0x8c, 0xe4, 0xe8, 0x8a, 0xe8, 0x9b, 0x89}
++	#define UVC_GUID_FORMAT_PAIR \
++	{ 'P',  'A',  'I',  'R', 0x36, 0x85, 0x41, 0x48, \
++	0xb6, 0xbf, 0x8f, 0xc6, 0xff, 0xb0, 0x83, 0xa8}
+ 
+ /* ------------------------------------------------------------------------
+  * Driver specific constants.
+diff --git a/drivers/media/v4l2-core/v4l2-ioctl.c b/drivers/media/v4l2-core/v4l2-ioctl.c
+index 7c596a85f34f..7c36ba1bb35a 100644
+--- a/drivers/media/v4l2-core/v4l2-ioctl.c
++++ b/drivers/media/v4l2-core/v4l2-ioctl.c
+@@ -1267,6 +1267,7 @@ static void v4l_fill_fmtdesc(struct v4l2_fmtdesc *fmt)
+ 	case V4L2_PIX_FMT_Y10P:		descr = "10-bit Greyscale (MIPI Packed)"; break;
+ 	case V4L2_PIX_FMT_Y8I:		descr = "Interleaved 8-bit Greyscale"; break;
+ 	case V4L2_PIX_FMT_Y12I:		descr = "Interleaved 12-bit Greyscale"; break;
++	case V4L2_PIX_FMT_Y16I:		descr = "Interleaved 16-bit Greyscale"; break;
+ 	case V4L2_PIX_FMT_Z16:		descr = "16-bit Depth"; break;
+ 	case V4L2_PIX_FMT_INZI:		descr = "Planar 10:16 Greyscale Depth"; break;
+ 	case V4L2_PIX_FMT_CNF4:		descr = "4-bit Depth Confidence (Packed)"; break;
+@@ -1387,6 +1388,14 @@ static void v4l_fill_fmtdesc(struct v4l2_fmtdesc *fmt)
+ 	case V4L2_META_FMT_VIVID:       descr = "Vivid Metadata"; break;
+ 	case V4L2_META_FMT_RK_ISP1_PARAMS:	descr = "Rockchip ISP1 3A Parameters"; break;
+ 	case V4L2_META_FMT_RK_ISP1_STAT_3A:	descr = "Rockchip ISP1 3A Statistics"; break;
++	/* Librealsense formats*/
++	case V4L2_PIX_FMT_RW16:		descr = "16-bit Raw data"; break;
++	case V4L2_PIX_FMT_W10:		descr = "10-bit packed 8888[2222]"; break;
++	case V4L2_PIX_FMT_CONFIDENCE_MAP:	descr = "Packed [44] confidence data"; break;
++	case V4L2_PIX_FMT_FG:		descr = "Frame Grabber (FG  )"; break;
++	case V4L2_PIX_FMT_INZC:		descr = "Planar Depth/Confidence (INZC)"; break;
++	case V4L2_PIX_FMT_PAIR:		descr = "Relative IR (PAIR)"; break;
++	case V4L2_PIX_FMT_Z16H:		descr = "Z16 Huffman Compression"; break;
+ 
+ 	default:
+ 		/* Compressed formats */
+diff --git a/include/uapi/linux/videodev2.h b/include/uapi/linux/videodev2.h
+index 9260791b8438..fd50e9c34a0e 100644
+--- a/include/uapi/linux/videodev2.h
++++ b/include/uapi/linux/videodev2.h
+@@ -731,12 +731,21 @@ struct v4l2_pix_format {
+ #define V4L2_PIX_FMT_S5C_UYVY_JPG v4l2_fourcc('S', '5', 'C', 'I') /* S5C73M3 interleaved UYVY/JPEG */
+ #define V4L2_PIX_FMT_Y8I      v4l2_fourcc('Y', '8', 'I', ' ') /* Greyscale 8-bit L/R interleaved */
+ #define V4L2_PIX_FMT_Y12I     v4l2_fourcc('Y', '1', '2', 'I') /* Greyscale 12-bit L/R interleaved */
++#define V4L2_PIX_FMT_Y16I     v4l2_fourcc('Y', '1', '6', 'I') /* Greyscale 16-bit L/R interleaved */
+ #define V4L2_PIX_FMT_Z16      v4l2_fourcc('Z', '1', '6', ' ') /* Depth data 16-bit */
+ #define V4L2_PIX_FMT_MT21C    v4l2_fourcc('M', 'T', '2', '1') /* Mediatek compressed block mode  */
+ #define V4L2_PIX_FMT_INZI     v4l2_fourcc('I', 'N', 'Z', 'I') /* Intel Planar Greyscale 10-bit and Depth 16-bit */
+ #define V4L2_PIX_FMT_SUNXI_TILED_NV12 v4l2_fourcc('S', 'T', '1', '2') /* Sunxi Tiled NV12 Format */
+ #define V4L2_PIX_FMT_CNF4     v4l2_fourcc('C', 'N', 'F', '4') /* Intel 4-bit packed depth confidence information */
+ #define V4L2_PIX_FMT_HI240    v4l2_fourcc('H', 'I', '2', '4') /* BTTV 8-bit dithered RGB */
++#define V4L2_PIX_FMT_RW16     v4l2_fourcc('R', 'W', '1', '6') /* Raw data 16-bit */
++#define V4L2_PIX_FMT_W10      v4l2_fourcc('W', '1', '0', ' ') /* Packed raw data 10-bit */
++#define V4L2_PIX_FMT_CONFIDENCE_MAP	v4l2_fourcc('C', ' ', ' ', ' ') /* Two pixels in one byte */
++/*  Librealsense development*/
++#define V4L2_PIX_FMT_FG       v4l2_fourcc('F', 'G', ' ', ' ') /* Frame Grabber */
++#define V4L2_PIX_FMT_INZC     v4l2_fourcc('I', 'N', 'Z', 'C') /* Planar Depth/Confidence */
++#define V4L2_PIX_FMT_PAIR     v4l2_fourcc('P', 'A', 'I', 'R') /* Relative IR */
++#define V4L2_PIX_FMT_Z16H     v4l2_fourcc('Z', '1', '6', 'H') /* Depth Z16 custom Huffman Code compression*/
+ 
+ /* 10bit raw bayer packed, 32 bytes for every 25 pixels, last LSB 6 bits unused */
+ #define V4L2_PIX_FMT_IPU3_SBGGR10	v4l2_fourcc('i', 'p', '3', 'b') /* IPU3 packed 10-bit BGGR bayer */
+-- 
+2.37.1
+

--- a/kernel/kernel-jammy-src/6.2.1/0003-realsense-metadata-jammy-master.patch
+++ b/kernel/kernel-jammy-src/6.2.1/0003-realsense-metadata-jammy-master.patch
@@ -1,0 +1,320 @@
+From 68ebc4e3fb3729f2b6804ea4d72d5dfda356512f Mon Sep 17 00:00:00 2001
+From: Dmitry Perchanov <dmitry.perchanov@intel.com>
+Date: Sun, 22 Jan 2023 12:58:19 +0200
+Subject: [PATCH] Enabling UVC Metadata attributes with Ubuntu 22.04. Kernel
+ 5.15
+
+Co-developed-by: Yu MENG <yu1.meng@intel.com>
+Co-developed-by: Evgeni Raikhel <evgeni.raikhel@intel.com>
+Signed-off-by: Dmitry Perchanov <dmitry.perchanov@intel.com>
+---
+ drivers/media/usb/uvc/uvc_driver.c | 279 +++++++++++++++++++++++++++++
+ drivers/media/usb/uvc/uvcvideo.h   |   2 +-
+ 2 files changed, 280 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/media/usb/uvc/uvc_driver.c b/drivers/media/usb/uvc/uvc_driver.c
+index 2e7df1de0..848417912 100644
+--- a/drivers/media/usb/uvc/uvc_driver.c
++++ b/drivers/media/usb/uvc/uvc_driver.c
+@@ -3152,6 +3152,285 @@ static const struct usb_device_id uvc_ids[] = {
+ 	  .bInterfaceSubClass	= 1,
+ 	  .bInterfaceProtocol	= 0,
+ 	  .driver_info		= UVC_INFO_META(V4L2_META_FMT_D4XX) },
++	  /* Intel SR306 depth camera */
++	{ .match_flags		= USB_DEVICE_ID_MATCH_DEVICE
++				| USB_DEVICE_ID_MATCH_INT_INFO,
++	  .idVendor			= 0x8086,
++	  .idProduct		= 0x0aa3,
++	  .bInterfaceClass	= USB_CLASS_VIDEO,
++	  .bInterfaceSubClass	= 1,
++	  .bInterfaceProtocol	= 0,
++	  .driver_info		= UVC_INFO_META(V4L2_META_FMT_D4XX) },
++	  /* Intel SR300 depth camera */
++	{ .match_flags		= USB_DEVICE_ID_MATCH_DEVICE
++				| USB_DEVICE_ID_MATCH_INT_INFO,
++	  .idVendor			= 0x8086,
++	  .idProduct		= 0x0aa5,
++	  .bInterfaceClass	= USB_CLASS_VIDEO,
++	  .bInterfaceSubClass	= 1,
++	  .bInterfaceProtocol	= 0,
++	  .driver_info		= UVC_INFO_META(V4L2_META_FMT_D4XX) },
++	/* Intel D400/PSR depth camera*/
++	{ .match_flags		= USB_DEVICE_ID_MATCH_DEVICE
++				| USB_DEVICE_ID_MATCH_INT_INFO,
++	  .idVendor			= 0x8086,
++	  .idProduct		= 0x0ad1,
++	  .bInterfaceClass	= USB_CLASS_VIDEO,
++	  .bInterfaceSubClass	= 1,
++	  .bInterfaceProtocol	= 0,
++	  .driver_info		= UVC_INFO_META(V4L2_META_FMT_D4XX) },
++	  /* Intel D410/ASR depth camera */
++	{ .match_flags		= USB_DEVICE_ID_MATCH_DEVICE
++				| USB_DEVICE_ID_MATCH_INT_INFO,
++	  .idVendor			= 0x8086,
++	  .idProduct		= 0x0ad2,
++	  .bInterfaceClass	= USB_CLASS_VIDEO,
++	  .bInterfaceSubClass	= 1,
++	  .bInterfaceProtocol	= 0,
++	  .driver_info		= UVC_INFO_META(V4L2_META_FMT_D4XX) },
++	  /* Intel D415/ASRC depth camera */
++	{ .match_flags		= USB_DEVICE_ID_MATCH_DEVICE
++				| USB_DEVICE_ID_MATCH_INT_INFO,
++	  .idVendor			= 0x8086,
++	  .idProduct		= 0x0ad3,
++	  .bInterfaceClass	= USB_CLASS_VIDEO,
++	  .bInterfaceSubClass	= 1,
++	  .bInterfaceProtocol	= 0,
++	  .driver_info		= UVC_INFO_META(V4L2_META_FMT_D4XX) },
++	  /* Intel D430/AWG depth camera */
++	{ .match_flags		= USB_DEVICE_ID_MATCH_DEVICE
++				| USB_DEVICE_ID_MATCH_INT_INFO,
++	  .idVendor			= 0x8086,
++	  .idProduct		= 0x0ad4,
++	  .bInterfaceClass	= USB_CLASS_VIDEO,
++	  .bInterfaceSubClass	= 1,
++	  .bInterfaceProtocol	= 0,
++	  .driver_info		= UVC_INFO_META(V4L2_META_FMT_D4XX) },
++	/* Intel D450/AWGT depth camera */
++	{ .match_flags		= USB_DEVICE_ID_MATCH_DEVICE
++				| USB_DEVICE_ID_MATCH_INT_INFO,
++	  .idVendor			= 0x8086,
++	  .idProduct		= 0x0ad5,
++	  .bInterfaceClass	= USB_CLASS_VIDEO,
++	  .bInterfaceSubClass	= 1,
++	  .bInterfaceProtocol	= 0,
++	  .driver_info		= UVC_INFO_META(V4L2_META_FMT_D4XX) },
++	/* USB2 Descriptor, Depth Sensor */
++	{ .match_flags		= USB_DEVICE_ID_MATCH_DEVICE
++				| USB_DEVICE_ID_MATCH_INT_INFO,
++	  .idVendor			= 0x8086,
++	  .idProduct		= 0x0ad6,
++	  .bInterfaceClass	= USB_CLASS_VIDEO,
++	  .bInterfaceSubClass	= 1,
++	  .bInterfaceProtocol	= 0,
++	  .driver_info		= UVC_INFO_META(V4L2_META_FMT_D4XX) },
++	  /* Intel D400 IMU Module */
++	{ .match_flags		= USB_DEVICE_ID_MATCH_DEVICE
++				| USB_DEVICE_ID_MATCH_INT_INFO,
++	  .idVendor			= 0x8086,
++	  .idProduct		= 0x0af2,
++	  .bInterfaceClass	= USB_CLASS_VIDEO,
++	  .bInterfaceSubClass	= 1,
++	  .bInterfaceProtocol	= 0,
++	  .driver_info		= UVC_INFO_META(V4L2_META_FMT_D4XX) },
++	/* Intel D420/PWG depth camera */
++	{ .match_flags		= USB_DEVICE_ID_MATCH_DEVICE
++				| USB_DEVICE_ID_MATCH_INT_INFO,
++	  .idVendor			= 0x8086,
++	  .idProduct		= 0x0af6,
++	  .bInterfaceClass	= USB_CLASS_VIDEO,
++	  .bInterfaceSubClass	= 1,
++	  .bInterfaceProtocol	= 0,
++	  .driver_info		= UVC_INFO_META(V4L2_META_FMT_D4XX) },
++	/* Intel D420_MM/PWGT depth camera */
++	{ .match_flags		= USB_DEVICE_ID_MATCH_DEVICE
++				| USB_DEVICE_ID_MATCH_INT_INFO,
++	  .idVendor			= 0x8086,
++	  .idProduct		= 0x0afe,
++	  .bInterfaceClass	= USB_CLASS_VIDEO,
++	  .bInterfaceSubClass	= 1,
++	  .bInterfaceProtocol	= 0,
++	  .driver_info		= UVC_INFO_META(V4L2_META_FMT_D4XX) },
++	  /* Intel D410_MM/ASRT depth camera */
++	{ .match_flags		= USB_DEVICE_ID_MATCH_DEVICE
++				| USB_DEVICE_ID_MATCH_INT_INFO,
++	  .idVendor			= 0x8086,
++	  .idProduct		= 0x0aff,
++	  .bInterfaceClass	= USB_CLASS_VIDEO,
++	  .bInterfaceSubClass	= 1,
++	  .bInterfaceProtocol	= 0,
++	  .driver_info		= UVC_INFO_META(V4L2_META_FMT_D4XX) },
++	  /* Intel D400_MM/PSRT depth camera */
++	{ .match_flags		= USB_DEVICE_ID_MATCH_DEVICE
++				| USB_DEVICE_ID_MATCH_INT_INFO,
++	  .idVendor			= 0x8086,
++	  .idProduct		= 0x0b00,
++	  .bInterfaceClass	= USB_CLASS_VIDEO,
++	  .bInterfaceSubClass	= 1,
++	  .bInterfaceProtocol	= 0,
++	  .driver_info		= UVC_INFO_META(V4L2_META_FMT_D4XX) },
++	  /* Intel D430_MM/AWGCT depth camera */
++	{ .match_flags		= USB_DEVICE_ID_MATCH_DEVICE
++				| USB_DEVICE_ID_MATCH_INT_INFO,
++	  .idVendor			= 0x8086,
++	  .idProduct		= 0x0b01,
++	  .bInterfaceClass	= USB_CLASS_VIDEO,
++	  .bInterfaceSubClass	= 1,
++	  .bInterfaceProtocol	= 0,
++	  .driver_info		= UVC_INFO_META(V4L2_META_FMT_D4XX) },
++	  /* Intel D460/DS5U depth camera */
++	{ .match_flags		= USB_DEVICE_ID_MATCH_DEVICE
++				| USB_DEVICE_ID_MATCH_INT_INFO,
++	  .idVendor			= 0x8086,
++	  .idProduct		= 0x0b03,
++	  .bInterfaceClass	= USB_CLASS_VIDEO,
++	  .bInterfaceSubClass	= 1,
++	  .bInterfaceProtocol	= 0,
++	  .driver_info		= UVC_INFO_META(V4L2_META_FMT_D4XX) },
++	  /* Intel D435/AWGC depth camera */
++	{ .match_flags		= USB_DEVICE_ID_MATCH_DEVICE
++				| USB_DEVICE_ID_MATCH_INT_INFO,
++	  .idVendor			= 0x8086,
++	  .idProduct		= 0x0b07,
++	  .bInterfaceClass	= USB_CLASS_VIDEO,
++	  .bInterfaceSubClass	= 1,
++	  .bInterfaceProtocol	= 0,
++	  .driver_info		= UVC_INFO_META(V4L2_META_FMT_D4XX) },
++	  /* Intel D405 S depth camera */
++	{ .match_flags		= USB_DEVICE_ID_MATCH_DEVICE
++				| USB_DEVICE_ID_MATCH_INT_INFO,
++	  .idVendor			= 0x8086,
++	  .idProduct		= 0x0b0c,
++	  .bInterfaceClass	= USB_CLASS_VIDEO,
++	  .bInterfaceSubClass	= 1,
++	  .bInterfaceProtocol	= 0,
++	  .driver_info		= UVC_INFO_META(V4L2_META_FMT_D4XX) },
++	  /* Intel L500 depth camera */
++	{ .match_flags		= USB_DEVICE_ID_MATCH_DEVICE
++				| USB_DEVICE_ID_MATCH_INT_INFO,
++	  .idVendor			= 0x8086,
++	  .idProduct		= 0x0b0d,
++	  .bInterfaceClass	= USB_CLASS_VIDEO,
++	  .bInterfaceSubClass	= 1,
++	  .bInterfaceProtocol	= 0,
++	  .driver_info		= UVC_INFO_META(V4L2_META_FMT_D4XX) },
++	  /* Intel D435i depth camera */
++	{ .match_flags		= USB_DEVICE_ID_MATCH_DEVICE
++				| USB_DEVICE_ID_MATCH_INT_INFO,
++	  .idVendor			= 0x8086,
++	  .idProduct		= 0x0b3a,
++	  .bInterfaceClass	= USB_CLASS_VIDEO,
++	  .bInterfaceSubClass	= 1,
++	  .bInterfaceProtocol	= 0,
++	  .driver_info		= UVC_INFO_META(V4L2_META_FMT_D4XX) },
++	  /* Intel L515 Pre-PRQ */
++	{ .match_flags		= USB_DEVICE_ID_MATCH_DEVICE
++				| USB_DEVICE_ID_MATCH_INT_INFO,
++	  .idVendor			= 0x8086,
++	  .idProduct		= 0x0b3d,
++	  .bInterfaceClass	= USB_CLASS_VIDEO,
++	  .bInterfaceSubClass	= 1,
++	  .bInterfaceProtocol	= 0,
++	  .driver_info		= UVC_INFO_META(V4L2_META_FMT_D4XX) },
++	  /* Intel SR305 Depth Camera*/
++	{ .match_flags		= USB_DEVICE_ID_MATCH_DEVICE
++				| USB_DEVICE_ID_MATCH_INT_INFO,
++	  .idVendor			= 0x8086,
++	  .idProduct		= 0x0b48,
++	  .bInterfaceClass	= USB_CLASS_VIDEO,
++	  .bInterfaceSubClass	= 1,
++	  .bInterfaceProtocol	= 0,
++	  .driver_info		= UVC_INFO_META(V4L2_META_FMT_D4XX) },
++	  /* Intel D416 Depth Camera */
++	{ .match_flags		= USB_DEVICE_ID_MATCH_DEVICE
++				| USB_DEVICE_ID_MATCH_INT_INFO,
++	  .idVendor			= 0x8086,
++	  .idProduct		= 0x0b49,
++	  .bInterfaceClass	= USB_CLASS_VIDEO,
++	  .bInterfaceSubClass	= 1,
++	  .bInterfaceProtocol	= 0,
++	  .driver_info		= UVC_INFO_META(V4L2_META_FMT_D4XX) },
++	  /* Intel D430i depth camera */
++	{ .match_flags		= USB_DEVICE_ID_MATCH_DEVICE
++				| USB_DEVICE_ID_MATCH_INT_INFO,
++	  .idVendor			= 0x8086,
++	  .idProduct		= 0x0b4b,
++	  .bInterfaceClass	= USB_CLASS_VIDEO,
++	  .bInterfaceSubClass	= 1,
++	  .bInterfaceProtocol	= 0,
++	  .driver_info		= UVC_INFO_META(V4L2_META_FMT_D4XX) },
++	  /* Intel D465 */
++	{ .match_flags		= USB_DEVICE_ID_MATCH_DEVICE
++				| USB_DEVICE_ID_MATCH_INT_INFO,
++	  .idVendor			= 0x8086,
++	  .idProduct		= 0x0b4d,
++	  .bInterfaceClass	= USB_CLASS_VIDEO,
++	  .bInterfaceSubClass	= 1,
++	  .bInterfaceProtocol	= 0,
++	  .driver_info		= UVC_INFO_META(V4L2_META_FMT_D4XX) },
++	/* Intel D555e Depth Camera */
++	{ .match_flags		= USB_DEVICE_ID_MATCH_DEVICE
++				| USB_DEVICE_ID_MATCH_INT_INFO,
++	  .idVendor		= 0x8086,
++	  .idProduct		= 0x0b56,
++	  .bInterfaceClass	= USB_CLASS_VIDEO,
++	  .bInterfaceSubClass	= 1,
++	  .bInterfaceProtocol	= UVC_PC_PROTOCOL_15,
++	  .driver_info		= UVC_INFO_META(V4L2_META_FMT_D4XX) },
++	  /* Intel D405 */
++	{ .match_flags		= USB_DEVICE_ID_MATCH_DEVICE
++				| USB_DEVICE_ID_MATCH_INT_INFO,
++	  .idVendor			= 0x8086,
++	  .idProduct		= 0x0b5b,
++	  .bInterfaceClass	= USB_CLASS_VIDEO,
++	  .bInterfaceSubClass	= 1,
++	  .bInterfaceProtocol	= 0,
++	  .driver_info		= UVC_INFO_META(V4L2_META_FMT_D4XX) },
++	  /* Intel D455 */
++	{ .match_flags		= USB_DEVICE_ID_MATCH_DEVICE
++				| USB_DEVICE_ID_MATCH_INT_INFO,
++	  .idVendor			= 0x8086,
++	  .idProduct		= 0x0b5c,
++	  .bInterfaceClass	= USB_CLASS_VIDEO,
++	  .bInterfaceSubClass	= 1,
++	  .bInterfaceProtocol	= 0,
++	  .driver_info		= UVC_INFO_META(V4L2_META_FMT_D4XX) },
++	  /* Intel L515 */
++	{ .match_flags		= USB_DEVICE_ID_MATCH_DEVICE
++				| USB_DEVICE_ID_MATCH_INT_INFO,
++	  .idVendor			= 0x8086,
++	  .idProduct		= 0x0b64,
++	  .bInterfaceClass	= USB_CLASS_VIDEO,
++	  .bInterfaceSubClass	= 1,
++	  .bInterfaceProtocol	= 0,
++	  .driver_info		= UVC_INFO_META(V4L2_META_FMT_D4XX) },
++	  /* Intel L535 */
++	{ .match_flags		= USB_DEVICE_ID_MATCH_DEVICE
++				| USB_DEVICE_ID_MATCH_INT_INFO,
++	  .idVendor			= 0x8086,
++	  .idProduct		= 0x0b68,
++	  .bInterfaceClass	= USB_CLASS_VIDEO,
++	  .bInterfaceSubClass	= 1,
++	  .bInterfaceProtocol	= 0,
++	  .driver_info		= UVC_INFO_META(V4L2_META_FMT_D4XX) },
++	  /* Intel D585 Depth Camera */
++	{ .match_flags		= USB_DEVICE_ID_MATCH_DEVICE
++				| USB_DEVICE_ID_MATCH_INT_INFO,
++	  .idVendor			= 0x8086,
++	  .idProduct		= 0x0b6a,
++	  .bInterfaceClass	= USB_CLASS_VIDEO,
++	  .bInterfaceSubClass	= 1,
++	  .bInterfaceProtocol	= UVC_PC_PROTOCOL_15,
++	  .driver_info		= UVC_INFO_META(V4L2_META_FMT_D4XX) },
++	  /* Intel 585 Camera */
++	{ .match_flags		= USB_DEVICE_ID_MATCH_DEVICE
++				| USB_DEVICE_ID_MATCH_INT_INFO,
++	  .idVendor			= 0x8086,
++	  .idProduct		= 0x0b6b,
++	  .bInterfaceClass	= USB_CLASS_VIDEO,
++	  .bInterfaceSubClass	= 1,
++	  .bInterfaceProtocol	= UVC_PC_PROTOCOL_15,
++	  .driver_info		= UVC_INFO_META(V4L2_META_FMT_D4XX) },
+ 	/* Generic USB Video Class */
+ 	{ USB_INTERFACE_INFO(USB_CLASS_VIDEO, 1, UVC_PC_PROTOCOL_UNDEFINED) },
+ 	{ USB_INTERFACE_INFO(USB_CLASS_VIDEO, 1, UVC_PC_PROTOCOL_15) },
+diff --git a/drivers/media/usb/uvc/uvcvideo.h b/drivers/media/usb/uvc/uvcvideo.h
+index 1aa2cc985..2772a4640 100644
+--- a/drivers/media/usb/uvc/uvcvideo.h
++++ b/drivers/media/usb/uvc/uvcvideo.h
+@@ -187,7 +187,7 @@
+ /* Maximum number of packets per URB. */
+ #define UVC_MAX_PACKETS		32
+ /* Maximum status buffer size in bytes of interrupt URB. */
+-#define UVC_MAX_STATUS_SIZE	16
++#define UVC_MAX_STATUS_SIZE	32
+ 
+ #define UVC_CTRL_CONTROL_TIMEOUT	5000
+ #define UVC_CTRL_STREAMING_TIMEOUT	5000
+-- 
+2.34.1
+

--- a/kernel/kernel-jammy-src/6.2.1/0004-realsense-powerlinefrequency-control-fix-jammy.patch
+++ b/kernel/kernel-jammy-src/6.2.1/0004-realsense-powerlinefrequency-control-fix-jammy.patch
@@ -1,0 +1,25 @@
+From 1e4a8437c9caee068f53cbaae00d1d76a8db21e5 Mon Sep 17 00:00:00 2001
+From: Dmitry Perchanov <dmitry.perchanov@intel.com>
+Date: Wed, 24 May 2023 19:52:05 +0300
+Subject: [PATCH] Bug fix for inclomplete PowerLineFrequency enumeration map
+
+Signed-off-by: Dmitry Perchanov <dmitry.perchanov@intel.com>
+---
+ drivers/media/usb/uvc/uvc_ctrl.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/drivers/media/usb/uvc/uvc_ctrl.c b/drivers/media/usb/uvc/uvc_ctrl.c
+index b3dde9849..63b9bf310 100644
+--- a/drivers/media/usb/uvc/uvc_ctrl.c
++++ b/drivers/media/usb/uvc/uvc_ctrl.c
+@@ -361,6 +361,7 @@ static const struct uvc_menu_info power_line_frequency_controls[] = {
+ 	{ 0, "Disabled" },
+ 	{ 1, "50 Hz" },
+ 	{ 2, "60 Hz" },
++	{ 3, "Auto" },
+ };
+ 
+ static const struct uvc_menu_info exposure_auto_controls[] = {
+-- 
+2.34.1
+

--- a/kernel/kernel-jammy-src/6.2.1/0005-support-for-dynamic-change-of-i2c-bus-clk-rate.patch
+++ b/kernel/kernel-jammy-src/6.2.1/0005-support-for-dynamic-change-of-i2c-bus-clk-rate.patch
@@ -1,0 +1,172 @@
+From ce6faaedef68204e8b132bf44a0e4d2432dfb7ad Mon Sep 17 00:00:00 2001
+From: Arun-Prasad-V <arun.prasad.v@intel.com>
+Date: Mon, 4 Nov 2024 12:52:39 +0530
+Subject: [PATCH] Support for dynamic change of i2c bus-clk-rate
+
+Signed-off-by: Arun Prasad V <arun.prasad.v@intel.com>
+---
+ drivers/i2c/busses/i2c-tegra.c | 42 +++++++++++++++++++++++++++++++
+ drivers/i2c/i2c-core-base.c    | 45 ++++++++++++++++++++++++++++++++++
+ include/linux/i2c.h            |  5 ++++
+ 3 files changed, 92 insertions(+)
+
+diff --git a/drivers/i2c/busses/i2c-tegra.c b/drivers/i2c/busses/i2c-tegra.c
+index cd50436e5734..4269343266c2 100644
+--- a/drivers/i2c/busses/i2c-tegra.c
++++ b/drivers/i2c/busses/i2c-tegra.c
+@@ -1484,6 +1484,37 @@ static int tegra_i2c_xfer_msg(struct tegra_i2c_dev *i2c_dev,
+ 	return 0;
+ }
+ 
++static int tegra_i2c_change_clock_rate(struct tegra_i2c_dev *i2c_dev)
++{
++	u32 val;
++	int err;
++
++	val = I2C_CNFG_NEW_MASTER_FSM | I2C_CNFG_PACKET_MODE_EN |
++	      FIELD_PREP(I2C_CNFG_DEBOUNCE_CNT, 2);
++
++	if (i2c_dev->hw->has_multi_master_mode)
++		val |= I2C_CNFG_MULTI_MASTER_MODE;
++
++	i2c_writel(i2c_dev, val, I2C_CNFG);
++
++	if (i2c_dev->prod_list)
++		tegra_i2c_config_prod_settings(i2c_dev);
++	else
++		tegra_i2c_set_clk_params(i2c_dev);
++
++	err = tegra_i2c_set_div_clk(i2c_dev);
++	if (err) {
++		dev_err(i2c_dev->dev, "failed to set div-clk rate: %d\n", err);
++		return err;
++	}
++
++	err = tegra_i2c_wait_for_config_load(i2c_dev);
++	if (err)
++		return err;
++
++	return err;
++}
++
+ static int tegra_i2c_xfer(struct i2c_adapter *adap, struct i2c_msg msgs[],
+ 			  int num)
+ {
+@@ -1497,6 +1528,16 @@ static int tegra_i2c_xfer(struct i2c_adapter *adap, struct i2c_msg msgs[],
+ 		return ret;
+ 	}
+ 
++	if (adap->bus_clk_rate != i2c_dev->bus_clk_rate) {
++		i2c_dev->bus_clk_rate = adap->bus_clk_rate;
++		 ret = tegra_i2c_change_clock_rate(i2c_dev);
++		 if (ret) {
++			 dev_err(i2c_dev->dev,
++					 "failed changing clock rate: %d\n", ret);
++			 return ret;
++		 }
++	}
++
+ 	for (i = 0; i < num; i++) {
+ 		enum msg_end_type end_type = MSG_END_STOP;
+ 
+@@ -1957,6 +1998,7 @@ static int tegra_i2c_probe(struct platform_device *pdev)
+ 	i2c_dev->adapter.class = I2C_CLASS_DEPRECATED;
+ 	i2c_dev->adapter.algo = &tegra_i2c_algo;
+ 	i2c_dev->adapter.nr = pdev->id;
++	i2c_dev->adapter.bus_clk_rate = i2c_dev->bus_clk_rate;
+ 
+ 	if (i2c_dev->hw->supports_bus_clear)
+ 		i2c_dev->adapter.bus_recovery_info = &tegra_i2c_recovery_info;
+diff --git a/drivers/i2c/i2c-core-base.c b/drivers/i2c/i2c-core-base.c
+index c232535ca8f4..2edd24973cca 100644
+--- a/drivers/i2c/i2c-core-base.c
++++ b/drivers/i2c/i2c-core-base.c
+@@ -1285,10 +1285,33 @@ delete_device_store(struct device *dev, struct device_attribute *attr,
+ static DEVICE_ATTR_IGNORE_LOCKDEP(delete_device, S_IWUSR, NULL,
+ 				  delete_device_store);
+ 
++static ssize_t show_bus_clk_rate(struct device *dev,
++		struct device_attribute *attr, char *buf)
++{
++	struct i2c_adapter *adap = to_i2c_adapter(dev);
++
++	return sprintf(buf, "%ld\n", adap->bus_clk_rate);
++}
++
++static ssize_t set_bus_clk_rate(struct device *dev,
++		struct device_attribute *attr, const char *buf, size_t count)
++{
++	struct i2c_adapter *adap = to_i2c_adapter(dev);
++	char *p = (char *)buf;
++	int bus_clk_rate;
++
++	bus_clk_rate = memparse(p, &p);
++	dev_info(dev, "Setting clock rate %d on next transfer\n", bus_clk_rate);
++	adap->bus_clk_rate = bus_clk_rate;
++	return count;
++}
++static DEVICE_ATTR(bus_clk_rate, 0644, show_bus_clk_rate, set_bus_clk_rate);
++
+ static struct attribute *i2c_adapter_attrs[] = {
+ 	&dev_attr_name.attr,
+ 	&dev_attr_new_device.attr,
+ 	&dev_attr_delete_device.attr,
++	&dev_attr_bus_clk_rate.attr,
+ 	NULL
+ };
+ ATTRIBUTE_GROUPS(i2c_adapter);
+@@ -1401,6 +1424,28 @@ static int i2c_setup_host_notify_irq_domain(struct i2c_adapter *adap)
+ 	return 0;
+ }
+ 
++int i2c_set_adapter_bus_clk_rate(struct i2c_adapter *adap, int bus_rate)
++{
++	i2c_lock_bus(adap, I2C_LOCK_ROOT_ADAPTER);
++	adap->bus_clk_rate = bus_rate;
++	i2c_unlock_bus(adap, I2C_LOCK_ROOT_ADAPTER);
++
++	return 0;
++}
++EXPORT_SYMBOL_GPL(i2c_set_adapter_bus_clk_rate);
++
++int i2c_get_adapter_bus_clk_rate(struct i2c_adapter *adap)
++{
++	int bus_clk_rate;
++
++	i2c_lock_bus(adap, I2C_LOCK_ROOT_ADAPTER);
++	bus_clk_rate = adap->bus_clk_rate;
++	i2c_unlock_bus(adap, I2C_LOCK_ROOT_ADAPTER);
++
++	return bus_clk_rate;
++}
++EXPORT_SYMBOL_GPL(i2c_get_adapter_bus_clk_rate);
++
+ /**
+  * i2c_handle_smbus_host_notify - Forward a Host Notify event to the correct
+  * I2C client.
+diff --git a/include/linux/i2c.h b/include/linux/i2c.h
+index 2ce3efbe9198..9d876ad6373c 100644
+--- a/include/linux/i2c.h
++++ b/include/linux/i2c.h
+@@ -131,6 +131,10 @@ int i2c_transfer(struct i2c_adapter *adap, struct i2c_msg *msgs, int num);
+ /* Unlocked flavor */
+ int __i2c_transfer(struct i2c_adapter *adap, struct i2c_msg *msgs, int num);
+ 
++/* Change bus clock rate for i2c adapter */
++extern int i2c_set_adapter_bus_clk_rate(struct i2c_adapter *adap, int bus_rate);
++extern int i2c_get_adapter_bus_clk_rate(struct i2c_adapter *adap);
++
+ /* This is the very generalized SMBus access routine. You probably do not
+    want to use this, though; one of the functions below may be much easier,
+    and probably just as fast.
+@@ -737,6 +741,7 @@ struct i2c_adapter {
+ 	const struct i2c_adapter_quirks *quirks;
+ 
+ 	struct irq_domain *host_notify_domain;
++	unsigned long bus_clk_rate;
+ 	struct regulator *bus_regulator;
+ };
+ #define to_i2c_adapter(d) container_of(d, struct i2c_adapter, dev)
+-- 
+2.34.1
+

--- a/nvidia-oot/6.2.1/0001-Porting-nvidia-driver-patches-to-jetpack-6.0.patch
+++ b/nvidia-oot/6.2.1/0001-Porting-nvidia-driver-patches-to-jetpack-6.0.patch
@@ -1,0 +1,1260 @@
+From 1ce2b2e647c63724bfd1434f963eabbe4aa83941 Mon Sep 17 00:00:00 2001
+From: Dmitry Perchanov <dmitry.perchanov@intel.com>
+Date: Mon, 20 May 2024 18:08:02 +0300
+Subject: [PATCH] Porting nvidia driver patches to jetpack 6.0
+
+Signed-off-by: Dmitry Perchanov <dmitry.perchanov@intel.com>
+---
+ drivers/media/i2c/Makefile                    |   3 +
+ drivers/media/i2c/max9295.c                   | 139 ++++++
+ drivers/media/i2c/max9296.c                   | 190 +++++++++
+ .../platform/tegra/camera/sensor_common.c     |   4 +
+ .../media/platform/tegra/camera/vi/channel.c  | 401 +++++++++++++++++-
+ .../media/platform/tegra/camera/vi/graph.c    |  38 +-
+ .../platform/tegra/camera/vi/mc_common.c      |  27 ++
+ .../media/platform/tegra/camera/vi/vi5_fops.c |  36 ++
+ .../platform/tegra/camera/vi/vi5_formats.h    |  30 +-
+ include/media/gmsl-link.h                     |   3 +
+ include/media/max9295.h                       |   4 +
+ include/media/max9296.h                       |   8 +
+ include/media/mc_common.h                     |  22 +
+ include/media/tegra_camera_core.h             |   8 +
+ 14 files changed, 902 insertions(+), 11 deletions(-)
+
+diff --git a/drivers/media/i2c/Makefile b/drivers/media/i2c/Makefile
+index 7c5913c6..396b9bc3 100644
+--- a/drivers/media/i2c/Makefile
++++ b/drivers/media/i2c/Makefile
+@@ -5,6 +5,9 @@ subdir-ccflags-y += -Werror
+ 
+ obj-m += max9295.o
+ obj-m += max9296.o
++subdir-ccflags-y += -DCONFIG_VIDEO_D4XX_SERDES
++subdir-ccflags-y += -DCONFIG_TEGRA_CAMERA_PLATFORM
++obj-m += d4xx.o
+ ifeq ($(findstring ack_src,$(NV_BUILD_KERNEL_OPTIONS)),)
+ obj-m += max96712.o
+ 
+diff --git a/drivers/media/i2c/max9295.c b/drivers/media/i2c/max9295.c
+index b363d5f6..e7c77845 100644
+--- a/drivers/media/i2c/max9295.c
++++ b/drivers/media/i2c/max9295.c
+@@ -465,6 +465,145 @@ static  struct regmap_config max9295_regmap_config = {
+ 	.cache_type = REGCACHE_RBTREE,
+ };
+ 
++struct reg_pair {
++	u16 addr;
++	u8 val;
++};
++
++static int max9295_set_registers(struct device *dev, struct reg_pair *map,
++				 u32 count)
++{
++	int err = 0;
++	u32 j = 0;
++
++	for (j = 0; j < count; j++) {
++		err = max9295_write_reg(dev,
++			map[j].addr, map[j].val);
++		if (err != 0)
++			break;
++	}
++
++	return err;
++}
++
++static int __max9295_set_pipe(struct device *dev, int pipe_id, u8 data_type1,
++			      u8 data_type2, u32 vc_id)
++{
++	int err = 0;
++	u8 bpp = 0x30;
++	static u8 pipe_x_val = 0x0;
++	struct reg_pair map_multi_pipe_en[] = {
++		{0x0315, 0x80},
++	};
++	struct reg_pair map_bpp8dbl[] = {
++		{0x0312, 0x0F},
++	};
++	struct reg_pair map_pipe_control[] = {
++		/* addr, val */
++		{MAX9295_PIPE_X_DT_ADDR, 0x5E}, // Pipe X pulls data_type1
++		{0x0315, 0x52}, // Pipe X pulls data_type2
++		{0x0309, 0x01}, // # Pipe X pulls vc_id
++		{0x030A, 0x00},
++		{0x031C, 0x30}, // BPP in pipe X
++		{0x0102, 0x0E}, // LIM_HEART Pipe X: Disabled
++	};
++
++	if (data_type1 == GMSL_CSI_DT_RAW_8 || data_type1 == GMSL_CSI_DT_EMBED
++	    || data_type2 == GMSL_CSI_DT_RAW_8 || data_type2 == GMSL_CSI_DT_EMBED) {
++		map_bpp8dbl[0].val |= (1 << pipe_id);
++	} else {
++		map_bpp8dbl[0].val &= ~(1 << pipe_id);
++	}
++	err |= max9295_set_registers(dev, map_bpp8dbl, ARRAY_SIZE(map_bpp8dbl));
++
++	if (data_type1 == GMSL_CSI_DT_RGB_888)
++		bpp = 0x18;
++
++	map_pipe_control[0].addr += 0x2 * pipe_id;
++	map_pipe_control[1].addr += 0x2 * pipe_id;
++	map_pipe_control[2].addr += 0x2 * pipe_id;
++	map_pipe_control[3].addr += 0x2 * pipe_id;
++	map_pipe_control[4].addr += 0x1 * pipe_id;
++	map_pipe_control[5].addr += 0x8 * pipe_id;
++
++	map_pipe_control[0].val = 0x40 | data_type1;
++	map_pipe_control[1].val = 0x40 | data_type2;
++	map_pipe_control[2].val = 1 << vc_id;
++	map_pipe_control[3].val = 0x00;
++	map_pipe_control[4].val = bpp;
++	map_pipe_control[5].val = 0x0E;
++
++	if (pipe_id == 0)
++		pipe_x_val = map_pipe_control[1].val;
++
++	err |= max9295_set_registers(dev, map_pipe_control,
++				     ARRAY_SIZE(map_pipe_control));
++
++	map_multi_pipe_en[0].val = 0x80 | pipe_x_val;
++	err |= max9295_set_registers(dev, map_multi_pipe_en,
++				     ARRAY_SIZE(map_multi_pipe_en));
++
++	return err;
++}
++
++int max9295_init_settings(struct device *dev)
++{
++	int err = 0;
++	int i;
++	struct max9295 *priv = dev_get_drvdata(dev);
++
++	struct reg_pair map_pipe_opt[] = {
++		// Enable all pipes
++		{MAX9295_PIPE_EN_ADDR, 0xF3},
++		// Write 0x33 for 4 lanes
++		{MAX9295_MIPI_RX1_ADDR, 0x11},
++		// All pipes pull clock from port B
++		{MAX9295_CSI_PORT_SEL_ADDR, 0x6F},
++		// All pipes pull data from port B
++		{MAX9295_START_PIPE_ADDR, 0xF0},
++	};
++
++	mutex_lock(&priv->lock);
++
++	// Init control
++	err |= max9295_set_registers(dev, map_pipe_opt,
++				     ARRAY_SIZE(map_pipe_opt));
++
++	for (i = 0; i < MAX9295_MAX_PIPES; i++)
++		err |= __max9295_set_pipe(dev, i, GMSL_CSI_DT_YUV422_8,
++					  GMSL_CSI_DT_EMBED, i);
++
++	mutex_unlock(&priv->lock);
++
++	return err;
++}
++EXPORT_SYMBOL(max9295_init_settings);
++
++int max9295_set_pipe(struct device *dev, int pipe_id,
++		     u8 data_type1, u8 data_type2, u32 vc_id)
++{
++	struct max9295 *priv = dev_get_drvdata(dev);
++	int err = 0;
++
++	if (pipe_id > (MAX9295_MAX_PIPES - 1)) {
++		dev_info(dev, "%s, input pipe_id: %d exceed max9295 max pipes\n",
++			 __func__, pipe_id);
++		return -EINVAL;
++	}
++
++	dev_dbg(dev, "%s pipe_id %d, data_type1 %u, data_type2 %u, vc_id %u\n",
++		__func__, pipe_id, data_type1, data_type2, vc_id);
++
++	mutex_lock(&priv->lock);
++
++	err = __max9295_set_pipe(dev, pipe_id, data_type1, data_type2, vc_id);
++
++	mutex_unlock(&priv->lock);
++
++	return err;
++}
++EXPORT_SYMBOL(max9295_set_pipe);
++
+ #if defined(NV_I2C_DRIVER_STRUCT_PROBE_WITHOUT_I2C_DEVICE_ID_ARG) /* Linux 6.3 */
+ static int max9295_probe(struct i2c_client *client)
+ #else
+diff --git a/drivers/media/i2c/max9296.c b/drivers/media/i2c/max9296.c
+index 1ceaf3cd..97559460 100644
+--- a/drivers/media/i2c/max9296.c
++++ b/drivers/media/i2c/max9296.c
+@@ -34,6 +34,8 @@
+ #define MAX9296_PIPE_X_DST_1_MAP_ADDR 0x410
+ #define MAX9296_PIPE_X_SRC_2_MAP_ADDR 0x411
+ #define MAX9296_PIPE_X_DST_2_MAP_ADDR 0x412
++#define MAX9296_PIPE_X_SRC_3_MAP_ADDR 0x413
++#define MAX9296_PIPE_X_DST_3_MAP_ADDR 0x414
+ 
+ #define MAX9296_PIPE_X_ST_SEL_ADDR 0x50
+ 
+@@ -250,6 +252,9 @@ void max9296_power_off(struct device *dev)
+ 	mutex_lock(&priv->lock);
+ 	priv->pw_ref--;
+ 
++	if (priv->pw_ref < 0)
++		priv->pw_ref = 0;
++
+ 	if (priv->pw_ref == 0) {
+ 		/* enter reset mode: XCLR */
+ 		usleep_range(1, 2);
+@@ -769,6 +774,191 @@ ret:
+ }
+ EXPORT_SYMBOL(max9296_setup_streaming);
+ 
++static int max9296_set_registers(struct device *dev, struct reg_pair *map,
++				 u32 count)
++{
++	int err = 0;
++	u32 j = 0;
++
++	for (j = 0; j < count; j++) {
++		err = max9296_write_reg(dev,
++			map[j].addr, map[j].val);
++		if (err != 0)
++			break;
++	}
++
++	return err;
++}
++
++int max9296_get_available_pipe_id(struct device *dev, int vc_id)
++{
++	int i;
++	int pipe_id = -ENOMEM;
++	struct max9296 *priv = dev_get_drvdata(dev);
++
++	mutex_lock(&priv->lock);
++	for (i = 0; i < MAX9296_MAX_PIPES; i++) {
++		if (i == vc_id && !priv->pipe[i].st_count) {
++			priv->pipe[i].st_count++;
++			pipe_id = i;
++			break;
++		}
++	}
++	mutex_unlock(&priv->lock);
++
++	return pipe_id;
++}
++EXPORT_SYMBOL(max9296_get_available_pipe_id);
++
++int max9296_release_pipe(struct device *dev, int pipe_id)
++{
++	struct max9296 *priv = dev_get_drvdata(dev);
++
++	if (pipe_id < 0 || pipe_id >= MAX9296_MAX_PIPES)
++		return -EINVAL;
++
++	mutex_lock(&priv->lock);
++	priv->pipe[pipe_id].st_count = 0;
++	mutex_unlock(&priv->lock);
++
++	return 0;
++}
++EXPORT_SYMBOL(max9296_release_pipe);
++
++void max9296_reset_oneshot(struct device *dev)
++{
++	struct max9296 *priv = dev_get_drvdata(dev);
++
++	mutex_lock(&priv->lock);
++	if (priv->splitter_enabled) {
++		max9296_write_reg(dev, MAX9296_CTRL0_ADDR, 0x03);
++		max9296_write_reg(dev, MAX9296_CTRL0_ADDR, 0x23);
++	} else {
++		max9296_write_reg(dev, MAX9296_CTRL0_ADDR, 0x31);
++	}
++	/* delay to settle link */
++	msleep(100);
++	mutex_unlock(&priv->lock);
++}
++EXPORT_SYMBOL(max9296_reset_oneshot);
++
++static int __max9296_set_pipe(struct device *dev, int pipe_id, u8 data_type1,
++			      u8 data_type2, u32 vc_id)
++{
++	int err = 0;
++	int i = 0;
++	u8 en_mapping_num = 0x0F;
++	u8 all_mapping_phy = 0x55;
++	struct reg_pair map_pipe_opt[] = {
++		{0x1458, 0x28}, // PHY A Optimization
++		{0x1459, 0x68}, // PHY A Optimization
++		{0x1558, 0x28}, // PHY B Optimization
++		{0x1559, 0x68}, // PHY B Optimization
++		// 4 lanes on port A, write 0x50 for 2 lanes
++		{MAX9296_LANE_CTRL1_ADDR, 0x50},
++		// 1500Mbps/lane on port A
++		{MAX9296_PHY1_CLK_ADDR, 0x2F},
++		// Do not un-double 8bpp (Un-double 8bpp data)
++		//{0x031C, 0x00},
++		// Do not un-double 8bpp
++		//{0x031F, 0x00},
++		// 0x02: ALT_MEM_MAP8, 0x10: ALT2_MEM_MAP8
++		{0x0473, 0x10},
++	};
++	struct reg_pair map_pipe_control[] = {
++		// Enable 4 mappings for Pipe X
++		{MAX9296_TX11_PIPE_X_EN_ADDR, 0x0F},
++		// Map data_type1 on vc_id
++		{MAX9296_PIPE_X_SRC_0_MAP_ADDR, 0x1E},
++		{MAX9296_PIPE_X_DST_0_MAP_ADDR, 0x1E},
++		// Map frame_start on vc_id
++		{MAX9296_PIPE_X_SRC_1_MAP_ADDR, 0x00},
++		{MAX9296_PIPE_X_DST_1_MAP_ADDR, 0x00},
++		// Map frame end on vc_id
++		{MAX9296_PIPE_X_SRC_2_MAP_ADDR, 0x01},
++		{MAX9296_PIPE_X_DST_2_MAP_ADDR, 0x01},
++		// Map data_type2 on vc_id
++		{MAX9296_PIPE_X_SRC_3_MAP_ADDR, 0x12},
++		{MAX9296_PIPE_X_DST_3_MAP_ADDR, 0x12},
++		// All mappings to PHY1 (master for port A)
++		{MAX9296_TX45_PIPE_X_DST_CTRL_ADDR, 0x55},
++		// SEQ_MISS_EN: Disabled / DIS_PKT_DET: Disabled
++		{0x0100, 0x23}, // pipe X
++	};
++
++	for (i = 0; i < 10; i++) {
++		map_pipe_control[i].addr += 0x40 * pipe_id;
++	}
++	map_pipe_control[10].addr += 0x12 * pipe_id;
++
++	if (data_type2 == 0x0) {
++		en_mapping_num = 0x07;
++		all_mapping_phy = 0x15;
++	}
++	map_pipe_control[0].val = en_mapping_num;
++	map_pipe_control[1].val = (vc_id << 6) | data_type1;
++	map_pipe_control[2].val = (vc_id << 6) | data_type1;
++	map_pipe_control[3].val = (vc_id << 6) | 0x00;
++	map_pipe_control[4].val = (vc_id << 6) | 0x00;
++	map_pipe_control[5].val = (vc_id << 6) | 0x01;
++	map_pipe_control[6].val = (vc_id << 6) | 0x01;
++	map_pipe_control[7].val = (vc_id << 6) | data_type2;
++	map_pipe_control[8].val = (vc_id << 6) | data_type2;
++	map_pipe_control[9].val = all_mapping_phy;
++	map_pipe_control[10].val = 0x23;
++
++	err |= max9296_set_registers(dev, map_pipe_control,
++				     ARRAY_SIZE(map_pipe_control));
++
++	err |= max9296_set_registers(dev, map_pipe_opt,
++				     ARRAY_SIZE(map_pipe_opt));
++
++	return err;
++}
++
++int max9296_init_settings(struct device *dev)
++{
++	int err = 0;
++	int i;
++	struct max9296 *priv = dev_get_drvdata(dev);
++
++	mutex_lock(&priv->lock);
++
++	for (i = 0; i < MAX9296_MAX_PIPES; i++)
++		err |= __max9296_set_pipe(dev, i, GMSL_CSI_DT_YUV422_8,
++					  GMSL_CSI_DT_EMBED, i);
++
++	mutex_unlock(&priv->lock);
++
++	return err;
++}
++EXPORT_SYMBOL(max9296_init_settings);
++
++int max9296_set_pipe(struct device *dev, int pipe_id,
++		     u8 data_type1, u8 data_type2, u32 vc_id)
++{
++	struct max9296 *priv = dev_get_drvdata(dev);
++	int err = 0;
++
++	if (pipe_id > (MAX9296_MAX_PIPES - 1)) {
++		dev_info(dev, "%s, input pipe_id: %d exceed max9296 max pipes\n",
++			 __func__, pipe_id);
++		return -EINVAL;
++	}
++
++	dev_dbg(dev, "%s pipe_id %d, data_type1 %u, data_type2 %u, vc_id %u\n",
++		__func__, pipe_id, data_type1, data_type2, vc_id);
++
++	mutex_lock(&priv->lock);
++
++	err = __max9296_set_pipe(dev, pipe_id, data_type1, data_type2, vc_id);
++
++	mutex_unlock(&priv->lock);
++
++	return err;
++}
++EXPORT_SYMBOL(max9296_set_pipe);
++
+ static const struct of_device_id max9296_of_match[] = {
+ 	{ .compatible = "maxim,max9296", },
+ 	{ },
+diff --git a/drivers/media/platform/tegra/camera/sensor_common.c b/drivers/media/platform/tegra/camera/sensor_common.c
+index 92cc2fdf..69139eee 100644
+--- a/drivers/media/platform/tegra/camera/sensor_common.c
++++ b/drivers/media/platform/tegra/camera/sensor_common.c
+@@ -267,6 +267,10 @@ static int extract_pixel_format(
+ 		*format = V4L2_PIX_FMT_UYVY;
+ 	else if (strncmp(pixel_t, "yuv_vyuy16", size) == 0)
+ 		*format = V4L2_PIX_FMT_VYUY;
++	else if (strncmp(pixel_t, "grey_y8", size) == 0)
++		*format = V4L2_PIX_FMT_GREY;
++	else if (strncmp(pixel_t, "grey_y16", size) == 0)
++		*format = V4L2_PIX_FMT_Y16;
+ 	else {
+ 		pr_err("%s: Need to extend format%s\n", __func__, pixel_t);
+ 		return -EINVAL;
+diff --git a/drivers/media/platform/tegra/camera/vi/channel.c b/drivers/media/platform/tegra/camera/vi/channel.c
+index 91f8d5f8..d9be2677 100644
+--- a/drivers/media/platform/tegra/camera/vi/channel.c
++++ b/drivers/media/platform/tegra/camera/vi/channel.c
+@@ -202,7 +202,12 @@ static void tegra_channel_fmt_align(struct tegra_channel *chan,
+ 	 * different. Aligned width also may force a sensor mode change other
+ 	 * than the requested one
+ 	 */
+-	*height = clamp(*height, TEGRA_MIN_HEIGHT, TEGRA_MAX_HEIGHT);
++	/* For D4XX IMU, the total size of one frame is 32 while the width:height
++	* should be set to 32:1. Therefore, ignored the clamping on height here by
++	* replacing TEGRA_MIN_HEIGHT with 1U ((unsigned int) 1).
++	*/
++	*height = clamp(*height, 1U /*TEGRA_MIN_HEIGHT*/, TEGRA_MAX_HEIGHT);
++
+ 
+ 	/* Clamp the requested bytes per line value. If the maximum bytes per
+ 	 * line value is zero, the module doesn't support user configurable line
+@@ -1027,7 +1032,8 @@ tegra_channel_querycap(struct file *file, void *fh, struct v4l2_capability *cap)
+ 
+ 	cap->device_caps = V4L2_CAP_VIDEO_CAPTURE | V4L2_CAP_STREAMING;
+ 	cap->device_caps |= V4L2_CAP_EXT_PIX_FORMAT;
+-	cap->capabilities = cap->device_caps | V4L2_CAP_DEVICE_CAPS;
++	cap->capabilities = cap->device_caps | V4L2_CAP_DEVICE_CAPS |
++			V4L2_CAP_META_CAPTURE;
+ 
+ 	len = strscpy(cap->driver, "tegra-video", sizeof(cap->driver));
+ 	if (len < 0)
+@@ -2224,6 +2230,62 @@ static long tegra_channel_default_ioctl(struct file *file, void *fh,
+ 	return v4l2_g_parm_cap(chan->video, sd, a);
+ }
+ 
++static int
++__tegra_channel_get_parm(struct tegra_channel *chan,
++			  struct v4l2_streamparm *a)
++{
++	struct v4l2_subdev *sd = chan->subdev_on_csi;
++	int ret = 0;
++	struct v4l2_subdev_frame_interval interval;
++
++	/* dmipx: fixing G_PARM EINVAL error */
++//	ret = v4l2_subdev_call(sd, video, g_frame_interval, &interval);
++	ret = sd->ops->video->g_frame_interval(sd, &interval);
++
++	a->parm.capture.timeperframe.numerator = interval.interval.numerator;
++	a->parm.capture.timeperframe.denominator = interval.interval.denominator;
++
++	return ret;
++}
++
++static int tegra_channel_get_parm(struct file *file, void *fh, struct v4l2_streamparm *a)
++{
++	struct tegra_channel *chan = video_drvdata(file);
++
++	a->parm.capture.timeperframe.numerator = 1;
++	a->parm.capture.timeperframe.denominator = 12;
++
++	return __tegra_channel_get_parm(chan, a);
++}
++
++static int
++__tegra_channel_set_parm(struct tegra_channel *chan,
++			  struct v4l2_streamparm *a)
++{
++	struct v4l2_subdev *sd = chan->subdev_on_csi;
++	int ret = 0;
++
++	struct v4l2_subdev_frame_interval interval;
++	interval.pad = 1;
++	interval.interval.numerator = a->parm.capture.timeperframe.numerator;
++	interval.interval.denominator = a->parm.capture.timeperframe.denominator;
++
++	ret = v4l2_subdev_call(sd, video, s_frame_interval, &interval);
++	if (ret == -ENOIOCTLCMD)
++			return -ENOTTY;
++
++	return ret;
++}
++static int tegra_channel_set_parm(struct file *file, void *fh, struct v4l2_streamparm *a)
++{
++	struct tegra_channel *chan = video_drvdata(file);
++
++	if (vb2_is_busy(&chan->queue))
++			return -EBUSY;
++
++	return __tegra_channel_set_parm(chan, a);
++}
++
+ static const struct v4l2_ioctl_ops tegra_channel_ioctl_ops = {
+ 	.vidioc_querycap		= tegra_channel_querycap,
+ 	.vidioc_enum_framesizes		= tegra_channel_enum_framesizes,
+@@ -2255,6 +2317,9 @@ static const struct v4l2_ioctl_ops tegra_channel_ioctl_ops = {
+ 	.vidioc_s_input			= tegra_channel_s_input,
+ 	.vidioc_log_status		= tegra_channel_log_status,
+ 	.vidioc_default			= tegra_channel_default_ioctl,
++	.vidioc_g_parm			= tegra_channel_get_parm,
++	.vidioc_s_parm			= tegra_channel_set_parm,
++
+ };
+ 
+ static int tegra_channel_close(struct file *fp);
+@@ -2470,6 +2535,331 @@ static int tegra_channel_csi_init(struct tegra_channel *chan)
+ 	return ret;
+ }
+ 
++static int tegra_metadata_open(struct file *fp)
++{
++	struct video_device *vdev = video_devdata(fp);
++	struct tegra_channel *chan = video_get_drvdata(vdev);
++	int ret;
++
++	mutex_lock(&chan->embedded.lock);
++	ret = v4l2_fh_open(fp);
++	mutex_unlock(&chan->embedded.lock);
++
++	return ret;
++}
++
++static int tegra_metadata_close(struct file *fp)
++{
++	struct video_device *vdev = video_devdata(fp);
++	struct tegra_channel *chan = video_get_drvdata(vdev);
++	int ret = _vb2_fop_release(fp, &chan->embedded.lock);
++
++	return ret;
++}
++
++static const struct v4l2_file_operations tegra_metadata_fops = {
++	.owner          = THIS_MODULE,
++	.unlocked_ioctl = video_ioctl2,
++	.open           = tegra_metadata_open,
++	.release        = tegra_metadata_close,
++	.read           = vb2_fop_read,
++	.poll           = vb2_fop_poll,
++	.mmap           = vb2_fop_mmap,
++};
++
++static int tegra_metadata_querycap(struct file *file, void *fh,
++                                 struct v4l2_capability *cap)
++{
++	struct v4l2_fh *vfh = file->private_data;
++	struct tegra_channel *chan = video_drvdata(file);
++
++	/* FIXME: why do Device Caps show V4L2_CAP_EXT_PIX_FORMAT? */
++	cap->device_caps = V4L2_CAP_META_CAPTURE | V4L2_CAP_STREAMING;
++	cap->capabilities = cap->device_caps | V4L2_CAP_DEVICE_CAPS |
++			V4L2_CAP_EXT_PIX_FORMAT | V4L2_CAP_VIDEO_CAPTURE;
++
++	strlcpy(cap->driver, "tegra-embedded", sizeof(cap->driver));
++	strlcpy(cap->card, vfh->vdev->name, sizeof(cap->card));
++	snprintf(cap->bus_info, sizeof(cap->bus_info), "platform:%s:%u",
++			dev_name(chan->vi->dev), chan->port[0]);
++
++	return 0;
++}
++
++static int tegra_metadata_enum_format(struct file *file, void *fh,
++                                     struct v4l2_fmtdesc *f)
++{
++	if (f->index)
++		return -EINVAL;
++
++	f->pixelformat = V4L2_META_FMT_D4XX;
++	strlcpy(f->description, "D4XX metadata format", sizeof(f->description));
++
++	return 0;
++}
++
++static int tegra_metadata_get_format(struct file *file, void *fh,
++                                    struct v4l2_format *format)
++{
++	struct v4l2_fh *vfh = file->private_data;
++	struct v4l2_meta_format *fmt = &format->fmt.meta;
++
++	if (format->type != vfh->vdev->queue->type)
++		return -EINVAL;
++
++	memset(fmt, 0, sizeof(*fmt));
++
++	fmt->dataformat = V4L2_META_FMT_D4XX;
++	fmt->buffersize = 255;
++
++	return 0;
++}
++static int tegra_metadata_set_format(struct file *file, void *fh,
++                                    struct v4l2_format *format)
++{
++   return 0;
++}
++
++static int tegra_metadata_try_format(struct file *file, void *fh,
++                                    struct v4l2_format *format)
++{
++    return 0;
++}
++static const struct v4l2_ioctl_ops tegra_metadata_ioctl_ops = {
++	.vidioc_querycap                = tegra_metadata_querycap,
++	.vidioc_enum_fmt_meta_cap       = tegra_metadata_enum_format,
++	.vidioc_g_fmt_meta_cap          = tegra_metadata_get_format,
++	.vidioc_s_fmt_meta_cap          = tegra_metadata_set_format,
++	.vidioc_try_fmt_meta_cap        = tegra_metadata_try_format,
++	.vidioc_reqbufs                 = vb2_ioctl_reqbufs,
++	.vidioc_querybuf                = vb2_ioctl_querybuf,
++	.vidioc_qbuf                    = vb2_ioctl_qbuf,
++	.vidioc_dqbuf                   = vb2_ioctl_dqbuf,
++	.vidioc_create_bufs             = vb2_ioctl_create_bufs,
++	.vidioc_expbuf                  = vb2_ioctl_expbuf,
++	.vidioc_streamon                = vb2_ioctl_streamon,
++	.vidioc_streamoff               = vb2_ioctl_streamoff,
++};
++
++static int tegra_metadata_queue_setup(struct vb2_queue *vq,
++                    unsigned int *nbuffers, unsigned int *nplanes,
++                    unsigned int sizes[], struct device *alloc_devs[])
++{
++	struct tegra_channel *chan = vb2_get_drv_priv(vq);
++
++	if (*nplanes) {
++		if (*nplanes != 1)
++			return -EINVAL;
++
++		if (sizes[0] < 255)
++			return -EINVAL;
++
++		return 0;
++	}
++
++	*nplanes = 1;
++	sizes[0] = 255;
++	alloc_devs[0] = chan->vi->dev;
++
++
++	return 0;
++}
++
++static int tegra_metadata_buffer_prepare(struct vb2_buffer *vb)
++{
++	if (vb->num_planes != 1)
++		return -EINVAL;
++
++	if (vb2_plane_size(vb, 0) < 255)
++		return -EINVAL;
++
++	return 0;
++}
++
++static void tegra_metadata_buffer_queue(struct vb2_buffer *vb)
++{
++	struct tegra_channel *chan = vb2_get_drv_priv(vb->vb2_queue);
++
++	spin_lock(&chan->embedded.spin_lock);
++	if (chan->embedded.num_buffers < 16) {
++		chan->embedded.buffers[chan->embedded.head] = vb;
++		chan->embedded.head++;
++		if (chan->embedded.head > 15)
++			chan->embedded.head = chan->embedded.head - 16;
++		chan->embedded.num_buffers++;
++	}
++	spin_unlock(&chan->embedded.spin_lock);
++}
++
++static int tegra_metadata_start_streaming(struct vb2_queue *vq, unsigned int count)
++{
++	return 0;
++}
++
++static void tegra_metadata_stop_streaming(struct vb2_queue *vq)
++{
++	struct tegra_channel *chan = vb2_get_drv_priv(vq);
++	int i = 0;
++
++	spin_lock(&chan->embedded.spin_lock);
++	for (i = 0; i < chan->embedded.num_buffers; i++) {
++		struct vb2_buffer *evb;
++		evb = chan->embedded.buffers[chan->embedded.tail];
++		chan->embedded.buffers[chan->embedded.tail] = NULL;
++		chan->embedded.tail++;
++		if (chan->embedded.tail > 15)
++			chan->embedded.tail = chan->embedded.tail - 16;
++		vb2_buffer_done(evb, VB2_BUF_STATE_ERROR);
++	}
++	spin_unlock(&chan->embedded.spin_lock);
++
++	chan->embedded.head = 0;
++	chan->embedded.tail = 0;;
++	chan->embedded.num_buffers = 0;
++}
++
++static const struct vb2_ops tegra_metadata_qops = {
++	.queue_setup            = tegra_metadata_queue_setup,
++	.buf_prepare            = tegra_metadata_buffer_prepare,
++	.buf_queue              = tegra_metadata_buffer_queue,
++	.wait_prepare           = vb2_ops_wait_prepare,
++	.wait_finish            = vb2_ops_wait_finish,
++	.start_streaming        = tegra_metadata_start_streaming,
++	.stop_streaming         = tegra_metadata_stop_streaming,
++};
++
++int tegra_channel_init_video_embedded(struct tegra_channel *chan)
++{
++	struct video_device *video;
++	struct vb2_queue *queue = &chan->embedded.queue;
++	struct tegra_mc_vi *vi = chan->vi;
++	int ret;
++
++	mutex_init(&chan->embedded.lock);
++	spin_lock_init(&chan->embedded.spin_lock);
++
++	video = chan->embedded.video = video_device_alloc();
++	chan->embedded.pad.flags = MEDIA_PAD_FL_SINK;
++
++	ret = tegra_media_entity_init(&video->entity, 1,
++									&chan->embedded.pad, false, false);
++	if (ret < 0) {
++		video_device_release(video);
++		dev_err(vi->dev, "%s(): metadata entity init: %d\n",
++				__func__, ret);
++		return ret;
++	}
++
++	ret = v4l2_ctrl_handler_init(&chan->embedded.ctrl_handler,
++									MAX_CID_CONTROLS);
++	if (chan->embedded.ctrl_handler.error) {
++		dev_err(&video->dev, "failed to init control handler\n");
++		return ret;
++	}
++
++	video->fops = &tegra_metadata_fops;
++	video->v4l2_dev = &vi->v4l2_dev;
++	video->queue = queue;
++	snprintf(video->name, sizeof(video->name), "%s-metadata-%u",
++			dev_name(vi->dev), chan->port[0]);
++#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 4, 0)
++	video->vfl_type = VFL_TYPE_GRABBER;
++#else
++	video->vfl_type = VFL_TYPE_VIDEO;
++	video->device_caps = V4L2_CAP_META_CAPTURE | V4L2_CAP_STREAMING;
++#endif
++	video->vfl_dir = VFL_DIR_RX;
++	video->release = video_device_release_empty;
++	video->ioctl_ops = &tegra_metadata_ioctl_ops;
++	video->ctrl_handler = &chan->embedded.ctrl_handler;
++	video->lock = &chan->embedded.lock;
++
++	video_set_drvdata(video, chan);
++
++#if defined(CONFIG_VIDEOBUF2_DMA_CONTIG)
++	/* get the buffers queue... */
++	ret = tegra_vb2_dma_init(vi->dev, &chan->embedded.alloc_ctx,
++					SZ_64K, &vi->vb2_dma_alloc_refcnt);
++	if (ret < 0)
++		goto ctx_alloc_error;
++
++#endif
++//#if defined(CONFIG_VIDEOBUF2_DMA_CONTIG)
++	/* get the buffers queue... */
++//     chan->embedded.alloc_ctx = vb2_dma_contig_init_ctx(vi->dev);
++//     if (IS_ERR(chan->embedded.alloc_ctx)) {
++//             dev_err(vi->dev, "%s(): vb2 buffer init: %ld\n", __func__,
++//                     PTR_ERR(chan->embedded.alloc_ctx));
++//             goto ctx_alloc_error;
++//     }
++//#endif
++
++	queue->type = V4L2_BUF_TYPE_META_CAPTURE;
++	queue->io_modes = VB2_MMAP | VB2_DMABUF | VB2_READ | VB2_USERPTR;
++	queue->lock = &chan->embedded.lock;
++	queue->drv_priv = chan;
++	queue->buf_struct_size = sizeof(struct tegra_channel_buffer);
++	queue->ops = &tegra_metadata_qops;
++#if defined(CONFIG_VIDEOBUF2_DMA_CONTIG)
++	queue->mem_ops = &vb2_dma_contig_memops;
++#endif
++	queue->timestamp_flags = V4L2_BUF_FLAG_TIMESTAMP_MONOTONIC |
++			V4L2_BUF_FLAG_TSTAMP_SRC_EOF;
++	ret = vb2_queue_init(queue);
++	if (ret < 0) {
++		dev_err(vi->dev, "%s(): metadata queue initialize: %d\n",
++				__func__, ret);
++		goto vb2_queue_error;
++	}
++
++	return 0;
++
++vb2_queue_error:
++#if defined(CONFIG_VIDEOBUF2_DMA_CONTIG)
++	tegra_vb2_dma_cleanup(vi->dev, chan->embedded.alloc_ctx,
++			&vi->vb2_dma_alloc_refcnt);
++ctx_alloc_error:
++#endif
++	media_entity_cleanup(&video->entity);
++
++	return ret;
++}
++
++int tegra_channel_cleanup_video_embedded(struct tegra_channel *chan)
++{
++	struct video_device *video = chan->embedded.video;
++	struct vb2_queue *queue = &chan->embedded.queue;
++	struct device *vi_unit_dev = tegra_channel_get_vi_unit(chan);
++
++	if (!video)
++		return -EINVAL;
++
++	video_unregister_device(video);
++
++	/* release embedded data buffer */
++	if (chan->emb_buf_size > 0) {
++		dma_free_coherent(vi_unit_dev,
++				chan->emb_buf_size,
++				chan->emb_buf_addr, chan->emb_buf);
++		chan->emb_buf_size = 0;
++		vb2_queue_release(queue);
++#if defined(CONFIG_VIDEOBUF2_DMA_CONTIG)
++		tegra_vb2_dma_cleanup(vi_unit_dev, chan->embedded.alloc_ctx,
++						&chan->vi->vb2_dma_alloc_refcnt);
++#endif
++	}
++
++	v4l2_ctrl_handler_free(&chan->embedded.ctrl_handler);
++
++#if defined(CONFIG_MEDIA_CONTROLLER)
++	media_entity_cleanup(&video->entity);
++#endif
++
++	video_device_release(video);
++
++	return 0;
++}
++
+ int tegra_channel_init_video(struct tegra_channel *chan)
+ {
+ 	struct tegra_mc_vi *vi = chan->vi;
+@@ -2656,6 +3046,13 @@ int tegra_channel_cleanup(struct tegra_channel *chan)
+ 			chan->emb_buf_size,
+ 			chan->emb_buf_addr, chan->emb_buf);
+ 		chan->emb_buf_size = 0;
++		vb2_queue_release(&chan->embedded.queue);
++#if IS_ENABLED(CONFIG_VIDEOBUF2_DMA_CONTIG)
++		tegra_vb2_dma_cleanup(vi_unit_dev, chan->embedded.alloc_ctx,
++			&chan->vi->vb2_dma_alloc_refcnt);
++		//vb2_dma_contig_cleanup_ctx(chan->embedded.alloc_ctx);
++#endif
++		media_entity_cleanup(&chan->embedded.video->entity);
+ 	}
+ 
+ 	tegra_channel_dealloc_buffer_queue(chan);
+diff --git a/drivers/media/platform/tegra/camera/vi/graph.c b/drivers/media/platform/tegra/camera/vi/graph.c
+index 7c2d05e7..5e25cf6a 100644
+--- a/drivers/media/platform/tegra/camera/vi/graph.c
++++ b/drivers/media/platform/tegra/camera/vi/graph.c
+@@ -292,6 +292,11 @@ static int tegra_vi_graph_notify_complete(struct v4l2_async_notifier *notifier)
+ 	struct tegra_channel *chan =
+ 		container_of(notifier, struct tegra_channel, notifier);
+ 	struct tegra_vi_graph_entity *entity;
++	struct camera_common_data *s_data;
++	struct device_node *node;
++	struct sensor_mode_properties *sensor_mode = NULL;
++	int idx;
++
+ 	int ret;
+ 
+ 	dev_dbg(chan->vi->dev, "notify complete, all subdevs registered\n");
+@@ -325,16 +330,46 @@ static int tegra_vi_graph_notify_complete(struct v4l2_async_notifier *notifier)
+ 	if (ret < 0)
+ 		goto graph_error;
+ 
++	/* Init embedded channel only if embedded is set in DT*/
++	s_data = to_camera_common_data(chan->subdev_on_csi->dev);
++	node = chan->subdev_on_csi->dev->of_node;
++	if (s_data && node) {
++		idx = s_data->mode_prop_idx;
++		if (idx < s_data->sensor_props.num_modes)
++			sensor_mode = &s_data->sensor_props.sensor_modes[idx];
++	}
++
++	if (sensor_mode &&
++		sensor_mode->image_properties.embedded_metadata_height > 0) {
++		ret = tegra_channel_init_video_embedded(chan);
++		if (ret < 0) {
++			dev_err(chan->vi->dev,
++					"failed to initialize embedded channel\n");
++			goto register_embedded_device_error;
++		}
++		ret = video_register_device(chan->embedded.video, VFL_TYPE_VIDEO, -1);
++		if (ret < 0) {
++			dev_err(&chan->video->dev, "failed to register embedded %s: %d\n",
++					chan->embedded.video->name, ret);
++			goto register_embedded_device_error;
++		}
++	}
++
++
+ 	ret = v4l2_device_register_subdev_nodes(&chan->vi->v4l2_dev);
+ 	if (ret < 0) {
+ 		dev_err(chan->vi->dev, "failed to register subdev nodes\n");
+-		goto graph_error;
++		goto register_nodes_error;
+ 	}
+ 
+ 	chan->link_status++;
+ 
+ 	return 0;
+ 
++register_nodes_error:
++	video_unregister_device(chan->embedded.video);
++register_embedded_device_error:
++	tegra_vi_graph_remove_links(chan);
+ graph_error:
+ 	video_unregister_device(chan->video);
+ register_device_error:
+@@ -398,6 +433,7 @@ static void tegra_vi_graph_notify_unbind(struct v4l2_async_notifier *notifier,
+ 
+ 	/* cleanup for complete */
+ 	if (chan->link_status) {
++		tegra_channel_cleanup_video_embedded(chan);
+ 		tegra_vi_graph_remove_links(chan);
+ 		tegra_channel_cleanup_video(chan);
+ 		chan->link_status--;
+diff --git a/drivers/media/platform/tegra/camera/vi/mc_common.c b/drivers/media/platform/tegra/camera/vi/mc_common.c
+index ae6b4927..6288d712 100644
+--- a/drivers/media/platform/tegra/camera/vi/mc_common.c
++++ b/drivers/media/platform/tegra/camera/vi/mc_common.c
+@@ -164,6 +164,10 @@ static int vi_parse_dt(struct tegra_mc_vi *vi, struct platform_device *dev)
+ 	struct device_node *port;
+ 	int value = 0xFF;
+ 	int ret = 0;
++	struct device_node *dser_node = NULL;
++	struct i2c_client *dser_i2c = NULL;
++	struct device_node *ser_node = NULL;
++	struct i2c_client *ser_i2c = NULL;
+ 
+ 	err = of_property_read_u32(node, "num-channels", &num_channels);
+ 	if (err) {
+@@ -173,6 +177,29 @@ static int vi_parse_dt(struct tegra_mc_vi *vi, struct platform_device *dev)
+ 	}
+ 	vi->num_channels = num_channels;
+ 
++	vi->dser_dev = NULL;
++	dser_node = of_parse_phandle(node, "nvidia,gmsl-dser-device", 0);
++	if (dser_node) {
++		dser_i2c = of_find_i2c_device_by_node(dser_node);
++		of_node_put(dser_node);
++		if (dser_i2c) {
++			dev_info(&dev->dev, "dser_i2c->addr 0x%x", dser_i2c->addr);
++			vi->dser_dev = &dser_i2c->dev;
++		}
++	}
++
++	vi->ser_dev = NULL;
++	ser_node = of_parse_phandle(node, "nvidia,gmsl-ser-device", 0);
++	if (ser_node) {
++		ser_i2c = of_find_i2c_device_by_node(ser_node);
++		of_node_put(ser_node);
++		if (ser_i2c) {
++			dev_info(&dev->dev, "ser_i2c->addr 0x%x", ser_i2c->addr);
++			vi->ser_dev = &ser_i2c->dev;
++		}
++	}
++
++	vi->num_channels = num_channels;
+ 	ports = of_get_child_by_name(node, "ports");
+ 	if (ports == NULL)
+ 		ports = node;
+diff --git a/drivers/media/platform/tegra/camera/vi/vi5_fops.c b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
+index 7b16dcaf..487ae44b 100644
+--- a/drivers/media/platform/tegra/camera/vi/vi5_fops.c
++++ b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
+@@ -426,6 +426,39 @@ static void vi5_setup_surface(struct tegra_channel *chan,
+ 		chan->capture_descr_sequence += 1;
+ }
+ 
++static void vi5_release_metadata_buffer(struct tegra_channel *chan,
++	struct vb2_v4l2_buffer *vbuf)
++{
++	struct vb2_buffer *evb = NULL;
++	struct vb2_v4l2_buffer *evbuf;
++	void* frm_buffer;
++
++	spin_lock(&chan->embedded.spin_lock);
++	if (0 < chan->embedded.num_buffers) {
++		evb = chan->embedded.buffers[chan->embedded.tail];
++		chan->embedded.buffers[chan->embedded.tail] = NULL;
++		chan->embedded.tail++;
++		if (chan->embedded.tail > 15)
++			chan->embedded.tail = chan->embedded.tail - 16;
++		chan->embedded.num_buffers--;
++	}
++	spin_unlock(&chan->embedded.spin_lock);
++
++	if (!evb)
++		return;
++
++	frm_buffer = vb2_plane_vaddr(evb, 0);
++	if (!frm_buffer)
++		return;
++
++	memcpy(frm_buffer, chan->emb_buf_addr, 255);
++	evbuf = to_vb2_v4l2_buffer(evb);
++	evbuf->sequence = vbuf->sequence;
++	vb2_set_plane_payload(evb, 0, 68);
++	evb->timestamp = vbuf->vb2_buf.timestamp;
++	vb2_buffer_done(evb, VB2_BUF_STATE_DONE);
++}
++
+ static void vi5_release_buffer(struct tegra_channel *chan,
+ 	struct tegra_channel_buffer *buf)
+ {
+@@ -436,6 +469,9 @@ static void vi5_release_buffer(struct tegra_channel *chan,
+ 	vb2_set_plane_payload(&vbuf->vb2_buf, 0, chan->format.sizeimage);
+ 
+ 	vb2_buffer_done(&vbuf->vb2_buf, buf->vb2_state);
++
++	if (chan->embedded_data_height == 1 && buf->vb2_state == VB2_BUF_STATE_DONE)
++		vi5_release_metadata_buffer(chan, vbuf);
+ }
+ 
+ static void vi5_capture_enqueue(struct tegra_channel *chan,
+diff --git a/drivers/media/platform/tegra/camera/vi/vi5_formats.h b/drivers/media/platform/tegra/camera/vi/vi5_formats.h
+index 1d0c1133..1d375de5 100644
+--- a/drivers/media/platform/tegra/camera/vi/vi5_formats.h
++++ b/drivers/media/platform/tegra/camera/vi/vi5_formats.h
+@@ -82,6 +82,8 @@ static const struct tegra_video_format vi5_video_formats[] = {
+ 	/* RAW 7: TODO */
+ 
+ 	/* RAW 8 */
++	TEGRA_VIDEO_FORMAT(RAW8, 8, Y8_1X8, 1, 1, T_R8,
++				RAW8, GREY, "Greyscale 8"),
+ 	TEGRA_VIDEO_FORMAT(RAW8, 8, SRGGB8_1X8, 1, 1, T_R8,
+ 				RAW8, SRGGB8, "RGRG.. GBGB.."),
+ 	TEGRA_VIDEO_FORMAT(RAW8, 8, SGRBG8_1X8, 1, 1, T_R8,
+@@ -112,22 +114,22 @@ static const struct tegra_video_format vi5_video_formats[] = {
+ 				RAW12, SBGGR12, "BGBG.. GRGR.."),
+ 
+ 	/* RGB888 */
+-	TEGRA_VIDEO_FORMAT(RGB888, 24, RGB888_1X24, 4, 1, T_A8R8G8B8,
+-				RGB888, RGBA32, "RGBA-8-8-8-8"),
++	// TEGRA_VIDEO_FORMAT(RGB888, 24, RGB888_1X24, 4, 1, T_A8R8G8B8,
++	// 			RGB888, RGBA32, "RGBA-8-8-8-8"),
+ 	TEGRA_VIDEO_FORMAT(RGB888, 24, RGB888_1X32_PADHI, 4, 1, T_A8B8G8R8,
+ 				RGB888, RGB32, "RGB-8-8-8-8"),
+ 
+ 	/* YUV422 */
+-	TEGRA_VIDEO_FORMAT(YUV422, 16, UYVY8_1X16, 2, 1, T_U8_Y8__V8_Y8,
+-				YUV422_8, UYVY, "YUV 4:2:2"),
+-	TEGRA_VIDEO_FORMAT(YUV422, 16, VYUY8_1X16, 2, 1, T_V8_Y8__U8_Y8,
+-				YUV422_8, VYUY, "YUV 4:2:2"),
++	// TEGRA_VIDEO_FORMAT(YUV422, 16, UYVY8_1X16, 2, 1, T_U8_Y8__V8_Y8,
++	// 			YUV422_8, UYVY, "YUV 4:2:2"),
++	// TEGRA_VIDEO_FORMAT(YUV422, 16, VYUY8_1X16, 2, 1, T_V8_Y8__U8_Y8,
++	// 			YUV422_8, VYUY, "YUV 4:2:2"),
+ 	TEGRA_VIDEO_FORMAT(YUV422, 16, YUYV8_1X16, 2, 1, T_Y8_U8__Y8_V8,
+ 				YUV422_8, YUYV, "YUV 4:2:2"),
+ 	TEGRA_VIDEO_FORMAT(YUV422, 16, YVYU8_1X16, 2, 1, T_Y8_V8__Y8_U8,
+ 				YUV422_8, YVYU, "YUV 4:2:2"),
+-	TEGRA_VIDEO_FORMAT(YUV422, 16, UYVY8_1X16, 1, 1, T_Y8__V8U8_N422,
+-				YUV422_8, NV16, "NV16"),
++	// TEGRA_VIDEO_FORMAT(YUV422, 16, UYVY8_1X16, 1, 1, T_Y8__V8U8_N422,
++	// 			YUV422_8, NV16, "NV16"),
+ 	TEGRA_VIDEO_FORMAT(YUV422, 16, UYVY8_2X8, 2, 1, T_U8_Y8__V8_Y8,
+ 				YUV422_8, UYVY, "YUV 4:2:2 UYVY"),
+ 	TEGRA_VIDEO_FORMAT(YUV422, 16, VYUY8_2X8, 2, 1, T_V8_Y8__U8_Y8,
+@@ -136,6 +138,18 @@ static const struct tegra_video_format vi5_video_formats[] = {
+ 				YUV422_8, YUYV, "YUV 4:2:2 YUYV"),
+ 	TEGRA_VIDEO_FORMAT(YUV422, 16, YVYU8_2X8, 2, 1, T_Y8_V8__Y8_U8,
+ 				YUV422_8, YVYU, "YUV 4:2:2 YVYU"),
++
++	TEGRA_VIDEO_FORMAT(YUV422, 16, UYVY8_1X16, 2, 1, T_U8_Y8__V8_Y8,
++				YUV422_8, Z16, "Depth 16"),
++	TEGRA_VIDEO_FORMAT(YUV422, 16, VYUY8_1X16, 2, 1, T_V8_Y8__U8_Y8,
++				YUV422_8, Y8I, "Y8I 16"),
++	// TODO: RealSesne calibration format Y12I should be 3-byte,
++	// R[7:3]R[3:0] | L[3:0]R[11:8] | L[11:8]L[7:4]
++	// but, currently, it's 4-byte, one byte is added as alignment
++	// R[7:3]R[3:0] | L[3:0]R[11:8] | L[11:8]L[7:4] | ALIGN[7:0]
++	TEGRA_VIDEO_FORMAT(RGB888, 24, RGB888_1X24, 4, 1, T_A8R8G8B8,
++				RGB888, Y12I, "Y12I 24"),
++
+ };
+ 
+ #endif
+diff --git a/include/media/gmsl-link.h b/include/media/gmsl-link.h
+index ad902d0a..7dce2356 100644
+--- a/include/media/gmsl-link.h
++++ b/include/media/gmsl-link.h
+@@ -40,6 +40,9 @@
+ #define GMSL_CSI_DT_RAW_12 0x2C
+ #define GMSL_CSI_DT_UED_U1 0x30
+ #define GMSL_CSI_DT_EMBED 0x12
++#define GMSL_CSI_DT_YUV422_8 0x1E
++#define GMSL_CSI_DT_RGB_888 0x24
++#define GMSL_CSI_DT_RAW_8 0x2A
+ 
+ #define GMSL_ST_ID_UNUSED 0xFF
+ 
+diff --git a/include/media/max9295.h b/include/media/max9295.h
+index bf801aa2..c576e3e5 100644
+--- a/include/media/max9295.h
++++ b/include/media/max9295.h
+@@ -12,6 +12,7 @@
+ #ifndef __MAX9295_H__
+ #define __MAX9295_H__
+ 
++#include <linux/types.h>
+ #include <media/gmsl-link.h>
+ /**
+  * \defgroup max9295 MAX9295 serializer driver
+@@ -22,6 +23,8 @@
+  * @{
+  */
+ 
++int max9295_set_pipe(struct device *dev, int pipe_id, u8 data_type1,
++		     u8 data_type2, u32 vc_id);
+ 
+ /**
+  * @brief  Powers on a serializer device and performs the I2C overrides
+@@ -82,6 +85,7 @@ int max9295_sdev_unpair(struct device *dev, struct device *s_dev);
+  */
+ int max9295_setup_streaming(struct device *dev);
+ 
++int max9295_init_settings(struct device *dev);
+ /** @} */
+ 
+ #endif  /* __MAX9295_H__ */
+diff --git a/include/media/max9296.h b/include/media/max9296.h
+index 210dbc80..6b4c796e 100644
+--- a/include/media/max9296.h
++++ b/include/media/max9296.h
+@@ -12,6 +12,7 @@
+ #ifndef __MAX9296_H__
+ #define __MAX9296_H__
+ 
++#include <linux/types.h>
+ #include <media/gmsl-link.h>
+ /**
+  * \defgroup max9296 MAX9296 deserializer driver
+@@ -22,6 +23,12 @@
+  * @{
+  */
+ 
++int max9296_get_available_pipe_id(struct device *dev, int vc_id);
++int max9296_set_pipe(struct device *dev, int pipe_id, u8 data_type1,
++		     u8 data_type2, u32 vc_id);
++int max9296_release_pipe(struct device *dev, int pipe_id);
++void max9296_reset_oneshot(struct device *dev);
++
+ /**
+  * Puts a deserializer device in single exclusive link mode, so link-specific
+  * I2C overrides can be performed for sensor and serializer devices.
+@@ -146,6 +153,7 @@ int max9296_power_on(struct device *dev);
+  */
+ void max9296_power_off(struct device *dev);
+ 
++int max9296_init_settings(struct device *dev);
+ /** @} */
+ 
+ #endif  /* __MAX9296_H__ */
+diff --git a/include/media/mc_common.h b/include/media/mc_common.h
+index 0408ba67..1252fb3f 100644
+--- a/include/media/mc_common.h
++++ b/include/media/mc_common.h
+@@ -224,6 +224,23 @@ struct tegra_channel {
+ 	unsigned int embedded_data_width;
+ 	unsigned int embedded_data_height;
+ 
++	struct {
++		struct video_device *video;
++		struct mutex lock;
++		spinlock_t spin_lock;
++		struct vb2_queue queue;
++		/*FIXME: 16 is max queued metadata buffers
++		* define 16
++		*/
++		struct vb2_buffer *buffers[16];
++		unsigned int head;
++		unsigned int tail;
++		unsigned int num_buffers;
++		void *alloc_ctx;
++		struct media_pad pad;
++		struct v4l2_ctrl_handler ctrl_handler;
++	} embedded;
++
+ 	DECLARE_BITMAP(fmts_bitmap, MAX_FORMAT_NUM);
+ 	atomic_t power_on_refcnt;
+ 	struct v4l2_fh *fh;
+@@ -304,6 +321,9 @@ struct tegra_mc_vi {
+ 	unsigned int num_channels;
+ 	unsigned int num_subdevs;
+ 
++	struct device *dser_dev;
++	struct device *ser_dev;
++
+ 	struct tegra_csi_device *csi;
+ 	struct list_head vi_chans;
+ 	struct tegra_channel *tpg_start;
+@@ -400,7 +420,9 @@ struct tegra_channel_buffer *dequeue_inflight(struct tegra_channel *chan);
+ int tegra_channel_set_power(struct tegra_channel *chan, bool on);
+ 
+ int tegra_channel_init_video(struct tegra_channel *chan);
++int tegra_channel_init_video_embedded(struct tegra_channel *chan);
+ int tegra_channel_cleanup_video(struct tegra_channel *chan);
++int tegra_channel_cleanup_video_embedded(struct tegra_channel *chan);
+ 
+ struct tegra_vi_fops {
+ 	int (*vi_power_on)(struct tegra_channel *chan);
+diff --git a/include/media/tegra_camera_core.h b/include/media/tegra_camera_core.h
+index e6d9a2b1..38634b77 100644
+--- a/include/media/tegra_camera_core.h
++++ b/include/media/tegra_camera_core.h
+@@ -18,7 +18,7 @@
+ /* Width alignment */
+ #define TEGRA_WIDTH_ALIGNMENT	1
+ /* Stride alignment */
+-#define TEGRA_STRIDE_ALIGNMENT	1
++#define TEGRA_STRIDE_ALIGNMENT	64
+ /* Height alignment */
+ #define TEGRA_HEIGHT_ALIGNMENT	1
+ /* Size alignment */
+@@ -32,6 +32,8 @@
+ #define TEGRA_IMAGE_FORMAT_DEF	32
+ 
+ enum tegra_image_dt {
++	TEGRA_IMAGE_DT_EMBEDDED_8 = 18,
++
+ 	TEGRA_IMAGE_DT_YUV420_8 = 24,
+ 	TEGRA_IMAGE_DT_YUV420_10,
+ 
+@@ -51,6 +53,12 @@ enum tegra_image_dt {
+ 	TEGRA_IMAGE_DT_RAW10,
+ 	TEGRA_IMAGE_DT_RAW12,
+ 	TEGRA_IMAGE_DT_RAW14,
++
++	TEGRA_IMAGE_DT_USER_1 = 48,
++	TEGRA_IMAGE_DT_USER_2,
++	TEGRA_IMAGE_DT_USER_3,
++	TEGRA_IMAGE_DT_USER_4,
++
+ };
+ 
+ /* Supported CSI to VI Data Formats */
+-- 
+2.34.1
+

--- a/nvidia-oot/6.2.1/0002-Adding-stream-restart-upon-capture-timeout.patch
+++ b/nvidia-oot/6.2.1/0002-Adding-stream-restart-upon-capture-timeout.patch
@@ -1,0 +1,57 @@
+From ccdb810c2454b30ddf8016666f38a334bb7038eb Mon Sep 17 00:00:00 2001
+From: ejgoldik <ehud.joseph.goldik@realsenseai.com>
+Date: Thu, 18 Sep 2025 15:36:36 +0300
+Subject: [PATCH] Adding stream restart upon capture timeout
+
+Ehud J. Goldik <ehud.joseph.goldik@realsenseai.com>
+---
+ .../media/platform/tegra/camera/vi/vi5_fops.c | 25 ++++++++++++++++++-
+ 1 file changed, 24 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/media/platform/tegra/camera/vi/vi5_fops.c b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
+index b990c09f..9304751f 100644
+--- a/drivers/media/platform/tegra/camera/vi/vi5_fops.c
++++ b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
+@@ -542,6 +542,24 @@ uncorr_err:
+ 	spin_unlock_irqrestore(&chan->capture_state_lock, flags);
+ }
+ 
++static int vi5_attempt_restart_stream(struct tegra_channel *chan)
++{
++	int err = -EPERM;
++
++	if (chan->num_subdevs > 1) {
++		/* Restart meant for D4xx devices where device 1 is DS5 mux */
++		if (strncmp(chan->subdev[1]->name, "DS5 mux", 7) == 0) {
++			/* Stream OFF */
++			err = v4l2_subdev_call(chan->subdev[1], video, s_stream, 0);
++			if (err == 0) {
++				/* Stream ON */
++				err = v4l2_subdev_call(chan->subdev[1], video, s_stream, 1);
++			}
++		}
++	}
++	return err;
++}
++
+ static void vi5_capture_dequeue(struct tegra_channel *chan,
+ 	struct tegra_channel_buffer *buf)
+ {
+@@ -575,8 +591,13 @@ static void vi5_capture_dequeue(struct tegra_channel *chan,
+ 					goto rel_buf;
+ 				} else {
+ 					dev_err(vi->dev,
+-						"uncorr_err: request timed out after %d ms\n",
++						"uncorr_err: request timed out after %d ms - attempting restart\n",
+ 						timeout_ms);
++					err = vi5_attempt_restart_stream(chan);
++					if (err != 0) {
++						dev_err(vi->dev,
++							"uncorr_err: Restart failed\n");
++					}
+ 				}
+ 			} else {
+ 				dev_err(vi->dev, "uncorr_err: request err %d\n", err);
+-- 
+2.43.0
+

--- a/nvidia-oot/6.2.1/0003-Fix-y12i-calibration-stream.patch
+++ b/nvidia-oot/6.2.1/0003-Fix-y12i-calibration-stream.patch
@@ -1,0 +1,1 @@
+../6.0/0003-Fix-y12i-calibration-stream.patch

--- a/nvidia-oot/6.2.1/0004-Add-GPIO-tunneling-for-the-external-sync-support.patch
+++ b/nvidia-oot/6.2.1/0004-Add-GPIO-tunneling-for-the-external-sync-support.patch
@@ -1,0 +1,1 @@
+../6.0/0004-Add-GPIO-tunneling-for-the-external-sync-support.patch

--- a/scripts/aggregate_kernel_6.x.sh
+++ b/scripts/aggregate_kernel_6.x.sh
@@ -7,7 +7,7 @@ show_help() {
     echo "Aggregate kernel modules and optionally copy them to a remote device."
     echo ""
     echo "Arguments:"
-    echo "  KERNEL_VERSION  Kernel version to aggregate (6.0, 6.1, or 6.2) (required)"
+    echo "  KERNEL_VERSION  Kernel version to aggregate (6.0, 6.1, 6.2, or 6.2.1) (required)"
     echo "  IP_ADDRESS      Target device IP address (optional - if not provided, only aggregates locally)"
     echo "  USERNAME        SSH username for remote device (default: administrator)"
     echo "  REMOTE_PATH     Remote path to copy files to (default: /home/USERNAME/)"
@@ -42,8 +42,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 # Validate kernel version
-if [[ "$KERNEL_VERSION" != "6.0" && "$KERNEL_VERSION" != "6.1" && "$KERNEL_VERSION" != "6.2" ]]; then
-    echo "Error: Invalid kernel version '$KERNEL_VERSION'. Must be 6.0, 6.1, or 6.2"
+if [[ "$KERNEL_VERSION" != "6.0" && "$KERNEL_VERSION" != "6.1" && "$KERNEL_VERSION" != "6.2" && "$KERNEL_VERSION" != "6.2.1" ]]; then
+    echo "Error: Invalid kernel version '$KERNEL_VERSION'. Must be 6.0, 6.1, 6.2, or 6.2.1"
     echo ""
     show_help
 fi

--- a/scripts/deploy_kernel.sh
+++ b/scripts/deploy_kernel.sh
@@ -8,7 +8,7 @@ if [ "$#" -eq 0 ] || [ "$1" == "-h" ] || [ "$1" == "--help" ]; then
     echo "Package kernel modules, optionally copy them to the TARGET, update boot files and reboot the TARGET."
     echo ""
     echo "Arguments:"
-    echo "  JETPACK_VERSION   JetPack version (e.g., 5.0.2, 5.1.2, 6.0, 6.2) - REQUIRED"
+    echo "  JETPACK_VERSION   JetPack version (e.g., 5.0.2, 5.1.2, 6.0, 6.1, 6.2, 6.2.1) - REQUIRED"
     echo "  TARGET            Target device hostname or IP address"
     echo "  USERNAME          SSH username for TARGET (default: administrator)"
     echo "  REMOTE_PATH       Remote path to copy files to (default: dev)"
@@ -58,7 +58,7 @@ if [ "${JETPACK_VERSION}" = "5.0.2" ]; then
     cp "${IMG_DIR}/drivers/media/usb/uvc/uvcvideo.ko" "${DEST_DIR}/" 2>/dev/null || true
     cp "${IMG_DIR}/drivers/media/v4l2-core/videobuf-core.ko" "${DEST_DIR}/" 2>/dev/null || true
     cp "${IMG_DIR}/drivers/media/v4l2-core/videobuf-vmalloc.ko" "${DEST_DIR}/" 2>/dev/null || true
-elif [ "${JETPACK_VERSION}" = "6.2" ]; then
+elif [ "${JETPACK_VERSION}" = "6.0" ] || [ "${JETPACK_VERSION}" = "6.1" ] || [ "${JETPACK_VERSION}" = "6.2" ] || [ "${JETPACK_VERSION}" = "6.2.1" ]; then
     echo "Packing ${DEST_DIR}/rootfs.tar.gz"
     tar czf ${DEST_DIR}/rootfs.tar.gz -C images/${JETPACK_VERSION}/rootfs boot lib
 fi

--- a/scripts/install_to_kernel.sh
+++ b/scripts/install_to_kernel.sh
@@ -7,7 +7,7 @@ if [ "$#" -lt 1 ] || [ "$1" == "-h" ] || [ "$1" == "--help" ]; then
       echo "Update the kernel modules and boot files on the local device for a specific JetPack version."
       echo ""
       echo "Arguments:"
-      echo "  JETPACK_VERSION   JetPack version (e.g., 5.0.2, 5.1.2, 6.2)"
+      echo "  JETPACK_VERSION   JetPack version (e.g., 5.0.2, 5.1.2, 6.0, 6.1, 6.2, 6.2.1)"
       echo "  BOOT_FOLDER       Folder name under /boot to copy Image (default: dev)"
       echo ""
       echo "Example:"
@@ -41,9 +41,7 @@ if [ "${JETPACK_VERSION}" = "5.0.2" ]; then
           sudo cp videobuf-core.ko /lib/modules/$(uname -r)/updates/
     echo "sudo cp videobuf-vmalloc.ko /lib/modules/$(uname -r)/updates/"
           sudo cp videobuf-vmalloc.ko /lib/modules/$(uname -r)/updates/
-    echo "sudo cp Image /boot/${FOLDER}/."
-          sudo cp Image /boot/${FOLDER}/.
-elif [ "${JETPACK_VERSION}" = "6.2" ]; then
+elif [ "${JETPACK_VERSION}" = "6.0" ] || [ "${JETPACK_VERSION}" = "6.1" ] || [ "${JETPACK_VERSION}" = "6.2" ] || [ "${JETPACK_VERSION}" = "6.2.1" ]; then
     tar xf rootfs.tar.gz
     echo "sudo cp -r lib/modules/$(uname -r) /lib/modules/."
           sudo cp -r lib/modules/$(uname -r) /lib/modules/.
@@ -51,10 +49,10 @@ elif [ "${JETPACK_VERSION}" = "6.2" ]; then
           sudo cp boot/tegra234-camera-d4xx-overlay*.dtbo /boot/.
     echo "sudo cp boot/dtb/tegra234-p3737-0000+p3701-0005-nv.dtb /boot/dtb/."
           sudo cp boot/dtb/tegra234-p3737-0000+p3701-0005-nv.dtb /boot/dtb/.
-    echo "sudo cp boot/Image /boot/${FOLDER}/."
-          sudo cp boot/Image /boot/${FOLDER}/.
 fi
 
+echo "sudo cp boot/Image /boot/${FOLDER}/."
+      sudo cp boot/Image /boot/${FOLDER}/.
 echo "sudo depmod"
       sudo depmod
 echo "done - rebooting"

--- a/scripts/setup-common
+++ b/scripts/setup-common
@@ -6,8 +6,10 @@ export L4T_VERSION=jetson_"${REVISION}"
 export KERNEL_DIR="kernel/kernel-5.10"
 export LICENSE=release
 
-if [[ "$JETPACK_VERSION" =~ ^6\.[0-2]$ ]]; then
-    if [[ $JETPACK_VERSION == "6.2" ]]; then
+if [[ "$JETPACK_VERSION" =~ ^6\.[0-2](\.[0-9]+)?$ ]]; then
+    if [[ $JETPACK_VERSION == "6.2.1" ]]; then
+	    REVISION="36.4.4"
+    elif [[ $JETPACK_VERSION == "6.2" ]]; then
 	    REVISION="36.4.3"
     elif [[ $JETPACK_VERSION == "6.1" ]]; then
 	    REVISION="36.4"
@@ -33,6 +35,6 @@ elif [[ $JETPACK_VERSION == "4.6.1" ]]; then
     L4T_VERSION="tegra-l4t-r${REVISION}"
 	LICENSE=T186
 else
-    echo "Wrong JetPack version ($JETPACK_VERSION)! Only 6.2, 6.1, 6.0, 5.1.2, 5.0.2 and 4.6.1 supported."
+    echo "Wrong JetPack version ($JETPACK_VERSION)! Only 6.2.1, 6.2, 6.1, 6.0, 5.1.2, 5.0.2 and 4.6.1 supported."
     exit 1
 fi

--- a/scripts/source_sync_4.6.1.sh
+++ b/scripts/source_sync_4.6.1.sh
@@ -312,12 +312,12 @@ for ((i=0; i < NSOURCES; i++)); do
 	DNLOAD=$(echo "${SOURCE_INFO_PROCESSED[i]}" | cut -f 5 -d ':')
 
 	if [ $DALL -eq 1 -o "x${DNLOAD}" == "xy" ]; then
-		if DownloadAndSync "$WHAT" "${LDK_DIR}/${WHAT}" "https://${REPO}" "${TAG}" "${OPT}"; then
+		if DownloadAndSync "$WHAT" "${LDK_DIR}/${WHAT}" "git://${REPO}" "${TAG}" "${OPT}"; then
 			true
 		else
 			if [[ $? == 3 ]]; then
-				echo "Trying git protocol"
-				DownloadAndSync "$WHAT" "${LDK_DIR}/${WHAT}" "git://${REPO}" "${TAG}" "${OPT}"
+				echo "Trying https protocol"
+				DownloadAndSync "$WHAT" "${LDK_DIR}/${WHAT}" "https://${REPO}" "${TAG}" "${OPT}"
 			else
 				exit 1
 			fi

--- a/scripts/source_sync_5.0.2.sh
+++ b/scripts/source_sync_5.0.2.sh
@@ -323,12 +323,12 @@ for ((i=0; i < NSOURCES; i++)); do
 	DNLOAD=$(echo "${SOURCE_INFO_PROCESSED[i]}" | cut -f 5 -d ':')
 
 	if [ $DALL -eq 1 -o "x${DNLOAD}" == "xy" ]; then
-		if DownloadAndSync "$WHAT" "${LDK_DIR}/${WHAT}" "https://${REPO}" "${TAG}" "${OPT}"; then
+		if DownloadAndSync "$WHAT" "${LDK_DIR}/${WHAT}" "git://${REPO}" "${TAG}" "${OPT}"; then
 			true
 		else
 			if [[ $? == 3 ]]; then
-				echo "Trying git protocol"
-				DownloadAndSync "$WHAT" "${LDK_DIR}/${WHAT}" "git://${REPO}" "${TAG}" "${OPT}"
+				echo "Trying https protocol"
+				DownloadAndSync "$WHAT" "${LDK_DIR}/${WHAT}" "https://${REPO}" "${TAG}" "${OPT}"
 			else
 				exit 1
 			fi

--- a/scripts/source_sync_5.1.2.sh
+++ b/scripts/source_sync_5.1.2.sh
@@ -327,12 +327,12 @@ for ((i=0; i < NSOURCES; i++)); do
 	DNLOAD=$(echo "${SOURCE_INFO_PROCESSED[i]}" | cut -f 5 -d ':')
 
 	if [ $DALL -eq 1 -o "x${DNLOAD}" == "xy" ]; then
-		if DownloadAndSync "$WHAT" "${LDK_DIR}/${WHAT}" "https://${REPO}" "${TAG}" "${OPT}"; then
+		if DownloadAndSync "$WHAT" "${LDK_DIR}/${WHAT}" "git://${REPO}" "${TAG}" "${OPT}"; then
 			true
 		else
 			if [[ $? == 3 ]]; then
-				echo "Trying git protocol"
-				DownloadAndSync "$WHAT" "${LDK_DIR}/${WHAT}" "git://${REPO}" "${TAG}" "${OPT}"
+				echo "Trying https protocol"
+				DownloadAndSync "$WHAT" "${LDK_DIR}/${WHAT}" "https://${REPO}" "${TAG}" "${OPT}"
 			else
 				exit 1
 			fi

--- a/scripts/source_sync_6.x.sh
+++ b/scripts/source_sync_6.x.sh
@@ -320,17 +320,15 @@ for ((i=0; i < NSOURCES; i++)); do
 	DNLOAD=$(echo "${SOURCE_INFO_PROCESSED[i]}" | cut -f 5 -d ':')
 
 	if [ $DALL -eq 1 -o "x${DNLOAD}" == "xy" ]; then
-		if DownloadAndSync "$WHAT" "${LDK_DIR}/${WHAT}" "https://${REPO}" "${TAG}" "${OPT}"; then
+		if DownloadAndSync "$WHAT" "${LDK_DIR}/${WHAT}" "git://${REPO}" "${TAG}" "${OPT}"; then
 			true
 		else
 			if [[ $? == 3 ]]; then
-				echo "Trying git protocol"
-				DownloadAndSync "$WHAT" "${LDK_DIR}/${WHAT}" "git://${REPO}" "${TAG}" "${OPT}"
+				echo "Trying https protocol"
+				DownloadAndSync "$WHAT" "${LDK_DIR}/${WHAT}" "https://${REPO}" "${TAG}" "${OPT}"
 			else
 				exit 1
 			fi
 		fi
 	fi
 done
-
-ln -sf ../../../../../../nvethernetrm ${LDK_DIR}/nvidia-oot/drivers/net/ethernet/nvidia/nvethernet/nvethernetrm

--- a/setup_workspace.sh
+++ b/setup_workspace.sh
@@ -33,7 +33,7 @@ function DisplayNvidiaLicense {
 if [[ "$1" == "-h" ]]; then
     echo "setup_workspace.sh [JetPack_version]"
     echo "setup_workspace.sh -h"
-    echo "JetPack_version can be 4.6.1, 5.0.2, 5.1.2, 6.0, 6.1, 6.2"
+    echo "JetPack_version can be 4.6.1, 5.0.2, 5.1.2, 6.0, 6.1, 6.2, 6.2.1"
     exit 1
 fi
 


### PR DESCRIPTION
Introduce support for JetPack version 6.2.1, including updates to the documentation and scripts to reflect the new version. Adjust the source download protocol to prioritize Git over HTTPS.
6.2.1 is compilation only - not tested yet on Jetson.