### PR TITLE
Update README links: migrate to realsenseai GitHub and store

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 The RealSense™ MIPI platform driver enables the user to control and stream RealSense™ 3D MIPI cameras.
 The system shall include:
 * NVIDIA® Jetson platform (Currently Supported JetPack versions are: 6.2.1, 6.2, 6.1, 6.0, 5.1.2, 5.0.2, 4.6.1)
-* RealSense™ De-Serialize board (DS457)
+* RealSense™ De-Serialize board
 * NVIDIA® Jetson AGX Orin™ Passive adapter board from [Leopard Imaging LI-JTX1-SUB-ADPT](https://leopardimaging.com/product/accessories/adapters-carrier-boards/for-nvidia-jetson/li-jtx1-sub-adpt/)
 * RS MIPI camera (e.g. https://store.realsenseai.com/buy-intel-realsense-depth-camera-d457.html)
 

--- a/README_JP4.md
+++ b/README_JP4.md
@@ -5,7 +5,7 @@ The RealSense™ MIPI platform driver enables the user to control and stream Rea
 
 The system shall include:
 * NVIDIA® Jetson™ platform (Currently Supported JetPack versions are: 4.6.1)
-* RealSense™ De-Serialize board (DS457)
+* RealSense™ De-Serialize board
 * RS MIPI camera (e.g. https://store.realsenseai.com/buy-intel-realsense-depth-camera-d457.html)
 
 > Note: This MIPI reference driver is based on RealSense™ de-serialize board. For other de-serialize boards, modification might be needed.

--- a/README_JP5.md
+++ b/README_JP5.md
@@ -5,7 +5,7 @@ The RealSense™ MIPI platform driver enables the user to control and stream Rea
 
 The system shall include:
 * NVIDIA® Jetson™ platform (Currently Supported JetPack versions are: 5.1.2, 5.0.2)
-* RealSense™ De-Serialize board (DS457)
+* RealSense™ De-Serialize board
 * RS MIPI camera (e.g. https://store.realsenseai.com/buy-intel-realsense-depth-camera-d457.html)
 
 > Note: This MIPI reference driver is based on RealSense™ de-serialize board. For other de-serialize boards, modification might be needed.

--- a/README_JP6.0.md
+++ b/README_JP6.0.md
@@ -7,7 +7,7 @@ The system shall include:
     - [6.2 production release](https://developer.nvidia.com/embedded/jetpack-sdk-62)
     - [6.1 production release](https://developer.nvidia.com/embedded/jetpack-sdk-61)
     - [6.0 production release](https://developer.nvidia.com/embedded/jetpack-sdk-60)
-* RealSense™ De-Serialize board (DS457)
+* RealSense™ De-Serialize board
 * Jetson AGX Orin™ Passive adapter board from [Leopard Imaging® LI-JTX1-SUB-ADPT](https://leopardimaging.com/product/accessories/adapters-carrier-boards/for-nvidia-jetson/li-jtx1-sub-adpt/)
 * RS MIPI camera [D457](https://store.realsenseai.com/buy-intel-realsense-depth-camera-d457.html)
 

--- a/README_JP6.2.md
+++ b/README_JP6.2.md
@@ -8,7 +8,7 @@ The system shall include:
     - [6.2 production release](https://developer.nvidia.com/embedded/jetpack-sdk-62)
     - [6.1 production release](https://developer.nvidia.com/embedded/jetpack-sdk-61)
     - [6.0 production release](https://developer.nvidia.com/embedded/jetpack-sdk-60)
-* RealSense™ De-Serialize board (DS457)
+* RealSense™ De-Serialize board
 * Jetson AGX Orin™ Passive adapter board from [Leopard Imaging® LI-JTX1-SUB-ADPT](https://leopardimaging.com/product/accessories/adapters-carrier-boards/for-nvidia-jetson/li-jtx1-sub-adpt/)
 * RS MIPI camera [D457](https://store.realsenseai.com/buy-intel-realsense-depth-camera-d457.html)
 

--- a/README_tools.md
+++ b/README_tools.md
@@ -46,7 +46,7 @@ Reset D457 patches (and any other changes) for kernel image, dtb and D457 driver
 ```
 
 Note: The `--one-cam` and `--dual-cam` option applies only for JetPack 5.0.2,
-compatible with RealSense™ DES457 deserializer.
+compatible with RealSense™ deserializer.
 - By setting the `--one-cam` option it builds DT with only camera on GMSL link A (default).
 
 - By setting the `--dual-cam` option it builds DT with dual cameras on GMSL link A and B.


### PR DESCRIPTION
## Summary
- Update GitHub repo URLs from IntelRealSense to realsenseai
- Update store URLs from store.intelrealsense.com to store.realsenseai.com
- Remove "Intel®" branding from titles and descriptions
- Replace broken DES457 store links with text-only mentions

## Test plan
- [ ] Verify all GitHub links point to https://github.com/realsenseai/realsense_mipi_platform_driver
- [ ] Verify D457 store link works: https://store.realsenseai.com/buy-intel-realsense-depth-camera-d457.html
- [ ] Verify DES457 references are text-only (no broken links)

🤖 Generated with [Claude Code](https://claude.ai/code)