### PR TITLE
Fix/hw reset gmsl recovery

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,184 @@
+# Copilot Instructions
+
+## Project Overview
+
+Linux kernel driver and userspace utilities for Intel RealSense D4XX series 3D depth cameras operating over GMSL (Gigabit Multimedia Serial Link) MIPI CSI-2 interface on NVIDIA Jetson platforms. Licensed under GPL-2.0.
+
+- **Supported platforms:** Jetson AGX Xavier (JetPack 4.6.1, 5.0.2, 5.1.2) and AGX Orin (JetPack 6.0, 6.1, 6.2, 6.2.1)
+- **Supported cameras:** D457 (primary), D401, D40x, D41x, D43x, D45x, D46x series
+
+## Coding Conventions
+
+### Kernel Driver (C — `kernel/realsense/d4xx.c`)
+
+- **Follow Linux kernel coding style**: tabs for indentation (8-space width), `/* */` block comments, max ~80–100 char lines.
+- **Keep changes minimal**: do not inflate code. Prefer single-line expressions over multi-line blocks, reuse existing helpers/paths instead of adding new ones, and avoid verbose comments that restate what the code already says. Every added line must earn its place — if a change can be expressed more concisely without losing clarity, use the shorter form.
+- **Before adding new code, check callers and existing paths**: when introducing a check, loop, or helper, first verify whether the same logic already exists elsewhere in the call chain. If a function has only one caller, consider placing the logic in the caller instead of duplicating it. Never add a second copy of logic that can be combined with an existing one — consolidate first, don't layer.
+- **After removing code, clean up stale references**: when deleting a function, code block, or feature, immediately search for defines, variables, struct fields, forward declarations, and comments that were only used by the removed code. Remove all of them in the same patch. Do not leave dead code behind.
+- **Function naming**: prefix all functions with `ds5_`. Mux-related functions use `ds5_mux_`. Examples: `ds5_read()`, `ds5_write()`, `ds5_probe()`, `ds5_mux_s_stream()`.
+- **Struct naming**: prefix with `ds5_`. Examples: `struct ds5`, `struct ds5_sensor`, `struct ds5_ctrls`, `struct ds5_format`.
+- **Macro naming**: prefix with `DS5_`. Register addresses: `DS5_FW_VERSION`, `DS5_START_STOP_STREAM`, `DS5_DEPTH_STREAM_DT`.
+- **Driver name**: `DS5_DRIVER_NAME` = `"d4xx"`, with variants `-awg`, `-asr`, `-class`, `-dfu`.
+- **I2C access**: use `ds5_read()` / `ds5_write()` wrappers around `regmap_raw_read()` / `regmap_raw_write()` with built-in retry logic (`DS5_I2C_RETRY_COUNT=5`, `DS5_I2C_RETRY_DELAY_US=5000`).
+- **Helper macros**: `ds5_read_with_check()`, `ds5_write_with_check()`, `ds5_raw_read_with_check()`, `ds5_raw_write_with_check()` — these return on error.
+- **Logging**: use `dev_err()`, `dev_warn()`, `dev_info()`, `dev_dbg()` with `&state->client->dev` as the device. Always include `__func__` in log messages.
+- **Locking**: `mutex_lock()` / `mutex_unlock()` for state synchronization.
+- **SERDES topology locking**: protect global topology scans/updates of `ds5_inited[]` and `dser_inited[]` with `serdes_lock__`. Use `struct ds5_dev::lock` for per-camera mutable fields (`ds5_primary`, `*_streaming`) and `struct dser_control::lock` for per-deserializer slot fields (`dser_dev`). For sibling checks, snapshot under lock and do I2C probing after unlocking.
+- **Module registration**: `module_i2c_driver()` pattern.
+- **Conditional compilation**:
+  - `CONFIG_VIDEO_D4XX_SERDES` — SerDes (GMSL) support vs non-SerDes path.
+  - `CONFIG_TEGRA_CAMERA_PLATFORM` — Tegra-specific camera platform integration.
+  - `LINUX_VERSION_CODE` checks for API differences between kernel versions (4.9, 5.10, 5.15+).
+- **Prefer lazy invalidation over explicit loops**: when state must be invalidated across multiple instances (e.g. after a deserializer reset), increment an atomic generation counter (`atomic_inc()`) and let each instance detect the bump lazily (e.g. in `ds5_configure()`). Avoid O(N) loops that iterate `ds5_inited[]` to poke siblings. Combine lazy checks when possible — if an existing function already detects a generation mismatch, add new invalidation logic there rather than adding a separate check elsewhere.
+
+### V4L2 Subdev Architecture
+
+Each camera registers four sensor subdevices: Depth, RGB, IR (Y8/Y8I/Y12I), and IMU. Each has separate V4L2 subdev ops structs:
+- `ds5_depth_subdev_ops`, `ds5_ir_subdev_ops`, `ds5_rgb_subdev_ops`, `ds5_imu_subdev_ops`
+- Mux ops: `ds5_mux_subdev_ops`, `ds5_mux_pad_ops`, `ds5_mux_core_ops`, `ds5_mux_video_ops`
+
+A deserializer abstraction layer (`struct dser_interface`) provides function pointer tables for MAX9296 vs MAX96712 variants.
+
+- **SerDes pipe configuration**: the **driver** configures all four SerDes pipes (Depth, RGB, IR, IMU) at stream start via `ds5_configure()`. The D457 firmware does **not** configure any pipes. Do not add probe-time pipe setup or special-case individual pipes (e.g. IMU) in `ds5_probe()`.
+- **Device tree assumptions**: all supported device trees include all four sensor instances (Depth, RGB, IR, IMU). Do not add DT-scanning logic to check for the presence of individual sensor types.
+
+### Video Device Layout (per camera)
+
+| Device  | Stream           | Format                 |
+|---------|-----------------|------------------------|
+| video0  | Depth           | Z16                    |
+| video1  | Depth metadata  | D4XX custom format     |
+| video2  | Color RGB       | RGB888/YUV422          |
+| video3  | Color metadata  | D4XX custom format     |
+| video4  | IR              | GREY, Y8I, Y12I        |
+| video5  | IMU             | Custom                 |
+
+### Tests (Python — `test/v4l2_test/`)
+
+- **Framework**: pytest with marker `@pytest.mark.d457` on all test classes.
+- **Class-based tests**: `class TestCameraDiscovery`, `class TestLaserControl`, `class TestFirmwareVersion`, etc.
+- **Test naming**: `test_at_least_one_camera`, `test_driver_name`, `test_six_devices_exist`, `test_fw_version_format`.
+- **Fixtures**: session-scoped `all_cameras`, `camera`; per-test `depth_device`, `fw_version`.
+- **Constants**: `test/v4l2_test/d4xx/constants.py` mirrors driver CIDs from `d4xx.c`.
+- **Categories**: Discovery, Streaming, Controls, Metadata, Error Handling.
+- **Streaming validation**: FPS tolerance 5%, frame count 60, min 90% frame arrival, consecutive drop limit 2.
+- **Test timeout**: 200 seconds (configured in `test/pytest.ini`).
+
+### Shell Scripts
+
+- Use `#!/bin/bash` with `set -e` (fail-on-error).
+- Source `scripts/setup-common` for JetPack version normalization.
+- Use `DEVDIR=$(cd \`dirname $0\` && pwd)` to resolve repo root.
+- Branch on JetPack major version (4.x / 5.x / 6.x) for platform-specific logic.
+
+### Device Tree
+
+- **Xavier (Tegra194)**: `.dtsi` includes, pattern `tegra194-camera-d4xx-{variant}.dtsi`.
+- **Orin (Tegra234)**: DT overlays (`.dts`), pattern `tegra234-camera-d4xx-overlay-{variant}.dts`, uses `/dts-v1/; /plugin/;`.
+- Variants: `single`, `dual`, `single.calib`, `dual.calib`, `fg12-16ch`, `max96712-EVB`.
+
+## Build System
+
+### Prerequisites
+
+```bash
+sudo apt install -y build-essential bc wget flex bison curl libssl-dev xxd
+```
+
+### Full Build Flow
+
+```bash
+./setup_workspace.sh <version>    # Clone NVIDIA sources, install toolchain
+./apply_patches.sh <version>      # Apply D4XX patches to kernel + NVIDIA OOT modules
+./build_all.sh <version>          # Build kernel, DTBs, and driver modules
+```
+
+Build outputs go to `images/<version>/`.
+
+### Version Mapping
+
+| JetPack | L4T Revision | Kernel Dir                    | Normalized |
+|---------|-------------|-------------------------------|------------|
+| 4.6.1   | 32.7.1      | `kernel/kernel-4.9`           | 4.6.1      |
+| 5.0.2   | 35.1        | `kernel/kernel-5.10`          | 5.x        |
+| 5.1.2   | 35.4.1      | `kernel/kernel-5.10`          | 5.x        |
+| 6.0     | 36.3        | `kernel/kernel-jammy-src`     | 6.x        |
+| 6.1     | 36.4        | `kernel/kernel-jammy-src`     | 6.x        |
+| 6.2     | 36.4.3      | `kernel/kernel-jammy-src`     | 6.x        |
+| 6.2.1   | 36.4.4      | `kernel/kernel-jammy-src`     | 6.x        |
+
+### Cross-Compilation Toolchains
+
+- JP 4.6.1: Linaro GCC 7.3
+- JP 5.x: Bootlin GCC 9.3
+- JP 6.x: Bootlin GCC 11.3 (`aarch64-buildroot-linux-gnu`)
+
+### Patch Application
+
+`apply_patches.sh` copies `kernel/realsense/d4xx.c`, device tree files, and `nvidia-oot/max96712.h` into the NVIDIA source tree, applies git patches, and commits with `"RS patched"`. The `reset` action uses `git reset --hard` to a stored base commit.
+
+Camera variant flags: `--one-cam`, `--dual-cam`, `--max96712-EVB`, `--fg12-16ch`, `--fg12-16ch-dual` (only some apply to specific JetPack versions).
+
+## Key Directories
+
+| Path | Description |
+|------|-------------|
+| `kernel/realsense/d4xx.c` | Main V4L2 I2C subdevice driver (~6900 lines) |
+| `kernel/kernel-4.9/` | Kernel patches for JetPack 4.6.1 |
+| `kernel/kernel-5.10/` | Kernel patches for JetPack 5.x |
+| `kernel/kernel-jammy-src/` | Kernel patches for JetPack 6.x |
+| `kernel/nvidia/` | NVIDIA driver patches (MAX9295/9296 SerDes, VI capture) |
+| `nvidia-oot/` | Out-of-tree NVIDIA module patches for JetPack 6.x |
+| `hardware/realsense/` | Device tree source files |
+| `hardware/nvidia/` | Platform-level DT patches |
+| `scripts/` | Build orchestration and SerDes configuration scripts |
+| `test/v4l2_test/` | V4L2 pytest test suite |
+| `utilities/streamApp/` | C++ V4L2 streaming application |
+| `utilities/JsonToBin/` | Python JSON-to-binary preset converter |
+
+## CI
+
+CI workflows (`.github/workflows/build-jp*.yml`) build for each JetPack version on pushes to `master`/`dev` and all PRs. The V4L2 test workflow runs on a self-hosted Jetson runner when `kernel/realsense/**` or `test/v4l2_test/**` paths change.
+
+CI requires `git config user.email/name` to be set before `apply_patches.sh`.
+
+## Branching
+
+- `master` — primary/release branch
+- `dev` — active development branch
+-
+## Refactoring notes (recent commit)
+
+Short summary of approaches used in the refactor of `kernel/realsense/d4xx.c`:
+
+- **Encapsulated shared state**: introduced `struct ds5_dev` (per-camera) and
+  `struct dser_control` (per-deserializer) to centralize reset generation,
+  cached device type and last-reset timestamps instead of scattered globals.
+- **Separated reset generation**: split camera-level and deserializer-level
+  reset counters so camera resets and deserializer resets are independent;
+  callers check both generation counters and invalidate cached state on mismatch.
+- **Atomic, lazy invalidation**: replaced many explicit peer-invalidation loops
+  with `atomic_inc()` of the appropriate reset-gen; peers detect the bump in
+  `ds5_configure()` and invalidate themselves lazily, reducing O(N) churn.
+- **Single registration/link path**: factored duplicate SERDES/board registration
+  logic into `ds5_setup_and_link()` to avoid repeated code paths and make
+  primary/peer linking explicit.
+- **Keep streaming visibility consistent**: driver now maintains per-camera
+  streaming flags (kept in sync from `ds5_mux_s_stream()`) so recovery and
+  sibling checks can reliably detect active streams.
+- **Non-SERDES compatibility**: added small fallbacks so callers can use the
+  same reset-gen accessors in non-SERDES builds (where applicable).
+
+Advantages: clearer ownership of shared state, fewer global arrays and linear
+searches, more deterministic recovery behavior, and reduced duplicate code.
+
+## Workflow Rules
+
+### Post-patch configuration review (mandatory)
+
+After every confirmed code patch, review and update this file and `CLAUDE.md`:
+
+1. **Stale facts**: correct or remove architectural claims, assumptions, or descriptions that the patch invalidated.
+2. **New conventions**: if the patch exposed a coding practice gap (e.g. a cleanup step that was missed), add a general coding convention so it is enforced going forward — do not just fix the specific instance.
+
+Do not leave stale or incorrect claims in configuration files after changing the code they describe.

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /sources_*
 /.claude/skills/v4l2-test/v4l2-test_results
 **__pycache__
+/test.logs

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 /.claude/skills/v4l2-test/v4l2-test_results
 **__pycache__
 /test.logs
+/.vscode/*.db*
+/.vscode/compile_commands.json

--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -1,0 +1,32 @@
+{
+  "configurations": [
+    {
+      "name": "Linux",
+      "includePath": [
+        "${workspaceFolder}/**",
+        "${workspaceFolder}/kernel/**",
+        "${workspaceFolder}/kernel/kernel-jammy-src/include",
+        "${workspaceFolder}/kernel/kernel-jammy-src/arch/**/include",
+        "${workspaceFolder}/kernel/realsense",
+        "${workspaceFolder}/nvidia-oot/**",
+        "/usr/include"
+      ],
+      "defines": [],
+      "compilerPath": "/usr/bin/gcc",
+      "cStandard": "c11",
+      "cppStandard": "c++17",
+      "intelliSenseMode": "linux-gcc-x64",
+      "compileCommands": "${workspaceFolder}/.vscode/compile_commands.json",
+      "browse": {
+        "path": [
+          "${workspaceFolder}/kernel/kernel-jammy-src/include",
+          "${workspaceFolder}/kernel/realsense",
+          "${workspaceFolder}/**"
+        ],
+        "limitSymbolsToIncludedHeaders": false,
+        "databaseFilename": "${workspaceFolder}/.vscode/browse.vc.db"
+      }
+    }
+  ],
+  "version": 4
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+  "C_Cpp.default.configurationProvider": "ms-vscode.cpptools",
+  "C_Cpp.default.compileCommands": "${workspaceFolder}/.vscode/compile_commands.json",
+  "C_Cpp.intelliSenseEngine": "Default",
+  "files.exclude": {
+    "**/.cache": true
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,3 +120,10 @@ The build system cross-compiles for ARM64. Toolchains vary by JetPack:
 - `master` — primary/release branch
 - `dev` — active development branch
 - CI builds run on pushes to `master` and `dev`, and on all PRs
+
+## Concurrency notes
+
+- In SERDES builds, hold `serdes_lock__` while scanning or assigning global topology slots (`ds5_inited[]`, `dser_inited[]`).
+- Protect per-camera mutable slot state (`ds5_primary`, `depth/rgb/ir/imu_streaming`) with `struct ds5_dev::lock`.
+- Protect per-deserializer slot assignment (`dser_dev`) with `struct dser_control::lock`.
+- For sibling-health checks, snapshot pointers/flags under lock and perform I2C probing after unlocking.

--- a/build_all.sh
+++ b/build_all.sh
@@ -107,6 +107,7 @@ if [[ "$JETPACK_VERSION" == "6.x" ]]; then
         make ARCH=arm64 -C kernel
     fi
     make ARCH=arm64 modules
+    D4XX_CMD_FILE="$SRCS/nvidia-oot/drivers/media/i2c/.d4xx.o.cmd"
     make ARCH=arm64 dtbs
     mkdir -p $TEGRA_KERNEL_OUT/rootfs/boot/dtb
     cp $SRCS/nvidia-oot/device-tree/platform/generic-dts/dtbs/tegra234-p3737-0000+p3701-0000-nv.dtb $TEGRA_KERNEL_OUT/rootfs/boot/dtb/
@@ -138,5 +139,15 @@ else
     fi
     make ARCH=arm64 O=$TEGRA_KERNEL_OUT -j${NPROC}
     make ARCH=arm64 O=$TEGRA_KERNEL_OUT modules_install INSTALL_MOD_PATH=$KERNEL_MODULES_OUT
+    D4XX_CMD_FILE="$(find "$TEGRA_KERNEL_OUT" -name '.d4xx.o.cmd' 2>/dev/null | head -1)"
+fi
+
+# Generate .vscode/compile_commands.json from the cached module build artefact
+echo "Generating .vscode/compile_commands.json..."
+if [ -n "${D4XX_CMD_FILE:-}" ] && [ -f "$D4XX_CMD_FILE" ]; then
+    "$DEVDIR/scripts/generate_compile_commands.sh" "$D4XX_CMD_FILE" || \
+        echo "Warning: compile_commands.json generation failed (non-fatal)"
+else
+    echo "Warning: .d4xx.o.cmd not found; skipping compile_commands.json generation"
 fi
 

--- a/docs/hw-reset-followup-plan.md
+++ b/docs/hw-reset-followup-plan.md
@@ -1,0 +1,81 @@
+# HW Reset Follow-up Plan: Circuit-Breaker & Phase 1 Dual-Camera Safety
+
+**Date:** 2026-03-02
+**Branch:** `fix/hw-reset-gmsl-recovery`
+**Commits:** ecbfa82 → 97b91b9 → 0e205e5
+**JIRA:** RSDSO-21151, RSDSO-21257, RSDSO-21254
+
+## Summary
+
+Two follow-up items from the log analysis. **Item 1** (circuit-breaker) adds rate-limiting and consecutive-failure tracking to `ds5_hw_reset_with_recovery()` to break the 35-reset infinite loop seen in `reset_issue_dmesg.txt`. **Item 2** (Phase 1 dual-camera impact) is largely resolved by analysis — `max9295_init_settings()` only writes serializer-local registers and cannot disrupt siblings — but a lightweight safety check should be added.
+
+---
+
+## Item 1: Reset Circuit-Breaker (High Priority)
+
+The `reset_issue_dmesg.txt` log shows 35 consecutive userspace-triggered HW resets (~30s apart) via `HWMC_RW` opcode 0x20, each triggering full SERDES recovery. After ~3 resets, I2C errors (err -121) appear and the device never recovers — yet the driver keeps accepting reset commands indefinitely.
+
+### Steps
+
+1. **Add tracking fields to `struct ds5`** (`kernel/realsense/d4xx.c`):
+   - `int consecutive_reset_failures` — incremented when `ds5_hw_reset_with_recovery()` returns an error, reset to 0 on success
+   - `unsigned long last_reset_jiffies` — timestamp of the last reset attempt
+   - `int total_resets` — lifetime counter for diagnostics (never reset)
+
+2. **Add circuit-breaker constants** near the existing `DS5_HW_RESET_*` defines:
+   - `DS5_HW_RESET_MAX_CONSECUTIVE_FAILURES` = 3 — after 3 consecutive failed resets, refuse further resets
+   - `DS5_HW_RESET_COOLDOWN_MS` = 5000 — minimum interval between resets (5 seconds)
+   - `DS5_HW_RESET_BREAKER_RESET_MS` = 60000 — if no reset for 60s, clear the failure counter (auto-recovery)
+
+3. **Add gating logic at top of `ds5_hw_reset_with_recovery()`**:
+   - Check `consecutive_reset_failures >= MAX_CONSECUTIVE_FAILURES`:
+     - If the breaker timeout (`DS5_HW_RESET_BREAKER_RESET_MS`) has elapsed since `last_reset_jiffies`, auto-clear the counter and allow the reset (self-healing)
+     - Otherwise, log `dev_err` "circuit breaker tripped — %d consecutive failures, refusing HW reset. Will auto-reset after %d seconds of inactivity" and return `-EBUSY`
+   - Check cooldown: if `jiffies - last_reset_jiffies < msecs_to_jiffies(COOLDOWN_MS)`, log `dev_warn` "HW reset throttled — last reset was %d ms ago" and return `-EAGAIN`
+
+4. **Update success/failure tracking at bottom of function**:
+   - On success (return 0): set `state->consecutive_reset_failures = 0`, update `state->last_reset_jiffies = jiffies`, increment `state->total_resets`
+   - On failure: increment `state->consecutive_reset_failures`, update `state->last_reset_jiffies = jiffies`, increment `state->total_resets`
+
+5. **Expose diagnostic counters via existing V4L2 log** — add the counters to the final `dev_info` message at the end of `ds5_hw_reset_with_recovery()` so they appear in dmesg.
+
+6. **Skip circuit-breaker for probe path** — the `ds5_probe()` call should bypass the circuit-breaker since it's a one-time initialization, not a userspace retry loop. Add a `bool force` parameter to `ds5_hw_reset_with_recovery()`, or handle it by checking `last_reset_jiffies == 0` (uninitialized).
+
+---
+
+## Item 2: Phase 1 Dual-Camera Safety (Low Priority)
+
+### Analysis Conclusion
+
+The D401 dual-camera log errors (bus 12 I2C failures 12ms after SERDES re-init) occurred with the **old driver code** that did full SERDES re-init including deserializer `reset_oneshot`. Our new Phase 1 calls only `max9295_init_settings()`, which writes exclusively to serializer-local registers (`PIPE_EN`=0x2, `START_PIPE`=0x311, `MIPI_RX1`=0x331, `CSI_PORT_SEL`). This **cannot** disrupt sibling cameras on a different serializer.
+
+### Remaining Risk
+
+Theoretical — if the GMSL link is unstable, a serializer register write could briefly glitch the shared GMSL bus during the I2C transaction. This is extremely unlikely with MAX9295/MAX9296 but worth monitoring.
+
+### Steps
+
+7. **Add post-Phase-1 sibling health check** in `ds5_hw_reset_serdes_recovery()` — after the Phase 1 success path (`return 0`), before returning:
+   - Iterate `serdes_inited[]` for true siblings (same `dser_dev`, different `ser_dev`)
+   - For each streaming sibling, do a quick I2C read (`ds5_read(sib, DS5_FW_VERSION, &tmp)`)
+   - If any fail: log `dev_warn` "Phase 1 serializer re-init may have disrupted sibling %s" (informational only — do NOT fail the reset)
+   - This is a **diagnostic-only** check that gives us data to decide if future mitigation is needed
+
+8. **Add a brief stabilization delay** — increase the post-Phase-1 `msleep(100)` to `msleep(150)` to give the GMSL link a bit more time to re-lock after serializer reconfiguration, before verifying. This is conservative and costs only 50ms.
+
+---
+
+## Verification Plan
+
+- **Circuit-breaker**: Trigger 5+ rapid HW resets on a camera with a broken GMSL link. Verify that after 3 failures, the driver logs "circuit breaker tripped" and returns `-EBUSY`. Wait 60s, verify reset is accepted again.
+- **Cooldown**: Send two HW resets <5s apart. Verify the second one returns `-EAGAIN` with a throttle warning.
+- **Probe bypass**: Verify `modprobe d4xx` still performs initial HW reset successfully without tripping the circuit-breaker.
+- **Phase 1 safety**: On a dual-camera Orin setup, HW-reset camera A while camera B is streaming. Check dmesg for "may have disrupted sibling" warning. Confirm camera B's stream is unaffected.
+- **Regression**: Run `python3 run_ci.py` from `test/` on a D457 to verify no existing tests break.
+
+## Design Decisions
+
+- **Circuit-breaker is per-instance, not per-camera**: Each `struct ds5` has its own counter. Since userspace sends HW reset to one instance (typically Depth at `9-001a`), this naturally tracks per-camera. Peer instances aren't reset independently.
+- **Return -EBUSY for tripped breaker, -EAGAIN for cooldown**: Distinct error codes let userspace distinguish "permanently failed" from "try again later".
+- **Auto-clear after 60s inactivity**: Avoids permanent lockout. If the camera recovers externally (e.g., power cycle), the driver will accept resets again.
+- **Phase 1 dual-camera is diagnostic only**: No blocking behavior added — just logging. If field data shows disruption, we can add a sibling-streaming gate in a future commit.

--- a/docs/hw-reset-followup-plan.md
+++ b/docs/hw-reset-followup-plan.md
@@ -17,7 +17,7 @@ The `reset_issue_dmesg.txt` log shows 35 consecutive userspace-triggered HW rese
 
 ### Steps
 
-1. **Add tracking fields to `struct ds5`** (`kernel/realsense/d4xx.c`):
+1. **Add tracking fields to `struct ds5_dev`** (`kernel/realsense/d4xx.c`):
    - `int consecutive_reset_failures` — incremented when `ds5_hw_reset_with_recovery()` returns an error, reset to 0 on success
    - `unsigned long last_reset_jiffies` — timestamp of the last reset attempt
    - `int total_resets` — lifetime counter for diagnostics (never reset)
@@ -27,39 +27,21 @@ The `reset_issue_dmesg.txt` log shows 35 consecutive userspace-triggered HW rese
    - `DS5_HW_RESET_COOLDOWN_MS` = 5000 — minimum interval between resets (5 seconds)
    - `DS5_HW_RESET_BREAKER_RESET_MS` = 60000 — if no reset for 60s, clear the failure counter (auto-recovery)
 
-3. **Add gating logic at top of `ds5_hw_reset_with_recovery()`**:
-   - Check `consecutive_reset_failures >= MAX_CONSECUTIVE_FAILURES`:
-     - If the breaker timeout (`DS5_HW_RESET_BREAKER_RESET_MS`) has elapsed since `last_reset_jiffies`, auto-clear the counter and allow the reset (self-healing)
-     - Otherwise, log `dev_err` "circuit breaker tripped — %d consecutive failures, refusing HW reset. Will auto-reset after %d seconds of inactivity" and return `-EBUSY`
-   - Check cooldown: if `jiffies - last_reset_jiffies < msecs_to_jiffies(COOLDOWN_MS)`, log `dev_warn` "HW reset throttled — last reset was %d ms ago" and return `-EAGAIN`
+### Implementation Notes (updated for refactored driver)
 
-4. **Update success/failure tracking at bottom of function**:
-   - On success (return 0): set `state->consecutive_reset_failures = 0`, update `state->last_reset_jiffies = jiffies`, increment `state->total_resets`
-   - On failure: increment `state->consecutive_reset_failures`, update `state->last_reset_jiffies = jiffies`, increment `state->total_resets`
-
-5. **Expose diagnostic counters via existing V4L2 log** — add the counters to the final `dev_info` message at the end of `ds5_hw_reset_with_recovery()` so they appear in dmesg.
-
-6. **Skip circuit-breaker for probe path** — the `ds5_probe()` call should bypass the circuit-breaker since it's a one-time initialization, not a userspace retry loop. Add a `bool force` parameter to `ds5_hw_reset_with_recovery()`, or handle it by checking `last_reset_jiffies == 0` (uninitialized).
-
----
-
-## Item 2: Phase 1 Dual-Camera Safety (Low Priority)
-
-### Analysis Conclusion
-
-The D401 dual-camera log errors (bus 12 I2C failures 12ms after SERDES re-init) occurred with the **old driver code** that did full SERDES re-init including deserializer `reset_oneshot`. Our new Phase 1 calls only `max9295_init_settings()`, which writes exclusively to serializer-local registers (`PIPE_EN`=0x2, `START_PIPE`=0x311, `MIPI_RX1`=0x331, `CSI_PORT_SEL`). This **cannot** disrupt sibling cameras on a different serializer.
-
-### Remaining Risk
-
-Theoretical — if the GMSL link is unstable, a serializer register write could briefly glitch the shared GMSL bus during the I2C transaction. This is extremely unlikely with MAX9295/MAX9296 but worth monitoring.
-
-### Steps
-
-7. **Add post-Phase-1 sibling health check** in `ds5_hw_reset_serdes_recovery()` — after the Phase 1 success path (`return 0`), before returning:
-   - Iterate `serdes_inited[]` for true siblings (same `dser_dev`, different `ser_dev`)
-   - For each streaming sibling, do a quick I2C read (`ds5_read(sib, DS5_FW_VERSION, &tmp)`)
-   - If any fail: log `dev_warn` "Phase 1 serializer re-init may have disrupted sibling %s" (informational only — do NOT fail the reset)
-   - This is a **diagnostic-only** check that gives us data to decide if future mitigation is needed
+- Use tracking fields in `struct ds5_dev`: `consecutive_reset_failures`, `last_reset_jiffies`, and `total_resets` (all per-camera, shared across sensor instances).
+- Reference `ds5_inited[]` for sibling streaming checks (not `serdes_inited[]`).
+- Circuit-breaker logic:
+   - Check `ds5_dev->consecutive_reset_failures >= DS5_HW_RESET_MAX_CONSECUTIVE_FAILURES`.
+      - If `DS5_HW_RESET_BREAKER_RESET_MS` has elapsed since `ds5_dev->last_reset_jiffies`, auto-clear the failure counter and allow the reset (self-healing).
+      - Otherwise, log `dev_err` "circuit breaker tripped — %d consecutive failures, refusing HW reset. Will auto-reset after %d seconds of inactivity" and return `-EBUSY`.
+   - Cooldown: if `jiffies - ds5_dev->last_reset_jiffies < msecs_to_jiffies(DS5_HW_RESET_COOLDOWN_MS)`, log `dev_warn` "HW reset throttled — last reset was %d ms ago" and return `-EAGAIN`.
+- Update success/failure tracking at the end of `ds5_hw_reset_with_recovery()`:
+   - On success: set `ds5_dev->consecutive_reset_failures = 0`, update `ds5_dev->last_reset_jiffies = jiffies`, increment `ds5_dev->total_resets`.
+   - On failure: increment `ds5_dev->consecutive_reset_failures`, update `ds5_dev->last_reset_jiffies = jiffies`, increment `ds5_dev->total_resets`.
+- Expose diagnostic counters via the final `dev_info` log in `ds5_hw_reset_with_recovery()` so they appear in dmesg.
+- Skip circuit-breaker for probe path: ensure probe-time HW reset bypasses the breaker logic (e.g., by checking `last_reset_jiffies == 0` or using a `force` parameter).
+- For dual-camera safety, after Phase 1 serializer re-init, iterate `ds5_inited[]` for sibling instances (same `ds5_dev`, different sensor). For each streaming sibling, perform a quick I2C read (`ds5_read(sib, DS5_FW_VERSION, &tmp)`). If any fail, log `dev_warn` "Phase 1 serializer re-init may have disrupted sibling %s" (diagnostic only, do not fail the reset).
 
 8. **Add a brief stabilization delay** — increase the post-Phase-1 `msleep(100)` to `msleep(150)` to give the GMSL link a bit more time to re-lock after serializer reconfiguration, before verifying. This is conservative and costs only 50ms.
 
@@ -75,7 +57,7 @@ Theoretical — if the GMSL link is unstable, a serializer register write could 
 
 ## Design Decisions
 
-- **Circuit-breaker is per-instance, not per-camera**: Each `struct ds5` has its own counter. Since userspace sends HW reset to one instance (typically Depth at `9-001a`), this naturally tracks per-camera. Peer instances aren't reset independently.
+- **Circuit-breaker is per-camera, shared across instances**: The tracking fields live in `struct ds5_dev`, so all `struct ds5` instances for the same physical camera share a single counter and breaker state. If any instance (typically Depth at `9-001a`) trips the breaker, further HW reset requests from any instance for that camera are rejected until the breaker auto‑clears.
 - **Return -EBUSY for tripped breaker, -EAGAIN for cooldown**: Distinct error codes let userspace distinguish "permanently failed" from "try again later".
 - **Auto-clear after 60s inactivity**: Avoids permanent lockout. If the camera recovers externally (e.g., power cycle), the driver will accept resets again.
 - **Phase 1 dual-camera is diagnostic only**: No blocking behavior added — just logging. If field data shows disruption, we can add a sibling-streaming gate in a future commit.

--- a/kernel/realsense/d4xx.c
+++ b/kernel/realsense/d4xx.c
@@ -2332,37 +2332,59 @@ static int ds5_hw_reset_serdes_recovery(struct ds5 *state)
 		"%s(): Phase 1 failed (I2C err %d), checking siblings before deser reset\n",
 		__func__, ret);
 
