### PR TITLE
[RSDEV-6494] - Fix rmmod/modprobe after camera disconnect

### DIFF
--- a/hardware/realsense/tegra194-camera-d4xx-single.dtsi
+++ b/hardware/realsense/tegra194-camera-d4xx-single.dtsi
@@ -92,16 +92,10 @@
 					reset-gpios = <&tegra_main_gpio CAM0_RST_L GPIO_ACTIVE_HIGH>;
 				};
 
-				ser_prim: max9295_prim@40 {
-					status = "ok";
-					reg = <0x40>;
-					compatible = "maxim,max9295";
-					is-prim-ser;
-				};
 
-				ser_a: max9295_a@42 {
+				ser_a: max9295_a@40 {
 					compatible = "maxim,max9295";
-					reg = <0x42>;
+					reg = <0x40>;
 					maxim,gmsl-dser-device = <&dser>;
 				};
 

--- a/kernel/realsense/d4xx.c
+++ b/kernel/realsense/d4xx.c
@@ -3780,34 +3780,40 @@ static int ds5_serdes_setup(struct ds5 *state)
 	ret = max9295_sdev_pair(state->ser_dev, &state->g_ctx);
 	if (ret) {
 		dev_err(&c->dev, "gmsl ser pairing failed\n");
-		return ret;
+		goto serdes_setup_end;
 	}
 
 	/* Register sensor to deserializer dev */
 	ret = state->dser_ops->sdev_register(state->dser_dev, &state->g_ctx);
 	if (ret) {
 		dev_err(&c->dev, "gmsl deserializer register failed\n");
-		return ret;
+		goto serdes_setup_end;
 	}
 
 	ret = ds5_gmsl_serdes_setup(state);
 	if (ret) {
 		dev_err(&c->dev, "%s gmsl serdes setup failed\n", __func__);
-		return ret;
+		goto serdes_setup_end;
 	}
 
 	ret = max9295_init_settings(state->ser_dev);
 	if (ret) {
 		dev_warn(&c->dev, "%s, failed to init max9295 settings\n",
 			__func__);
-		return ret;
+		goto serdes_setup_end;
 	}
 
 	ret = state->dser_ops->init_settings(state->dser_dev);
 	if (ret) {
 		dev_warn(&c->dev, "%s, failed to init %s settings\n",
 			__func__, state->dser_ops->name);
-		return ret;
+		goto serdes_setup_end;
+	}
+
+serdes_setup_end:
+	if (ret) {
+		max9295_sdev_unpair(state->ser_dev, state->g_ctx.s_dev);
+		state->dser_ops->sdev_unregister(state->dser_dev, state->g_ctx.s_dev);
 	}
 
 	return ret;


### PR DESCRIPTION
- Removed "ser_prim" from xavier device tree - thus removing the ser address change to 0x42
- Added slight cleanup when probe fails, so next probe attempt will start cleanly