### PR TITLE
Implement HW reset recovery and refactor sensor invalidation logic

### DIFF
--- a/kernel/realsense/d4xx.c
+++ b/kernel/realsense/d4xx.c
@@ -703,12 +703,12 @@ static const u16 ds5_framerate_100[] = {100};
     { .width = (w), .height = (h), .framerates = (fr), .n_framerates = ARRAY_SIZE(fr) },
 
 #define D401_COMMON_RES	\
-	DS5_RES(1280, 720, ds5_framerate_15_30)\
-	DS5_RES(848, 480, ds5_framerate_15_60)\
-	DS5_RES(640, 480, ds5_framerate_15_60)\
-	DS5_RES(640, 360, ds5_framerate_15_60)\
-	DS5_RES(480, 270, ds5_framerate_15_60)\
-	DS5_RES(424, 240, ds5_framerate_15_60)\
+	DS5_RES(1280, 720, ds5_framerate_to_30)\
+	DS5_RES(848, 480, ds5_framerate_to_60)\
+	DS5_RES(640, 480, ds5_framerate_to_60)\
+	DS5_RES(640, 360, ds5_framerate_to_60)\
+	DS5_RES(480, 270, ds5_framerate_to_60)\
+	DS5_RES(424, 240, ds5_framerate_to_60)\
 
 static const struct ds5_resolution d40x_depth_sizes[] = {
 	D401_COMMON_RES

--- a/kernel/realsense/d4xx.c
+++ b/kernel/realsense/d4xx.c
@@ -6093,4 +6093,4 @@ MODULE_AUTHOR("Guennadi Liakhovetski <guennadi.liakhovetski@intel.com>,\n\
 				Shikun Ding <shikun.ding@intel.com>,\n\
 				Dmitry Perchanov <dmitry.perchanov@intel.com>");
 MODULE_LICENSE("GPL v2");
-MODULE_VERSION("1.0.2.15");
+MODULE_VERSION("1.0.2.16");

--- a/kernel/realsense/d4xx.c
+++ b/kernel/realsense/d4xx.c
@@ -703,12 +703,12 @@ static const u16 ds5_framerate_100[] = {100};
     { .width = (w), .height = (h), .framerates = (fr), .n_framerates = ARRAY_SIZE(fr) },
 
 #define D401_COMMON_RES	\
-	DS5_RES(1280, 720, ds5_framerate_to_30)\
-	DS5_RES(848, 480, ds5_framerate_to_60)\
-	DS5_RES(640, 480, ds5_framerate_to_60)\
-	DS5_RES(640, 360, ds5_framerate_to_60)\
-	DS5_RES(480, 270, ds5_framerate_to_60)\
-	DS5_RES(424, 240, ds5_framerate_to_60)\
+	DS5_RES(1280, 720, ds5_framerate_15_30)\
+	DS5_RES(848, 480, ds5_framerate_15_60)\
+	DS5_RES(640, 480, ds5_framerate_15_60)\
+	DS5_RES(640, 360, ds5_framerate_15_60)\
+	DS5_RES(480, 270, ds5_framerate_15_60)\
+	DS5_RES(424, 240, ds5_framerate_15_60)\
 
 static const struct ds5_resolution d40x_depth_sizes[] = {
 	D401_COMMON_RES
@@ -2385,6 +2385,35 @@ static int ds5_hw_reset_with_recovery(struct ds5 *state)
 		dev_err(&state->client->dev,
 			"%s(): Failed to read firmware build: %d\n", __func__, ret);
 		return ret;
+	}
+
+	/* 6. Wait for device type register to be populated.
+	 * After HW reset the firmware sets status to 0xDEAD before fully
+	 * initializing configuration registers (DS5_DEVICE_TYPE, stream DT,
+	 * resolution, etc.).  If ds5_fixed_configuration() reads device type
+	 * as 0 it falls into the default switch case and selects D46X format
+	 * arrays (2 depth resolutions) instead of the correct tables per SKU
+	 * Poll until the register returns a known valid value or timeout.
+	 */
+	{
+		u16 dev_type = 0;
+
+		for (retry = 0; retry < DS5_HW_RESET_MAX_RETRIES; retry++) {
+			ret = ds5_read(state, DS5_DEVICE_TYPE, &dev_type);
+			if (ret == 0 && dev_type != 0) {
+				dev_dbg(&state->client->dev,
+					"%s(): Device type 0x%x ready after %d ms\n",
+					__func__, dev_type,
+					(retry + 1) * DS5_HW_RESET_POLL_INTERVAL_MS);
+				break;
+			}
+			msleep(DS5_HW_RESET_POLL_INTERVAL_MS);
+		}
+
+		if (retry >= DS5_HW_RESET_MAX_RETRIES)
+			dev_warn(&state->client->dev,
+				"%s(): Device type register not ready (0x%x) after %d ms, formats may be wrong\n",
+				__func__, dev_type, DS5_HW_RESET_TIMEOUT_MS);
 	}
 
 	dev_info(&state->client->dev,

--- a/kernel/realsense/d4xx.c
+++ b/kernel/realsense/d4xx.c
@@ -6093,4 +6093,4 @@ MODULE_AUTHOR("Guennadi Liakhovetski <guennadi.liakhovetski@intel.com>,\n\
 				Shikun Ding <shikun.ding@intel.com>,\n\
 				Dmitry Perchanov <dmitry.perchanov@intel.com>");
 MODULE_LICENSE("GPL v2");
-MODULE_VERSION("1.0.2.16");
+MODULE_VERSION("1.0.2.17");

--- a/kernel/realsense/d4xx.c
+++ b/kernel/realsense/d4xx.c
@@ -494,6 +494,7 @@ struct ds5_counters {
 };
 
 static atomic_t ds5_reset_gen = ATOMIC_INIT(0);
+static atomic_t ds5_probe_reset_once = ATOMIC_INIT(0);
 
 #ifdef CONFIG_VIDEO_D4XX_SERDES
 static DEFINE_MUTEX(serdes_lock__);
@@ -702,12 +703,12 @@ static const u16 ds5_framerate_100[] = {100};
     { .width = (w), .height = (h), .framerates = (fr), .n_framerates = ARRAY_SIZE(fr) },
 
 #define D401_COMMON_RES	\
-	DS5_RES(1280, 720, ds5_framerate_15_30)\
-	DS5_RES(848, 480, ds5_framerate_15_60)\
-	DS5_RES(640, 480, ds5_framerate_15_60)\
-	DS5_RES(640, 360, ds5_framerate_15_60)\
-	DS5_RES(480, 270, ds5_framerate_15_60)\
-	DS5_RES(424, 240, ds5_framerate_15_60)\
+	DS5_RES(1280, 720, ds5_framerate_to_30)\
+	DS5_RES(848, 480, ds5_framerate_to_60)\
+	DS5_RES(640, 480, ds5_framerate_to_60)\
+	DS5_RES(640, 360, ds5_framerate_to_60)\
+	DS5_RES(480, 270, ds5_framerate_to_60)\
+	DS5_RES(424, 240, ds5_framerate_to_60)\
 
 static const struct ds5_resolution d40x_depth_sizes[] = {
 	D401_COMMON_RES
@@ -1664,25 +1665,33 @@ static void ds5_config_cache_clear(struct ds5_sensor *sensor)
 	sensor->cached_height_value = 0xFFFF;
 }
 
-static void ds5_invalidate_state_cache(struct ds5 *state)
+static struct ds5_sensor *ds5_get_active_sensor(struct ds5 *state)
 {
-	struct ds5_sensor *sensors[] = {
-		&state->depth.sensor,
-		&state->ir.sensor,
-		&state->rgb.sensor,
-		&state->imu.sensor,
-	};
-	int i;
+	if (state->is_depth)
+		return &state->depth.sensor;
+	if (state->is_rgb)
+		return &state->rgb.sensor;
+	if (state->is_y8)
+		return &state->ir.sensor;
+	if (state->is_imu)
+		return &state->imu.sensor;
+	return NULL;
+}
 
-	for (i = 0; i < ARRAY_SIZE(sensors); i++) {
-		struct ds5_sensor *sensor = sensors[i];
-
-		ds5_config_cache_clear(sensor);
-		sensor->pipe_id = PIPE_NOT_CONFIGURED;
-		sensor->pipe_data_type1 = 0;
-		sensor->pipe_data_type2 = 0;
-		sensor->pipe_vc_id = 0;
+static void ds5_invalidate_sensor(struct ds5 *state, struct ds5_sensor *sensor)
+{
+	ds5_config_cache_clear(sensor);
+#ifdef CONFIG_VIDEO_D4XX_SERDES
+	if (sensor->pipe_id >= 0 && state->dser_dev) {
+		mutex_lock(&serdes_lock__);
+		state->dser_ops->release_pipe(state->dser_dev, sensor->pipe_id);
+		mutex_unlock(&serdes_lock__);
 	}
+#endif
+	sensor->pipe_id = PIPE_NOT_CONFIGURED;
+	sensor->pipe_data_type1 = 0;
+	sensor->pipe_data_type2 = 0;
+	sensor->pipe_vc_id = 0;
 }
 
 static int ds5_configure(struct ds5 *state)
@@ -1704,7 +1713,10 @@ static int ds5_configure(struct ds5 *state)
 
 	current_reset_gen = atomic_read(&ds5_reset_gen);
 	if (state->reset_gen != current_reset_gen) {
-		ds5_invalidate_state_cache(state);
+		struct ds5_sensor *active = ds5_get_active_sensor(state);
+
+		if (active)
+			ds5_invalidate_sensor(state, active);
 		state->reset_gen = current_reset_gen;
 	}
 
@@ -2243,6 +2255,13 @@ static int ds5_hw_reset_with_recovery(struct ds5 *state)
 	int retry;
 	u16 status = 0;
 	bool device_went_down = false;
+
+	dev_info(&state->client->dev, "%s(): Initiating HW reset with recovery\n",
+		__func__);
+
+	/* Invalidate cached sensor configs and release SERDES pipes before reset, since reset will clear device state but not driver state.
+	    This ensures we don't try to reuse stale configs or pipes after reset. */
+	/* TBD: Open for single instance architecture and remove ds5_invalidate_sensor multi instance solution
 	struct ds5_sensor *sensors[] = {
 		&state->depth.sensor,
 		&state->ir.sensor,
@@ -2270,9 +2289,7 @@ static int ds5_hw_reset_with_recovery(struct ds5 *state)
 		}
 		mutex_unlock(&serdes_lock__);
 	}
-
-	dev_info(&state->client->dev, "%s(): Initiating HW reset with recovery\n",
-		__func__);
+	*/
 
 	/* 1. Send HW reset command */
 	ret = ds5_raw_write(state, DS5_HWMC_DATA, &cmd_hw_reset, sizeof(cmd_hw_reset));
@@ -2289,7 +2306,6 @@ static int ds5_hw_reset_with_recovery(struct ds5 *state)
 		return ret;
 	}
 	atomic_inc(&ds5_reset_gen);
-	state->reset_gen = atomic_read(&ds5_reset_gen);
 
 	dev_info(&state->client->dev, "%s(): HW reset command sent, waiting for device...\n",
 		__func__);
@@ -5871,6 +5887,17 @@ static int ds5_probe(struct i2c_client *c, const struct i2c_device_id *id)
 		ret = ds5_chrdev_init(c, state);
 		if (ret < 0)
 			goto e_regulator;
+	}
+
+	if (atomic_cmpxchg(&ds5_probe_reset_once, 0, 1) == 0) {
+		dev_info(&c->dev, "%s(): first probe instance, running HW reset recovery\n",
+			__func__);
+		ret = ds5_hw_reset_with_recovery(state);
+		if (ret < 0) {
+			dev_err(&c->dev, "%s(): probe HW reset recovery failed: %d\n",
+				__func__, ret);
+			goto e_chardev;
+		}
 	}
 
 	ret = ds5_read(state, 0x5020, &rec_state);


### PR DESCRIPTION
Implement hardware reset recovery for the first probe instance and enhance sensor invalidation logic to ensure proper initialization after a reset. This change improves device reliability and state management.
Fixing 5 FPS issue: https://rsjira.realsenseai.com/browse/RSDSO-21189