+	/*
+	 * In the D4XX architecture each physical camera has 4 driver instances
+	 * (Depth, RGB, IR, IMU) sharing the same ser_dev.  A "true sibling" is
+	 * a different physical camera on the same deserializer: same dser_dev
+	 * but different ser_dev.
+	 *
+	 * Same-camera instances are always safe to reset together since they
+	 * share the same camera ASIC — the HW reset already killed them all.
+	 */
 	for (i = 0; i < MAX_DEV_NUM; i++) {
 		struct ds5 *sib = serdes_inited[i];
+		bool sib_streaming;
 
-		if (!sib || sib == state || sib->dser_dev != state->dser_dev)
+		if (!sib || sib == state)
 			continue;
 
-		/* Check if sibling can still communicate over I2C */
-		if (ds5_read(sib, DS5_FW_VERSION, &tmp) == 0) {
-			/* Check if sibling has any active stream */
-			if (sib->depth.sensor.streaming ||
-			    sib->ir.sensor.streaming ||
-			    sib->rgb.sensor.streaming ||
-			    sib->imu.sensor.streaming) {
-				sibling_alive = true;
-				dev_warn(&state->client->dev,
-					"%s(): sibling %s alive & streaming, skipping deser reset\n",
-					__func__, dev_name(&sib->client->dev));
-				break;
-			}
+		/* Skip instances of the SAME physical camera (same serializer) */
+		if (sib->ser_dev == state->ser_dev)
+			continue;
+
+		/* Only check cameras on the same deserializer (true siblings) */
+		if (sib->dser_dev != state->dser_dev)
+			continue;
+
+		/* True sibling — check if its I2C link is alive */
+		if (ds5_read(sib, DS5_FW_VERSION, &tmp) != 0)
+			continue;
+
+		/* Check only the sensor type this instance actually manages */
+		sib_streaming = (sib->is_depth && sib->depth.sensor.streaming) ||
+				(sib->is_rgb  && sib->rgb.sensor.streaming) ||
+				(sib->is_y8   && sib->ir.sensor.streaming) ||
+				(sib->is_imu  && sib->imu.sensor.streaming);
+
+		if (sib_streaming) {
+			sibling_alive = true;
+			dev_warn(&state->client->dev,
+				"%s(): true sibling %s alive & streaming, skipping deser reset\n",
+				__func__, dev_name(&sib->client->dev));
+			break;
 		}
 	}
 
 	if (sibling_alive) {
 		dev_err(&state->client->dev,
-			"%s(): GMSL link broken but sibling streaming — cannot reset deserializer. "
-			"Manual recovery (driver reload / camera power cycle) may be needed.\n",
+			"%s(): GMSL link broken but sibling camera streaming — "
+			"cannot reset deserializer. Manual recovery "
+			"(driver reload / camera power cycle) may be needed.\n",
 			__func__);
 		return -EIO;
 	}
 
-	/* All siblings dead or none exist — safe to reset entire deserializer */
+	/* All true siblings dead or none streaming — safe to reset entire deserializer */
 	dev_info(&state->client->dev,
 		"%s(): Phase 2 - performing full deserializer reset\n", __func__);
 
@@ -2412,25 +2434,31 @@ static int ds5_hw_reset_serdes_recovery(struct ds5 *state)
 	dev_info(&state->client->dev,
 		"%s(): Phase 2 succeeded, full deser recovery complete\n", __func__);
 
-	/* Invalidate all sibling cameras so they re-configure on next stream start */
+	/* Invalidate all cameras on this deserializer so they re-configure
+	 * on next stream start.  This covers both same-camera peer instances
+	 * (same ser_dev) and true sibling cameras (different ser_dev).
+	 */
 	for (i = 0; i < MAX_DEV_NUM; i++) {
 		struct ds5 *sib = serdes_inited[i];
+		struct ds5_sensor *active;
 
-		if (!sib || sib == state || sib->dser_dev != state->dser_dev)
+		if (!sib || sib == state)
+			continue;
+		if (sib->dser_dev != state->dser_dev)
 			continue;
 
-		ds5_invalidate_sensor(sib, &sib->depth.sensor);
-		ds5_invalidate_sensor(sib, &sib->ir.sensor);
-		ds5_invalidate_sensor(sib, &sib->rgb.sensor);
-		ds5_invalidate_sensor(sib, &sib->imu.sensor);
-		sib->depth.sensor.streaming = false;
-		sib->ir.sensor.streaming = false;
-		sib->rgb.sensor.streaming = false;
-		sib->imu.sensor.streaming = false;
+		/* Invalidate only the sensor type this instance manages */
+		active = ds5_get_active_sensor(sib);
+		if (active) {
+			ds5_invalidate_sensor(sib, active);
+			active->streaming = false;
+		}
 
 		dev_warn(&state->client->dev,
-			"%s(): invalidated sibling %s after deser reset\n",
-			__func__, dev_name(&sib->client->dev));
+			"%s(): invalidated %s %s after deser reset\n",
+			__func__,
+			(sib->ser_dev == state->ser_dev) ? "same-cam" : "sibling",
+			dev_name(&sib->client->dev));
 	}
 
 	return 0;
@@ -2453,73 +2481,116 @@ static int ds5_hw_reset_with_recovery(struct ds5 *state)
 {
 	int ret;
 	int retry;
-	int i;
+	int __maybe_unused i;
 	u16 status = 0;
 	bool device_went_down = false;
-	struct ds5_sensor *sensors[] = {
-		&state->depth.sensor,
-		&state->ir.sensor,
-		&state->rgb.sensor,
-		&state->imu.sensor,
-	};
-	static const u16 stream_ids[] = {
-		DS5_STREAM_DEPTH,
-		DS5_STREAM_IR,
-		DS5_STREAM_RGB,
-		DS5_STREAM_IMU,
-	};
 
 	dev_info(&state->client->dev, "%s(): Initiating HW reset with recovery\n",
 		__func__);
 
 	/* 1. Stop active streams on the device before reset.
 	 *    This ensures FW and SERDES are in a clean state.
+	 *
+	 *    In the D4XX architecture each physical camera has 4 driver
+	 *    instances (Depth, RGB, IR, IMU) sharing the same ser_dev.
+	 *    HW reset kills all streams on the camera ASIC, so we must
+	 *    stop and invalidate all peer instances of the same camera.
 	 */
-	for (i = 0; i < ARRAY_SIZE(sensors); i++) {
-		if (sensors[i]->streaming) {
+	{
+		struct ds5_sensor *active = ds5_get_active_sensor(state);
+
+		if (active && active->streaming) {
+			u16 sid = state->is_depth ? DS5_STREAM_DEPTH :
+				  state->is_rgb   ? DS5_STREAM_RGB :
+				  state->is_y8    ? DS5_STREAM_IR :
+						    DS5_STREAM_IMU;
 			dev_info(&state->client->dev,
-				"%s(): stopping active stream %d before reset\n",
-				__func__, stream_ids[i]);
+				"%s(): stopping own stream %d before reset\n",
+				__func__, sid);
 			ds5_write(state, DS5_START_STOP_STREAM,
-				DS5_STREAM_STOP | stream_ids[i]);
+				DS5_STREAM_STOP | sid);
 		}
 	}
 
-	/* 2. Invalidate all sensor state and release SERDES pipes.
+#ifdef CONFIG_VIDEO_D4XX_SERDES
+	/* Stop streams on peer instances of the same physical camera */
+	for (i = 0; i < MAX_DEV_NUM; i++) {
+		struct ds5 *peer = serdes_inited[i];
+		struct ds5_sensor *peer_active;
+
+		if (!peer || peer == state)
+			continue;
+		if (peer->ser_dev != state->ser_dev)
+			continue;
+
+		peer_active = ds5_get_active_sensor(peer);
+		if (peer_active && peer_active->streaming) {
+			u16 sid = peer->is_depth ? DS5_STREAM_DEPTH :
+				  peer->is_rgb   ? DS5_STREAM_RGB :
+				  peer->is_y8    ? DS5_STREAM_IR :
+						    DS5_STREAM_IMU;
+			dev_info(&state->client->dev,
+				"%s(): stopping peer %s stream %d before reset\n",
+				__func__, dev_name(&peer->client->dev), sid);
+			ds5_write(peer, DS5_START_STOP_STREAM,
+				DS5_STREAM_STOP | sid);
+		}
+	}
+#endif
+
+	/* 2. Invalidate sensor state and release SERDES pipes.
 	 *    After HW reset the device loses all configuration, so driver
 	 *    state must be brought in sync.  Clear streaming flags so that
 	 *    ds5_mux_s_stream() won't silently skip the next stream-start.
+	 *    Covers this instance AND all peer instances of the same camera.
 	 */
+	{
+		struct ds5_sensor *active = ds5_get_active_sensor(state);
+
+		if (active) {
+			ds5_config_cache_clear(active);
+			active->streaming = false;
 #ifdef CONFIG_VIDEO_D4XX_SERDES
-	if (state->dser_dev) {
-		mutex_lock(&serdes_lock__);
-		for (i = 0; i < ARRAY_SIZE(sensors); i++) {
-			struct ds5_sensor *sensor = sensors[i];
+			if (active->pipe_id >= 0 && state->dser_dev) {
+				int release_ret;
 
-			ds5_config_cache_clear(sensor);
-			sensor->streaming = false;
-
-			if (sensor->pipe_id >= 0) {
-				int release_ret = state->dser_ops->release_pipe(
-					state->dser_dev, sensor->pipe_id);
+				mutex_lock(&serdes_lock__);
+				release_ret = state->dser_ops->release_pipe(
+					state->dser_dev, active->pipe_id);
+				mutex_unlock(&serdes_lock__);
 				dev_info(&state->client->dev,
 					"%s(): released pipe %d (%d)\n",
-					__func__, sensor->pipe_id, release_ret);
-				sensor->pipe_id = PIPE_NOT_CONFIGURED;
+					__func__, active->pipe_id, release_ret);
+				active->pipe_id = PIPE_NOT_CONFIGURED;
 			}
-			sensor->pipe_data_type1 = 0;
-			sensor->pipe_data_type2 = 0;
-			sensor->pipe_vc_id = 0;
-		}
-		mutex_unlock(&serdes_lock__);
-	} else
+			active->pipe_data_type1 = 0;
+			active->pipe_data_type2 = 0;
+			active->pipe_vc_id = 0;
 #endif
-	{
-		for (i = 0; i < ARRAY_SIZE(sensors); i++) {
-			ds5_config_cache_clear(sensors[i]);
-			sensors[i]->streaming = false;
 		}
 	}
+
+#ifdef CONFIG_VIDEO_D4XX_SERDES
+	/* Invalidate peer instances of the same physical camera */
+	for (i = 0; i < MAX_DEV_NUM; i++) {
+		struct ds5 *peer = serdes_inited[i];
+		struct ds5_sensor *peer_active;
+
+		if (!peer || peer == state)
+			continue;
+		if (peer->ser_dev != state->ser_dev)
+			continue;
+
+		peer_active = ds5_get_active_sensor(peer);
+		if (peer_active) {
+			ds5_invalidate_sensor(peer, peer_active);
+			peer_active->streaming = false;
+			dev_info(&state->client->dev,
+				"%s(): invalidated peer %s\n",
+				__func__, dev_name(&peer->client->dev));
+		}
+	}
+#endif
 
 	/* 3. Send HW reset command */
 	ret = ds5_raw_write(state, DS5_HWMC_DATA, &cmd_hw_reset, sizeof(cmd_hw_reset));

--- a/kernel/realsense/d4xx.c
+++ b/kernel/realsense/d4xx.c
@@ -497,6 +497,12 @@ struct ds5_counters {
 static atomic_t ds5_reset_gen = ATOMIC_INIT(0);
 static atomic_t ds5_probe_reset_once = ATOMIC_INIT(0);
 
+/* Timestamp (jiffies) of last completed HW reset.
+ * Used to enforce DS5_HW_RESET_COOLDOWN_MS between consecutive resets
+ * and prevent GMSL link degradation from rapid reset cycles.
+ */
+static unsigned long ds5_last_reset_jiffies;
+
 /* Cached device type from HW reset Step 8.
  * During probe the first instance resets the camera, causing DS5_DEVICE_TYPE
  * to temporarily return 0.  Step 8 polls until the register is valid and
@@ -2303,6 +2309,22 @@ static int ds5_set_calibration_data(struct ds5 *state,
 #define DS5_HW_RESET_TIMEOUT_MS		10000
 #define DS5_HW_RESET_MAX_RETRIES	(DS5_HW_RESET_TIMEOUT_MS / DS5_HW_RESET_POLL_INTERVAL_MS)
 
+/* Post-reset I2C stability verification (Step 10).
+ * After FW reports ready and HWMC passes, verify the I2C link is
+ * *sustained* — some camera SKUs (D401) have a secondary FW init phase
+ * that briefly drops I2C ~65ms after the initial checks pass.
+ */
+#define DS5_HW_RESET_STABILITY_READS	3	/* consecutive successful reads */
+#define DS5_HW_RESET_STABILITY_INTERVAL_MS 200	/* between each check */
+#define DS5_HW_RESET_STABILITY_TIMEOUT_MS 3000	/* max wait for stable link */
+
+/* Minimum interval between consecutive HW resets (ms).
+ * Rapid back-to-back resets degrade the GMSL link because each
+ * serializer re-init (Phase 1) conflicts with the camera FW's own
+ * I2C bus reconfiguration after reboot.
+ */
+#define DS5_HW_RESET_COOLDOWN_MS	5000
+
 /*
  * Register 0x5020 status values (from firmware):
  * - 0xDEAD: Device in normal UVC mode (ready) - ICT returns error for unhandled cmd
@@ -2314,16 +2336,21 @@ static int ds5_set_calibration_data(struct ds5 *state,
 
 /*
  * ds5_hw_reset_serdes_recovery - Tiered SERDES recovery after HW reset.
+ * @state: Driver state
+ * @force_phase2: When true, skip Phase 1 and go straight to Phase 2
+ *                (full deserializer reset).  Used by Step 10 when the
+ *                I2C link is unstable despite Phase 1 having passed.
  *
  * Phase 1: Re-init serializer only (per-camera, non-disruptive).
- * Phase 2: If I2C still fails, perform a full deserializer reset_oneshot
- *          (chip-wide, disruptive) only when no sibling camera on the same
- *          deserializer is currently reachable over I2C and streaming.
+ * Phase 2: If I2C still fails (or force_phase2), perform a full deserializer
+ *          reset_oneshot (chip-wide, disruptive) only when no sibling camera
+ *          on the same deserializer is currently reachable over I2C and
+ *          streaming.
  *
  * Returns 0 on success, negative errno on failure.
  */
 #ifdef CONFIG_VIDEO_D4XX_SERDES
-static int ds5_hw_reset_serdes_recovery(struct ds5 *state)
+static int ds5_hw_reset_serdes_recovery(struct ds5 *state, bool force_phase2)
 {
 	int ret;
 	int i;
@@ -2333,29 +2360,35 @@ static int ds5_hw_reset_serdes_recovery(struct ds5 *state)
 	if (!state->ser_dev || !state->dser_dev)
 		return 0;
 
-	/* Phase 1 — serializer-only re-init (per-camera, safe) */
-	dev_info(&state->client->dev,
-		"%s(): Phase 1 - re-initializing serializer\n", __func__);
-	ret = max9295_init_settings(state->ser_dev);
-	if (ret < 0)
-		dev_warn(&state->client->dev,
-			"%s(): serializer init_settings failed: %d\n",
-			__func__, ret);
-
-	msleep(100);
-
-	/* Verify I2C link to camera is working */
-	ret = ds5_read(state, DS5_FW_VERSION, &tmp);
-	if (ret == 0) {
+	if (!force_phase2) {
+		/* Phase 1 — serializer-only re-init (per-camera, safe) */
 		dev_info(&state->client->dev,
-			"%s(): Phase 1 succeeded, I2C link OK\n", __func__);
-		return 0;
-	}
+			"%s(): Phase 1 - re-initializing serializer\n", __func__);
+		ret = max9295_init_settings(state->ser_dev);
+		if (ret < 0)
+			dev_warn(&state->client->dev,
+				"%s(): serializer init_settings failed: %d\n",
+				__func__, ret);
 
-	/* Phase 2 — I2C still broken; consider full deserializer reset */
-	dev_warn(&state->client->dev,
-		"%s(): Phase 1 failed (I2C err %d), checking siblings before deser reset\n",
-		__func__, ret);
+		msleep(100);
+
+		/* Verify I2C link to camera is working */
+		ret = ds5_read(state, DS5_FW_VERSION, &tmp);
+		if (ret == 0) {
+			dev_info(&state->client->dev,
+				"%s(): Phase 1 succeeded, I2C link OK\n", __func__);
+			return 0;
+		}
+
+		/* Phase 2 — I2C still broken; consider full deserializer reset */
+		dev_warn(&state->client->dev,
+			"%s(): Phase 1 failed (I2C err %d), checking siblings before deser reset\n",
+			__func__, ret);
+	} else {
+		dev_info(&state->client->dev,
+			"%s(): Phase 2 forced (I2C link unstable after Phase 1), checking siblings\n",
+			__func__);
+	}
 
 	/*
 	 * In the D4XX architecture each physical camera has 4 driver instances
@@ -2511,6 +2544,28 @@ static int ds5_hw_reset_with_recovery(struct ds5 *state)
 
 	dev_info(&state->client->dev, "%s(): Initiating HW reset with recovery\n",
 		__func__);
+
+	/* 0. Reset cooldown — prevent rapid consecutive resets.
+	 *    Repeated HW reset + Phase-1 serializer re-init without letting
+	 *    the camera FW finish its post-boot I2C bus reconfiguration
+	 *    progressively degrades the GMSL link until even SERDES pipe
+	 *    setup fails.  Enforce a minimum interval between resets.
+	 *    Skip check on the very first reset (ds5_last_reset_jiffies == 0).
+	 */
+	if (ds5_last_reset_jiffies) {
+		unsigned long elapsed = jiffies - ds5_last_reset_jiffies;
+		unsigned long cooldown = msecs_to_jiffies(DS5_HW_RESET_COOLDOWN_MS);
+
+		if (time_before(jiffies, ds5_last_reset_jiffies + cooldown)) {
+			unsigned long remaining = cooldown - elapsed;
+
+			dev_info(&state->client->dev,
+				"%s(): Reset cooldown — last reset %u ms ago, waiting %u ms\n",
+				__func__, jiffies_to_msecs(elapsed),
+				jiffies_to_msecs(remaining));
+			msleep(jiffies_to_msecs(remaining));
+		}
+	}
 
 	/* 1. Stop active streams on the device before reset.
 	 *    This ensures FW and SERDES are in a clean state.
@@ -2691,7 +2746,7 @@ static int ds5_hw_reset_with_recovery(struct ds5 *state)
 	 *    Phase 1: serializer-only re-init (per-camera, non-disruptive).
 	 *    Phase 2: full deserializer reset only if ALL siblings are also dead.
 	 */
-	ret = ds5_hw_reset_serdes_recovery(state);
+	ret = ds5_hw_reset_serdes_recovery(state, false);
 	if (ret < 0) {
 		dev_err(&state->client->dev,
 			"%s(): SERDES recovery failed: %d\n", __func__, ret);
@@ -2813,11 +2868,104 @@ static int ds5_hw_reset_with_recovery(struct ds5 *state)
 				__func__, DS5_HW_RESET_TIMEOUT_MS);
 	}
 
+#ifdef CONFIG_VIDEO_D4XX_SERDES
+	/* 10. Post-reset I2C stability verification.
+	 *     Some camera SKUs (notably D401 with FW 5.17.x) have a secondary
+	 *     FW initialization phase that briefly drops the I2C bus ~65ms after
+	 *     the initial readiness checks (Steps 7-9) pass.  If we return now,
+	 *     userspace HWMC queries NAK, the viewer triggers another reset,
+	 *     and repeated rapid resets degrade the GMSL link until SERDES pipe
+	 *     setup fails and the device is unrecoverable without a host reboot.
+	 *
+	 *     Verify I2C stability by performing DS5_HW_RESET_STABILITY_READS
+	 *     consecutive successful reads spaced DS5_HW_RESET_STABILITY_INTERVAL_MS
+	 *     apart.  If the link drops mid-verification, reset the counter and
+	 *     keep waiting (up to DS5_HW_RESET_STABILITY_TIMEOUT_MS).  If it
+	 *     remains unstable, escalate to Phase 2 (full deserializer reset).
+	 */
+	{
+		int stable_count = 0;
+		unsigned long stab_ts = jiffies;
+		unsigned long stab_timeout =
+			stab_ts + msecs_to_jiffies(DS5_HW_RESET_STABILITY_TIMEOUT_MS);
+		u16 stab_val = 0;
+
+		while (time_before(jiffies, stab_timeout)) {
+			msleep(DS5_HW_RESET_STABILITY_INTERVAL_MS);
+
+			ret = ds5_read(state, DS5_FW_VERSION, &stab_val);
+			if (ret == 0 && stab_val != 0) {
+				stable_count++;
+				if (stable_count >= DS5_HW_RESET_STABILITY_READS) {
+					dev_info(&state->client->dev,
+						"%s(): I2C link stable after %d ms (%d consecutive reads OK)\n",
+						__func__,
+						jiffies_to_msecs(jiffies - stab_ts),
+						stable_count);
+					break;
+				}
+			} else {
+				if (stable_count > 0)
+					dev_warn(&state->client->dev,
+						"%s(): I2C stability check failed after %d OK reads (ret=%d, val=0x%x), resetting counter\n",
+						__func__, stable_count, ret, stab_val);
+				stable_count = 0;
+			}
+		}
+
+		if (stable_count < DS5_HW_RESET_STABILITY_READS) {
+			/* I2C link is unstable — escalate to Phase 2 (full deser reset) */
+			dev_warn(&state->client->dev,
+				"%s(): I2C link unstable after %d ms, escalating to Phase 2 SERDES recovery\n",
+				__func__,
+				jiffies_to_msecs(jiffies - stab_ts));
+
+			ret = ds5_hw_reset_serdes_recovery(state, true);
+			if (ret < 0) {
+				dev_err(&state->client->dev,
+					"%s(): Phase 2 escalation failed: %d\n",
+					__func__, ret);
+				/* Continue anyway — the device might still be partially usable */
+			} else {
+				/* Re-verify stability after Phase 2 */
+				stable_count = 0;
+				stab_ts = jiffies;
+				stab_timeout = stab_ts + msecs_to_jiffies(
+					DS5_HW_RESET_STABILITY_TIMEOUT_MS);
+
+				while (time_before(jiffies, stab_timeout)) {
+					msleep(DS5_HW_RESET_STABILITY_INTERVAL_MS);
+					ret = ds5_read(state, DS5_FW_VERSION, &stab_val);
+					if (ret == 0 && stab_val != 0) {
+						stable_count++;
+						if (stable_count >= DS5_HW_RESET_STABILITY_READS) {
+							dev_info(&state->client->dev,
+								"%s(): I2C link stable after Phase 2 (%d ms)\n",
+								__func__,
+								jiffies_to_msecs(jiffies - stab_ts));
+							break;
+						}
+					} else {
+						stable_count = 0;
+					}
+				}
+
+				if (stable_count < DS5_HW_RESET_STABILITY_READS)
+					dev_warn(&state->client->dev,
+						"%s(): I2C still unstable after Phase 2, proceeding anyway\n",
+						__func__);
+			}
+		}
+	}
+#endif
+
 	dev_info(&state->client->dev,
 		"%s(): HW reset complete. Firmware: %d.%d.%d.%d\n",
 		__func__,
 		(state->fw_version >> 8) & 0xff, state->fw_version & 0xff,
 		(state->fw_build >> 8) & 0xff, state->fw_build & 0xff);
+
+	ds5_last_reset_jiffies = jiffies;
 
 	return 0;
 }

--- a/kernel/realsense/d4xx.c
+++ b/kernel/realsense/d4xx.c
@@ -2323,7 +2323,7 @@ static int ds5_set_calibration_data(struct ds5 *state,
  * serializer re-init (Phase 1) conflicts with the camera FW's own
  * I2C bus reconfiguration after reboot.
  */
-#define DS5_HW_RESET_COOLDOWN_MS	5000
+#define DS5_HW_RESET_COOLDOWN_MS	2000
 
 /*
  * Register 0x5020 status values (from firmware):
@@ -2641,6 +2641,9 @@ static int ds5_hw_reset_with_recovery(struct ds5 *state)
 	int retry;
 	int __maybe_unused i;
 	u16 status = 0;
+#ifdef CONFIG_VIDEO_D4XX_SERDES
+	bool serdes_recovery_ran = false;
+#endif
 
 	dev_info(&state->client->dev, "%s(): Initiating HW reset with recovery\n",
 		__func__);
@@ -2842,15 +2845,58 @@ static int ds5_hw_reset_with_recovery(struct ds5 *state)
 	}
 
 #ifdef CONFIG_VIDEO_D4XX_SERDES
-	/* 6. Tiered SERDES recovery:
-	 *    Phase 1: serializer-only re-init (per-camera, non-disruptive).
-	 *    Phase 2: full deserializer reset only if ALL siblings are also dead.
+	/* 6. Tiered SERDES recovery (conditional).
+	 *    Step 5 polled the device over I2C until 0xDEAD was returned,
+	 *    which means the GMSL link was already up at that point.  Probe
+	 *    the I2C link once more: if it is still alive, the GMSL link
+	 *    recovered naturally and full SERDES recovery (Phase 1 stability
+	 *    dance + potential Phase 2 escalation) is unnecessary — this is
+	 *    the common case for D457.
+	 *
+	 *    However, we must ALWAYS call max9295_init_settings() to restore
+	 *    the serializer's global pipe-enable, CSI port selection, and
+	 *    data-source registers.  The D457 FW reconfigures the MAX9295
+	 *    during its post-boot sequence, potentially overwriting these
+	 *    global registers.  Without re-init, per-pipe setup later in
+	 *    ds5_setup_pipeline() may fail — especially for pipe 3 (IMU)
+	 *    which the FW does not configure for its own use.
+	 *
+	 *    Only run the FULL tiered recovery (with stability checks and
+	 *    Phase 2 escalation) when the I2C link is actually broken —
+	 *    e.g. the camera FW's secondary init phase dropped the bus
+	 *    between Step 5 and now (observed on D401, occasionally D457).
 	 */
-	ret = ds5_hw_reset_serdes_recovery(state, false);
-	if (ret < 0) {
-		dev_err(&state->client->dev,
-			"%s(): SERDES recovery failed: %d\n", __func__, ret);
-		return ret;
+	{
+		u16 link_probe = 0;
+
+		/* Always restore serializer global state (pipe enables, port
+		 * selection, data sources).  This is a lightweight I2C write
+		 * sequence with no sleeps — ~0ms overhead.
+		 */
+		ret = max9295_init_settings(state->ser_dev);
+		if (ret < 0)
+			dev_warn(&state->client->dev,
+				"%s(): serializer init_settings failed: %d (continuing)\n",
+				__func__, ret);
+
+		ret = ds5_read(state, DS5_FW_VERSION, &link_probe);
+		if (ret < 0 || link_probe == 0) {
+			dev_info(&state->client->dev,
+				"%s(): I2C link dead after Step 5 (ret=%d, val=0x%x), running full SERDES recovery\n",
+				__func__, ret, link_probe);
+			ret = ds5_hw_reset_serdes_recovery(state, false);
+			if (ret < 0) {
+				dev_err(&state->client->dev,
+					"%s(): SERDES recovery failed: %d\n",
+					__func__, ret);
+				return ret;
+			}
+			serdes_recovery_ran = true;
+		} else {
+			dev_info(&state->client->dev,
+				"%s(): GMSL link recovered naturally (FW ver 0x%04x), skipping full SERDES recovery\n",
+				__func__, link_probe);
+		}
 	}
 #endif
 
@@ -2969,7 +3015,14 @@ static int ds5_hw_reset_with_recovery(struct ds5 *state)
 	}
 
 #ifdef CONFIG_VIDEO_D4XX_SERDES
-	/* 10. Post-reset I2C stability verification.
+	/* 10. Post-reset I2C stability verification (conditional).
+	 *     Only needed when SERDES recovery was actively performed in Step 6,
+	 *     because the serializer/deserializer re-init can cause transient
+	 *     I2C instability.  When the GMSL link recovered naturally (Step 6
+	 *     was skipped), Steps 7-9 already verified the link via multiple
+	 *     I2C reads — an additional 600ms+ stability loop is unnecessary
+	 *     and causes timing-sensitive CI test failures.
+	 *
 	 *     Some camera SKUs have a secondary FW initialization phase that
 	 *     briefly drops the I2C bus ~65-110ms after the initial readiness
 	 *     checks (Steps 7-9) pass.  This has been observed on both D401
@@ -2984,7 +3037,11 @@ static int ds5_hw_reset_with_recovery(struct ds5 *state)
 	 *     keep waiting (up to DS5_HW_RESET_STABILITY_TIMEOUT_MS).  If it
 	 *     remains unstable, escalate to Phase 2 (full deserializer reset).
 	 */
-	{
+	if (!serdes_recovery_ran) {
+		dev_info(&state->client->dev,
+			"%s(): SERDES recovery was skipped (natural link recovery), "
+			"bypassing Step 10 stability verification\n", __func__);
+	} else {
 		int stable_count = 0;
 		unsigned long stab_ts = jiffies;
 		unsigned long stab_timeout =
@@ -3057,7 +3114,7 @@ static int ds5_hw_reset_with_recovery(struct ds5 *state)
 						__func__);
 			}
 		}
-	}
+	} /* if (serdes_recovery_ran) */
 #endif
 
 	dev_info(&state->client->dev,

--- a/kernel/realsense/d4xx.c
+++ b/kernel/realsense/d4xx.c
@@ -1756,14 +1756,13 @@ static struct ds5_sensor *ds5_get_active_sensor(struct ds5 *state)
 static void ds5_invalidate_sensor(struct ds5 *state, struct ds5_sensor *sensor)
 {
 	ds5_config_cache_clear(sensor);
-#ifdef CONFIG_VIDEO_D4XX_SERDES
-	if (sensor->pipe_id >= 0 && state->dser_dev) {
-		mutex_lock(&serdes_lock__);
-		state->dser_ops->release_pipe(state->dser_dev, sensor->pipe_id);
-		mutex_unlock(&serdes_lock__);
-	}
-#endif
-	sensor->pipe_id = PIPE_NOT_CONFIGURED;
+	/* Do NOT release SERDES pipes or clear pipe_id here.
+	 * Preserve the existing pipe_id so that ds5_configure() can
+	 * release-then-reallocate the pipe at stream-start time, when
+	 * the camera FW has finished its post-boot serializer init.
+	 * Clearing pipe_data_type forces ds5_configure() to enter the
+	 * re-allocation path (data_type mismatch triggers pipe setup).
+	 */
 	sensor->pipe_data_type1 = 0;
 	sensor->pipe_data_type2 = 0;
 	sensor->pipe_vc_id = 0;
@@ -2720,11 +2719,18 @@ static int ds5_hw_reset_with_recovery(struct ds5 *state)
 	}
 #endif
 
-	/* 2. Invalidate sensor state and release SERDES pipes.
+	/* 2. Invalidate sensor state (defer SERDES pipe release).
 	 *    After HW reset the device loses all configuration, so driver
 	 *    state must be brought in sync.  Clear streaming flags so that
 	 *    ds5_mux_s_stream() won't silently skip the next stream-start.
 	 *    Covers this instance AND all peer instances of the same camera.
+	 *
+	 *    Do NOT release SERDES pipes here — the D457 FW is still
+	 *    reconfiguring the MAX9295 serializer after reporting 0xDEAD.
+	 *    Releasing + re-allocating pipes now would race with FW init.
+	 *    Instead, clear pipe_data_type to force ds5_configure() to
+	 *    release-then-reallocate at stream-start time, when the FW
+	 *    has long finished its init (matching v1.0.1.33 behavior).
 	 */
 	{
 		struct ds5_sensor *active = ds5_get_active_sensor(state);
@@ -2733,18 +2739,6 @@ static int ds5_hw_reset_with_recovery(struct ds5 *state)
 			ds5_config_cache_clear(active);
 			active->streaming = false;
 #ifdef CONFIG_VIDEO_D4XX_SERDES
-			if (active->pipe_id >= 0 && state->dser_dev) {
-				int release_ret;
-
-				mutex_lock(&serdes_lock__);
-				release_ret = state->dser_ops->release_pipe(
-					state->dser_dev, active->pipe_id);
-				mutex_unlock(&serdes_lock__);
-				dev_info(&state->client->dev,
-					"%s(): released pipe %d (%d)\n",
-					__func__, active->pipe_id, release_ret);
-				active->pipe_id = PIPE_NOT_CONFIGURED;
-			}
 			active->pipe_data_type1 = 0;
 			active->pipe_data_type2 = 0;
 			active->pipe_vc_id = 0;
@@ -2845,39 +2839,28 @@ static int ds5_hw_reset_with_recovery(struct ds5 *state)
 	}
 
 #ifdef CONFIG_VIDEO_D4XX_SERDES
-	/* 6. Tiered SERDES recovery (conditional).
+	/* 6. SERDES recovery (conditional).
 	 *    Step 5 polled the device over I2C until 0xDEAD was returned,
-	 *    which means the GMSL link was already up at that point.  Probe
-	 *    the I2C link once more: if it is still alive, the GMSL link
-	 *    recovered naturally and full SERDES recovery (Phase 1 stability
-	 *    dance + potential Phase 2 escalation) is unnecessary — this is
-	 *    the common case for D457.
+	 *    which means the GMSL link is up.  Probe once more: if the
+	 *    link is still alive, the GMSL link recovered naturally — no
+	 *    SERDES intervention needed (the common case for D457).
 	 *
-	 *    However, we must ALWAYS call max9295_init_settings() to restore
-	 *    the serializer's global pipe-enable, CSI port selection, and
-	 *    data-source registers.  The D457 FW reconfigures the MAX9295
-	 *    during its post-boot sequence, potentially overwriting these
-	 *    global registers.  Without re-init, per-pipe setup later in
-	 *    ds5_setup_pipeline() may fail — especially for pipe 3 (IMU)
-	 *    which the FW does not configure for its own use.
+	 *    Do NOT call max9295_init_settings() on the light path.
+	 *    The D457 FW continues reconfiguring the MAX9295 serializer
+	 *    for ~50-100ms after reporting 0xDEAD.  Calling init_settings
+	 *    now gets overwritten by the FW's ongoing init.  Instead,
+	 *    let the FW finish naturally; ds5_setup_pipeline() will write
+	 *    per-pipe settings at stream-start time (seconds later) on
+	 *    top of the FW's stable final state.  This matches v1.0.1.33
+	 *    behavior where HW reset was fire-and-forget with zero SERDES
+	 *    intervention and all CI tests passed.
 	 *
-	 *    Only run the FULL tiered recovery (with stability checks and
-	 *    Phase 2 escalation) when the I2C link is actually broken —
-	 *    e.g. the camera FW's secondary init phase dropped the bus
-	 *    between Step 5 and now (observed on D401, occasionally D457).
+	 *    Only run full tiered recovery (including init_settings +
+	 *    stability checks + Phase 2 escalation) when the I2C link
+	 *    is actually broken.
 	 */
 	{
 		u16 link_probe = 0;
-
-		/* Always restore serializer global state (pipe enables, port
-		 * selection, data sources).  This is a lightweight I2C write
-		 * sequence with no sleeps — ~0ms overhead.
-		 */
-		ret = max9295_init_settings(state->ser_dev);
-		if (ret < 0)
-			dev_warn(&state->client->dev,
-				"%s(): serializer init_settings failed: %d (continuing)\n",
-				__func__, ret);
 
 		ret = ds5_read(state, DS5_FW_VERSION, &link_probe);
 		if (ret < 0 || link_probe == 0) {
@@ -2894,7 +2877,7 @@ static int ds5_hw_reset_with_recovery(struct ds5 *state)
 			serdes_recovery_ran = true;
 		} else {
 			dev_info(&state->client->dev,
-				"%s(): GMSL link recovered naturally (FW ver 0x%04x), skipping full SERDES recovery\n",
+				"%s(): GMSL link recovered naturally (FW ver 0x%04x), no SERDES intervention needed\n",
 				__func__, link_probe);
 		}
 	}

--- a/kernel/realsense/d4xx.c
+++ b/kernel/realsense/d4xx.c
@@ -2177,7 +2177,12 @@ static int ds5_get_hwmc_status(struct ds5 *state)
 		if (retries != 100)
 			msleep_range(1);
 		ret = ds5_read(state, DS5_HWMC_STATUS, &status);
-	} while (!ret && retries-- && status == DS5_HWMC_STATUS_WIP);
+		if (ret) {
+			dev_dbg(&state->client->dev,
+				"%s(): I2C read failed (%d), retries left: %d\n",
+				__func__, ret, retries);
+		}
+	} while (retries-- && (ret || status == DS5_HWMC_STATUS_WIP));
 	dev_dbg(&state->client->dev,
 			"%s(): ret: 0x%x, status: 0x%x\n",
 			__func__, ret, status);
@@ -2730,6 +2735,75 @@ static int ds5_hw_reset_with_recovery(struct ds5 *state)
 				__func__, dev_type, DS5_HW_RESET_TIMEOUT_MS);
 	}
 
+	/* 9. Verify HWMC subsystem is ready to accept commands.
+	 * After HW reset the FW reports 0xDEAD and populates device type
+	 * before the HWM command processor is fully initialized.  If
+	 * userspace queries GVD/HWMC immediately after we return, the
+	 * I2C reads NAK (EREMOTEIO) or return stale status (WIP/ERR),
+	 * which can crash RS Viewer.  Send a lightweight GVD command and
+	 * poll HWMC_STATUS until it completes successfully.
+	 */
+	{
+		struct hwm_cmd hwmc_probe;
+		u16 hwmc_status = DS5_HWMC_STATUS_WIP;
+		int hwmc_ret;
+
+		memcpy(&hwmc_probe, &gvd, sizeof(gvd));
+
+		for (retry = 0; retry < DS5_HW_RESET_MAX_RETRIES; retry++) {
+			hwmc_ret = ds5_raw_write(state, DS5_HWMC_DATA,
+						 &hwmc_probe, sizeof(hwmc_probe));
+			if (hwmc_ret) {
+				dev_dbg(&state->client->dev,
+					"%s(): HWMC probe write failed (%d), retry %d\n",
+					__func__, hwmc_ret, retry);
+				msleep(DS5_HW_RESET_POLL_INTERVAL_MS);
+				continue;
+			}
+
+			hwmc_ret = ds5_write(state, DS5_HWMC_EXEC, 0x01);
+			if (hwmc_ret) {
+				dev_dbg(&state->client->dev,
+					"%s(): HWMC probe exec failed (%d), retry %d\n",
+					__func__, hwmc_ret, retry);
+				msleep(DS5_HW_RESET_POLL_INTERVAL_MS);
+				continue;
+			}
+
+			/* Poll status — allow both I2C and WIP retries */
+			{
+				int poll;
+
+				for (poll = 0; poll < 100; poll++) {
+					msleep_range(5);
+					hwmc_ret = ds5_read(state, DS5_HWMC_STATUS,
+							     &hwmc_status);
+					if (hwmc_ret == 0 &&
+					    hwmc_status == DS5_HWMC_STATUS_OK)
+						break;
+				}
+			}
+
+			if (hwmc_ret == 0 && hwmc_status == DS5_HWMC_STATUS_OK) {
+				dev_info(&state->client->dev,
+					"%s(): HWMC ready after %d ms\n",
+					__func__,
+					(retry + 1) * DS5_HW_RESET_POLL_INTERVAL_MS);
+				break;
+			}
+
+			dev_dbg(&state->client->dev,
+				"%s(): HWMC not ready (status: 0x%x, ret: %d), retry %d\n",
+				__func__, hwmc_status, hwmc_ret, retry);
+			msleep(DS5_HW_RESET_POLL_INTERVAL_MS);
+		}
+
+		if (retry >= DS5_HW_RESET_MAX_RETRIES)
+			dev_warn(&state->client->dev,
+				"%s(): HWMC subsystem not ready after %d ms, userspace queries may fail\n",
+				__func__, DS5_HW_RESET_TIMEOUT_MS);
+	}
+
 	dev_info(&state->client->dev,
 		"%s(): HW reset complete. Firmware: %d.%d.%d.%d\n",
 		__func__,
@@ -3126,24 +3200,24 @@ static int ds5_gvd(struct ds5 *state, unsigned char *data)
 	struct hwm_cmd cmd;
 	int ret = -1;
 	u16 length = 0;
-	u16 status = 2;
-	u8 retries = 3;
+	u16 status = DS5_HWMC_STATUS_WIP;
+	u8 retries = 20;
 
 	memcpy(&cmd, &gvd, sizeof(gvd));
 	ds5_raw_write_with_check(state, DS5_HWMC_DATA, &cmd, sizeof(cmd)); /* Write command data */
 	ds5_write_with_check(state, DS5_HWMC_EXEC, 0x01); /* execute cmd */
 	do {
-		if (retries != 3)
-			msleep_range(10);
+		if (retries != 20)
+			msleep_range(50);
 
 		ret = ds5_read(state, DS5_HWMC_STATUS, &status);
-	} while (ret && retries-- && status != 0);
+	} while ((ret || status == DS5_HWMC_STATUS_WIP) && retries--);
 
-	if (ret || status != 0) {
+	if (ret || status != DS5_HWMC_STATUS_OK) {
 		dev_err(&state->client->dev,
-				"%s(): Failed to read GVD, HWM cmd status: %x\n",
-				__func__, status);
-		return status;
+				"%s(): Failed to read GVD, HWM cmd status: %x, ret: %d\n",
+				__func__, status, ret);
+		return -EIO;
 	}
 
 	ret = ds5_raw_read(state, DS5_HWMC_RESP_LEN, &length, sizeof(length)); /* Read response length */

--- a/kernel/realsense/d4xx.c
+++ b/kernel/realsense/d4xx.c
@@ -6966,4 +6966,4 @@ MODULE_AUTHOR("Guennadi Liakhovetski <guennadi.liakhovetski@intel.com>,\n\
 				Shikun Ding <shikun.ding@intel.com>,\n\
 				Dmitry Perchanov <dmitry.perchanov@intel.com>");
 MODULE_LICENSE("GPL v2");
-MODULE_VERSION("1.0.2.21");
+MODULE_VERSION("1.0.2.22");

--- a/kernel/realsense/d4xx.c
+++ b/kernel/realsense/d4xx.c
@@ -497,6 +497,14 @@ struct ds5_counters {
 static atomic_t ds5_reset_gen = ATOMIC_INIT(0);
 static atomic_t ds5_probe_reset_once = ATOMIC_INIT(0);
 
+/* Cached device type from HW reset Step 8.
+ * During probe the first instance resets the camera, causing DS5_DEVICE_TYPE
+ * to temporarily return 0.  Step 8 polls until the register is valid and
+ * stores the result here so that all four probe instances (and any post-reset
+ * code path) can use the confirmed value even if the register read returns 0.
+ */
+static u16 ds5_cached_device_type;
+
 #ifdef CONFIG_VIDEO_D4XX_SERDES
 static DEFINE_MUTEX(serdes_lock__);
 
@@ -2720,10 +2728,11 @@ static int ds5_hw_reset_with_recovery(struct ds5 *state)
 		for (retry = 0; retry < DS5_HW_RESET_MAX_RETRIES; retry++) {
 			ret = ds5_read(state, DS5_DEVICE_TYPE, &dev_type);
 			if (ret == 0 && dev_type != 0) {
-				dev_dbg(&state->client->dev,
+				dev_info(&state->client->dev,
 					"%s(): Device type 0x%x ready after %d ms\n",
 					__func__, dev_type,
 					(retry + 1) * DS5_HW_RESET_POLL_INTERVAL_MS);
+				ds5_cached_device_type = dev_type;
 				break;
 			}
 			msleep(DS5_HW_RESET_POLL_INTERVAL_MS);
@@ -5390,6 +5399,16 @@ static int ds5_fixed_configuration(struct i2c_client *client, struct ds5 *state)
 	if (ret < 0)
 		return ret;
 
+	/* After HW reset the FW may not have populated DS5_DEVICE_TYPE yet.
+	 * Use the cached value confirmed by Step 8 in hw_reset_with_recovery.
+	 */
+	if (dev_type == 0 && ds5_cached_device_type != 0) {
+		dev_info(&client->dev,
+			"%s(): device type register returned 0, using cached type 0x%x\n",
+			__func__, ds5_cached_device_type);
+		dev_type = ds5_cached_device_type;
+	}
+
 	dev_dbg(&client->dev, "%s(): cfg0 %x %ux%u cfg0_md %x %ux%u\n", __func__,
 		 cfg0, dw, dh, cfg0_md, yw, yh);
 
@@ -5414,7 +5433,10 @@ static int ds5_fixed_configuration(struct i2c_client *client, struct ds5 *state)
 		sensor->formats = ds5_depth_formats_d46x;
 		break;
 	default:
-		sensor->formats = ds5_depth_formats_d46x;
+		dev_warn(&client->dev,
+			"%s(): unknown device type 0x%x, using D43X format tables\n",
+			__func__, dev_type);
+		sensor->formats = ds5_depth_formats_d43x;
 	}
 	sensor->n_formats = 1;
 	sensor->mux_pad = DS5_MUX_PAD_DEPTH;
@@ -5875,6 +5897,13 @@ static void ds5_adjust_sync_mode_control(struct i2c_client *client, struct ds5 *
 	if (ret < 0) {
 		dev_warn(&client->dev, "%s(): Failed to read device type\n", __func__);
 		return;
+	}
+
+	if (dev_type == 0 && ds5_cached_device_type != 0) {
+		dev_info(&client->dev,
+			"%s(): device type register returned 0, using cached type 0x%x\n",
+			__func__, ds5_cached_device_type);
+		dev_type = ds5_cached_device_type;
 	}
 
 	switch (dev_type) {

--- a/kernel/realsense/d4xx.c
+++ b/kernel/realsense/d4xx.c
@@ -2356,9 +2356,33 @@ static int ds5_hw_reset_serdes_recovery(struct ds5 *state, bool force_phase2)
 	int i;
 	u16 tmp = 0;
 	bool sibling_alive = false;
+	struct ds5 *primary = state; /* the instance that ran SERDES setup */
 
 	if (!state->ser_dev || !state->dser_dev)
 		return 0;
+
+	/* The deserializer/serializer API calls (setup_link, setup_control)
+	 * require the device that was originally paired via sdev_pair/
+	 * sdev_register during probe.  Only the primary instance (the first
+	 * probe of each physical camera) performs that pairing.  If we are
+	 * called from a non-primary instance (e.g. IMU = 9-001d) we must
+	 * find and use the primary's device, otherwise the deserializer
+	 * returns "no sdev found" (-EINVAL).
+	 */
+	if (!state->serdes_primary) {
+		for (i = 0; i < MAX_DEV_NUM; i++) {
+			struct ds5 *p = serdes_inited[i];
+
+			if (p && p->serdes_primary &&
+			    p->ser_dev == state->ser_dev) {
+				primary = p;
+				dev_dbg(&state->client->dev,
+					"%s(): using primary instance %s for SERDES API calls\n",
+					__func__, dev_name(&primary->client->dev));
+				break;
+			}
+		}
+	}
 
 	if (!force_phase2) {
 		/* Phase 1 — serializer-only re-init (per-camera, safe) */
@@ -2372,18 +2396,43 @@ static int ds5_hw_reset_serdes_recovery(struct ds5 *state, bool force_phase2)
 
 		msleep(100);
 
-		/* Verify I2C link to camera is working */
+		/* Verify I2C link to camera is working AND stable.
+		 * A single successful read is not enough — the D457 FW can
+		 * momentarily restore the GMSL link during its late-boot
+		 * serializer reconfiguration, only to kill it again ~100 ms
+		 * later.  Do multiple reads with delays to catch oscillation.
+		 */
 		ret = ds5_read(state, DS5_FW_VERSION, &tmp);
 		if (ret == 0) {
-			dev_info(&state->client->dev,
-				"%s(): Phase 1 succeeded, I2C link OK\n", __func__);
-			return 0;
-		}
+			int k;
+			bool stable = true;
 
-		/* Phase 2 — I2C still broken; consider full deserializer reset */
-		dev_warn(&state->client->dev,
-			"%s(): Phase 1 failed (I2C err %d), checking siblings before deser reset\n",
-			__func__, ret);
+			for (k = 0; k < 3; k++) {
+				msleep(200);
+				ret = ds5_read(state, DS5_FW_VERSION, &tmp);
+				if (ret < 0) {
+					dev_warn(&state->client->dev,
+						"%s(): Phase 1 stability check %d/3 failed (err %d)\n",
+						__func__, k + 1, ret);
+					stable = false;
+					break;
+				}
+			}
+			if (stable) {
+				dev_info(&state->client->dev,
+					"%s(): Phase 1 succeeded, I2C link stable (3 consecutive reads OK)\n",
+					__func__);
+				return 0;
+			}
+			dev_warn(&state->client->dev,
+				"%s(): Phase 1 link unstable, escalating to Phase 2\n",
+				__func__);
+		} else {
+			/* Phase 2 — I2C still broken; consider full deserializer reset */
+			dev_warn(&state->client->dev,
+				"%s(): Phase 1 failed (I2C err %d), checking siblings before deser reset\n",
+				__func__, ret);
+		}
 	} else {
 		dev_info(&state->client->dev,
 			"%s(): Phase 2 forced (I2C link unstable after Phase 1), checking siblings\n",
@@ -2446,24 +2495,63 @@ static int ds5_hw_reset_serdes_recovery(struct ds5 *state, bool force_phase2)
 	dev_info(&state->client->dev,
 		"%s(): Phase 2 - performing full deserializer reset\n", __func__);
 
+	/* Use reset_oneshot (software GMSL link reset) rather than a full
+	 * GPIO power cycle.  reset_oneshot preserves the MAX9296's I2C
+	 * pass-through table and per-pipe config while re-initializing the
+	 * GMSL link channels.  Testing shows the GMSL link reliably
+	 * re-establishes after reset_oneshot (typically 2-4 s), whereas a
+	 * full power_off/power_on GPIO reset destroys all deserializer
+	 * state and the link does NOT come back.
+	 */
 	mutex_lock(&serdes_lock__);
 	state->dser_ops->reset_oneshot(state->dser_dev);
 	msleep(300);
 
-	/* Re-establish link & control for this camera's serializer */
-	ret = state->dser_ops->setup_link(state->dser_dev, &state->client->dev);
+	/* setup_link writes to deserializer registers via host I2C (always
+	 * reachable, no GMSL needed).  This configures the link mode so
+	 * GMSL auto-negotiation can proceed.
+	 */
+	ret = state->dser_ops->setup_link(state->dser_dev, &primary->client->dev);
 	if (ret)
 		dev_warn(&state->client->dev,
 			"%s(): deser setup_link failed: %d\n", __func__, ret);
+	mutex_unlock(&serdes_lock__);
 
-	msleep(100);
+	/* The GMSL link may take several seconds to fully re-establish
+	 * after reset_oneshot.  In testing, the D457 camera's serializer
+	 * becomes reachable 2-4 s after the reset.  Poll for I2C recovery
+	 * before attempting serializer/deserializer control setup.
+	 */
+	for (i = 0; i < 8; i++) {
+		msleep(500);
+		ret = ds5_read(state, DS5_FW_VERSION, &tmp);
+		if (ret == 0) {
+			dev_info(&state->client->dev,
+				"%s(): Phase 2: I2C link up after %d ms\n",
+				__func__, (i + 1) * 500 + 300);
+			break;
+		}
+	}
+
+	if (ret < 0) {
+		dev_err(&state->client->dev,
+			"%s(): Phase 2 failed, I2C unrecoverable after %d ms\n",
+			__func__, 8 * 500 + 300);
+		return ret;
+	}
+
+	/* GMSL link is up — now configure serializer and deserializer.
+	 * Use the primary instance's device for deserializer API calls
+	 * (the one paired via sdev_pair/sdev_register during probe).
+	 */
+	mutex_lock(&serdes_lock__);
 
 	ret = max9295_setup_control(state->ser_dev);
 	if (ret)
 		dev_warn(&state->client->dev,
 			"%s(): ser setup_control failed: %d\n", __func__, ret);
 
-	ret = state->dser_ops->setup_control(state->dser_dev, &state->client->dev);
+	ret = state->dser_ops->setup_control(state->dser_dev, &primary->client->dev);
 	if (ret)
 		dev_warn(&state->client->dev,
 			"%s(): deser setup_control failed: %d\n", __func__, ret);
@@ -2480,13 +2568,25 @@ static int ds5_hw_reset_serdes_recovery(struct ds5 *state, bool force_phase2)
 
 	mutex_unlock(&serdes_lock__);
 
-	/* Verify I2C link after full recovery */
-	ret = ds5_read(state, DS5_FW_VERSION, &tmp);
-	if (ret < 0) {
-		dev_err(&state->client->dev,
-			"%s(): Phase 2 failed, I2C still broken: %d\n",
-			__func__, ret);
-		return ret;
+	/* Final stability check — ensure the link is reliably up */
+	{
+		int k;
+		bool stable = true;
+
+		for (k = 0; k < 3; k++) {
+			msleep(200);
+			ret = ds5_read(state, DS5_FW_VERSION, &tmp);
+			if (ret < 0) {
+				stable = false;
+				break;
+			}
+		}
+		if (!stable) {
+			dev_err(&state->client->dev,
+				"%s(): Phase 2 setup done but I2C unstable: %d\n",
+				__func__, ret);
+			return ret;
+		}
 	}
 
 	dev_info(&state->client->dev,
@@ -2870,9 +2970,10 @@ static int ds5_hw_reset_with_recovery(struct ds5 *state)
 
 #ifdef CONFIG_VIDEO_D4XX_SERDES
 	/* 10. Post-reset I2C stability verification.
-	 *     Some camera SKUs (notably D401 with FW 5.17.x) have a secondary
-	 *     FW initialization phase that briefly drops the I2C bus ~65ms after
-	 *     the initial readiness checks (Steps 7-9) pass.  If we return now,
+	 *     Some camera SKUs have a secondary FW initialization phase that
+	 *     briefly drops the I2C bus ~65-110ms after the initial readiness
+	 *     checks (Steps 7-9) pass.  This has been observed on both D401
+	 *     (FW 5.17.x) and D457 (FW 5.17.2.7).  If we return now,
 	 *     userspace HWMC queries NAK, the viewer triggers another reset,
 	 *     and repeated rapid resets degrade the GMSL link until SERDES pipe
 	 *     setup fails and the device is unrecoverable without a host reboot.
@@ -5076,6 +5177,9 @@ static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on)
 	struct ds5_sensor *sensor = state->mux.last_set;
 	u16 expected_streaming_state;
 	bool ds5_config_done = !on; /* for stop, skip config */
+#ifdef CONFIG_VIDEO_D4XX_SERDES
+	int serdes_recovery_attempts = 0;
+#endif
 
 	// spare duplicate calls
 	if (sensor->streaming == on)
@@ -5121,6 +5225,9 @@ static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on)
 		status = DS5_STATUS_STREAMING;
 	}
 
+#ifdef CONFIG_VIDEO_D4XX_SERDES
+retry_after_serdes_recovery:
+#endif
 	/* Verify stream is in the expected state before issuing command */
 	ts = jiffies;
 	for (timeout = ts + msecs_to_jiffies(DS5_START_MAX_TIME), i = 0;
@@ -5226,6 +5333,58 @@ static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on)
 		dev_warn(&state->client->dev,
 			"stream %d toggle to %d timeout in %dms, retries %d\n",
 			stream_id, on, jiffies_to_msecs(jiffies - ts), i);
+
+#ifdef CONFIG_VIDEO_D4XX_SERDES
+		/* Stream start timed out.  Probe the I2C link: if it is dead
+		 * (EREMOTEIO / -121), the GMSL link dropped — possibly a
+		 * delayed secondary failure after a prior HW reset.  Attempt
+		 * SerDes recovery (Phase 1: serializer re-init, Phase 2: full
+		 * deserializer reset if serializer is also unreachable) and
+		 * retry the stream start once.
+		 */
+		if (on && serdes_recovery_attempts < 2 &&
+		    state->ser_dev && state->dser_dev) {
+			u16 probe_val;
+			int probe_ret = ds5_read(state, DS5_FW_VERSION, &probe_val);
+
+			if (probe_ret < 0) {
+				serdes_recovery_attempts++;
+				dev_warn(&state->client->dev,
+					"stream %d: I2C link dead (err %d), "
+					"attempting GMSL recovery (attempt %d/2)\n",
+					stream_id, probe_ret,
+					serdes_recovery_attempts);
+
+				/* Clean up partial state from the failed attempt */
+				sensor->streaming = restore_val;
+				ds5_invalidate_sensor(state, sensor);
+
+				/* 1st attempt: Phase 1 (ser re-init), escalate to
+				 *   Phase 2 (reset_oneshot + poll) if unstable.
+				 * 2nd attempt: skip Phase 1, go straight to Phase 2.
+				 *   The reset_oneshot from attempt 1 may have already
+				 *   started the link recovery — Phase 2 polling will
+				 *   detect it.
+				 */
+				if (ds5_hw_reset_serdes_recovery(state,
+						serdes_recovery_attempts > 1) == 0) {
+					dev_info(&state->client->dev,
+						"stream %d: GMSL recovery OK, "
+						"retrying stream start\n",
+						stream_id);
+					ds5_config_done = false;
+					ds5_config_retries = MAX_DS5_CONFIG_RETRIES;
+					status = on ? 0 : DS5_STATUS_STREAMING;
+					goto retry_after_serdes_recovery;
+				}
+				dev_err(&state->client->dev,
+					"stream %d: GMSL recovery failed "
+					"(attempt %d/2), stream start aborted\n",
+					stream_id, serdes_recovery_attempts);
+			}
+		}
+#endif
+
 		if (streaming == expected_streaming_state) { /* try to toggle stream back on timeout  */
 			ds5_write(state, DS5_START_STOP_STREAM,
 				(on ? DS5_STREAM_STOP : DS5_STREAM_START) | stream_id);

--- a/kernel/realsense/d4xx.c
+++ b/kernel/realsense/d4xx.c
@@ -6937,4 +6937,4 @@ MODULE_AUTHOR("Guennadi Liakhovetski <guennadi.liakhovetski@intel.com>,\n\
 				Shikun Ding <shikun.ding@intel.com>,\n\
 				Dmitry Perchanov <dmitry.perchanov@intel.com>");
 MODULE_LICENSE("GPL v2");
-MODULE_VERSION("1.0.2.20");
+MODULE_VERSION("1.0.2.21");

--- a/kernel/realsense/d4xx.c
+++ b/kernel/realsense/d4xx.c
@@ -6450,4 +6450,4 @@ MODULE_AUTHOR("Guennadi Liakhovetski <guennadi.liakhovetski@intel.com>,\n\
 				Shikun Ding <shikun.ding@intel.com>,\n\
 				Dmitry Perchanov <dmitry.perchanov@intel.com>");
 MODULE_LICENSE("GPL v2");
-MODULE_VERSION("1.0.2.17");
+MODULE_VERSION("1.0.2.18");

--- a/kernel/realsense/d4xx.c
+++ b/kernel/realsense/d4xx.c
@@ -484,6 +484,7 @@ struct ds5 {
 	struct i2c_client *ser_i2c;
 	struct i2c_client *dser_i2c;
 	const struct dser_interface *dser_ops;
+	bool serdes_primary; /* true for the instance that ran SERDES setup */
 #endif
 };
 
@@ -3857,11 +3858,30 @@ static int ds5_board_setup(struct ds5 *state)
 	state->g_ctx.s_dev = dev;
 
 	for (i = 0; i < MAX_DEV_NUM; i++) {
+		if (serdes_inited[i] && serdes_inited[i]->ser_dev == state->ser_dev) {
+			/* Same camera, different stream instance.
+			 * Register in serdes_inited[] so peer iteration
+			 * can find it, but return -ENOTSUPP to skip
+			 * duplicate SERDES setup.
+			 */
+			int j;
+
+			for (j = i + 1; j < MAX_DEV_NUM; j++) {
+				if (!serdes_inited[j]) {
+					serdes_inited[j] = state;
+					dev_info(dev, "registered peer instance in serdes_inited[%d]\n", j);
+					return -ENOTSUPP;
+				}
+			}
+			dev_err(dev, "cannot register more than %d D4XX instances\n", MAX_DEV_NUM);
+			return -ENOTSUPP;
+		}
+	}
+	/* First instance of a new camera */
+	for (i = 0; i < MAX_DEV_NUM; i++) {
 		if (!serdes_inited[i]) {
 			serdes_inited[i] = state;
 			return 0;
-		} else if (serdes_inited[i]->ser_dev == state->ser_dev) {
-			return -ENOTSUPP;
 		}
 	}
 	err = -EINVAL;
@@ -4004,11 +4024,24 @@ static int ds5_board_setup(struct ds5 *state)
 	state->g_ctx.s_dev = dev;
 
 	for (i = 0; i < MAX_DEV_NUM; i++) {
+		if (serdes_inited[i] && serdes_inited[i]->ser_dev == state->ser_dev) {
+			int j;
+
+			for (j = i + 1; j < MAX_DEV_NUM; j++) {
+				if (!serdes_inited[j]) {
+					serdes_inited[j] = state;
+					dev_info(dev, "registered peer instance in serdes_inited[%d]\n", j);
+					return -ENOTSUPP;
+				}
+			}
+			dev_err(dev, "cannot register more than %d D4XX instances\n", MAX_DEV_NUM);
+			return -ENOTSUPP;
+		}
+	}
+	for (i = 0; i < MAX_DEV_NUM; i++) {
 		if (!serdes_inited[i]) {
 			serdes_inited[i] = state;
 			return 0;
-		} else if (serdes_inited[i]->ser_dev == state->ser_dev) {
-			return -ENOTSUPP;
 		}
 	}
 	err = -EINVAL;
@@ -4070,11 +4103,17 @@ static int ds5_serdes_setup(struct ds5 *state)
 
 	ret = ds5_board_setup(state);
 	if (ret) {
-		if (ret == -ENOTSUPP)
+		if (ret == -ENOTSUPP) {
+			/* Peer instance of already-initialized camera.
+			 * Registered in serdes_inited[] but skips SERDES setup.
+			 */
+			state->serdes_primary = false;
 			return 0;
+		}
 		dev_err(&c->dev, "board setup failed\n");
 		return ret;
 	}
+	state->serdes_primary = true;
 
 	/* Pair sensor to serializer dev */
 	ret = max9295_sdev_pair(state->ser_dev, &state->g_ctx);
@@ -4858,10 +4897,17 @@ static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on)
 			"stream %d in expected state, toggling to %d (status: 0x%04x) %dms\n",
 			stream_id, on, status, jiffies_to_msecs(jiffies - ts));
 	} else {
+		/* After HW reset the FW reboots and all streams return to
+		 * idle.  If VI error recovery tries to stop a stream that
+		 * is already stopped (or start one already started), treat
+		 * it as a no-op so the upper layer can proceed with
+		 * restart instead of getting stuck in an EBUSY loop.
+		 */
 		dev_warn(&state->client->dev,
-			"stream %d in %d state already (status: 0x%04x) %dms, return busy\n",
+			"stream %d in %d state already (status: 0x%04x) %dms, treating as no-op\n",
 			stream_id, on, status, jiffies_to_msecs(jiffies - ts));
-		return -EBUSY;
+		sensor->streaming = on;
+		return 0;
 	}
 
 	restore_val = sensor->streaming;
@@ -6303,6 +6349,14 @@ static int ds5_remove(struct i2c_client *c)
 	for (i = 0; i < MAX_DEV_NUM; i++) {
 		if (serdes_inited[i] && serdes_inited[i] == state) {
 			serdes_inited[i] = NULL;
+
+			/* Only the primary instance (the one that did SERDES
+			 * setup) should tear down the serializer/deserializer.
+			 * Peer instances just unregister from the array.
+			 */
+			if (!state->serdes_primary)
+				break;
+
 			mutex_lock(&serdes_lock__);
 
 			ret = max9295_reset_control(state->ser_dev);

--- a/kernel/realsense/d4xx.c
+++ b/kernel/realsense/d4xx.c
@@ -6478,4 +6478,4 @@ MODULE_AUTHOR("Guennadi Liakhovetski <guennadi.liakhovetski@intel.com>,\n\
 				Shikun Ding <shikun.ding@intel.com>,\n\
 				Dmitry Perchanov <dmitry.perchanov@intel.com>");
 MODULE_LICENSE("GPL v2");
-MODULE_VERSION("1.0.2.18");
+MODULE_VERSION("1.0.2.19");

--- a/kernel/realsense/d4xx.c
+++ b/kernel/realsense/d4xx.c
@@ -6590,4 +6590,4 @@ MODULE_AUTHOR("Guennadi Liakhovetski <guennadi.liakhovetski@intel.com>,\n\
 				Shikun Ding <shikun.ding@intel.com>,\n\
 				Dmitry Perchanov <dmitry.perchanov@intel.com>");
 MODULE_LICENSE("GPL v2");
-MODULE_VERSION("1.0.2.19");
+MODULE_VERSION("1.0.2.20");

--- a/kernel/realsense/d4xx.c
+++ b/kernel/realsense/d4xx.c
@@ -30,6 +30,7 @@
 #include <linux/string.h>
 #include <linux/videodev2.h>
 #include <linux/version.h>
+#include <linux/mutex.h>
 #include <media/media-entity.h>
 #include <media/v4l2-ctrls.h>
 #include <media/v4l2-device.h>
@@ -2428,9 +2429,9 @@ static int ds5_hw_reset_serdes_recovery(struct ds5 *state, bool force_phase2)
 		 * later.  Do multiple reads with delays to catch oscillation.
 		 */
 		ret = ds5_read(state, DS5_FW_VERSION, &tmp);
-        if (ret == 0) {
-            int k;
-            bool stable = true;
+		if (ret == 0) {
+			int k;
+			bool stable = true;
 
 			for (k = 0; k < DS5_HW_RESET_STABILITY_READS; k++) {
 				msleep(DS5_HW_RESET_STABILITY_INTERVAL_MS);
@@ -6692,11 +6693,13 @@ static int ds5_probe(struct i2c_client *c, const struct i2c_device_id *id)
 	state->reset_ref_dser = atomic_read(dser_get_reset_gen(state));
 #else
 	ds5_init_global_slots_once();
+	mutex_lock(&ds5_inited[0].lock);
 	if (NULL == ds5_inited[0].ds5_primary) {
 		ds5_init_ds5_dev(state, &ds5_inited[0]);
 		dev_dbg(&c->dev, "%s(): set primary ds5 instance\n", __func__);
 	}
 	state->ds5_dev = &ds5_inited[0];
+	mutex_unlock(&ds5_inited[0].lock);
 #endif
 	state->reset_ref_ds5 = atomic_read(ds5_get_reset_gen(state));
 

--- a/kernel/realsense/d4xx.c
+++ b/kernel/realsense/d4xx.c
@@ -6270,15 +6270,43 @@ static int ds5_probe(struct i2c_client *c, const struct i2c_device_id *id)
 	if (atomic_cmpxchg(&ds5_probe_reset_once, 0, 1) == 0) {
 		dev_info(&c->dev, "%s(): first probe instance, running HW reset recovery\n",
 			__func__);
+
+		/* Initialize sensor pipe_ids to PIPE_NOT_CONFIGURED before
+		 * hw_reset_with_recovery, otherwise the kzalloc default of 0
+		 * causes a spurious release_pipe(0) in step 2.
+		 */
+		state->depth.sensor.pipe_id = PIPE_NOT_CONFIGURED;
+		state->ir.sensor.pipe_id = PIPE_NOT_CONFIGURED;
+		state->rgb.sensor.pipe_id = PIPE_NOT_CONFIGURED;
+		state->imu.sensor.pipe_id = PIPE_NOT_CONFIGURED;
+
 		ret = ds5_hw_reset_with_recovery(state);
 		if (ret < 0) {
 			dev_err(&c->dev, "%s(): probe HW reset recovery failed: %d\n",
 				__func__, ret);
 			goto e_chardev;
 		}
+
+		/* Allow the camera firmware to fully stabilize after HW reset
+		 * before subsequent driver instances attempt I2C communication.
+		 * Without this delay, the D457's FW may be briefly unresponsive
+		 * during a post-reset initialization phase, causing later probe
+		 * instances (especially the 4th/IMU) to fail I2C checks.
+		 */
+		msleep(100);
 	}
 
-	ret = ds5_read(state, 0x5020, &rec_state);
+	/* Verify communication with retries and delay.
+	 * After HW reset (done by the first probe instance), the camera
+	 * firmware may still be initializing and briefly NAK I2C requests.
+	 * Use the same retry pattern as the initial communication check.
+	 */
+	retry = 10;
+	do {
+		ret = ds5_read(state, 0x5020, &rec_state);
+		if (ret < 0)
+			msleep(50);
+	} while (retry-- && ret < 0);
 	if (ret < 0) {
 		dev_err(&c->dev, "%s(): cannot communicate with D4XX: %d\n",
 				__func__, ret);

--- a/kernel/realsense/d4xx.c
+++ b/kernel/realsense/d4xx.c
@@ -517,20 +517,31 @@ static struct dser_reset_gen dser_reset_gens[MAX_DSER_NUM];
 static atomic_t *ds5_get_reset_gen(struct ds5 *state)
 {
 	int i;
+	int free_idx = -1;
+	atomic_t *gen = &ds5_reset_gen;
 
 	if (state->dser_dev) {
+		mutex_lock(&serdes_lock__);
 		for (i = 0; i < MAX_DSER_NUM; i++) {
-			if (dser_reset_gens[i].dser_dev == state->dser_dev)
-				return &dser_reset_gens[i].gen;
-			if (!dser_reset_gens[i].dser_dev) {
-				dser_reset_gens[i].dser_dev = state->dser_dev;
-				atomic_set(&dser_reset_gens[i].gen, 0);
-				return &dser_reset_gens[i].gen;
+			if (dser_reset_gens[i].dser_dev == state->dser_dev) {
+				gen = &dser_reset_gens[i].gen;
+				goto out_unlock;
 			}
+			if (!dser_reset_gens[i].dser_dev && free_idx < 0)
+				free_idx = i;
 		}
+
+		if (free_idx >= 0) {
+			dser_reset_gens[free_idx].dser_dev = state->dser_dev;
+			atomic_set(&dser_reset_gens[free_idx].gen, 0);
+			gen = &dser_reset_gens[free_idx].gen;
+		}
+out_unlock:
+		mutex_unlock(&serdes_lock__);
 	}
+
 	/* Fallback: table full or no deserializer */
-	return &ds5_reset_gen;
+	return gen;
 }
 #else
 static inline atomic_t *ds5_get_reset_gen(struct ds5 *state)
@@ -2292,9 +2303,9 @@ static int ds5_set_calibration_data(struct ds5 *state,
  * ds5_hw_reset_serdes_recovery - Tiered SERDES recovery after HW reset.
  *
  * Phase 1: Re-init serializer only (per-camera, non-disruptive).
- * Phase 2: If I2C still fails, check whether all sibling cameras on the
- *          same deserializer are also dead.  Only then perform a full
- *          deserializer reset_oneshot (chip-wide, disruptive).
+ * Phase 2: If I2C still fails, perform a full deserializer reset_oneshot
+ *          (chip-wide, disruptive) only when no sibling camera on the same
+ *          deserializer is currently reachable over I2C and streaming.
  *
  * Returns 0 on success, negative errno on failure.
  */
@@ -2484,7 +2495,6 @@ static int ds5_hw_reset_with_recovery(struct ds5 *state)
 	int retry;
 	int __maybe_unused i;
 	u16 status = 0;
-	bool device_went_down = false;
 
 	dev_info(&state->client->dev, "%s(): Initiating HW reset with recovery\n",
 		__func__);
@@ -2623,7 +2633,6 @@ static int ds5_hw_reset_with_recovery(struct ds5 *state)
 
 		if (ret < 0) {
 			/* I2C failed - device is resetting (expected during reset) */
-			device_went_down = true;
 			dev_dbg(&state->client->dev,
 				"%s(): Device not responding (resetting), retry %d\n",
 				__func__, retry);
@@ -3874,7 +3883,7 @@ static int ds5_board_setup(struct ds5 *state)
 				}
 			}
 			dev_err(dev, "cannot register more than %d D4XX instances\n", MAX_DEV_NUM);
-			return -ENOTSUPP;
+			return -ENOSPC;
 		}
 	}
 	/* First instance of a new camera */
@@ -4035,7 +4044,7 @@ static int ds5_board_setup(struct ds5 *state)
 				}
 			}
 			dev_err(dev, "cannot register more than %d D4XX instances\n", MAX_DEV_NUM);
-			return -ENOTSUPP;
+			return -ENOSPC;
 		}
 	}
 	for (i = 0; i < MAX_DEV_NUM; i++) {
@@ -6414,7 +6423,7 @@ static int ds5_remove(struct i2c_client *c)
 	}
 	if (state->ser_i2c)
 		i2c_unregister_device(state->ser_i2c);
-	if (state->dser_i2c)
+	if (state->dser_i2c && !state->aggregated)
 		i2c_unregister_device(state->dser_i2c);
 #endif
 #ifndef CONFIG_TEGRA_CAMERA_PLATFORM

--- a/kernel/realsense/d4xx.c
+++ b/kernel/realsense/d4xx.c
@@ -499,6 +499,55 @@ static atomic_t ds5_probe_reset_once = ATOMIC_INIT(0);
 #ifdef CONFIG_VIDEO_D4XX_SERDES
 static DEFINE_MUTEX(serdes_lock__);
 
+/*
+ * Per-deserializer reset generation counter.
+ * Replaces the old global ds5_reset_gen for SERDES builds so that
+ * resetting camera A does not force camera B (on a different deserializer)
+ * to invalidate its state.  Cameras sharing the same deserializer still
+ * see each other's resets through the shared counter.
+ */
+#define MAX_DSER_NUM 8
+struct dser_reset_gen {
+	struct device *dser_dev;
+	atomic_t gen;
+};
+static struct dser_reset_gen dser_reset_gens[MAX_DSER_NUM];
+
+static atomic_t *ds5_get_reset_gen(struct ds5 *state)
+{
+	int i;
+
+	if (state->dser_dev) {
+		for (i = 0; i < MAX_DSER_NUM; i++) {
+			if (dser_reset_gens[i].dser_dev == state->dser_dev)
+				return &dser_reset_gens[i].gen;
+			if (!dser_reset_gens[i].dser_dev) {
+				dser_reset_gens[i].dser_dev = state->dser_dev;
+				atomic_set(&dser_reset_gens[i].gen, 0);
+				return &dser_reset_gens[i].gen;
+			}
+		}
+	}
+	/* Fallback: table full or no deserializer */
+	return &ds5_reset_gen;
+}
+#else
+static inline atomic_t *ds5_get_reset_gen(struct ds5 *state)
+{
+	return &ds5_reset_gen;
+}
+#endif
+
+/*
+ * max 24 number from this link:
+ * https://docs.nvidia.com/jetson/archives/r35.1/DeveloperGuide/text/
+ * SD/CameraDevelopment/JetsonVirtualChannelWithGmslCameraFramework.html
+ * #jetson-agx-xavier-series
+ */
+#define MAX_DEV_NUM 24
+#ifdef CONFIG_VIDEO_D4XX_SERDES
+static struct ds5 *serdes_inited[MAX_DEV_NUM];
+
 /* MAX9296 deserializer interface implementation */
 static const struct dser_interface max9296_interface = {
 	.get_available_pipe_id = max9296_get_available_pipe_id,
@@ -1711,7 +1760,7 @@ static int ds5_configure(struct ds5 *state)
 	u16 height_value = 0;
 	int ret;
 
-	current_reset_gen = atomic_read(&ds5_reset_gen);
+	current_reset_gen = atomic_read(ds5_get_reset_gen(state));
 	if (state->reset_gen != current_reset_gen) {
 		struct ds5_sensor *active = ds5_get_active_sensor(state);
 
@@ -2239,13 +2288,164 @@ static int ds5_set_calibration_data(struct ds5 *state,
 #define DS5_HW_RESET_DFU_MAGIC_LSW	0x0201  /* Lower 16 bits of 0x04030201 */
 
 /*
+ * ds5_hw_reset_serdes_recovery - Tiered SERDES recovery after HW reset.
+ *
+ * Phase 1: Re-init serializer only (per-camera, non-disruptive).
+ * Phase 2: If I2C still fails, check whether all sibling cameras on the
+ *          same deserializer are also dead.  Only then perform a full
+ *          deserializer reset_oneshot (chip-wide, disruptive).
+ *
+ * Returns 0 on success, negative errno on failure.
+ */
+#ifdef CONFIG_VIDEO_D4XX_SERDES
+static int ds5_hw_reset_serdes_recovery(struct ds5 *state)
+{
+	int ret;
+	int i;
+	u16 tmp = 0;
+	bool sibling_alive = false;
+
+	if (!state->ser_dev || !state->dser_dev)
+		return 0;
+
+	/* Phase 1 — serializer-only re-init (per-camera, safe) */
+	dev_info(&state->client->dev,
+		"%s(): Phase 1 - re-initializing serializer\n", __func__);
+	ret = max9295_init_settings(state->ser_dev);
+	if (ret < 0)
+		dev_warn(&state->client->dev,
+			"%s(): serializer init_settings failed: %d\n",
+			__func__, ret);
+
+	msleep(100);
+
+	/* Verify I2C link to camera is working */
+	ret = ds5_read(state, DS5_FW_VERSION, &tmp);
+	if (ret == 0) {
+		dev_info(&state->client->dev,
+			"%s(): Phase 1 succeeded, I2C link OK\n", __func__);
+		return 0;
+	}
+
+	/* Phase 2 — I2C still broken; consider full deserializer reset */
+	dev_warn(&state->client->dev,
+		"%s(): Phase 1 failed (I2C err %d), checking siblings before deser reset\n",
+		__func__, ret);
+
+	for (i = 0; i < MAX_DEV_NUM; i++) {
+		struct ds5 *sib = serdes_inited[i];
+
+		if (!sib || sib == state || sib->dser_dev != state->dser_dev)
+			continue;
+
+		/* Check if sibling can still communicate over I2C */
+		if (ds5_read(sib, DS5_FW_VERSION, &tmp) == 0) {
+			/* Check if sibling has any active stream */
+			if (sib->depth.sensor.streaming ||
+			    sib->ir.sensor.streaming ||
+			    sib->rgb.sensor.streaming ||
+			    sib->imu.sensor.streaming) {
+				sibling_alive = true;
+				dev_warn(&state->client->dev,
+					"%s(): sibling %s alive & streaming, skipping deser reset\n",
+					__func__, dev_name(&sib->client->dev));
+				break;
+			}
+		}
+	}
+
+	if (sibling_alive) {
+		dev_err(&state->client->dev,
+			"%s(): GMSL link broken but sibling streaming — cannot reset deserializer. "
+			"Manual recovery (driver reload / camera power cycle) may be needed.\n",
+			__func__);
+		return -EIO;
+	}
+
+	/* All siblings dead or none exist — safe to reset entire deserializer */
+	dev_info(&state->client->dev,
+		"%s(): Phase 2 - performing full deserializer reset\n", __func__);
+
+	mutex_lock(&serdes_lock__);
+	state->dser_ops->reset_oneshot(state->dser_dev);
+	msleep(300);
+
+	/* Re-establish link & control for this camera's serializer */
+	ret = state->dser_ops->setup_link(state->dser_dev, &state->client->dev);
+	if (ret)
+		dev_warn(&state->client->dev,
+			"%s(): deser setup_link failed: %d\n", __func__, ret);
+
+	msleep(100);
+
+	ret = max9295_setup_control(state->ser_dev);
+	if (ret)
+		dev_warn(&state->client->dev,
+			"%s(): ser setup_control failed: %d\n", __func__, ret);
+
+	ret = state->dser_ops->setup_control(state->dser_dev, &state->client->dev);
+	if (ret)
+		dev_warn(&state->client->dev,
+			"%s(): deser setup_control failed: %d\n", __func__, ret);
+
+	ret = max9295_init_settings(state->ser_dev);
+	if (ret)
+		dev_warn(&state->client->dev,
+			"%s(): ser init_settings failed: %d\n", __func__, ret);
+
+	ret = state->dser_ops->init_settings(state->dser_dev);
+	if (ret)
+		dev_warn(&state->client->dev,
+			"%s(): deser init_settings failed: %d\n", __func__, ret);
+
+	mutex_unlock(&serdes_lock__);
+
+	/* Verify I2C link after full recovery */
+	ret = ds5_read(state, DS5_FW_VERSION, &tmp);
+	if (ret < 0) {
+		dev_err(&state->client->dev,
+			"%s(): Phase 2 failed, I2C still broken: %d\n",
+			__func__, ret);
+		return ret;
+	}
+
+	dev_info(&state->client->dev,
+		"%s(): Phase 2 succeeded, full deser recovery complete\n", __func__);
+
+	/* Invalidate all sibling cameras so they re-configure on next stream start */
+	for (i = 0; i < MAX_DEV_NUM; i++) {
+		struct ds5 *sib = serdes_inited[i];
+
+		if (!sib || sib == state || sib->dser_dev != state->dser_dev)
+			continue;
+
+		ds5_invalidate_sensor(sib, &sib->depth.sensor);
+		ds5_invalidate_sensor(sib, &sib->ir.sensor);
+		ds5_invalidate_sensor(sib, &sib->rgb.sensor);
+		ds5_invalidate_sensor(sib, &sib->imu.sensor);
+		sib->depth.sensor.streaming = false;
+		sib->ir.sensor.streaming = false;
+		sib->rgb.sensor.streaming = false;
+		sib->imu.sensor.streaming = false;
+
+		dev_warn(&state->client->dev,
+			"%s(): invalidated sibling %s after deser reset\n",
+			__func__, dev_name(&sib->client->dev));
+	}
+
+	return 0;
+}
+#endif /* CONFIG_VIDEO_D4XX_SERDES */
+
+/*
  * ds5_hw_reset_with_recovery - Perform hardware reset with GMSL recovery
  * @state: Driver state structure
  *
- * This function sends a hardware reset command to the D4XX device and
- * waits for it to come back online. For GMSL connections, unlike USB,
- * there is no automatic re-enumeration, so we must poll the device
- * until it becomes responsive again.
+ * Sends a hardware reset command to the D4XX device and waits for it to
+ * come back online.  Before resetting, stops active streams and invalidates
+ * all driver-side sensor state (streaming flags, SERDES pipes, config cache).
+ * After the device responds, performs tiered SERDES recovery (serializer-only
+ * first, full deserializer reset only when all siblings are also dead).
  *
  * Returns 0 on success, negative error code on failure.
  */
@@ -2253,45 +2453,75 @@ static int ds5_hw_reset_with_recovery(struct ds5 *state)
 {
 	int ret;
 	int retry;
+	int i;
 	u16 status = 0;
 	bool device_went_down = false;
-
-	dev_info(&state->client->dev, "%s(): Initiating HW reset with recovery\n",
-		__func__);
-
-	/* Invalidate cached sensor configs and release SERDES pipes before reset, since reset will clear device state but not driver state.
-	    This ensures we don't try to reuse stale configs or pipes after reset. */
-	/* TBD: Open for single instance architecture and remove ds5_invalidate_sensor multi instance solution
 	struct ds5_sensor *sensors[] = {
 		&state->depth.sensor,
 		&state->ir.sensor,
 		&state->rgb.sensor,
 		&state->imu.sensor,
 	};
-	int i;
+	static const u16 stream_ids[] = {
+		DS5_STREAM_DEPTH,
+		DS5_STREAM_IR,
+		DS5_STREAM_RGB,
+		DS5_STREAM_IMU,
+	};
 
-	if (state->dser_dev)
-	{
+	dev_info(&state->client->dev, "%s(): Initiating HW reset with recovery\n",
+		__func__);
+
+	/* 1. Stop active streams on the device before reset.
+	 *    This ensures FW and SERDES are in a clean state.
+	 */
+	for (i = 0; i < ARRAY_SIZE(sensors); i++) {
+		if (sensors[i]->streaming) {
+			dev_info(&state->client->dev,
+				"%s(): stopping active stream %d before reset\n",
+				__func__, stream_ids[i]);
+			ds5_write(state, DS5_START_STOP_STREAM,
+				DS5_STREAM_STOP | stream_ids[i]);
+		}
+	}
+
+	/* 2. Invalidate all sensor state and release SERDES pipes.
+	 *    After HW reset the device loses all configuration, so driver
+	 *    state must be brought in sync.  Clear streaming flags so that
+	 *    ds5_mux_s_stream() won't silently skip the next stream-start.
+	 */
+#ifdef CONFIG_VIDEO_D4XX_SERDES
+	if (state->dser_dev) {
 		mutex_lock(&serdes_lock__);
-		for (i = 0; i < ARRAY_SIZE(sensors); i++)
-		{
+		for (i = 0; i < ARRAY_SIZE(sensors); i++) {
 			struct ds5_sensor *sensor = sensors[i];
 
 			ds5_config_cache_clear(sensor);
+			sensor->streaming = false;
 
-			if (sensor->pipe_id >= 0)
-			{
-				int release_ret = max9296_release_pipe(state->dser_dev, sensor->pipe_id);
-				dev_warn(&state->client->dev, "release pipe %d (%d)\n",
-					sensor->pipe_id, release_ret);
+			if (sensor->pipe_id >= 0) {
+				int release_ret = state->dser_ops->release_pipe(
+					state->dser_dev, sensor->pipe_id);
+				dev_info(&state->client->dev,
+					"%s(): released pipe %d (%d)\n",
+					__func__, sensor->pipe_id, release_ret);
 				sensor->pipe_id = PIPE_NOT_CONFIGURED;
 			}
+			sensor->pipe_data_type1 = 0;
+			sensor->pipe_data_type2 = 0;
+			sensor->pipe_vc_id = 0;
 		}
 		mutex_unlock(&serdes_lock__);
+	} else
+#endif
+	{
+		for (i = 0; i < ARRAY_SIZE(sensors); i++) {
+			ds5_config_cache_clear(sensors[i]);
+			sensors[i]->streaming = false;
+		}
 	}
-	*/
 
-	/* 1. Send HW reset command */
+	/* 3. Send HW reset command */
 	ret = ds5_raw_write(state, DS5_HWMC_DATA, &cmd_hw_reset, sizeof(cmd_hw_reset));
 	if (ret < 0) {
 		dev_err(&state->client->dev, "%s(): Failed to write HW reset command: %d\n",
@@ -2305,15 +2535,15 @@ static int ds5_hw_reset_with_recovery(struct ds5 *state)
 			__func__, ret);
 		return ret;
 	}
-	atomic_inc(&ds5_reset_gen);
+	atomic_inc(ds5_get_reset_gen(state));
 
 	dev_info(&state->client->dev, "%s(): HW reset command sent, waiting for device...\n",
 		__func__);
 
-	/* 2. Brief delay to allow reset to begin */
+	/* 4. Brief delay to allow reset to begin */
 	msleep(DS5_HW_RESET_INITIAL_DELAY_MS);
 
-	/* 3. Poll for device to come back online */
+	/* 5. Poll for device to come back online */
 	for (retry = 0; retry < DS5_HW_RESET_MAX_RETRIES; retry++) {
 		msleep(DS5_HW_RESET_POLL_INTERVAL_MS);
 
@@ -2363,16 +2593,19 @@ static int ds5_hw_reset_with_recovery(struct ds5 *state)
 	}
 
 #ifdef CONFIG_VIDEO_D4XX_SERDES
-	/* 4. Re-initialize SERDES link if available */
-	if (state->dser_dev) {
-		dev_info(&state->client->dev,
-			"%s(): Re-initializing SERDES link\n", __func__);
-		state->dser_ops->reset_oneshot(state->dser_dev);
-		msleep(300);
+	/* 6. Tiered SERDES recovery:
+	 *    Phase 1: serializer-only re-init (per-camera, non-disruptive).
+	 *    Phase 2: full deserializer reset only if ALL siblings are also dead.
+	 */
+	ret = ds5_hw_reset_serdes_recovery(state);
+	if (ret < 0) {
+		dev_err(&state->client->dev,
+			"%s(): SERDES recovery failed: %d\n", __func__, ret);
+		return ret;
 	}
 #endif
 
-	/* 5. Verify device is operational by reading firmware version */
+	/* 7. Verify device is operational by reading firmware version */
 	ret = ds5_read(state, DS5_FW_VERSION, &state->fw_version);
 	if (ret < 0) {
 		dev_err(&state->client->dev,
@@ -2387,7 +2620,7 @@ static int ds5_hw_reset_with_recovery(struct ds5 *state)
 		return ret;
 	}
 
-	/* 6. Wait for device type register to be populated.
+	/* 8. Wait for device type register to be populated.
 	 * After HW reset the firmware sets status to 0xDEAD before fully
 	 * initializing configuration registers (DS5_DEVICE_TYPE, stream DT,
 	 * resolution, etc.).  If ds5_fixed_configuration() reads device type
@@ -3386,13 +3619,9 @@ static const struct v4l2_subdev_internal_ops ds5_sensor_internal_ops = {
  * sensors into one i2c device. Only first sensor node per max9295 sets up the
  * link.
  *
- * max 24 number from this link:
- * https://docs.nvidia.com/jetson/archives/r35.1/DeveloperGuide/text/
- * SD/CameraDevelopment/JetsonVirtualChannelWithGmslCameraFramework.html
- * #jetson-agx-xavier-series
+ * serdes_inited[] and MAX_DEV_NUM are defined near the top of the file
+ * (after serdes_lock__).
  */
-#define MAX_DEV_NUM 24
-static struct ds5 *serdes_inited[MAX_DEV_NUM];
 #ifdef CONFIG_OF
 static int ds5_board_setup(struct ds5 *state)
 {
@@ -5819,7 +6048,6 @@ static int ds5_probe(struct i2c_client *c, const struct i2c_device_id *id)
 	mutex_init(&state->lock);
 
 	state->client = c;
-	state->reset_gen = atomic_read(&ds5_reset_gen);
 	dev_warn(&c->dev, "Probing driver for D4xx\n");
 #ifdef CONFIG_OF
 	ret = of_property_read_u32(c->dev.of_node, "override_reg", &override_addr);
@@ -5858,6 +6086,10 @@ static int ds5_probe(struct i2c_client *c, const struct i2c_device_id *id)
 	if (ret < 0)
 		goto e_regulator;
 #endif
+	/* Initialize reset generation counter after SERDES setup so that
+	 * ds5_get_reset_gen() can resolve the per-deserializer counter. */
+	state->reset_gen = atomic_read(ds5_get_reset_gen(state));
+
 	// Verify communication
 	retry = 5;
 	do {

--- a/kernel/realsense/d4xx.c
+++ b/kernel/realsense/d4xx.c
@@ -94,6 +94,7 @@ struct dser_interface {
 #define DS5_DEVICE_TYPE_D45X		6
 #define DS5_DEVICE_TYPE_D43X		5
 #define DS5_DEVICE_TYPE_D46X		4
+#define DS5_DEVICE_TYPE_UNKNOWN		0
 
 #define DS5_MIPI_LANE_NUMS		0x0400
 #define DS5_MIPI_LANE_DATARATE		0x0402
@@ -474,7 +475,8 @@ struct ds5 {
 	int is_depth, is_y8, is_rgb, is_imu;
 	bool metadata_enabled;
 	int aggregated;
-	int reset_gen;
+	int reset_ref_ds5;
+	int reset_ref_dser;
 	u16 fw_version;
 	u16 fw_build;
 #ifdef CONFIG_VIDEO_D4XX_SERDES
@@ -486,93 +488,101 @@ struct ds5 {
 	const struct dser_interface *dser_ops;
 	bool serdes_primary; /* true for the instance that ran SERDES setup */
 #endif
+	struct ds5_dev *ds5_dev; /* pointer to DS5 device struct */
 };
 
-struct ds5_counters {
-	unsigned int n_res;
-	unsigned int n_fmt;
-	unsigned int n_ctrl;
+struct ds5_dev {
+	struct mutex lock;
+
+	/*
+	* Per-camera reset generation counter.
+	* Incremented whenever the camera undergoes a HW reset,
+	*  either from its own instance or a sibling's instance.
+	* Each instance stores the last seen generation count
+	*  and compares it on each access to detect if a reset has occurred
+	*  and invalidates its own state if so.
+	*/
+	atomic_t reset_gen;
+
+	/* Cached device type from HW reset Step 8.
+	* During probe the first instance resets the camera, causing DS5_DEVICE_TYPE
+	* to temporarily return 0.  Step 8 polls until the register is valid and
+	* stores the result here so that all four probe instances (and any post-reset
+	* code path) can use the confirmed value even if the register read returns 0.
+	*/
+	u16 cached_device_type;
+
+	/* Timestamp (jiffies) of last completed HW reset.
+	* Used to enforce DS5_HW_RESET_COOLDOWN_MS between consecutive resets
+	* and prevent GMSL link degradation from rapid reset cycles.
+	*/
+	unsigned long last_reset_jiffies;
+
+#ifdef CONFIG_VIDEO_D4XX_SERDES
+ 	/* Pointer to the deserializer dev */
+	struct dser_control *dser_control;
+#endif
+
+	/* Pointer to the primary DS5 struct */
+	struct ds5 *ds5_primary;
+
+	bool depth_streaming;
+	bool ir_streaming;
+	bool rgb_streaming;
+	bool imu_streaming;
+	atomic_t ds5_probe_reset_once;
 };
 
-static atomic_t ds5_reset_gen = ATOMIC_INIT(0);
-static atomic_t ds5_probe_reset_once = ATOMIC_INIT(0);
-
-/* Timestamp (jiffies) of last completed HW reset.
- * Used to enforce DS5_HW_RESET_COOLDOWN_MS between consecutive resets
- * and prevent GMSL link degradation from rapid reset cycles.
- */
-static unsigned long ds5_last_reset_jiffies;
-
-/* Cached device type from HW reset Step 8.
- * During probe the first instance resets the camera, causing DS5_DEVICE_TYPE
- * to temporarily return 0.  Step 8 polls until the register is valid and
- * stores the result here so that all four probe instances (and any post-reset
- * code path) can use the confirmed value even if the register read returns 0.
- */
-static u16 ds5_cached_device_type;
 
 #ifdef CONFIG_VIDEO_D4XX_SERDES
 static DEFINE_MUTEX(serdes_lock__);
+static bool ds5_slots_inited;
 
-/*
- * Per-deserializer reset generation counter.
- * Replaces the old global ds5_reset_gen for SERDES builds so that
- * resetting camera A does not force camera B (on a different deserializer)
- * to invalidate its state.  Cameras sharing the same deserializer still
- * see each other's resets through the shared counter.
- */
-#define MAX_DSER_NUM 8
-struct dser_reset_gen {
+#define MAX_DSER_NUM 4
+struct dser_control {
+	struct mutex lock;
+
+	/*
+	* Per-deserializer reset generation counter.
+	* Replaces the old global ds5_reset_gen for SERDES builds so that
+	* resetting camera A does not force camera B (on a different deserializer)
+	* to invalidate its state.  Cameras sharing the same deserializer still
+	* see each other's resets through the shared counter.
+	*/
+	atomic_t reset_gen;
 	struct device *dser_dev;
-	atomic_t gen;
 };
-static struct dser_reset_gen dser_reset_gens[MAX_DSER_NUM];
+static struct dser_control dser_inited[MAX_DSER_NUM];
 
-static atomic_t *ds5_get_reset_gen(struct ds5 *state)
+#define MAX_DS5_NUM (MAX_DSER_NUM * 2) /* assuming max 2 DS5 cameras per deserializer */
+static struct ds5_dev ds5_inited[MAX_DS5_NUM];
+
+static void ds5_init_global_slots_once(void)
 {
 	int i;
-	int free_idx = -1;
-	atomic_t *gen = &ds5_reset_gen;
 
-	if (state->dser_dev) {
-		mutex_lock(&serdes_lock__);
-		for (i = 0; i < MAX_DSER_NUM; i++) {
-			if (dser_reset_gens[i].dser_dev == state->dser_dev) {
-				gen = &dser_reset_gens[i].gen;
-				goto out_unlock;
-			}
-			if (!dser_reset_gens[i].dser_dev && free_idx < 0)
-				free_idx = i;
-		}
-
-		if (free_idx >= 0) {
-			dser_reset_gens[free_idx].dser_dev = state->dser_dev;
-			atomic_set(&dser_reset_gens[free_idx].gen, 0);
-			gen = &dser_reset_gens[free_idx].gen;
-		}
-out_unlock:
-		mutex_unlock(&serdes_lock__);
+	if (ds5_slots_inited) {
+		return;
 	}
 
-	/* Fallback: table full or no deserializer */
-	return gen;
+	for (i = 0; i < MAX_DS5_NUM; i++)
+		mutex_init(&ds5_inited[i].lock);
+
+	for (i = 0; i < MAX_DSER_NUM; i++)
+		mutex_init(&dser_inited[i].lock);
+
+	ds5_slots_inited = true;
 }
-#else
+
 static inline atomic_t *ds5_get_reset_gen(struct ds5 *state)
 {
-	return &ds5_reset_gen;
+	return &state->ds5_dev->reset_gen;
 }
-#endif
 
-/*
- * max 24 number from this link:
- * https://docs.nvidia.com/jetson/archives/r35.1/DeveloperGuide/text/
- * SD/CameraDevelopment/JetsonVirtualChannelWithGmslCameraFramework.html
- * #jetson-agx-xavier-series
- */
-#define MAX_DEV_NUM 24
-#ifdef CONFIG_VIDEO_D4XX_SERDES
-static struct ds5 *serdes_inited[MAX_DEV_NUM];
+static inline atomic_t *dser_get_reset_gen(struct ds5 *state)
+{
+	return &state->ds5_dev->dser_control->reset_gen;
+}
 
 /* MAX9296 deserializer interface implementation */
 static const struct dser_interface max9296_interface = {
@@ -607,7 +617,42 @@ static const struct dser_interface max96712_interface = {
 	.init_settings = max96712_init_settings,
 	.name = "max96712",
 };
-#endif
+
+#else /* !CONFIG_VIDEO_D4XX_SERDES */
+
+static atomic_t ds5_reset_gen = ATOMIC_INIT(0);
+static inline atomic_t *ds5_get_reset_gen(struct ds5 *state)
+{
+	return &ds5_reset_gen;
+}
+
+#define MAX_DS5_NUM (1) /* assuming max 1 DS5 camera with RDK(?) */
+static struct ds5_dev ds5_inited[MAX_DS5_NUM];
+static bool ds5_slots_inited;
+static DEFINE_MUTEX(ds5_slots_lock__);
+
+static void ds5_init_global_slots_once(void)
+{
+	mutex_lock(&ds5_slots_lock__);
+	if (!ds5_slots_inited) {
+		mutex_init(&ds5_inited[0].lock);
+		ds5_slots_inited = true;
+	}
+	mutex_unlock(&ds5_slots_lock__);
+}
+
+#endif /* !CONFIG_VIDEO_D4XX_SERDES */
+
+static inline u16 ds5_dev_type(struct ds5 *state, u16 dev_type)
+{
+	if (dev_type == 0 && state->ds5_dev->cached_device_type != 0) {
+		dev_info(&state->client->dev,
+			"%s(): device type register returned 0, using cached type 0x%x\n",
+			__func__, state->ds5_dev->cached_device_type);
+		dev_type = state->ds5_dev->cached_device_type;
+	}
+	return dev_type;
+}
 
 #define ds5_from_depth_sd(sd) container_of(sd, struct ds5, depth.sd)
 #define ds5_from_ir_sd(sd) container_of(sd, struct ds5, ir.sd)
@@ -1740,19 +1785,6 @@ static void ds5_config_cache_clear(struct ds5_sensor *sensor)
 	sensor->cached_height_value = 0xFFFF;
 }
 
-static struct ds5_sensor *ds5_get_active_sensor(struct ds5 *state)
-{
-	if (state->is_depth)
-		return &state->depth.sensor;
-	if (state->is_rgb)
-		return &state->rgb.sensor;
-	if (state->is_y8)
-		return &state->ir.sensor;
-	if (state->is_imu)
-		return &state->imu.sensor;
-	return NULL;
-}
-
 static void ds5_invalidate_sensor(struct ds5 *state, struct ds5_sensor *sensor)
 {
 	ds5_config_cache_clear(sensor);
@@ -1765,13 +1797,12 @@ static void ds5_invalidate_sensor(struct ds5 *state, struct ds5_sensor *sensor)
 	 */
 	sensor->pipe_data_type1 = 0;
 	sensor->pipe_data_type2 = 0;
-	sensor->pipe_vc_id = 0;
+	sensor->pipe_vc_id = 0xFFFF;
 }
 
 static int ds5_configure(struct ds5 *state)
 {
 	struct ds5_sensor *sensor;
-	int current_reset_gen;
 	u16 fmt, md_fmt, vc_id;
 #ifdef CONFIG_VIDEO_D4XX_SERDES
 	u16 data_type1, data_type2;
@@ -1785,15 +1816,6 @@ static int ds5_configure(struct ds5 *state)
 	u16 height_value = 0;
 	int ret;
 
-	current_reset_gen = atomic_read(ds5_get_reset_gen(state));
-	if (state->reset_gen != current_reset_gen) {
-		struct ds5_sensor *active = ds5_get_active_sensor(state);
-
-		if (active)
-			ds5_invalidate_sensor(state, active);
-		state->reset_gen = current_reset_gen;
-	}
-
 	if (state->is_depth) {
 		sensor = &state->depth.sensor;
 		dt_addr = DS5_DEPTH_STREAM_DT;
@@ -1802,7 +1824,6 @@ static int ds5_configure(struct ds5 *state)
 		fps_addr = DS5_DEPTH_FPS;
 		width_addr = DS5_DEPTH_RES_WIDTH;
 		height_addr = DS5_DEPTH_RES_HEIGHT;
-		vc_id = 0;
 	} else if (state->is_rgb) {
 		sensor = &state->rgb.sensor;
 		dt_addr = DS5_RGB_STREAM_DT;
@@ -1811,7 +1832,6 @@ static int ds5_configure(struct ds5 *state)
 		fps_addr = DS5_RGB_FPS;
 		width_addr = DS5_RGB_RES_WIDTH;
 		height_addr = DS5_RGB_RES_HEIGHT;
-		vc_id = 1;
 	} else if (state->is_y8) {
 		sensor = &state->ir.sensor;
 		dt_addr = DS5_IR_STREAM_DT;
@@ -1820,7 +1840,6 @@ static int ds5_configure(struct ds5 *state)
 		fps_addr = DS5_IR_FPS;
 		width_addr = DS5_IR_RES_WIDTH;
 		height_addr = DS5_IR_RES_HEIGHT;
-		vc_id = 2;
 	} else if (state->is_imu) {
 		sensor = &state->imu.sensor;
 		dt_addr = DS5_IMU_STREAM_DT;
@@ -1829,7 +1848,6 @@ static int ds5_configure(struct ds5 *state)
 		fps_addr = DS5_IMU_FPS;
 		width_addr = DS5_IMU_RES_WIDTH;
 		height_addr = DS5_IMU_RES_HEIGHT;
-		vc_id = 3;
 	} else {
 		return -EINVAL;
 	}
@@ -1886,6 +1904,8 @@ static int ds5_configure(struct ds5 *state)
 				"pipe %d already configured (dt1=0x%x dt2=0x%x vc=%u)\n",
 				sensor->pipe_id, data_type1, data_type2, vc_id);
 	}
+#else /* Non-SERDES configuration */
+	vc_id = (state->is_depth) ? 0 : (state->is_rgb) ? 1 : (state->is_y8) ? 2 : 3;
 #endif
 
 	fmt = sensor->streaming ? sensor->config.format->data_type : 0;
@@ -2348,6 +2368,17 @@ static int ds5_set_calibration_data(struct ds5 *state,
  *
  * Returns 0 on success, negative errno on failure.
  */
+
+static void ds5_reset_streaming_flags(struct ds5_dev *ds5_dev)
+{
+	mutex_lock(&ds5_dev->lock);
+	ds5_dev->depth_streaming = false;
+	ds5_dev->ir_streaming = false;
+	ds5_dev->rgb_streaming = false;
+	ds5_dev->imu_streaming = false;
+	mutex_unlock(&ds5_dev->lock);
+}
+
 #ifdef CONFIG_VIDEO_D4XX_SERDES
 static int ds5_hw_reset_serdes_recovery(struct ds5 *state, bool force_phase2)
 {
@@ -2355,33 +2386,28 @@ static int ds5_hw_reset_serdes_recovery(struct ds5 *state, bool force_phase2)
 	int i;
 	u16 tmp = 0;
 	bool sibling_alive = false;
-	struct ds5 *primary = state; /* the instance that ran SERDES setup */
+	struct ds5 *sib_primary[MAX_DS5_NUM];
+	bool sib_streaming[MAX_DS5_NUM];
+	int sib_cnt = 0;
+	struct ds5 *primary;
+
+	mutex_lock(&state->ds5_dev->lock);
+	primary = state->ds5_dev->ds5_primary; /* the instance that ran SERDES setup */
+	mutex_unlock(&state->ds5_dev->lock);
+
+	if (!primary) {
+		dev_err(&state->client->dev,
+			"%s(): ds5_primary is NULL, cannot perform SERDES recovery\n",
+			__func__);
+		return -ENODEV;
+	}
+
+	dev_dbg(&state->client->dev,
+		"%s(): using primary instance %s for SERDES API calls\n",
+		__func__, dev_name(&primary->client->dev));
 
 	if (!state->ser_dev || !state->dser_dev)
 		return 0;
-
-	/* The deserializer/serializer API calls (setup_link, setup_control)
-	 * require the device that was originally paired via sdev_pair/
-	 * sdev_register during probe.  Only the primary instance (the first
-	 * probe of each physical camera) performs that pairing.  If we are
-	 * called from a non-primary instance (e.g. IMU = 9-001d) we must
-	 * find and use the primary's device, otherwise the deserializer
-	 * returns "no sdev found" (-EINVAL).
-	 */
-	if (!state->serdes_primary) {
-		for (i = 0; i < MAX_DEV_NUM; i++) {
-			struct ds5 *p = serdes_inited[i];
-
-			if (p && p->serdes_primary &&
-			    p->ser_dev == state->ser_dev) {
-				primary = p;
-				dev_dbg(&state->client->dev,
-					"%s(): using primary instance %s for SERDES API calls\n",
-					__func__, dev_name(&primary->client->dev));
-				break;
-			}
-		}
-	}
 
 	if (!force_phase2) {
 		/* Phase 1 — serializer-only re-init (per-camera, safe) */
@@ -2402,25 +2428,25 @@ static int ds5_hw_reset_serdes_recovery(struct ds5 *state, bool force_phase2)
 		 * later.  Do multiple reads with delays to catch oscillation.
 		 */
 		ret = ds5_read(state, DS5_FW_VERSION, &tmp);
-		if (ret == 0) {
-			int k;
-			bool stable = true;
+        if (ret == 0) {
+            int k;
+            bool stable = true;
 
-			for (k = 0; k < 3; k++) {
-				msleep(200);
+			for (k = 0; k < DS5_HW_RESET_STABILITY_READS; k++) {
+				msleep(DS5_HW_RESET_STABILITY_INTERVAL_MS);
 				ret = ds5_read(state, DS5_FW_VERSION, &tmp);
 				if (ret < 0) {
 					dev_warn(&state->client->dev,
-						"%s(): Phase 1 stability check %d/3 failed (err %d)\n",
-						__func__, k + 1, ret);
+						"%s(): Phase 1 stability check %d/%d failed (err %d)\n",
+						__func__, k + 1, DS5_HW_RESET_STABILITY_READS, ret);
 					stable = false;
 					break;
 				}
 			}
 			if (stable) {
 				dev_info(&state->client->dev,
-					"%s(): Phase 1 succeeded, I2C link stable (3 consecutive reads OK)\n",
-					__func__);
+					"%s(): Phase 1 succeeded, I2C link stable (%d consecutive reads OK)\n",
+					__func__, DS5_HW_RESET_STABILITY_READS);
 				return 0;
 			}
 			dev_warn(&state->client->dev,
@@ -2439,7 +2465,7 @@ static int ds5_hw_reset_serdes_recovery(struct ds5 *state, bool force_phase2)
 	}
 
 	/*
-	 * In the D4XX architecture each physical camera has 4 driver instances
+	 * In the D4XX architecture each physical camera has upto 4 driver instances
 	 * (Depth, RGB, IR, IMU) sharing the same ser_dev.  A "true sibling" is
 	 * a different physical camera on the same deserializer: same dser_dev
 	 * but different ser_dev.
@@ -2447,36 +2473,38 @@ static int ds5_hw_reset_serdes_recovery(struct ds5 *state, bool force_phase2)
 	 * Same-camera instances are always safe to reset together since they
 	 * share the same camera ASIC — the HW reset already killed them all.
 	 */
-	for (i = 0; i < MAX_DEV_NUM; i++) {
-		struct ds5 *sib = serdes_inited[i];
-		bool sib_streaming;
+	mutex_lock(&serdes_lock__);
+	for (i = 0; i < MAX_DS5_NUM; i++) {
+		struct ds5_dev *sib = &ds5_inited[i];
+		struct ds5 *sib_p;
+		bool streaming;
 
-		if (!sib || sib == state)
+		mutex_lock(&sib->lock);
+		sib_p = sib->ds5_primary;
+		streaming = sib->depth_streaming || sib->rgb_streaming ||
+			sib->ir_streaming || sib->imu_streaming;
+		mutex_unlock(&sib->lock);
+
+		if (!sib_p || sib == state->ds5_dev)
+			continue;
+		if (sib_p->dser_dev != state->dser_dev)
 			continue;
 
-		/* Skip instances of the SAME physical camera (same serializer) */
-		if (sib->ser_dev == state->ser_dev)
+		sib_primary[sib_cnt] = sib_p;
+		sib_streaming[sib_cnt] = streaming;
+		sib_cnt++;
+	}
+	mutex_unlock(&serdes_lock__);
+
+	for (i = 0; i < sib_cnt; i++) {
+		if (!sib_streaming[i])
 			continue;
 
-		/* Only check cameras on the same deserializer (true siblings) */
-		if (sib->dser_dev != state->dser_dev)
-			continue;
-
-		/* True sibling — check if its I2C link is alive */
-		if (ds5_read(sib, DS5_FW_VERSION, &tmp) != 0)
-			continue;
-
-		/* Check only the sensor type this instance actually manages */
-		sib_streaming = (sib->is_depth && sib->depth.sensor.streaming) ||
-				(sib->is_rgb  && sib->rgb.sensor.streaming) ||
-				(sib->is_y8   && sib->ir.sensor.streaming) ||
-				(sib->is_imu  && sib->imu.sensor.streaming);
-
-		if (sib_streaming) {
+		if (0 == ds5_read(sib_primary[i], DS5_FW_VERSION, &tmp)) {
 			sibling_alive = true;
 			dev_warn(&state->client->dev,
 				"%s(): true sibling %s alive & streaming, skipping deser reset\n",
-				__func__, dev_name(&sib->client->dev));
+				__func__, dev_name(&sib_primary[i]->client->dev));
 			break;
 		}
 	}
@@ -2591,32 +2619,12 @@ static int ds5_hw_reset_serdes_recovery(struct ds5 *state, bool force_phase2)
 	dev_info(&state->client->dev,
 		"%s(): Phase 2 succeeded, full deser recovery complete\n", __func__);
 
-	/* Invalidate all cameras on this deserializer so they re-configure
-	 * on next stream start.  This covers both same-camera peer instances
-	 * (same ser_dev) and true sibling cameras (different ser_dev).
-	 */
-	for (i = 0; i < MAX_DEV_NUM; i++) {
-		struct ds5 *sib = serdes_inited[i];
-		struct ds5_sensor *active;
-
-		if (!sib || sib == state)
-			continue;
-		if (sib->dser_dev != state->dser_dev)
-			continue;
-
-		/* Invalidate only the sensor type this instance manages */
-		active = ds5_get_active_sensor(sib);
-		if (active) {
-			ds5_invalidate_sensor(sib, active);
-			active->streaming = false;
-		}
-
-		dev_warn(&state->client->dev,
-			"%s(): invalidated %s %s after deser reset\n",
-			__func__,
-			(sib->ser_dev == state->ser_dev) ? "same-cam" : "sibling",
-			dev_name(&sib->client->dev));
-	}
+	/* Increment deserializer reset generation
+	 *	This results in all cameras connected to this deserializer
+	 *	invalidating serializer and ds5 caches,
+	 *	ensuring any stale state from the reset is cleared.
+	*/
+	atomic_inc(dser_get_reset_gen(state));
 
 	return 0;
 }
@@ -2640,9 +2648,14 @@ static int ds5_hw_reset_with_recovery(struct ds5 *state)
 	int retry;
 	int __maybe_unused i;
 	u16 status = 0;
+	bool depth_streaming;
+	bool rgb_streaming;
+	bool ir_streaming;
+	bool imu_streaming;
 #ifdef CONFIG_VIDEO_D4XX_SERDES
 	bool serdes_recovery_ran = false;
 #endif
+	unsigned long ds5_last_reset_jiffies = READ_ONCE(state->ds5_dev->last_reset_jiffies);
 
 	dev_info(&state->client->dev, "%s(): Initiating HW reset with recovery\n",
 		__func__);
@@ -2677,51 +2690,26 @@ static int ds5_hw_reset_with_recovery(struct ds5 *state)
 	 *    HW reset kills all streams on the camera ASIC, so we must
 	 *    stop and invalidate all peer instances of the same camera.
 	 */
-	{
-		struct ds5_sensor *active = ds5_get_active_sensor(state);
+	dev_info(&state->client->dev, "%s(): stopping streams before reset\n", __func__);
+	mutex_lock(&state->ds5_dev->lock);
+	depth_streaming = state->ds5_dev->depth_streaming;
+	rgb_streaming = state->ds5_dev->rgb_streaming;
+	ir_streaming = state->ds5_dev->ir_streaming;
+	imu_streaming = state->ds5_dev->imu_streaming;
+	mutex_unlock(&state->ds5_dev->lock);
 
-		if (active && active->streaming) {
-			u16 sid = state->is_depth ? DS5_STREAM_DEPTH :
-				  state->is_rgb   ? DS5_STREAM_RGB :
-				  state->is_y8    ? DS5_STREAM_IR :
-						    DS5_STREAM_IMU;
-			dev_info(&state->client->dev,
-				"%s(): stopping own stream %d before reset\n",
-				__func__, sid);
-			ds5_write(state, DS5_START_STOP_STREAM,
-				DS5_STREAM_STOP | sid);
-		}
-	}
+	if (depth_streaming)
+		ds5_write(state, DS5_START_STOP_STREAM,	DS5_STREAM_STOP | DS5_STREAM_DEPTH);
+	if (rgb_streaming)
+		ds5_write(state, DS5_START_STOP_STREAM,	DS5_STREAM_STOP | DS5_STREAM_RGB);
+	if (ir_streaming)
+		ds5_write(state, DS5_START_STOP_STREAM,	DS5_STREAM_STOP | DS5_STREAM_IR);
+	if (imu_streaming)
+		ds5_write(state, DS5_START_STOP_STREAM,	DS5_STREAM_STOP | DS5_STREAM_IMU);
 
-#ifdef CONFIG_VIDEO_D4XX_SERDES
-	/* Stop streams on peer instances of the same physical camera */
-	for (i = 0; i < MAX_DEV_NUM; i++) {
-		struct ds5 *peer = serdes_inited[i];
-		struct ds5_sensor *peer_active;
-
-		if (!peer || peer == state)
-			continue;
-		if (peer->ser_dev != state->ser_dev)
-			continue;
-
-		peer_active = ds5_get_active_sensor(peer);
-		if (peer_active && peer_active->streaming) {
-			u16 sid = peer->is_depth ? DS5_STREAM_DEPTH :
-				  peer->is_rgb   ? DS5_STREAM_RGB :
-				  peer->is_y8    ? DS5_STREAM_IR :
-						    DS5_STREAM_IMU;
-			dev_info(&state->client->dev,
-				"%s(): stopping peer %s stream %d before reset\n",
-				__func__, dev_name(&peer->client->dev), sid);
-			ds5_write(peer, DS5_START_STOP_STREAM,
-				DS5_STREAM_STOP | sid);
-		}
-	}
-#endif
-
-	/* 2. Invalidate sensor state (defer SERDES pipe release).
+	/* 2. Increment DS5 reset generation.
 	 *    After HW reset the device loses all configuration, so driver
-	 *    state must be brought in sync.  Clear streaming flags so that
+	 *    state must be brought in sync, like clearing streaming flags so that
 	 *    ds5_mux_s_stream() won't silently skip the next stream-start.
 	 *    Covers this instance AND all peer instances of the same camera.
 	 *
@@ -2732,41 +2720,8 @@ static int ds5_hw_reset_with_recovery(struct ds5 *state)
 	 *    release-then-reallocate at stream-start time, when the FW
 	 *    has long finished its init (matching v1.0.1.33 behavior).
 	 */
-	{
-		struct ds5_sensor *active = ds5_get_active_sensor(state);
-
-		if (active) {
-			ds5_config_cache_clear(active);
-			active->streaming = false;
-#ifdef CONFIG_VIDEO_D4XX_SERDES
-			active->pipe_data_type1 = 0;
-			active->pipe_data_type2 = 0;
-			active->pipe_vc_id = 0;
-#endif
-		}
-	}
-
-#ifdef CONFIG_VIDEO_D4XX_SERDES
-	/* Invalidate peer instances of the same physical camera */
-	for (i = 0; i < MAX_DEV_NUM; i++) {
-		struct ds5 *peer = serdes_inited[i];
-		struct ds5_sensor *peer_active;
-
-		if (!peer || peer == state)
-			continue;
-		if (peer->ser_dev != state->ser_dev)
-			continue;
-
-		peer_active = ds5_get_active_sensor(peer);
-		if (peer_active) {
-			ds5_invalidate_sensor(peer, peer_active);
-			peer_active->streaming = false;
-			dev_info(&state->client->dev,
-				"%s(): invalidated peer %s\n",
-				__func__, dev_name(&peer->client->dev));
-		}
-	}
-#endif
+	atomic_inc(ds5_get_reset_gen(state));
+	ds5_reset_streaming_flags(state->ds5_dev);
 
 	/* 3. Send HW reset command */
 	ret = ds5_raw_write(state, DS5_HWMC_DATA, &cmd_hw_reset, sizeof(cmd_hw_reset));
@@ -2782,7 +2737,6 @@ static int ds5_hw_reset_with_recovery(struct ds5 *state)
 			__func__, ret);
 		return ret;
 	}
-	atomic_inc(ds5_get_reset_gen(state));
 
 	dev_info(&state->client->dev, "%s(): HW reset command sent, waiting for device...\n",
 		__func__);
@@ -2843,17 +2797,17 @@ static int ds5_hw_reset_with_recovery(struct ds5 *state)
 	 *    Step 5 polled the device over I2C until 0xDEAD was returned,
 	 *    which means the GMSL link is up.  Probe once more: if the
 	 *    link is still alive, the GMSL link recovered naturally — no
-	 *    SERDES intervention needed (the common case for D457).
+	 *    full tiered SERDES recovery needed (the common case for D457).
 	 *
-	 *    Do NOT call max9295_init_settings() on the light path.
-	 *    The D457 FW continues reconfiguring the MAX9295 serializer
-	 *    for ~50-100ms after reporting 0xDEAD.  Calling init_settings
-	 *    now gets overwritten by the FW's ongoing init.  Instead,
-	 *    let the FW finish naturally; ds5_setup_pipeline() will write
-	 *    per-pipe settings at stream-start time (seconds later) on
-	 *    top of the FW's stable final state.  This matches v1.0.1.33
-	 *    behavior where HW reset was fire-and-forget with zero SERDES
-	 *    intervention and all CI tests passed.
+	 *    Do NOT call max9295_init_settings() here.  That function writes
+	 *    global serializer registers (0x02, 0x308, 0x311, 0x331) that
+	 *    disrupt the active GMSL link.  Per-pipe reconfiguration is
+	 *    handled by callers:
+	 *      - First-probe: ds5_probe() configures pipe 3 (IMU) after
+	 *        this function returns, before IMU peer probes.
+	 *      - HWMC reset: ds5_invalidate_sensor() clears pipe state for
+	 *        all peers; ds5_configure() re-runs ds5_setup_pipeline()
+	 *        at the next STREAMON for each stream.
 	 *
 	 *    Only run full tiered recovery (including init_settings +
 	 *    stability checks + Phase 2 escalation) when the I2C link
@@ -2916,7 +2870,7 @@ static int ds5_hw_reset_with_recovery(struct ds5 *state)
 					"%s(): Device type 0x%x ready after %d ms\n",
 					__func__, dev_type,
 					(retry + 1) * DS5_HW_RESET_POLL_INTERVAL_MS);
-				ds5_cached_device_type = dev_type;
+				state->ds5_dev->cached_device_type = dev_type;
 				break;
 			}
 			msleep(DS5_HW_RESET_POLL_INTERVAL_MS);
@@ -3098,6 +3052,19 @@ static int ds5_hw_reset_with_recovery(struct ds5 *state)
 			}
 		}
 	} /* if (serdes_recovery_ran) */
+
+	/* 11. Per-pipe reconfiguration is NOT done here.
+	 *     - First-probe: ds5_probe() configures pipe 3 (IMU) after
+	 *       this function returns, before IMU peer probes.
+	 *     - HWMC reset: (Step 2) invalidates all peer pipe state.
+	 *		 At next STREAMON, ds5_configure() detects the mismatch and calls
+	 *       ds5_setup_pipeline() to reconfigure each pipe.
+	 *
+	 *     Do NOT call max9295_init_settings() or ds5_setup_pipeline()
+	 *     here.  init_settings() writes global MAX9295 registers that
+	 *     kill the GMSL link.  And for HWMC resets, the existing
+	 *     ds5_configure() path handles pipe reconfiguration cleanly.
+	 */
 #endif
 
 	dev_info(&state->client->dev,
@@ -3106,7 +3073,7 @@ static int ds5_hw_reset_with_recovery(struct ds5 *state)
 		(state->fw_version >> 8) & 0xff, state->fw_version & 0xff,
 		(state->fw_build >> 8) & 0xff, state->fw_build & 0xff);
 
-	ds5_last_reset_jiffies = jiffies;
+	WRITE_ONCE(state->ds5_dev->last_reset_jiffies, jiffies);
 
 	return 0;
 }
@@ -4064,16 +4031,102 @@ static const struct v4l2_subdev_internal_ops ds5_sensor_internal_ops = {
 	.close = ds5_mux_close,
 };
 
+static void ds5_init_ds5_dev(struct ds5 *state, struct ds5_dev *ds5_dev)
+{
+	state->ds5_dev = ds5_dev;
+	mutex_lock(&ds5_dev->lock);
+	ds5_dev->ds5_primary = state;
+	atomic_set(&ds5_dev->ds5_probe_reset_once, 0);
+	ds5_dev->cached_device_type = DS5_DEVICE_TYPE_UNKNOWN;
+	mutex_unlock(&ds5_dev->lock);
+	ds5_reset_streaming_flags(ds5_dev);
+}
+
 #ifdef CONFIG_VIDEO_D4XX_SERDES
+static int ds5_setup_and_link(struct ds5 *state)
+{
+	int i;
+	int err = 0;
+	struct device *dev = &state->client->dev;
+
+	mutex_lock(&serdes_lock__);
+	ds5_init_global_slots_once();
+	state->ds5_dev = NULL;
+	/* Look for existing DS5 instances */
+	for (i = 0; i < MAX_DS5_NUM; i++) {
+		bool match;
+
+		mutex_lock(&ds5_inited[i].lock);
+		match = ds5_inited[i].ds5_primary &&
+			ds5_inited[i].ds5_primary->ser_dev == state->ser_dev;
+		mutex_unlock(&ds5_inited[i].lock);
+		if (match) { /* Same camera, different stream instance. */
+			state->serdes_primary = false;
+			state->ds5_dev = &ds5_inited[i];
+			break;
+		}
+	}
+	if (NULL == state->ds5_dev) {
+	/* First stream instance for this camera, setup and link new DS5. */
+		for (i = 0; i < MAX_DS5_NUM; i++) {
+			bool free_slot;
+
+			mutex_lock(&ds5_inited[i].lock);
+			free_slot = (NULL == ds5_inited[i].ds5_primary);
+			mutex_unlock(&ds5_inited[i].lock);
+			if (free_slot) {
+				int j;
+				ds5_init_ds5_dev(state, &ds5_inited[i]);
+				state->serdes_primary = true;
+				/* Look for matching deserializer */
+				state->ds5_dev->dser_control = NULL;
+				for (j = 0; j < MAX_DSER_NUM; j++) {
+					mutex_lock(&dser_inited[j].lock);
+					if (dser_inited[j].dser_dev == state->dser_dev)
+						state->ds5_dev->dser_control = &dser_inited[j];
+					mutex_unlock(&dser_inited[j].lock);
+					if (state->ds5_dev->dser_control)
+						break;
+				}
+				if (NULL == state->ds5_dev->dser_control) {
+				/* Setup and link new deserializer */
+					for (j = 0; j < MAX_DSER_NUM; j++) {
+						mutex_lock(&dser_inited[j].lock);
+						if (NULL == dser_inited[j].dser_dev) {
+							dser_inited[j].dser_dev = state->dser_dev;
+							state->ds5_dev->dser_control = &dser_inited[j];
+						}
+						mutex_unlock(&dser_inited[j].lock);
+						if (state->ds5_dev->dser_control)
+							break;
+					}
+				}
+				if (NULL == state->ds5_dev->dser_control) {
+					dev_err(dev, "cannot handle more than %d deserializers\n", MAX_DSER_NUM);
+					err = -ENOSPC;
+					goto out_unlock;
+				} else {
+					dev_info(dev, "Deserializer %s linked\n", dev_name(state->dser_dev));
+				}
+				break;
+			}
+		}
+	}
+	if (NULL == state->ds5_dev) {
+		err = -ENOSPC;
+		dev_err(dev, "cannot handle more than %d DS5 cameras\n", MAX_DS5_NUM);
+	}
+
+out_unlock:
+	mutex_unlock(&serdes_lock__);
+	return err;
+}
 
 /*
  * FIXME
  * temporary solution before changing GMSL data structure or merging all 4 D457
  * sensors into one i2c device. Only first sensor node per max9295 sets up the
  * link.
- *
- * serdes_inited[] and MAX_DEV_NUM are defined near the top of the file
- * (after serdes_lock__).
  */
 #ifdef CONFIG_OF
 static int ds5_board_setup(struct ds5 *state)
@@ -4088,7 +4141,6 @@ static int ds5_board_setup(struct ds5 *state)
 	int value = 0xFFFF;
 	const char *str_value;
 	int err;
-	int i;
 
 	state->g_ctx.sdev_reg = state->client->addr;
 
@@ -4238,40 +4290,11 @@ static int ds5_board_setup(struct ds5 *state)
 	state->g_ctx.num_csi_lanes = value;
 	state->g_ctx.s_dev = dev;
 
-	for (i = 0; i < MAX_DEV_NUM; i++) {
-		if (serdes_inited[i] && serdes_inited[i]->ser_dev == state->ser_dev) {
-			/* Same camera, different stream instance.
-			 * Register in serdes_inited[] so peer iteration
-			 * can find it, but return -ENOTSUPP to skip
-			 * duplicate SERDES setup.
-			 */
-			int j;
-
-			for (j = i + 1; j < MAX_DEV_NUM; j++) {
-				if (!serdes_inited[j]) {
-					serdes_inited[j] = state;
-					dev_info(dev, "registered peer instance in serdes_inited[%d]\n", j);
-					return -ENOTSUPP;
-				}
-			}
-			dev_err(dev, "cannot register more than %d D4XX instances\n", MAX_DEV_NUM);
-			return -ENOSPC;
-		}
-	}
-	/* First instance of a new camera */
-	for (i = 0; i < MAX_DEV_NUM; i++) {
-		if (!serdes_inited[i]) {
-			serdes_inited[i] = state;
-			return 0;
-		}
-	}
-	err = -EINVAL;
-	dev_err(dev, "cannot handle more than %d D457 cameras\n", MAX_DEV_NUM);
-
+	err = ds5_setup_and_link(state);
 error:
 	return err;
 }
-#else
+#else /* CONFIG_OF */
 // ds5mux i2c ser des
 // mux a - 2 0x42 0x48
 // mux b - 2 0x44 0x4a
@@ -4315,18 +4338,26 @@ static int ds5_board_setup(struct ds5 *state)
 	i2c_info_des.addr = pdata->subdev_info[0].board_info.addr; //0x48, 0x4a, 0x68, 0x6a
 
 	/* look for already registered max9296, use same context if found */
-	for (i = 0; i < MAX_DEV_NUM; i++) {
-		if (serdes_inited[i] && serdes_inited[i]->dser_i2c) {
+	mutex_lock(&serdes_lock__);
+	ds5_init_global_slots_once();
+	for (i = 0; i < MAX_DS5_NUM; i++) {
+		struct ds5 *primary;
+
+		mutex_lock(&ds5_inited[i].lock);
+		primary = ds5_inited[i].ds5_primary;
+		if (primary && primary->dser_i2c) {
 			dev_info(dev, "MAX9296 found device on %d@0x%x\n",
-				serdes_inited[i]->dser_i2c->adapter->nr, serdes_inited[i]->dser_i2c->addr);
-			if (bus == serdes_inited[i]->dser_i2c->adapter->nr
-				&& serdes_inited[i]->dser_i2c->addr == i2c_info_des.addr) {
+				primary->dser_i2c->adapter->nr, primary->dser_i2c->addr);
+			if (bus == primary->dser_i2c->adapter->nr
+				&& primary->dser_i2c->addr == i2c_info_des.addr) {
 				dev_info(dev, "MAX9296 AGGREGATION found device on 0x%x\n", i2c_info_des.addr);
-				state->dser_i2c = serdes_inited[i]->dser_i2c;
+				state->dser_i2c = primary->dser_i2c;
 				state->aggregated = 1;
 			}
 		}
+		mutex_unlock(&ds5_inited[i].lock);
 	}
+	mutex_unlock(&serdes_lock__);
 	if (state->aggregated)
 		suffix += 4;
 	dev_info(dev, "Init SerDes %c on %d@0x%x<->%d@0x%x\n",
@@ -4404,35 +4435,11 @@ static int ds5_board_setup(struct ds5 *state)
 	state->g_ctx.num_csi_lanes = 2;
 	state->g_ctx.s_dev = dev;
 
-	for (i = 0; i < MAX_DEV_NUM; i++) {
-		if (serdes_inited[i] && serdes_inited[i]->ser_dev == state->ser_dev) {
-			int j;
-
-			for (j = i + 1; j < MAX_DEV_NUM; j++) {
-				if (!serdes_inited[j]) {
-					serdes_inited[j] = state;
-					dev_info(dev, "registered peer instance in serdes_inited[%d]\n", j);
-					return -ENOTSUPP;
-				}
-			}
-			dev_err(dev, "cannot register more than %d D4XX instances\n", MAX_DEV_NUM);
-			return -ENOSPC;
-		}
-	}
-	for (i = 0; i < MAX_DEV_NUM; i++) {
-		if (!serdes_inited[i]) {
-			serdes_inited[i] = state;
-			return 0;
-		}
-	}
-	err = -EINVAL;
-	dev_err(dev, "cannot handle more than %d D457 cameras\n", MAX_DEV_NUM);
-
+	err = ds5_setup_and_link(state);
 error:
 	return err;
 }
-
-#endif
+#endif /* CONFIG_OF */
 
 static int ds5_gmsl_serdes_setup(struct ds5 *state)
 {
@@ -4484,17 +4491,19 @@ static int ds5_serdes_setup(struct ds5 *state)
 
 	ret = ds5_board_setup(state);
 	if (ret) {
-		if (ret == -ENOTSUPP) {
-			/* Peer instance of already-initialized camera.
-			 * Registered in serdes_inited[] but skips SERDES setup.
-			 */
-			state->serdes_primary = false;
-			return 0;
-		}
 		dev_err(&c->dev, "board setup failed\n");
 		return ret;
 	}
-	state->serdes_primary = true;
+
+	/* Peer instance of an already-initialized camera.
+	 * ds5_setup_and_link() found that another instance already set up
+	 * this serializer and marked us non-primary.  Skip SERDES setup
+	 * (pair, register, gmsl init) — the primary already did it.
+	 */
+	if (!state->serdes_primary) {
+		dev_info(&c->dev, "peer instance, skipping SERDES setup\n");
+		return 0;
+	}
 
 	/* Pair sensor to serializer dev */
 	ret = max9295_sdev_pair(state->ser_dev, &state->g_ctx);
@@ -5217,9 +5226,27 @@ static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on)
 	struct ds5_sensor *sensor = state->mux.last_set;
 	u16 expected_streaming_state;
 	bool ds5_config_done = !on; /* for stop, skip config */
+	bool *streaming_flag = NULL;
 #ifdef CONFIG_VIDEO_D4XX_SERDES
 	int serdes_recovery_attempts = 0;
+	int cur_dser = atomic_read(dser_get_reset_gen(state));
+#else
+	int cur_dser = 0;
 #endif
+	int cur_ds5 = atomic_read(ds5_get_reset_gen(state));
+
+	/* Lazy invalidation after HW or deserializer reset.
+	 * Detect gen-counter bumps, clear stale streaming/config/pipe
+	 * state, then update refs.  Must run before the duplicate-call
+	 * guard so a reset-killed stream is not mistaken for "already off".
+	 */
+	if (state->reset_ref_ds5 != cur_ds5
+			|| state->reset_ref_dser != cur_dser) {
+		ds5_invalidate_sensor(state, sensor);
+		sensor->streaming = false;
+		state->reset_ref_ds5 = cur_ds5;
+		state->reset_ref_dser = cur_dser;
+	}
 
 	// spare duplicate calls
 	if (sensor->streaming == on)
@@ -5229,21 +5256,25 @@ static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on)
 		stream_status_base = DS5_DEPTH_STREAM_STATUS;
 		stream_id = DS5_STREAM_DEPTH;
 		vc_id = 0;
+		streaming_flag = &state->ds5_dev->depth_streaming;
 	} else if (state->is_rgb) {
 		config_status_base = DS5_RGB_CONFIG_STATUS;
 		stream_status_base = DS5_RGB_STREAM_STATUS;
 		stream_id = DS5_STREAM_RGB;
 		vc_id = 1;
+		streaming_flag = &state->ds5_dev->rgb_streaming;
 	} else if (state->is_y8) {
 		config_status_base = DS5_IR_CONFIG_STATUS;
 		stream_status_base = DS5_IR_STREAM_STATUS;
 		stream_id = DS5_STREAM_IR;
 		vc_id = 2;
+		streaming_flag = &state->ds5_dev->ir_streaming;
 	} else if (state->is_imu) {
 		config_status_base = DS5_IMU_CONFIG_STATUS;
 		stream_status_base = DS5_IMU_STREAM_STATUS;
 		stream_id = DS5_STREAM_IMU;
 		vc_id = 3;
+		streaming_flag = &state->ds5_dev->imu_streaming;
 	} else {
 		return -EINVAL;
 	}
@@ -5293,11 +5324,17 @@ retry_after_serdes_recovery:
 		dev_warn(&state->client->dev,
 			"stream %d in %d state already (status: 0x%04x) %dms, treating as no-op\n",
 			stream_id, on, status, jiffies_to_msecs(jiffies - ts));
+		mutex_lock(&state->ds5_dev->lock);
+		*streaming_flag = on;
+		mutex_unlock(&state->ds5_dev->lock);
 		sensor->streaming = on;
 		return 0;
 	}
 
 	restore_val = sensor->streaming;
+	mutex_lock(&state->ds5_dev->lock);
+	*streaming_flag = on;
+	mutex_unlock(&state->ds5_dev->lock);
 	sensor->streaming = on;
 
 	/*
@@ -5396,6 +5433,9 @@ retry_after_serdes_recovery:
 					serdes_recovery_attempts);
 
 				/* Clean up partial state from the failed attempt */
+				mutex_lock(&state->ds5_dev->lock);
+				*streaming_flag = restore_val;
+				mutex_unlock(&state->ds5_dev->lock);
 				sensor->streaming = restore_val;
 				ds5_invalidate_sensor(state, sensor);
 
@@ -5441,6 +5481,9 @@ retry_after_serdes_recovery:
 			}
 		}
 #endif
+		mutex_lock(&state->ds5_dev->lock);
+		*streaming_flag = restore_val;
+		mutex_unlock(&state->ds5_dev->lock);
 		sensor->streaming = restore_val;
 		ret = -EAGAIN;
 	}
@@ -5746,16 +5789,6 @@ static int ds5_fixed_configuration(struct i2c_client *client, struct ds5 *state)
 	if (ret < 0)
 		return ret;
 
-	/* After HW reset the FW may not have populated DS5_DEVICE_TYPE yet.
-	 * Use the cached value confirmed by Step 8 in hw_reset_with_recovery.
-	 */
-	if (dev_type == 0 && ds5_cached_device_type != 0) {
-		dev_info(&client->dev,
-			"%s(): device type register returned 0, using cached type 0x%x\n",
-			__func__, ds5_cached_device_type);
-		dev_type = ds5_cached_device_type;
-	}
-
 	dev_dbg(&client->dev, "%s(): cfg0 %x %ux%u cfg0_md %x %ux%u\n", __func__,
 		 cfg0, dw, dh, cfg0_md, yw, yh);
 
@@ -5763,6 +5796,7 @@ static int ds5_fixed_configuration(struct i2c_client *client, struct ds5 *state)
 		 cfg1, dw, dh, cfg1_md, yw, yh);
 
 	sensor = &state->depth.sensor;
+	dev_type = ds5_dev_type(state, dev_type);
 	switch (dev_type) {
 	case DS5_DEVICE_TYPE_D41X:
 		sensor->formats = ds5_depth_formats_d41x;
@@ -6246,13 +6280,7 @@ static void ds5_adjust_sync_mode_control(struct i2c_client *client, struct ds5 *
 		return;
 	}
 
-	if (dev_type == 0 && ds5_cached_device_type != 0) {
-		dev_info(&client->dev,
-			"%s(): device type register returned 0, using cached type 0x%x\n",
-			__func__, ds5_cached_device_type);
-		dev_type = ds5_cached_device_type;
-	}
-
+	dev_type = ds5_dev_type(state, dev_type);
 	switch (dev_type) {
 	case DS5_DEVICE_TYPE_D41X:
 		/* D41X does not support sync mode */
@@ -6661,10 +6689,16 @@ static int ds5_probe(struct i2c_client *c, const struct i2c_device_id *id)
 	ret = ds5_serdes_setup(state);
 	if (ret < 0)
 		goto e_regulator;
+	state->reset_ref_dser = atomic_read(dser_get_reset_gen(state));
+#else
+	ds5_init_global_slots_once();
+	if (NULL == ds5_inited[0].ds5_primary) {
+		ds5_init_ds5_dev(state, &ds5_inited[0]);
+		dev_dbg(&c->dev, "%s(): set primary ds5 instance\n", __func__);
+	}
+	state->ds5_dev = &ds5_inited[0];
 #endif
-	/* Initialize reset generation counter after SERDES setup so that
-	 * ds5_get_reset_gen() can resolve the per-deserializer counter. */
-	state->reset_gen = atomic_read(ds5_get_reset_gen(state));
+	state->reset_ref_ds5 = atomic_read(ds5_get_reset_gen(state));
 
 	// Verify communication
 	retry = 5;
@@ -6726,7 +6760,7 @@ static int ds5_probe(struct i2c_client *c, const struct i2c_device_id *id)
 			goto e_regulator;
 	}
 
-	if (atomic_cmpxchg(&ds5_probe_reset_once, 0, 1) == 0) {
+	if (atomic_cmpxchg(&state->ds5_dev->ds5_probe_reset_once, 0, 1) == 0) {
 		dev_info(&c->dev, "%s(): first probe instance, running HW reset recovery\n",
 			__func__);
 
@@ -6746,13 +6780,10 @@ static int ds5_probe(struct i2c_client *c, const struct i2c_device_id *id)
 			goto e_chardev;
 		}
 
-		/* Allow the camera firmware to fully stabilize after HW reset
-		 * before subsequent driver instances attempt I2C communication.
-		 * Without this delay, the D457's FW may be briefly unresponsive
-		 * during a post-reset initialization phase, causing later probe
-		 * instances (especially the 4th/IMU) to fail I2C checks.
+		/* Wait after HW reset before touching MAX9295 serializer registers.
+		 * This delay helps ensure the device is ready.
 		 */
-		msleep(100);
+		msleep(200);
 	}
 
 	/* Verify communication with retries and delay.
@@ -6824,38 +6855,34 @@ e_regulator:
 
 static int ds5_remove(struct i2c_client *c)
 {
-#ifdef CONFIG_VIDEO_D4XX_SERDES
-	int i, ret;
-#endif
 	struct ds5 *state = container_of(i2c_get_clientdata(c), struct ds5, mux.sd.subdev);
 	if (state && !state->mux.sd.subdev.v4l2_dev) {
 		state = i2c_get_clientdata(c);
 	}
 
 #ifdef CONFIG_VIDEO_D4XX_SERDES
-	for (i = 0; i < MAX_DEV_NUM; i++) {
-		if (serdes_inited[i] && serdes_inited[i] == state) {
-			serdes_inited[i] = NULL;
+	if (state->serdes_primary) {
+		int ret;
+		bool do_cleanup = false;
 
-			/* Only the primary instance (the one that did SERDES
-			 * setup) should tear down the serializer/deserializer.
-			 * Peer instances just unregister from the array.
-			 */
-			if (!state->serdes_primary)
-				break;
+		mutex_lock(&serdes_lock__);
+		mutex_lock(&state->ds5_dev->lock);
+		if (state->ds5_dev->ds5_primary) {
+			state->ds5_dev->ds5_primary = NULL;
+			do_cleanup = true;
+		}
+		mutex_unlock(&state->ds5_dev->lock);
 
-			mutex_lock(&serdes_lock__);
-
+		if (do_cleanup) {
 			ret = max9295_reset_control(state->ser_dev);
 			if (ret)
 				dev_warn(&c->dev,
-				  "failed in 9295 reset control\n");
+					"failed in 9295 reset control\n");
 			ret = state->dser_ops->reset_control(state->dser_dev,
 				state->g_ctx.s_dev);
 			if (ret)
 				dev_warn(&c->dev,
-				  "failed in 9296 reset control\n");
-
+					"failed in %s reset control\n", state->dser_ops->name);
 			ret = max9295_sdev_unpair(state->ser_dev,
 				state->g_ctx.s_dev);
 			if (ret)
@@ -6864,12 +6891,11 @@ static int ds5_remove(struct i2c_client *c)
 				state->g_ctx.s_dev);
 			if (ret)
 				dev_warn(&c->dev,
-				  "failed to sdev unregister sdev\n");
+					"failed to %s unregister sdev\n", state->dser_ops->name);
 			state->dser_ops->power_off(state->dser_dev);
-
-			mutex_unlock(&serdes_lock__);
-			break;
 		}
+
+		mutex_unlock(&serdes_lock__);
 	}
 	if (state->ser_i2c)
 		i2c_unregister_device(state->ser_i2c);

--- a/scripts/generate_compile_commands.sh
+++ b/scripts/generate_compile_commands.sh
@@ -18,7 +18,7 @@ SOURCE_FILE="$REPO/kernel/realsense/d4xx.c"
 # ── locate the .d4xx.o.cmd file ───────────────────────────────────────────────
 CMD_FILE="${1:-}"
 if [ -z "$CMD_FILE" ]; then
-  CMD_FILE="$(find "$REPO/sources_"* -name '.d4xx.o.cmd' 2>/dev/null | head -1)"
+  CMD_FILE="$(find "$REPO/sources_"* -name '.d4xx.o.cmd' 2>/dev/null | head -1 || true)"
 fi
 
 if [ -z "$CMD_FILE" ] || [ ! -f "$CMD_FILE" ]; then

--- a/scripts/generate_compile_commands.sh
+++ b/scripts/generate_compile_commands.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+# generate_compile_commands.sh
+#
+# Generates .vscode/compile_commands.json for kernel/realsense/d4xx.c
+# by extracting the real compiler command from the cached .d4xx.o.cmd
+# that the kernel build writes after every module build.
+#
+# Usage (run from repo root after a module build):
+#   ./scripts/generate_compile_commands.sh
+#
+# Optional: pass a different .cmd file path as $1.
+set -euo pipefail
+
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+DEST="$REPO/.vscode/compile_commands.json"
+SOURCE_FILE="$REPO/kernel/realsense/d4xx.c"
+
+# ── locate the .d4xx.o.cmd file ───────────────────────────────────────────────
+CMD_FILE="${1:-}"
+if [ -z "$CMD_FILE" ]; then
+  CMD_FILE="$(find "$REPO/sources_"* -name '.d4xx.o.cmd' 2>/dev/null | head -1)"
+fi
+
+if [ -z "$CMD_FILE" ] || [ ! -f "$CMD_FILE" ]; then
+  echo "Error: could not find .d4xx.o.cmd under sources_*/." >&2
+  echo "  Run the module build first (build_all.sh), then re-run this script." >&2
+  exit 1
+fi
+echo "Using cmd file: $CMD_FILE"
+
+# ── extract the compiler command ──────────────────────────────────────────────
+# The file contains:  cmd_<target> := <full gcc invocation> \
+#                       <continuation lines>
+# Grab everything after ' := ' on the first cmd_ line and join continuations.
+RAW_CMD="$(sed -n '/^cmd_.*:=/{s/^cmd_[^ ]* := //; p}' "$CMD_FILE" | \
+           tr -d '\\\n' | sed 's/  */ /g')"
+
+if [ -z "$RAW_CMD" ]; then
+  echo "Error: could not parse cmd_ line from $CMD_FILE" >&2
+  exit 1
+fi
+
+# ── rewrite the command for IDE use ───────────────────────────────────────────
+# 1. Strip -Wp,-MMD,... (generates .d dependency files, confuses clangd/cpptools)
+# 2. Replace the original source path with our repo's d4xx.c
+# 3. Remove the -o <object> output flag (not needed for IndexDB)
+CLEAN_CMD="$(echo "$RAW_CMD" | \
+  sed -E 's|-Wp,-MMD,[^ ]+||g' | \
+  sed -E "s|[^ ]+/d4xx\.c|$SOURCE_FILE|g" | \
+  sed -E 's|-o [^ ]+\.o +||g' | \
+  sed 's/  */ /g; s/^ //; s/ $//')"
+
+# Append the source file at the end if not already present
+if ! echo "$CLEAN_CMD" | grep -q "$SOURCE_FILE"; then
+  CLEAN_CMD="$CLEAN_CMD $SOURCE_FILE"
+fi
+
+# ── write compile_commands.json ───────────────────────────────────────────────
+mkdir -p "$REPO/.vscode"
+python3 - "$DEST" "$REPO" "$CLEAN_CMD" "$SOURCE_FILE" <<'PY'
+import sys, json
+dest, directory, command, src = sys.argv[1:]
+db = [{"directory": directory, "command": command, "file": src}]
+with open(dest, "w") as f:
+    json.dump(db, f, indent=2)
+print(f"Written {dest}")
+PY


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><h4 style="line-height: normal; color: rgb(204, 204, 204); font-family: &quot;Segoe WPC&quot;, &quot;Segoe UI&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(37, 37, 38); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">1. New data structures:<span> </span><code style="font-family: Consolas, &quot;Courier New&quot;, monospace; font-size: 11.999px; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 1px 3px; border-radius: 4px; border-color: rgb(215, 186, 125); border-style: none; border-width: 0px; border-image: none 100% / 1 / 0 stretch; white-space: pre-wrap;">ds5_dev</code><span> </span>and<span> </span><code style="font-family: Consolas, &quot;Courier New&quot;, monospace; font-size: 11.999px; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 1px 3px; border-radius: 4px; border-color: rgb(215, 186, 125); border-style: none; border-width: 0px; border-image: none 100% / 1 / 0 stretch; white-space: pre-wrap;">dser_control</code></h4><p style="margin: 0px 0px 16px; color: rgb(204, 204, 204); font-family: &quot;Segoe WPC&quot;, &quot;Segoe UI&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(37, 37, 38); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Previously, per-camera and per-deserializer state (<code style="font-family: Consolas, &quot;Courier New&quot;, monospace; font-size: 11.999px; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 1px 3px; border-radius: 4px; border-color: rgb(215, 186, 125); border-style: none; border-width: 0px; border-image: none 100% / 1 / 0 stretch; white-space: pre-wrap;">reset_gen</code>,<span> </span><code style="font-family: Consolas, &quot;Courier New&quot;, monospace; font-size: 11.999px; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 1px 3px; border-radius: 4px; border-color: rgb(215, 186, 125); border-style: none; border-width: 0px; border-image: none 100% / 1 / 0 stretch; white-space: pre-wrap;">cached_device_type</code>,<span> </span><code style="font-family: Consolas, &quot;Courier New&quot;, monospace; font-size: 11.999px; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 1px 3px; border-radius: 4px; border-color: rgb(215, 186, 125); border-style: none; border-width: 0px; border-image: none 100% / 1 / 0 stretch; white-space: pre-wrap;">last_reset_jiffies</code>) was stored in scattered global variables. Now it's grouped into two proper structs:</p><ul style="padding-inline-start: 24px; color: rgb(204, 204, 204); font-family: &quot;Segoe WPC&quot;, &quot;Segoe UI&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(37, 37, 38); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li><strong><code style="font-family: Consolas, &quot;Courier New&quot;, monospace; font-size: 11.999px; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 1px 3px; border-radius: 4px; border-color: rgb(215, 186, 125); border-style: none; border-width: 0px; border-image: none 100% / 1 / 0 stretch; white-space: pre-wrap;">dser_control</code></strong><span> </span>— per-deserializer: own<span> </span><code style="font-family: Consolas, &quot;Courier New&quot;, monospace; font-size: 11.999px; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 1px 3px; border-radius: 4px; border-color: rgb(215, 186, 125); border-style: none; border-width: 0px; border-image: none 100% / 1 / 0 stretch; white-space: pre-wrap;">reset_gen</code>,<span> </span><code style="font-family: Consolas, &quot;Courier New&quot;, monospace; font-size: 11.999px; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 1px 3px; border-radius: 4px; border-color: rgb(215, 186, 125); border-style: none; border-width: 0px; border-image: none 100% / 1 / 0 stretch; white-space: pre-wrap;">dser_dev</code><span> </span>pointer</li><li><strong><code style="font-family: Consolas, &quot;Courier New&quot;, monospace; font-size: 11.999px; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 1px 3px; border-radius: 4px; border-color: rgb(215, 186, 125); border-style: none; border-width: 0px; border-image: none 100% / 1 / 0 stretch; white-space: pre-wrap;">ds5_dev</code></strong><span> </span>— per-camera: own<span> </span><code style="font-family: Consolas, &quot;Courier New&quot;, monospace; font-size: 11.999px; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 1px 3px; border-radius: 4px; border-color: rgb(215, 186, 125); border-style: none; border-width: 0px; border-image: none 100% / 1 / 0 stretch; white-space: pre-wrap;">reset_gen</code>,<span> </span><code style="font-family: Consolas, &quot;Courier New&quot;, monospace; font-size: 11.999px; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 1px 3px; border-radius: 4px; border-color: rgb(215, 186, 125); border-style: none; border-width: 0px; border-image: none 100% / 1 / 0 stretch; white-space: pre-wrap;">cached_device_type</code>,<span> </span><code style="font-family: Consolas, &quot;Courier New&quot;, monospace; font-size: 11.999px; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 1px 3px; border-radius: 4px; border-color: rgb(215, 186, 125); border-style: none; border-width: 0px; border-image: none 100% / 1 / 0 stretch; white-space: pre-wrap;">last_reset_jiffies</code>,<span> </span><code style="font-family: Consolas, &quot;Courier New&quot;, monospace; font-size: 11.999px; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 1px 3px; border-radius: 4px; border-color: rgb(215, 186, 125); border-style: none; border-width: 0px; border-image: none 100% / 1 / 0 stretch; white-space: pre-wrap;">dser_control*</code>,<span> </span><code style="font-family: Consolas, &quot;Courier New&quot;, monospace; font-size: 11.999px; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 1px 3px; border-radius: 4px; border-color: rgb(215, 186, 125); border-style: none; border-width: 0px; border-image: none 100% / 1 / 0 stretch; white-space: pre-wrap;">ds5_primary*</code>, and streaming flags</li></ul><p style="margin: 0px 0px 16px; color: rgb(204, 204, 204); font-family: &quot;Segoe WPC&quot;, &quot;Segoe UI&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(37, 37, 38); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Each<span> </span><code style="font-family: Consolas, &quot;Courier New&quot;, monospace; font-size: 11.999px; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 1px 3px; border-radius: 4px; border-color: rgb(215, 186, 125); border-style: none; border-width: 0px; border-image: none 100% / 1 / 0 stretch; white-space: pre-wrap;">ds5</code><span> </span>instance gets a<span> </span><code style="font-family: Consolas, &quot;Courier New&quot;, monospace; font-size: 11.999px; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 1px 3px; border-radius: 4px; border-color: rgb(215, 186, 125); border-style: none; border-width: 0px; border-image: none 100% / 1 / 0 stretch; white-space: pre-wrap;">-&gt;ds5_dev</code><span> </span>pointer to its camera's shared state, and each<span> </span><code style="font-family: Consolas, &quot;Courier New&quot;, monospace; font-size: 11.999px; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 1px 3px; border-radius: 4px; border-color: rgb(215, 186, 125); border-style: none; border-width: 0px; border-image: none 100% / 1 / 0 stretch; white-space: pre-wrap;">ds5_dev</code><span> </span>links to its<span> </span><code style="font-family: Consolas, &quot;Courier New&quot;, monospace; font-size: 11.999px; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 1px 3px; border-radius: 4px; border-color: rgb(215, 186, 125); border-style: none; border-width: 0px; border-image: none 100% / 1 / 0 stretch; white-space: pre-wrap;">dser_control</code>.</p><h4 style="line-height: normal; color: rgb(204, 204, 204); font-family: &quot;Segoe WPC&quot;, &quot;Segoe UI&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(37, 37, 38); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">2. Dual reset-generation tracking</h4><p style="margin: 0px 0px 16px; color: rgb(204, 204, 204); font-family: &quot;Segoe WPC&quot;, &quot;Segoe UI&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(37, 37, 38); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><code style="font-family: Consolas, &quot;Courier New&quot;, monospace; font-size: 11.999px; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 1px 3px; border-radius: 4px; border-color: rgb(215, 186, 125); border-style: none; border-width: 0px; border-image: none 100% / 1 / 0 stretch; white-space: pre-wrap;">state-&gt;reset_gen</code><span> </span>is split into<span> </span><code style="font-family: Consolas, &quot;Courier New&quot;, monospace; font-size: 11.999px; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 1px 3px; border-radius: 4px; border-color: rgb(215, 186, 125); border-style: none; border-width: 0px; border-image: none 100% / 1 / 0 stretch; white-space: pre-wrap;">reset_ref_ds5</code><span> </span>(camera-level) and<span> </span><code style="font-family: Consolas, &quot;Courier New&quot;, monospace; font-size: 11.999px; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 1px 3px; border-radius: 4px; border-color: rgb(215, 186, 125); border-style: none; border-width: 0px; border-image: none 100% / 1 / 0 stretch; white-space: pre-wrap;">reset_ref_dser</code><span> </span>(deserializer-level).<span> </span><code style="font-family: Consolas, &quot;Courier New&quot;, monospace; font-size: 11.999px; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 1px 3px; border-radius: 4px; border-color: rgb(215, 186, 125); border-style: none; border-width: 0px; border-image: none 100% / 1 / 0 stretch; white-space: pre-wrap;">ds5_mux_s_stream()</code><span> </span>now checks both: a mismatch on<span> </span><em>either</em><span> </span>triggers invalidation. This lets camera reset and deserializer reset be independent events, whereas before they were conflated into a single counter.</p><h4 style="line-height: normal; color: rgb(204, 204, 204); font-family: &quot;Segoe WPC&quot;, &quot;Segoe UI&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(37, 37, 38); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">3.<span> </span><code style="font-family: Consolas, &quot;Courier New&quot;, monospace; font-size: 11.999px; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 1px 3px; border-radius: 4px; border-color: rgb(215, 186, 125); border-style: none; border-width: 0px; border-image: none 100% / 1 / 0 stretch; white-space: pre-wrap;">ds5_setup_and_link()</code><span> </span>— deduplicated registration</h4><p style="margin: 0px 0px 16px; color: rgb(204, 204, 204); font-family: &quot;Segoe WPC&quot;, &quot;Segoe UI&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(37, 37, 38); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">The duplicated<span> </span><code style="font-family: Consolas, &quot;Courier New&quot;, monospace; font-size: 11.999px; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 1px 3px; border-radius: 4px; border-color: rgb(215, 186, 125); border-style: none; border-width: 0px; border-image: none 100% / 1 / 0 stretch; white-space: pre-wrap;">serdes_inited[]</code><span> </span>registration logic in both<span> </span><code style="font-family: Consolas, &quot;Courier New&quot;, monospace; font-size: 11.999px; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 1px 3px; border-radius: 4px; border-color: rgb(215, 186, 125); border-style: none; border-width: 0px; border-image: none 100% / 1 / 0 stretch; white-space: pre-wrap;">#ifdef CONFIG_OF</code><span> </span>and<span> </span><code style="font-family: Consolas, &quot;Courier New&quot;, monospace; font-size: 11.999px; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 1px 3px; border-radius: 4px; border-color: rgb(215, 186, 125); border-style: none; border-width: 0px; border-image: none 100% / 1 / 0 stretch; white-space: pre-wrap;">#else</code><span> </span>branches of<span> </span><code style="font-family: Consolas, &quot;Courier New&quot;, monospace; font-size: 11.999px; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 1px 3px; border-radius: 4px; border-color: rgb(215, 186, 125); border-style: none; border-width: 0px; border-image: none 100% / 1 / 0 stretch; white-space: pre-wrap;">ds5_board_setup()</code><span> </span>is extracted into one<span> </span><code style="font-family: Consolas, &quot;Courier New&quot;, monospace; font-size: 11.999px; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 1px 3px; border-radius: 4px; border-color: rgb(215, 186, 125); border-style: none; border-width: 0px; border-image: none 100% / 1 / 0 stretch; white-space: pre-wrap;">ds5_setup_and_link()</code><span> </span>function. Also handles deserializer linking in the same pass.</p><h4 style="line-height: normal; color: rgb(204, 204, 204); font-family: &quot;Segoe WPC&quot;, &quot;Segoe UI&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(37, 37, 38); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">4. Eliminated<span> </span><code style="font-family: Consolas, &quot;Courier New&quot;, monospace; font-size: 11.999px; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 1px 3px; border-radius: 4px; border-color: rgb(215, 186, 125); border-style: none; border-width: 0px; border-image: none 100% / 1 / 0 stretch; white-space: pre-wrap;">serdes_inited[]</code><span> </span>/<span> </span><code style="font-family: Consolas, &quot;Courier New&quot;, monospace; font-size: 11.999px; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 1px 3px; border-radius: 4px; border-color: rgb(215, 186, 125); border-style: none; border-width: 0px; border-image: none 100% / 1 / 0 stretch; white-space: pre-wrap;">MAX_DEV_NUM</code><span> </span>(24)</h4><p style="margin: 0px 0px 16px; color: rgb(204, 204, 204); font-family: &quot;Segoe WPC&quot;, &quot;Segoe UI&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(37, 37, 38); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Replaced by<span> </span><code style="font-family: Consolas, &quot;Courier New&quot;, monospace; font-size: 11.999px; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 1px 3px; border-radius: 4px; border-color: rgb(215, 186, 125); border-style: none; border-width: 0px; border-image: none 100% / 1 / 0 stretch; white-space: pre-wrap;">ds5_inited[MAX_DS5_NUM]</code><span> </span>(8 entries) and<span> </span><code style="font-family: Consolas, &quot;Courier New&quot;, monospace; font-size: 11.999px; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 1px 3px; border-radius: 4px; border-color: rgb(215, 186, 125); border-style: none; border-width: 0px; border-image: none 100% / 1 / 0 stretch; white-space: pre-wrap;">dser_inited[MAX_DSER_NUM]</code><span> </span>(4 entries). The old 24-entry flat array mixed camera instances and counted every V4L2 subdevice; the new arrays count physical cameras and deserializers.</p><h4 style="line-height: normal; color: rgb(204, 204, 204); font-family: &quot;Segoe WPC&quot;, &quot;Segoe UI&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(37, 37, 38); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">5. Simplified peer iteration</h4><p style="margin: 0px 0px 16px; color: rgb(204, 204, 204); font-family: &quot;Segoe WPC&quot;, &quot;Segoe UI&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(37, 37, 38); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">All loops that previously scanned 24<span> </span><code style="font-family: Consolas, &quot;Courier New&quot;, monospace; font-size: 11.999px; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 1px 3px; border-radius: 4px; border-color: rgb(215, 186, 125); border-style: none; border-width: 0px; border-image: none 100% / 1 / 0 stretch; white-space: pre-wrap;">serdes_inited[]</code><span> </span>entries with multi-condition filtering (same dser? different ser? skip self?) are replaced by shorter loops over<span> </span><code style="font-family: Consolas, &quot;Courier New&quot;, monospace; font-size: 11.999px; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 1px 3px; border-radius: 4px; border-color: rgb(215, 186, 125); border-style: none; border-width: 0px; border-image: none 100% / 1 / 0 stretch; white-space: pre-wrap;">ds5_inited[]</code>. Primary instance lookup is now O(1) via<span> </span><code style="font-family: Consolas, &quot;Courier New&quot;, monospace; font-size: 11.999px; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 1px 3px; border-radius: 4px; border-color: rgb(215, 186, 125); border-style: none; border-width: 0px; border-image: none 100% / 1 / 0 stretch; white-space: pre-wrap;">state-&gt;ds5_dev-&gt;ds5_primary</code>.</p><h4 style="line-height: normal; color: rgb(204, 204, 204); font-family: &quot;Segoe WPC&quot;, &quot;Segoe UI&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(37, 37, 38); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">6. Lazy invalidation via<span> </span><code style="font-family: Consolas, &quot;Courier New&quot;, monospace; font-size: 11.999px; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 1px 3px; border-radius: 4px; border-color: rgb(215, 186, 125); border-style: none; border-width: 0px; border-image: none 100% / 1 / 0 stretch; white-space: pre-wrap;">atomic_inc</code><span> </span>replaces explicit peer loops</h4><ul style="padding-inline-start: 24px; color: rgb(204, 204, 204); font-family: &quot;Segoe WPC&quot;, &quot;Segoe UI&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(37, 37, 38); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li>In<span> </span><code style="font-family: Consolas, &quot;Courier New&quot;, monospace; font-size: 11.999px; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 1px 3px; border-radius: 4px; border-color: rgb(215, 186, 125); border-style: none; border-width: 0px; border-image: none 100% / 1 / 0 stretch; white-space: pre-wrap;">ds5_hw_reset_serdes_recovery()</code><span> </span>Phase 2: the 20-line loop that explicitly invalidated all cameras on the deserializer is replaced by<span> </span><code style="font-family: Consolas, &quot;Courier New&quot;, monospace; font-size: 11.999px; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 1px 3px; border-radius: 4px; border-color: rgb(215, 186, 125); border-style: none; border-width: 0px; border-image: none 100% / 1 / 0 stretch; white-space: pre-wrap;">atomic_inc(dser_get_reset_gen(state))</code>. Peers detect the bump lazily in<span> </span><code style="font-family: Consolas, &quot;Courier New&quot;, monospace; font-size: 11.999px; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 1px 3px; border-radius: 4px; border-color: rgb(215, 186, 125); border-style: none; border-width: 0px; border-image: none 100% / 1 / 0 stretch; white-space: pre-wrap;">ds5_configure()</code>.</li><li>In<span> </span><code style="font-family: Consolas, &quot;Courier New&quot;, monospace; font-size: 11.999px; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 1px 3px; border-radius: 4px; border-color: rgb(215, 186, 125); border-style: none; border-width: 0px; border-image: none 100% / 1 / 0 stretch; white-space: pre-wrap;">ds5_hw_reset_with_recovery()</code><span> </span>Step 2: the explicit peer invalidation loop is replaced by<span> </span><code style="font-family: Consolas, &quot;Courier New&quot;, monospace; font-size: 11.999px; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 1px 3px; border-radius: 4px; border-color: rgb(215, 186, 125); border-style: none; border-width: 0px; border-image: none 100% / 1 / 0 stretch; white-space: pre-wrap;">atomic_inc(ds5_get_reset_gen(state))</code>.</li></ul><h4 style="line-height: normal; color: rgb(204, 204, 204); font-family: &quot;Segoe WPC&quot;, &quot;Segoe UI&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(37, 37, 38); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">7.<span> </span><code style="font-family: Consolas, &quot;Courier New&quot;, monospace; font-size: 11.999px; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 1px 3px; border-radius: 4px; border-color: rgb(215, 186, 125); border-style: none; border-width: 0px; border-image: none 100% / 1 / 0 stretch; white-space: pre-wrap;">ds5_dev_type()</code><span> </span>helper</h4><p style="margin: 0px 0px 16px; color: rgb(204, 204, 204); font-family: &quot;Segoe WPC&quot;, &quot;Segoe UI&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(37, 37, 38); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">The cached-device-type fallback pattern (check register value, substitute cached if 0) was duplicated in<span> </span><code style="font-family: Consolas, &quot;Courier New&quot;, monospace; font-size: 11.999px; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 1px 3px; border-radius: 4px; border-color: rgb(215, 186, 125); border-style: none; border-width: 0px; border-image: none 100% / 1 / 0 stretch; white-space: pre-wrap;">ds5_fixed_configuration()</code><span> </span>and<span> </span><code style="font-family: Consolas, &quot;Courier New&quot;, monospace; font-size: 11.999px; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 1px 3px; border-radius: 4px; border-color: rgb(215, 186, 125); border-style: none; border-width: 0px; border-image: none 100% / 1 / 0 stretch; white-space: pre-wrap;">ds5_adjust_sync_mode_control()</code>. Now a single inline function.</p><h4 style="line-height: normal; color: rgb(204, 204, 204); font-family: &quot;Segoe WPC&quot;, &quot;Segoe UI&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(37, 37, 38); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">8. Timing change: generation bump moved before HW reset command</h4><p style="margin: 0px 0px 16px; color: rgb(204, 204, 204); font-family: &quot;Segoe WPC&quot;, &quot;Segoe UI&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(37, 37, 38); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Old: explicit invalidation → HW reset →<span> </span><code style="font-family: Consolas, &quot;Courier New&quot;, monospace; font-size: 11.999px; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 1px 3px; border-radius: 4px; border-color: rgb(215, 186, 125); border-style: none; border-width: 0px; border-image: none 100% / 1 / 0 stretch; white-space: pre-wrap;">atomic_inc</code>. New:<span> </span><code style="font-family: Consolas, &quot;Courier New&quot;, monospace; font-size: 11.999px; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 1px 3px; border-radius: 4px; border-color: rgb(215, 186, 125); border-style: none; border-width: 0px; border-image: none 100% / 1 / 0 stretch; white-space: pre-wrap;">atomic_inc</code><span> </span>→ HW reset. This is slightly safer — eliminates a window where a peer could re-configure between explicit invalidation and the eventual<span> </span><code style="font-family: Consolas, &quot;Courier New&quot;, monospace; font-size: 11.999px; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 1px 3px; border-radius: 4px; border-color: rgb(215, 186, 125); border-style: none; border-width: 0px; border-image: none 100% / 1 / 0 stretch; white-space: pre-wrap;">atomic_inc</code>.</p><hr style="border-color: rgba(255, 255, 255, 0.18); font-family: &quot;Segoe WPC&quot;, &quot;Segoe UI&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(37, 37, 38); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><h3 style="line-height: normal; font-size: 13px; font-weight: unset; margin: 0px 0px 8px; font-family: &quot;Segoe WPC&quot;, &quot;Segoe UI&quot;, sans-serif; color: rgb(204, 204, 204); font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(37, 37, 38); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Advantages (weighted)</h3>
# | Advantage | Weight
-- | -- | --
1 | Structural clarity — per-camera/per-deserializer state is encapsulated, not scattered in globals | High
2 | ~120 fewer lines with no loss of functionality intent | High
3 | O(1) primary lookup — direct pointer vs. linear search through 24 entries | Medium
4 | Deduplicated registration — one ds5_setup_and_link() vs. two copies | Medium
5 | Dual reset-gen — camera and deserializer resets are independent signals | Medium
6 | Smaller iteration arrays — 8+4 entries vs. 24, less wasted scanning | Low
7 | ds5_dev_type() helper — eliminates repeated 7-line fallback blocks | Low

<br class="Apple-interchange-newline"><!--EndFragment-->
</body>
</html>