### PR TITLE
Fix ds5 reset and detection

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -160,7 +160,7 @@ Recent multi-phase refactoring of `kernel/realsense/d4xx.c`:
 - **Reset readiness migration**: replaced `DS5_DFU_MAGIC_REG` (0x5020) non-DFU readiness detection with CONTROL_STATUS scratch-and-poll handshake (scratch 0x00AD before reset, poll for 0x0000 restore after). Eliminated ~800 lines of post-ready compensating logic (device-type waits, HWMC probe loops, natural-recovery gates) that hinged on 0x5020 assumption.
 - **Per-instance control base init**: added `control_base` and `control_status_reg` fields to `struct ds5`, initialized once at probe based on camera type (Depth/Y8/IMU → DEPTH values 0x4100/0x401E; RGB → RGB values 0x4200/0x402E). Eliminates dynamic ternary recalculation across `ds5_s_ctrl()` and `ds5_g_volatile_ctrl()`, reducing code duplication and improving readability.
 - **Polling semantics separation**: introduced `ds5_read_poll()` helper for expected-transient-failure loops (HWMC status, reset readiness, SERDES recovery, DFU timeout, probe communication retries). Migrated 13 polling contexts to use single-shot direct regmap reads, eliminating false warnings and excessive log spam without changing I/O behavior. Preserves `ds5_read()` retry/logging semantics for normal I2C operations.
-- **HWMC helper consolidation**: refactored calibration set/get, GVD, LOG command send, and DFU switch to use `ds5_send_hwmc()` + `ds5_get_hwmc_status()` consistently instead of ad-hoc raw register writes.
+- **HWMC helper consolidation**: refactored calibration set/get, GVD, LOG command send, and DFU switch to use `ds5_hwmc_send()` + `ds5_hwmc_wait()` consistently instead of ad-hoc raw register writes.
 
 Earlier phases (below) documented for reference:
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -20,6 +20,7 @@ Linux kernel driver and userspace utilities for Intel RealSense D4XX series 3D d
 - **Macro naming**: prefix with `DS5_`. Register addresses: `DS5_FW_VERSION`, `DS5_START_STOP_STREAM`, `DS5_DEPTH_STREAM_DT`.
 - **Driver name**: `DS5_DRIVER_NAME` = `"d4xx"`, with variants `-awg`, `-asr`, `-class`, `-dfu`.
 - **I2C access**: use `ds5_read()` / `ds5_write()` wrappers around `regmap_raw_read()` / `regmap_raw_write()` with built-in retry logic (`DS5_I2C_RETRY_COUNT=5`, `DS5_I2C_RETRY_DELAY_US=5000`).
+- **Polling vs. normal I2C semantics**: for transient-failure-expected polling loops (HWMC status checks, reset readiness polls, SERDES recovery probes, DFU timeout checks), use `ds5_read_poll()` instead of `ds5_read()`. `ds5_read_poll()` performs a single direct `regmap_raw_read()` call without retry or logging, preventing false warnings and excessive log spam on expected transients. Reserve `ds5_read()` for normal I2C operations where retry logic and verbose failure logging are desired.
 - **Helper macros**: `ds5_read_with_check()`, `ds5_write_with_check()`, `ds5_raw_read_with_check()`, `ds5_raw_write_with_check()` — these return on error.
 - **Logging**: use `dev_err()`, `dev_warn()`, `dev_info()`, `dev_dbg()` with `&state->client->dev` as the device. Always include `__func__` in log messages.
 - **Locking**: `mutex_lock()` / `mutex_unlock()` for state synchronization.
@@ -30,7 +31,9 @@ Linux kernel driver and userspace utilities for Intel RealSense D4XX series 3D d
   - `CONFIG_TEGRA_CAMERA_PLATFORM` — Tegra-specific camera platform integration.
   - `LINUX_VERSION_CODE` checks for API differences between kernel versions (4.9, 5.10, 5.15+).
 - **Prefer lazy invalidation over explicit loops**: when state must be invalidated across multiple instances (e.g. after a deserializer reset), increment an atomic generation counter (`atomic_inc()`) and let each instance detect the bump lazily (e.g. in `ds5_configure()`). Avoid O(N) loops that iterate `ds5_inited[]` to poke siblings. Combine lazy checks when possible — if an existing function already detects a generation mismatch, add new invalidation logic there rather than adding a separate check elsewhere.
-- **HW reset natural recovery guard**: do not bypass Step 10 entirely when Step 6 is skipped. Keep a lightweight natural-recovery stability probe (2 reads spaced 100ms), and if it fails, run Phase 1 SERDES recovery before entering the full Step 10 stability verification path.
+- **HW reset readiness source of truth**: do not use register `0x5020` (`DS5_DFU_MAGIC_REG`) as a non-DFU reset-ready signal. Before HW reset, scratch `DS5_*_CONTROL_STATUS` with a non-zero sentinel (for example `0x00AD`), then after reset poll for the default `0x0000` restore to declare readiness. Keep `0x5020` only for DFU-magic detection (`0x04030201`).
+- **Post-reset operational readiness source of truth**: after reset completion, treat `DS5_DEVICE_TYPE` becoming valid as the firmware-ready gate for format/config-dependent code paths. `DS5_FW_VERSION` may become readable earlier and is acceptable for basic liveness checks, but do not use it as the only post-reset readiness signal.
+- **Reset-time cache invalidation for readiness gates**: whenever HW reset invalidates firmware-populated registers, clear any cached equivalents in the same reset path before readiness polling (for example reset `cached_device_type` before waiting on `DS5_DEVICE_TYPE`). Never allow a stale cache value to satisfy post-reset readiness checks.
 - **`ds5_mux_s_stream()` pre-toggle no-op rule**: for start (`on=1`), if reset-generation invalidation was detected and FW still reports streaming, do not return no-op; force a stop, clear cached stream state, and continue through normal start/configure flow.
 
 ### V4L2 Subdev Architecture
@@ -149,10 +152,19 @@ CI requires `git config user.email/name` to be set before `apply_patches.sh`.
 - `master` — primary/release branch
 - `dev` — active development branch
 -
-## Refactoring notes (recent commit)
+## Refactoring notes (recent commits)
 
-Short summary of approaches used in the refactor of `kernel/realsense/d4xx.c`:
+Recent multi-phase refactoring of `kernel/realsense/d4xx.c`:
 
+**Phase 1–3 (Reset Readiness + Per-Instance State Init + Polling Decoupling):**
+- **Reset readiness migration**: replaced `DS5_DFU_MAGIC_REG` (0x5020) non-DFU readiness detection with CONTROL_STATUS scratch-and-poll handshake (scratch 0x00AD before reset, poll for 0x0000 restore after). Eliminated ~800 lines of post-ready compensating logic (device-type waits, HWMC probe loops, natural-recovery gates) that hinged on 0x5020 assumption.
+- **Per-instance control base init**: added `control_base` and `control_status_reg` fields to `struct ds5`, initialized once at probe based on camera type (Depth/Y8/IMU → DEPTH values 0x4100/0x401E; RGB → RGB values 0x4200/0x402E). Eliminates dynamic ternary recalculation across `ds5_s_ctrl()` and `ds5_g_volatile_ctrl()`, reducing code duplication and improving readability.
+- **Polling semantics separation**: introduced `ds5_read_poll()` helper for expected-transient-failure loops (HWMC status, reset readiness, SERDES recovery, DFU timeout, probe communication retries). Migrated 13 polling contexts to use single-shot direct regmap reads, eliminating false warnings and excessive log spam without changing I/O behavior. Preserves `ds5_read()` retry/logging semantics for normal I2C operations.
+- **HWMC helper consolidation**: refactored calibration set/get, GVD, LOG command send, and DFU switch to use `ds5_send_hwmc()` + `ds5_get_hwmc_status()` consistently instead of ad-hoc raw register writes.
+
+Earlier phases (below) documented for reference:
+
+**Earlier Phases (Encapsulation + Lazy Invalidation):**
 - **Encapsulated shared state**: introduced `struct ds5_dev` (per-camera) and
   `struct dser_control` (per-deserializer) to centralize reset generation,
   cached device type and last-reset timestamps instead of scattered globals.
@@ -171,8 +183,9 @@ Short summary of approaches used in the refactor of `kernel/realsense/d4xx.c`:
 - **Non-SERDES compatibility**: added small fallbacks so callers can use the
   same reset-gen accessors in non-SERDES builds (where applicable).
 
-Advantages: clearer ownership of shared state, fewer global arrays and linear
-searches, more deterministic recovery behavior, and reduced duplicate code.
+Overall advantages: clearer ownership of shared state, fewer global arrays and linear
+searches, more deterministic recovery behavior, reduced duplicate code, improved logging
+clarity, and architectural separation of restart readiness detection from compensation logic.
 
 ## Workflow Rules
 
@@ -184,3 +197,10 @@ After every confirmed code patch, review and update this file and `CLAUDE.md`:
 2. **New conventions**: if the patch exposed a coding practice gap (e.g. a cleanup step that was missed), add a general coding convention so it is enforced going forward — do not just fix the specific instance.
 
 Do not leave stale or incorrect claims in configuration files after changing the code they describe.
+
+This review is not complete until the final response explicitly reports the outcome of both checks.
+
+- If a new convention was exposed, document it in the same patch series.
+- If no new convention was exposed, say that explicitly and give a short reason why the change was purely mechanical or already covered by existing rules.
+- If the code patch was refined by follow-up edits, re-run the convention review against the final net change, not just the first patch.
+- Treat a missed convention update as an incomplete task, even if the code change itself is correct.

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /test.logs
 /.vscode/*.db*
 /.vscode/compile_commands.json
+jetpack_version

--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -19,11 +19,9 @@
       "compileCommands": "${workspaceFolder}/.vscode/compile_commands.json",
       "browse": {
         "path": [
-          "${workspaceFolder}/kernel/kernel-jammy-src/include",
-          "${workspaceFolder}/kernel/realsense",
-          "${workspaceFolder}/**"
+          "${workspaceFolder}/kernel/realsense"
         ],
-        "limitSymbolsToIncludedHeaders": false,
+        "limitSymbolsToIncludedHeaders": true,
         "databaseFilename": "${workspaceFolder}/.vscode/browse.vc.db"
       }
     }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,6 +3,12 @@
   "C_Cpp.default.compileCommands": "${workspaceFolder}/.vscode/compile_commands.json",
   "C_Cpp.intelliSenseEngine": "Default",
   "files.exclude": {
-    "**/.cache": true
+    "**/.cache": true,
+    "**/images": true,
+    "**/kernel_mod": true,
+    "**/l4t-gcc": true,
+    "**/test.logs": true,
+    "**/.pytest_cache": true,
+    "sources_*/out": true
   }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,5 +127,17 @@ The build system cross-compiles for ARM64. Toolchains vary by JetPack:
 - Protect per-camera mutable slot state (`ds5_primary`, `depth/rgb/ir/imu_streaming`) with `struct ds5_dev::lock`.
 - Protect per-deserializer slot assignment (`dser_dev`) with `struct dser_control::lock`.
 - For sibling-health checks, snapshot pointers/flags under lock and perform I2C probing after unlocking.
-- In HW reset Step 10, natural-recovery path must still run a lightweight stability gate (2 reads x 100ms); on failure, trigger Phase 1 SERDES recovery and then continue full stability verification.
+- Do not use `0x5020` as non-DFU reset-ready status; in non-DFU mode it is not a readiness source of truth. For HW reset readiness, scratch `DS5_*_CONTROL_STATUS` with a non-zero sentinel before reset and wait for FW to restore default `0x0000` after reset. Use `0x5020` only for DFU magic detection.
+- After reset completion, use `DS5_DEVICE_TYPE` validity as the operational-readiness gate for code that depends on firmware-populated stream/config state. `DS5_FW_VERSION` can come back earlier and should only be treated as basic liveness, not full post-reset readiness.
+- On each HW reset, clear cached values for firmware-populated readiness registers before polling readiness (for example clear `cached_device_type` before waiting for `DS5_DEVICE_TYPE`). Do not let pre-reset cache values short-circuit post-reset readiness checks.
+- For polling loops expecting transient I2C failures (HWMC status checks, reset readiness polls, SERDES recovery probes, DFU timeout checks), use `ds5_read_poll()` which performs a single-shot regmap read without retry or logging. This prevents false warnings and excessive log spam. Reserve `ds5_read()` for normal I2C operations where retry semantics are desired.
 - In `ds5_mux_s_stream()`, treat pre-toggle "already streaming" as no-op only when state is coherent; after reset-generation invalidation on start path, force stop + state clear and proceed with normal reconfiguration flow.
+
+## Post-patch instruction hygiene
+
+After every confirmed code patch, review both `.github/copilot-instructions.md` and `CLAUDE.md` against the final net diff, including any follow-up tuning edits.
+
+- Check for stale architectural claims and remove or correct them immediately.
+- Check whether the patch exposed a reusable convention; if it did, write it down as a general rule instead of leaving it implicit in code.
+- If no new convention was exposed, state that explicitly in the final report and include a short justification.
+- Do not treat the task as complete until that review outcome has been reported.

--- a/kernel/realsense/d4xx.c
+++ b/kernel/realsense/d4xx.c
@@ -116,31 +116,35 @@ struct dser_interface {
 #define DS5_STREAM_IDLE			0x1
 #define DS5_STREAM_STREAMING		0x2
 
-#define DS5_DEPTH_STREAM_DT		0x4000
-#define DS5_DEPTH_STREAM_MD		0x4002
-#define DS5_DEPTH_RES_WIDTH		0x4004
-#define DS5_DEPTH_RES_HEIGHT		0x4008
-#define DS5_DEPTH_FPS			0x400C
-#define DS5_DEPTH_OVERRIDE		0x401C
+#define DS5_DEPTH_STREAM_DT		 0x4000
+#define DS5_DEPTH_STREAM_MD		 0x4002
+#define DS5_DEPTH_RES_WIDTH		 0x4004
+#define DS5_DEPTH_RES_HEIGHT	 0x4008
+#define DS5_DEPTH_FPS			 0x400C
+#define DS5_DEPTH_OVERRIDE		 0x401C
+#define DS5_DEPTH_CONTROL_STATUS 0x401E
 
 #define DS5_RGB_STREAM_DT		0x4020
 #define DS5_RGB_STREAM_MD		0x4022
 #define DS5_RGB_RES_WIDTH		0x4024
 #define DS5_RGB_RES_HEIGHT		0x4028
-#define DS5_RGB_FPS			0x402C
+#define DS5_RGB_FPS				0x402C
+#define DS5_RGB_CONTROL_STATUS 	0x402E
 
 #define DS5_IMU_STREAM_DT		0x4040
 #define DS5_IMU_STREAM_MD		0x4042
 #define DS5_IMU_RES_WIDTH		0x4044
 #define DS5_IMU_RES_HEIGHT		0x4048
-#define DS5_IMU_FPS			0x404C
+#define DS5_IMU_FPS				0x404C
+#define DS5_IMU_CONTROL_STATUS 	0x404E
 
 #define DS5_IR_STREAM_DT		0x4080
 #define DS5_IR_STREAM_MD		0x4082
 #define DS5_IR_RES_WIDTH		0x4084
 #define DS5_IR_RES_HEIGHT		0x4088
-#define DS5_IR_FPS			0x408C
+#define DS5_IR_FPS				0x408C
 #define DS5_IR_OVERRIDE			0x409C
+#define DS5_IR_CONTROL_STATUS 	0x409E
 
 #define DS5_DEPTH_CONTROL_BASE		0x4100
 #define DS5_RGB_CONTROL_BASE		0x4200
@@ -478,6 +482,8 @@ struct ds5 {
 	int reset_ref_dser;
 	u16 fw_version;
 	u16 fw_build;
+	u16 control_base;
+	u16 control_status_reg;
 #ifdef CONFIG_VIDEO_D4XX_SERDES
 	struct gmsl_link_ctx g_ctx;
 	struct device *ser_dev;
@@ -503,11 +509,12 @@ struct ds5_dev {
 	*/
 	atomic_t reset_gen;
 
-	/* Cached device type from HW reset Step 8.
+	/* Cached device type from post-reset device-type polling.
 	* During probe the first instance resets the camera, causing DS5_DEVICE_TYPE
-	* to temporarily return 0.  Step 8 polls until the register is valid and
-	* stores the result here so that all four probe instances (and any post-reset
-	* code path) can use the confirmed value even if the register read returns 0.
+	* to temporarily return 0. The reset path polls until the register is valid
+	* and stores the result here so that all four probe instances (and any
+	* post-reset code path) can use the confirmed value even if the register
+	* read still returns 0.
 	*/
 	u16 cached_device_type;
 
@@ -653,6 +660,20 @@ static inline u16 ds5_dev_type(struct ds5 *state, u16 dev_type)
 	return dev_type;
 }
 
+static bool ds5_is_valid_device_type(u16 dev_type)
+{
+	switch (dev_type) {
+	case DS5_DEVICE_TYPE_D40X:
+	case DS5_DEVICE_TYPE_D41X:
+	case DS5_DEVICE_TYPE_D43X:
+	case DS5_DEVICE_TYPE_D45X:
+	case DS5_DEVICE_TYPE_D46X:
+		return true;
+	default:
+		return false;
+	}
+}
+
 #define ds5_from_depth_sd(sd) container_of(sd, struct ds5, depth.sd)
 #define ds5_from_ir_sd(sd) container_of(sd, struct ds5, ir.sd)
 #define ds5_from_rgb_sd(sd) container_of(sd, struct ds5, rgb.sd)
@@ -757,6 +778,11 @@ static int ds5_read(struct ds5 *state, u16 reg, u16 *val)
 			__func__, reg, *val);
 
 	return ret;
+}
+
+static int ds5_read_poll(struct ds5 *state, u16 reg, u16 *val)
+{
+	return regmap_raw_read(state->regmap, reg, val, 2);
 }
 
 static int ds5_raw_read(struct ds5 *state, u16 reg, void *val, size_t val_len)
@@ -2208,7 +2234,7 @@ static int ds5_get_hwmc_status(struct ds5 *state)
 	do {
 		if (retries != 100)
 			msleep_range(1);
-		ret = ds5_read(state, DS5_HWMC_STATUS, &status);
+		ret = ds5_read_poll(state, DS5_HWMC_STATUS, &status);
 		if (ret) {
 			dev_dbg(&state->client->dev,
 				"%s(): I2C read failed (%d), retries left: %d\n",
@@ -2298,24 +2324,18 @@ static int ds5_send_hwmc(struct ds5 *state,
 static int ds5_set_calibration_data(struct ds5 *state,
 		struct hwm_cmd *cmd, u16 length)
 {
-	int ret = -1;
-	int retries = 10;
-	u16 status = 2;
+	int ret;
 
-	ds5_raw_write_with_check(state, DS5_HWMC_DATA, cmd, length); /* Write command data */
+	ret = ds5_send_hwmc(state, length, cmd);
+	if (ret)
+		return ret;
 
-	ds5_write_with_check(state, DS5_HWMC_EXEC, 0x01); /* execute cmd */
-	do {
-		if (retries != 10)
-			msleep_range(200);
-		ret = ds5_read(state, DS5_HWMC_STATUS, &status);
-	} while (retries-- && status != 0);
-
-	if (ret || status != 0) {
+	ret = ds5_get_hwmc_status(state);
+	if (ret) {
 		dev_err(&state->client->dev,
 				"%s(): Failed to set calibration table %d,"
 				"ret: %d, fw error: %x\n",
-				__func__, cmd->param1, ret, status);
+				__func__, cmd->param1, ret, ret);
 	}
 
 	return ret;
@@ -2327,16 +2347,10 @@ static int ds5_set_calibration_data(struct ds5 *state,
 #define DS5_HW_RESET_TIMEOUT_MS		10000
 #define DS5_HW_RESET_MAX_RETRIES	(DS5_HW_RESET_TIMEOUT_MS / DS5_HW_RESET_POLL_INTERVAL_MS)
 
-/* Post-reset I2C stability verification (Step 10).
- * After FW reports ready and HWMC passes, verify the I2C link is
- * *sustained* — some camera SKUs (D401) have a secondary FW init phase
- * that briefly drops I2C ~65ms after the initial checks pass.
- */
+/* Post-reset I2C stability verification parameters used by SERDES recovery. */
 #define DS5_HW_RESET_STABILITY_READS	3	/* consecutive successful reads */
 #define DS5_HW_RESET_STABILITY_INTERVAL_MS 200	/* between each check */
 #define DS5_HW_RESET_STABILITY_TIMEOUT_MS 3000	/* max wait for stable link */
-#define DS5_HW_RESET_NATURAL_STABILITY_READS	2
-#define DS5_HW_RESET_NATURAL_STABILITY_INTERVAL_MS 100
 
 /* Minimum interval between consecutive HW resets (ms).
  * Rapid back-to-back resets degrade the GMSL link because each
@@ -2345,14 +2359,47 @@ static int ds5_set_calibration_data(struct ds5 *state,
  */
 #define DS5_HW_RESET_COOLDOWN_MS	2000
 
-/*
- * Register 0x5020 status values (from firmware):
- * - 0xDEAD: Device in normal UVC mode (ready) - ICT returns error for unhandled cmd
- * - 0x04030201: Device in DFU mode (DFU magic bytes, little-endian)
- * - I2C error: Device not yet responding (still resetting)
+/* Reset readiness handshake:
+ * 1) write scratch value before reset,
+ * 2) wait for FW to restore control-status registers to default 0.
  */
-#define DS5_HW_RESET_STATUS_READY	0xDEAD
-#define DS5_HW_RESET_DFU_MAGIC_LSW	0x0201  /* Lower 16 bits of 0x04030201 */
+#define DS5_HW_RESET_READY_SCRATCH_VAL	0x00AD
+#define DS5_HW_RESET_READY_EXPECTED_VAL	0x0000
+
+/*
+ * Register holding DFU magic (0x5020).
+ * In non-DFU mode this register is not defined.
+ * - 0x04030201: Device in DFU mode (DFU magic bytes, little-endian)
+ */
+#define DS5_DFU_MAGIC_REG	0x5020
+#define DS5_DFU_MAGIC_LSW		0x0201  /* Lower 16 bits of 0x04030201 */
+
+static int ds5_wait_device_type(struct ds5 *state, u16 *dev_type)
+{
+	int ret = -ETIMEDOUT;
+	int retry;
+	u16 cached_type;
+	u16 probed_type = DS5_DEVICE_TYPE_UNKNOWN;
+
+	for (retry = 0; retry < DS5_HW_RESET_MAX_RETRIES;
+	     retry++, msleep(DS5_HW_RESET_POLL_INTERVAL_MS)) {
+		cached_type = READ_ONCE(state->ds5_dev->cached_device_type);
+		if (ds5_is_valid_device_type(cached_type)) {
+			*dev_type = cached_type;
+			return 0;
+		}
+
+		ret = ds5_read_poll(state, DS5_DEVICE_TYPE, &probed_type);
+		if (!ret && ds5_is_valid_device_type(probed_type)) {
+			WRITE_ONCE(state->ds5_dev->cached_device_type, probed_type);
+			*dev_type = probed_type;
+			return 0;
+		}
+	}
+
+	*dev_type = probed_type;
+	return ret ? ret : -ETIMEDOUT;
+}
 
 /*
  * ds5_hw_reset_serdes_recovery - Tiered SERDES recovery after HW reset.
@@ -2428,14 +2475,14 @@ static int ds5_hw_reset_serdes_recovery(struct ds5 *state, bool force_phase2)
 		 * serializer reconfiguration, only to kill it again ~100 ms
 		 * later.  Do multiple reads with delays to catch oscillation.
 		 */
-		ret = ds5_read(state, DS5_FW_VERSION, &tmp);
+		ret = ds5_read_poll(state, DS5_FW_VERSION, &tmp);
 		if (ret == 0) {
 			int k;
 			bool stable = true;
 
 			for (k = 0; k < DS5_HW_RESET_STABILITY_READS; k++) {
 				msleep(DS5_HW_RESET_STABILITY_INTERVAL_MS);
-				ret = ds5_read(state, DS5_FW_VERSION, &tmp);
+				ret = ds5_read_poll(state, DS5_FW_VERSION, &tmp);
 				if (ret < 0) {
 					dev_warn(&state->client->dev,
 						"%s(): Phase 1 stability check %d/%d failed (err %d)\n",
@@ -2501,7 +2548,7 @@ static int ds5_hw_reset_serdes_recovery(struct ds5 *state, bool force_phase2)
 		if (!sib_streaming[i])
 			continue;
 
-		if (0 == ds5_read(sib_primary[i], DS5_FW_VERSION, &tmp)) {
+		if (0 == ds5_read_poll(sib_primary[i], DS5_FW_VERSION, &tmp)) {
 			sibling_alive = true;
 			dev_warn(&state->client->dev,
 				"%s(): true sibling %s alive & streaming, skipping deser reset\n",
@@ -2552,7 +2599,7 @@ static int ds5_hw_reset_serdes_recovery(struct ds5 *state, bool force_phase2)
 	 */
 	for (i = 0; i < 8; i++) {
 		msleep(500);
-		ret = ds5_read(state, DS5_FW_VERSION, &tmp);
+		ret = ds5_read_poll(state, DS5_FW_VERSION, &tmp);
 		if (ret == 0) {
 			dev_info(&state->client->dev,
 				"%s(): Phase 2: I2C link up after %d ms\n",
@@ -2603,7 +2650,7 @@ static int ds5_hw_reset_serdes_recovery(struct ds5 *state, bool force_phase2)
 
 		for (k = 0; k < 3; k++) {
 			msleep(200);
-			ret = ds5_read(state, DS5_FW_VERSION, &tmp);
+			ret = ds5_read_poll(state, DS5_FW_VERSION, &tmp);
 			if (ret < 0) {
 				stable = false;
 				break;
@@ -2647,15 +2694,14 @@ static int ds5_hw_reset_with_recovery(struct ds5 *state)
 {
 	int ret;
 	int retry;
-	int __maybe_unused i;
-	u16 status = 0;
+	u16 dev_type = DS5_DEVICE_TYPE_UNKNOWN;
+	u16 ready_status = 0;
+	u16 ready_reg = state->control_status_reg;
+	struct hwm_cmd reset_cmd;
 	bool depth_streaming;
 	bool rgb_streaming;
 	bool ir_streaming;
 	bool imu_streaming;
-#ifdef CONFIG_VIDEO_D4XX_SERDES
-	bool serdes_recovery_ran = false;
-#endif
 	unsigned long ds5_last_reset_jiffies = READ_ONCE(state->ds5_dev->last_reset_jiffies);
 
 	dev_info(&state->client->dev, "%s(): Initiating HW reset with recovery\n",
@@ -2712,29 +2758,41 @@ static int ds5_hw_reset_with_recovery(struct ds5 *state)
 	 *    After HW reset the device loses all configuration, so driver
 	 *    state must be brought in sync, like clearing streaming flags so that
 	 *    ds5_mux_s_stream() won't silently skip the next stream-start.
+	 *    Also clear cached device type so post-reset readiness polling
+	 *    cannot be satisfied by stale pre-reset values.
 	 *    Covers this instance AND all peer instances of the same camera.
 	 *
-	 *    Do NOT release SERDES pipes here — the D457 FW is still
-	 *    reconfiguring the MAX9295 serializer after reporting 0xDEAD.
+	 *    Do NOT release SERDES pipes here — the D4XX FW may still
+	 *    reconfigure MAX9295 while reset completion propagates.
 	 *    Releasing + re-allocating pipes now would race with FW init.
 	 *    Instead, clear pipe_data_type to force ds5_configure() to
 	 *    release-then-reallocate at stream-start time, when the FW
 	 *    has long finished its init (matching v1.0.1.33 behavior).
 	 */
 	atomic_inc(ds5_get_reset_gen(state));
+	WRITE_ONCE(state->ds5_dev->cached_device_type, DS5_DEVICE_TYPE_UNKNOWN);
 	ds5_reset_streaming_flags(state->ds5_dev);
 
-	/* 3. Send HW reset command */
-	ret = ds5_raw_write(state, DS5_HWMC_DATA, &cmd_hw_reset, sizeof(cmd_hw_reset));
-	if (ret < 0) {
-		dev_err(&state->client->dev, "%s(): Failed to write HW reset command: %d\n",
-			__func__, ret);
+	/* 3. Scratch one control-status register before reset.
+	 *    FW restores them to default 0x0000 only after reset completes.
+	 */
+	if (!ready_reg)
+		ready_reg = DS5_DEPTH_CONTROL_STATUS;
+
+	ret = ds5_write(state, ready_reg, DS5_HW_RESET_READY_SCRATCH_VAL);
+	if (ret) {
+		dev_err(&state->client->dev,
+			"%s(): scratch write failed reg 0x%04x (%d)\n",
+			__func__, ready_reg, ret);
 		return ret;
 	}
 
-	ret = ds5_write(state, DS5_HWMC_EXEC, 0x01);
+	/* 4. Send HW reset command */
+	memcpy(&reset_cmd, &cmd_hw_reset, sizeof(reset_cmd));
+	ret = ds5_send_hwmc(state, sizeof(reset_cmd), &reset_cmd);
 	if (ret < 0) {
-		dev_err(&state->client->dev, "%s(): Failed to execute HW reset command: %d\n",
+		dev_err(&state->client->dev,
+			"%s(): Failed to send HW reset command: %d\n",
 			__func__, ret);
 		return ret;
 	}
@@ -2742,86 +2800,72 @@ static int ds5_hw_reset_with_recovery(struct ds5 *state)
 	dev_info(&state->client->dev, "%s(): HW reset command sent, waiting for device...\n",
 		__func__);
 
-	/* 4. Brief delay to allow reset to begin */
+	/* 5. Brief delay to allow reset to begin */
 	msleep(DS5_HW_RESET_INITIAL_DELAY_MS);
 
-	/* 5. Poll for device to come back online */
-	for (retry = 0; retry < DS5_HW_RESET_MAX_RETRIES; retry++) {
-		msleep(DS5_HW_RESET_POLL_INTERVAL_MS);
-
-		ret = ds5_read(state, 0x5020, &status);
+	/* 6. Poll for control-status defaults to confirm reset completion. */
+	for (retry = 0; retry < DS5_HW_RESET_MAX_RETRIES; retry++, msleep(DS5_HW_RESET_POLL_INTERVAL_MS)) {
+		ret = ds5_read_poll(state, ready_reg, &ready_status);
 
 		if (ret < 0) {
-			/* I2C failed - device is resetting (expected during reset) */
 			dev_dbg(&state->client->dev,
 				"%s(): Device not responding (resetting), retry %d\n",
 				__func__, retry);
 			continue;
 		}
 
-		/* I2C succeeded - check status */
-		if (status == DS5_HW_RESET_STATUS_READY) {
-			/* 0xDEAD means device is in normal UVC mode (ready) */
+		if (ready_status == DS5_HW_RESET_READY_EXPECTED_VAL) {
 			dev_info(&state->client->dev,
-				"%s(): Device ready after %d ms, status: 0x%04x\n",
+				"%s(): Device ready after %d ms (control-status default restored)\n",
 				__func__,
 				DS5_HW_RESET_INITIAL_DELAY_MS +
-				(retry + 1) * DS5_HW_RESET_POLL_INTERVAL_MS,
-				status);
+				(retry + 1) * DS5_HW_RESET_POLL_INTERVAL_MS);
 			break;
 		}
+	}
 
-		if (status == DS5_HW_RESET_DFU_MAGIC_LSW) {
-			/* 0x0201 is lower 16-bits of DFU magic 0x04030201 */
+	if (retry >= DS5_HW_RESET_MAX_RETRIES) {
+		u16 dfu_magic = 0;
+
+		ret = ds5_read_poll(state, DS5_DFU_MAGIC_REG, &dfu_magic);
+		if (!ret && dfu_magic == DS5_DFU_MAGIC_LSW) {
 			dev_warn(&state->client->dev,
 				"%s(): Device in DFU/recovery mode after reset\n", __func__);
 			state->dfu_dev.dfu_state_flag = DS5_DFU_RECOVERY;
 			return 0;
 		}
 
-		/* Other status - keep waiting */
-		dev_dbg(&state->client->dev,
-			"%s(): Unexpected status 0x%04x, retry %d\n",
-			__func__, status, retry);
-	}
-
-	if (retry >= DS5_HW_RESET_MAX_RETRIES) {
 		dev_err(&state->client->dev,
-			"%s(): Device did not become ready after %d ms (last status: 0x%04x, i2c ret: %d)\n",
+			"%s(): Device did not become ready after %d ms (last control-status: 0x%04x, i2c ret: %d)\n",
 			__func__, DS5_HW_RESET_INITIAL_DELAY_MS + DS5_HW_RESET_TIMEOUT_MS,
-			status, ret);
+			ready_status, ret);
 		return -ETIMEDOUT;
 	}
 
 #ifdef CONFIG_VIDEO_D4XX_SERDES
-	/* 6. SERDES recovery (conditional).
-	 *    Step 5 polled the device over I2C until 0xDEAD was returned,
-	 *    which means the GMSL link is up.  Probe once more: if the
-	 *    link is still alive, the GMSL link recovered naturally — no
-	 *    full tiered SERDES recovery needed (the common case for D457).
+	/* 7. SERDES recovery (conditional).
+	 *    Step 6 confirmed reset completion via control-status defaults.
+	 *    Wait for DEVICE_TYPE: if the register becomes valid,
+	 *    the GMSL link recovered naturally and the firmware progressed far
+	 *    enough for format-dependent paths — no
+	 *    full tiered SERDES recovery needed (the common case for D4xx).
 	 *
 	 *    Do NOT call max9295_init_settings() here.  That function writes
 	 *    global serializer registers (0x02, 0x308, 0x311, 0x331) that
 	 *    disrupt the active GMSL link.  Per-pipe reconfiguration is
-	 *    handled by callers:
-	 *      - First-probe: ds5_probe() configures pipe 3 (IMU) after
-	 *        this function returns, before IMU peer probes.
-	 *      - HWMC reset: ds5_invalidate_sensor() clears pipe state for
-	 *        all peers; ds5_configure() re-runs ds5_setup_pipeline()
-	 *        at the next STREAMON for each stream.
+	 *    handled by ds5_configure()->ds5_setup_pipeline()
+	 *    at the next STREAMON for each stream.
 	 *
 	 *    Only run full tiered recovery (including init_settings +
 	 *    stability checks + Phase 2 escalation) when the I2C link
 	 *    is actually broken.
 	 */
 	{
-		u16 link_probe = 0;
-
-		ret = ds5_read(state, DS5_FW_VERSION, &link_probe);
-		if (ret < 0 || link_probe == 0) {
+		ret = ds5_wait_device_type(state, &dev_type);
+		if (ret < 0) {
 			dev_info(&state->client->dev,
-				"%s(): I2C link dead after Step 5 (ret=%d, val=0x%x), running full SERDES recovery\n",
-				__func__, ret, link_probe);
+				"%s(): device type not ready after reset (ret=%d, val=0x%x), running full SERDES recovery\n",
+				__func__, ret, dev_type);
 			ret = ds5_hw_reset_serdes_recovery(state, false);
 			if (ret < 0) {
 				dev_err(&state->client->dev,
@@ -2829,16 +2873,31 @@ static int ds5_hw_reset_with_recovery(struct ds5 *state)
 					__func__, ret);
 				return ret;
 			}
-			serdes_recovery_ran = true;
+
+			ret = ds5_wait_device_type(state, &dev_type);
+			if (ret < 0) {
+				dev_err(&state->client->dev,
+					"%s(): device type still not ready after SERDES recovery (ret=%d, val=0x%x)\n",
+					__func__, ret, dev_type);
+				return ret;
+			}
 		} else {
 			dev_info(&state->client->dev,
-				"%s(): GMSL link recovered naturally (FW ver 0x%04x), no SERDES intervention needed\n",
-				__func__, link_probe);
+				"%s(): GMSL link recovered naturally (device type 0x%04x), no SERDES intervention needed\n",
+				__func__, dev_type);
 		}
+	}
+#else
+	ret = ds5_wait_device_type(state, &dev_type);
+	if (ret < 0) {
+		dev_err(&state->client->dev,
+			"%s(): device type not ready after reset (ret=%d, val=0x%x)\n",
+			__func__, ret, dev_type);
+		return ret;
 	}
 #endif
 
-	/* 7. Verify device is operational by reading firmware version */
+	/* 8. Verify device is operational by reading firmware version */
 	ret = ds5_read(state, DS5_FW_VERSION, &state->fw_version);
 	if (ret < 0) {
 		dev_err(&state->client->dev,
@@ -2853,244 +2912,10 @@ static int ds5_hw_reset_with_recovery(struct ds5 *state)
 		return ret;
 	}
 
-	/* 8. Wait for device type register to be populated.
-	 * After HW reset the firmware sets status to 0xDEAD before fully
-	 * initializing configuration registers (DS5_DEVICE_TYPE, stream DT,
-	 * resolution, etc.).  If ds5_fixed_configuration() reads device type
-	 * as 0 it falls into the default switch case and selects D46X format
-	 * arrays (2 depth resolutions) instead of the correct tables per SKU
-	 * Poll until the register returns a known valid value or timeout.
-	 */
-	{
-		u16 dev_type = 0;
-
-		for (retry = 0; retry < DS5_HW_RESET_MAX_RETRIES; retry++) {
-			ret = ds5_read(state, DS5_DEVICE_TYPE, &dev_type);
-			if (ret == 0 && dev_type != 0) {
-				dev_info(&state->client->dev,
-					"%s(): Device type 0x%x ready after %d ms\n",
-					__func__, dev_type,
-					(retry + 1) * DS5_HW_RESET_POLL_INTERVAL_MS);
-				state->ds5_dev->cached_device_type = dev_type;
-				break;
-			}
-			msleep(DS5_HW_RESET_POLL_INTERVAL_MS);
-		}
-
-		if (retry >= DS5_HW_RESET_MAX_RETRIES)
-			dev_warn(&state->client->dev,
-				"%s(): Device type register not ready (0x%x) after %d ms, formats may be wrong\n",
-				__func__, dev_type, DS5_HW_RESET_TIMEOUT_MS);
-	}
-
-	/* 9. Verify HWMC subsystem is ready to accept commands.
-	 * After HW reset the FW reports 0xDEAD and populates device type
-	 * before the HWM command processor is fully initialized.  If
-	 * userspace queries GVD/HWMC immediately after we return, the
-	 * I2C reads NAK (EREMOTEIO) or return stale status (WIP/ERR),
-	 * which can crash RS Viewer.  Send a lightweight GVD command and
-	 * poll HWMC_STATUS until it completes successfully.
-	 */
-	{
-		struct hwm_cmd hwmc_probe;
-		u16 hwmc_status = DS5_HWMC_STATUS_WIP;
-		int hwmc_ret;
-
-		memcpy(&hwmc_probe, &gvd, sizeof(gvd));
-
-		for (retry = 0; retry < DS5_HW_RESET_MAX_RETRIES; retry++) {
-			hwmc_ret = ds5_raw_write(state, DS5_HWMC_DATA,
-						 &hwmc_probe, sizeof(hwmc_probe));
-			if (hwmc_ret) {
-				dev_dbg(&state->client->dev,
-					"%s(): HWMC probe write failed (%d), retry %d\n",
-					__func__, hwmc_ret, retry);
-				msleep(DS5_HW_RESET_POLL_INTERVAL_MS);
-				continue;
-			}
-
-			hwmc_ret = ds5_write(state, DS5_HWMC_EXEC, 0x01);
-			if (hwmc_ret) {
-				dev_dbg(&state->client->dev,
-					"%s(): HWMC probe exec failed (%d), retry %d\n",
-					__func__, hwmc_ret, retry);
-				msleep(DS5_HW_RESET_POLL_INTERVAL_MS);
-				continue;
-			}
-
-			/* Poll status — allow both I2C and WIP retries */
-			{
-				int poll;
-
-				for (poll = 0; poll < 100; poll++) {
-					msleep_range(5);
-					hwmc_ret = ds5_read(state, DS5_HWMC_STATUS,
-							     &hwmc_status);
-					if (hwmc_ret == 0 &&
-					    hwmc_status == DS5_HWMC_STATUS_OK)
-						break;
-				}
-			}
-
-			if (hwmc_ret == 0 && hwmc_status == DS5_HWMC_STATUS_OK) {
-				dev_info(&state->client->dev,
-					"%s(): HWMC ready after %d ms\n",
-					__func__,
-					(retry + 1) * DS5_HW_RESET_POLL_INTERVAL_MS);
-				break;
-			}
-
-			dev_dbg(&state->client->dev,
-				"%s(): HWMC not ready (status: 0x%x, ret: %d), retry %d\n",
-				__func__, hwmc_status, hwmc_ret, retry);
-			msleep(DS5_HW_RESET_POLL_INTERVAL_MS);
-		}
-
-		if (retry >= DS5_HW_RESET_MAX_RETRIES)
-			dev_warn(&state->client->dev,
-				"%s(): HWMC subsystem not ready after %d ms, userspace queries may fail\n",
-				__func__, DS5_HW_RESET_TIMEOUT_MS);
-	}
-
-#ifdef CONFIG_VIDEO_D4XX_SERDES
-	/* 10. Post-reset I2C stability verification.
-	 *
-	 *     Natural-recovery path: perform a lightweight stability gate
-	 *     (2 reads, 100ms apart).  This catches the FW secondary init
-	 *     window that can occur in parallel with the earlier readiness
-	 *     checks (Steps 5 and 7–9).
-	 *     If any probe fails, run Phase 1 SERDES recovery and continue with
-	 *     the full Step 10 verification loop.
-	 *
-	 *     Full verification loop: when SERDES recovery ran, verify I2C
-	 *     stability with DS5_HW_RESET_STABILITY_READS consecutive reads
-	 *     spaced DS5_HW_RESET_STABILITY_INTERVAL_MS apart.  If unstable,
-	 *     escalate to Phase 2 (full deserializer reset).
-	 */
-	if (!serdes_recovery_ran) {
-		int natural_ok = 0;
-		u16 natural_val = 0;
-
-		for (; natural_ok < DS5_HW_RESET_NATURAL_STABILITY_READS;
-			     natural_ok++) {
-			msleep(DS5_HW_RESET_NATURAL_STABILITY_INTERVAL_MS);
-			ret = ds5_read(state, DS5_FW_VERSION, &natural_val);
-			if (ret < 0 || natural_val == 0)
-				break;
-		}
-
-		if (natural_ok < DS5_HW_RESET_NATURAL_STABILITY_READS) {
-			dev_warn(&state->client->dev,
-				"%s(): natural recovery stability probe failed (ret=%d, val=0x%x), running Phase 1 SERDES recovery\n",
-				__func__, ret, natural_val);
-			ret = ds5_hw_reset_serdes_recovery(state, false);
-			if (ret < 0) {
-				dev_err(&state->client->dev,
-					"%s(): Phase 1 recovery from natural path failed: %d\n",
-					__func__, ret);
-				return ret;
-			}
-			serdes_recovery_ran = true;
-		} else {
-			dev_info(&state->client->dev,
-				"%s(): natural recovery stable (%d reads x %d ms), skipping full Step 10 loop\n",
-				__func__, DS5_HW_RESET_NATURAL_STABILITY_READS,
-				DS5_HW_RESET_NATURAL_STABILITY_INTERVAL_MS);
-		}
-	}
-
-	if (serdes_recovery_ran) {
-		int stable_count = 0;
-		unsigned long stab_ts = jiffies;
-		unsigned long stab_timeout =
-			stab_ts + msecs_to_jiffies(DS5_HW_RESET_STABILITY_TIMEOUT_MS);
-		u16 stab_val = 0;
-
-		while (time_before(jiffies, stab_timeout)) {
-			msleep(DS5_HW_RESET_STABILITY_INTERVAL_MS);
-
-			ret = ds5_read(state, DS5_FW_VERSION, &stab_val);
-			if (ret == 0 && stab_val != 0) {
-				stable_count++;
-				if (stable_count >= DS5_HW_RESET_STABILITY_READS) {
-					dev_info(&state->client->dev,
-						"%s(): I2C link stable after %d ms (%d consecutive reads OK)\n",
-						__func__,
-						jiffies_to_msecs(jiffies - stab_ts),
-						stable_count);
-					break;
-				}
-			} else {
-				if (stable_count > 0)
-					dev_warn(&state->client->dev,
-						"%s(): I2C stability check failed after %d OK reads (ret=%d, val=0x%x), resetting counter\n",
-						__func__, stable_count, ret, stab_val);
-				stable_count = 0;
-			}
-		}
-
-		if (stable_count < DS5_HW_RESET_STABILITY_READS) {
-			/* I2C link is unstable — escalate to Phase 2 (full deser reset) */
-			dev_warn(&state->client->dev,
-				"%s(): I2C link unstable after %d ms, escalating to Phase 2 SERDES recovery\n",
-				__func__,
-				jiffies_to_msecs(jiffies - stab_ts));
-
-			ret = ds5_hw_reset_serdes_recovery(state, true);
-			if (ret < 0) {
-				dev_err(&state->client->dev,
-					"%s(): Phase 2 escalation failed: %d\n",
-					__func__, ret);
-				/* Continue anyway — the device might still be partially usable */
-			} else {
-				/* Re-verify stability after Phase 2 */
-				stable_count = 0;
-				stab_ts = jiffies;
-				stab_timeout = stab_ts + msecs_to_jiffies(
-					DS5_HW_RESET_STABILITY_TIMEOUT_MS);
-
-				while (time_before(jiffies, stab_timeout)) {
-					msleep(DS5_HW_RESET_STABILITY_INTERVAL_MS);
-					ret = ds5_read(state, DS5_FW_VERSION, &stab_val);
-					if (ret == 0 && stab_val != 0) {
-						stable_count++;
-						if (stable_count >= DS5_HW_RESET_STABILITY_READS) {
-							dev_info(&state->client->dev,
-								"%s(): I2C link stable after Phase 2 (%d ms)\n",
-								__func__,
-								jiffies_to_msecs(jiffies - stab_ts));
-							break;
-						}
-					} else {
-						stable_count = 0;
-					}
-				}
-
-				if (stable_count < DS5_HW_RESET_STABILITY_READS)
-					dev_warn(&state->client->dev,
-						"%s(): I2C still unstable after Phase 2, proceeding anyway\n",
-						__func__);
-			}
-		}
-	} /* if (serdes_recovery_ran) */
-
-	/* 11. Per-pipe reconfiguration is NOT done here.
-	 *     - First-probe: ds5_probe() configures pipe 3 (IMU) after
-	 *       this function returns, before IMU peer probes.
-	 *     - HWMC reset: (Step 2) invalidates all peer pipe state.
-	 *		 At next STREAMON, ds5_configure() detects the mismatch and calls
-	 *       ds5_setup_pipeline() to reconfigure each pipe.
-	 *
-	 *     Do NOT call max9295_init_settings() or ds5_setup_pipeline()
-	 *     here.  init_settings() writes global MAX9295 registers that
-	 *     kill the GMSL link.  And for HWMC resets, the existing
-	 *     ds5_configure() path handles pipe reconfiguration cleanly.
-	 */
-#endif
-
 	dev_info(&state->client->dev,
-		"%s(): HW reset complete. Firmware: %d.%d.%d.%d\n",
+		"%s(): HW reset complete. Device type 0x%04x, firmware: %d.%d.%d.%d\n",
 		__func__,
+		dev_type,
 		(state->fw_version >> 8) & 0xff, state->fw_version & 0xff,
 		(state->fw_build >> 8) & 0xff, state->fw_build & 0xff);
 
@@ -3108,50 +2933,28 @@ static int ds5_s_ctrl(struct v4l2_ctrl *ctrl)
 	struct v4l2_subdev *sd = &state->mux.sd.subdev;
 	struct ds5_sensor *sensor = (struct ds5_sensor *)ctrl->priv;
 	int ret = -EINVAL;
-	u16 base = DS5_DEPTH_CONTROL_BASE;
+	u16 base;
 
 	if (sensor) {
 		switch (sensor->mux_pad) {
 		case DS5_MUX_PAD_DEPTH:
 			state = container_of(ctrl->handler, struct ds5, ctrls.handler_depth);
-			state->is_rgb = 0;
-			state->is_depth = 1;
-			state->is_y8 = 0;
-			state->is_imu = 0;
-		break;
+			break;
 		case DS5_MUX_PAD_RGB:
 			state = container_of(ctrl->handler, struct ds5, ctrls.handler_rgb);
-			state->is_rgb = 1;
-			state->is_depth = 0;
-			state->is_y8 = 0;
-			state->is_imu = 0;
-		break;
+			break;
 		case DS5_MUX_PAD_IR:
 			state = container_of(ctrl->handler, struct ds5, ctrls.handler_y8);
-			state->is_rgb = 0;
-			state->is_depth = 0;
-			state->is_y8 = 1;
-			state->is_imu = 0;
-		break;
+			break;
 		case DS5_MUX_PAD_IMU:
 			state = container_of(ctrl->handler, struct ds5, ctrls.handler_imu);
-			state->is_rgb = 0;
-			state->is_depth = 0;
-			state->is_y8 = 0;
-			state->is_imu = 1;
-		break;
+			break;
 		default:
-			state->is_rgb = 0;
-			state->is_depth = 0;
-			state->is_y8 = 0;
-			state->is_imu = 1;
-		break;
-
+			break;
 		}
 	}
 
-	if (state->is_rgb)
-		base = DS5_RGB_CONTROL_BASE;
+	base = state->control_base;
 	v4l2_dbg(3, 1, sd, "ctrl: %s, value: %d\n", ctrl->name, ctrl->val);
 	dev_dbg(&state->client->dev, "%s(): %s - ctrl: %s, value: %d\n",
 		__func__, ds5_get_sensor_name(state), ctrl->name, ctrl->val);
@@ -3438,9 +3241,7 @@ static int ds5_get_calibration_data(struct ds5 *state, enum table_id id,
 		unsigned char *table, unsigned int length)
 {
 	struct hwm_cmd *cmd;
-	int ret = -1;
-	int retries = 3;
-	u16 status = 2;
+	int ret;
 	u16 table_length;
 
 	cmd = devm_kzalloc(&state->client->dev,
@@ -3452,20 +3253,20 @@ static int ds5_get_calibration_data(struct ds5 *state, enum table_id id,
 
 	memcpy(cmd, &get_calib_data, sizeof(get_calib_data));
 	cmd->param1 = id;
-	ds5_raw_write_with_check(state, DS5_HWMC_DATA, cmd, sizeof(struct hwm_cmd)); /* Write command data */
-	ds5_write_with_check(state, DS5_HWMC_EXEC, 0x01); /* execute cmd */
-	do {
-		if (retries != 3)
-			msleep_range(10);
-		ret = ds5_read(state, DS5_HWMC_STATUS, &status);
-	} while (ret && retries-- && status != 0);
+	ret = ds5_send_hwmc(state, sizeof(struct hwm_cmd), cmd);
+	if (ret) {
+		devm_kfree(&state->client->dev, cmd);
+		return ret;
+	}
 
-	if (ret || status != 0) {
+	ret = ds5_get_hwmc_status(state);
+
+	if (ret) {
 		dev_err(&state->client->dev,
 				"%s(): Failed to get calibration table %d, fw error: %x\n",
-				__func__, id, status);
+				__func__, id, ret);
 		devm_kfree(&state->client->dev, cmd);
-		return status;
+		return ret;
 	}
 
 	// get table length from fw
@@ -3484,25 +3285,19 @@ static int ds5_get_calibration_data(struct ds5 *state, enum table_id id,
 static int ds5_gvd(struct ds5 *state, unsigned char *data)
 {
 	struct hwm_cmd cmd;
-	int ret = -1;
+	int ret;
 	u16 length = 0;
-	u16 status = DS5_HWMC_STATUS_WIP;
-	u8 retries = 20;
 
 	memcpy(&cmd, &gvd, sizeof(gvd));
-	ds5_raw_write_with_check(state, DS5_HWMC_DATA, &cmd, sizeof(cmd)); /* Write command data */
-	ds5_write_with_check(state, DS5_HWMC_EXEC, 0x01); /* execute cmd */
-	do {
-		if (retries != 20)
-			msleep_range(50);
+	ret = ds5_send_hwmc(state, sizeof(cmd), &cmd);
+	if (ret)
+		return ret;
 
-		ret = ds5_read(state, DS5_HWMC_STATUS, &status);
-	} while ((ret || status == DS5_HWMC_STATUS_WIP) && retries--);
-
-	if (ret || status != DS5_HWMC_STATUS_OK) {
+	ret = ds5_get_hwmc_status(state);
+	if (ret) {
 		dev_err(&state->client->dev,
-				"%s(): Failed to read GVD, HWM cmd status: %x, ret: %d\n",
-				__func__, status, ret);
+			"%s(): Failed to read GVD, HWM cmd status ret: %d\n",
+			__func__, ret);
 		return -EIO;
 	}
 
@@ -3518,54 +3313,31 @@ static int ds5_g_volatile_ctrl(struct v4l2_ctrl *ctrl)
 			ctrls.handler);
 	u16 log_prepare[] = {0x0014, 0xcdab, 0x000f, 0x0000, 0x0400, 0x0000,
 			0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000};
-	u16 execute_cmd = 0x0001;
-	unsigned int i;
 	u32 data;
 	int ret = 0;
 	struct ds5_sensor *sensor = (struct ds5_sensor *)ctrl->priv;
-	u16 base = (state->is_rgb) ? DS5_RGB_CONTROL_BASE : DS5_DEPTH_CONTROL_BASE;
+	u16 base;
 	u16 reg;
 
 	if (sensor) {
 		switch (sensor->mux_pad) {
 		case DS5_MUX_PAD_DEPTH:
 			state = container_of(ctrl->handler, struct ds5, ctrls.handler_depth);
-			state->is_rgb = 0;
-			state->is_depth = 1;
-			state->is_y8 = 0;
-			state->is_imu = 0;
-		break;
+			break;
 		case DS5_MUX_PAD_RGB:
 			state = container_of(ctrl->handler, struct ds5, ctrls.handler_rgb);
-			state->is_rgb = 1;
-			state->is_depth = 0;
-			state->is_y8 = 0;
-			state->is_imu = 0;
-		break;
+			break;
 		case DS5_MUX_PAD_IR:
 			state = container_of(ctrl->handler, struct ds5, ctrls.handler_y8);
-			state->is_rgb = 0;
-			state->is_depth = 0;
-			state->is_y8 = 1;
-			state->is_imu = 0;
-		break;
+			break;
 		case DS5_MUX_PAD_IMU:
 			state = container_of(ctrl->handler, struct ds5, ctrls.handler_imu);
-			state->is_rgb = 0;
-			state->is_depth = 0;
-			state->is_y8 = 0;
-			state->is_imu = 1;
-		break;
+			break;
 		default:
-			state->is_rgb = 0;
-			state->is_depth = 0;
-			state->is_y8 = 0;
-			state->is_imu = 1;
-		break;
-
+			break;
 		}
 	}
-	base = (state->is_rgb) ? DS5_RGB_CONTROL_BASE : DS5_DEPTH_CONTROL_BASE;
+	base = state->control_base;
 
 	dev_dbg(&state->client->dev, "%s(): %s - ctrl: %s \n",
 		__func__, ds5_get_sensor_name(state), ctrl->name);
@@ -3618,35 +3390,14 @@ static int ds5_g_volatile_ctrl(struct v4l2_ctrl *ctrl)
 		break;
 
 	case DS5_CAMERA_CID_LOG:
-		// TODO: wrap HWMonitor command
-		//       1. prepare and send command
-		//       2. send command
-		//       3. execute command
-		//       4. wait for completion
-		ret = ds5_raw_write(state, DS5_HWMC_DATA, /* Write command data */
-				log_prepare, sizeof(log_prepare));
-		if (ret < 0)
+		ret = ds5_send_hwmc(state, sizeof(log_prepare),
+					    (struct hwm_cmd *)log_prepare);
+		if (ret)
 			return ret;
 
-		ret = ds5_raw_write(state, DS5_HWMC_EXEC,
-				&execute_cmd, sizeof(execute_cmd)); /* execute cmd */
-		if (ret < 0)
+		ret = ds5_get_hwmc_status(state);
+		if (ret)
 			return ret;
-
-		for (i = 0; i < DS5_MAX_LOG_POLL; i++) {
-			ret = ds5_raw_read(state, DS5_HWMC_STATUS,
-					&data, sizeof(data));
-			dev_dbg(&state->client->dev, "%s(): log ready 0x%x\n",
-				 __func__, data);
-			if (ret < 0)
-				return ret;
-			if (!data)
-				break;
-			msleep_range(5);
-		}
-
-//		if (i == DS5_MAX_LOG_POLL)
-//			return -ETIMEDOUT;
 
 		ret = ds5_raw_read(state, DS5_HWMC_RESP_LEN, &data, sizeof(data)); /* Read response length */
 		dev_dbg(&state->client->dev, "%s(): log size 0x%x\n", __func__, data);
@@ -6055,9 +5806,10 @@ static int ds5_dfu_switch_to_dfu(struct ds5 *state)
 	int i = DS5_START_MAX_COUNT;
 	u16 status;
 
-	ds5_raw_write_with_check(state, DS5_HWMC_DATA,
-			&cmd_switch_to_dfu, sizeof(cmd_switch_to_dfu)); /* Write command data */
-	ds5_write_with_check(state, DS5_HWMC_EXEC, 0x01); /* execute cmd */
+	ret = ds5_send_hwmc(state, sizeof(cmd_switch_to_dfu),
+			    (struct hwm_cmd *)&cmd_switch_to_dfu);
+	if (ret)
+		return ret;
 	/*Wait for DFU fw to boot*/
 	do {
 		msleep_range(DS5_START_POLL_TIME*10);
@@ -6791,7 +6543,7 @@ static int ds5_probe(struct i2c_client *c
 	// Verify communication
 	retry = 5;
 	do {
-		ret = ds5_read(state, 0x5020, &rec_state);
+		ret = ds5_read_poll(state, DS5_FW_VERSION, &state->fw_version);
 	} while (retry-- && ret < 0);
 	if (ret < 0) {
 		dev_err(&c->dev,
@@ -6808,15 +6560,23 @@ static int ds5_probe(struct i2c_client *c
 	ret = of_property_read_string(c->dev.of_node, "cam-type", &str);
 	if (!ret && !strncmp(str, "Depth", strlen("Depth"))) {
 		state->is_depth = 1;
+		state->control_base = DS5_DEPTH_CONTROL_BASE;
+		state->control_status_reg = DS5_DEPTH_CONTROL_STATUS;
 	}
 	if (!ret && !strncmp(str, "Y8", strlen("Y8"))) {
 		state->is_y8 = 1;
+		state->control_base = DS5_DEPTH_CONTROL_BASE;
+		state->control_status_reg = DS5_DEPTH_CONTROL_STATUS;
 	}
 	if (!ret && !strncmp(str, "RGB", strlen("RGB"))) {
 		state->is_rgb = 1;
+		state->control_base = DS5_RGB_CONTROL_BASE;
+		state->control_status_reg = DS5_RGB_CONTROL_STATUS;
 	}
 	if (!ret && !strncmp(str, "IMU", strlen("IMU"))) {
 		state->is_imu = 1;
+		state->control_base = DS5_DEPTH_CONTROL_BASE;
+		state->control_status_reg = DS5_DEPTH_CONTROL_STATUS;
 	}
 
 	mode0_node = of_get_child_by_name(state->client->dev.of_node, "mode0");
@@ -6840,7 +6600,14 @@ static int ds5_probe(struct i2c_client *c
 	dev_dbg(&state->client->dev, "metadata_enabled = %d\n", state->metadata_enabled);
 #else
 	state->is_depth = 1;
+	state->control_base = DS5_DEPTH_CONTROL_BASE;
+	state->control_status_reg = DS5_DEPTH_CONTROL_STATUS;
 #endif
+
+	if (!state->control_base) {
+		state->control_base = DS5_DEPTH_CONTROL_BASE;
+		state->control_status_reg = DS5_DEPTH_CONTROL_STATUS;
+	}
 	/* create DFU chardev once */
 	if (state->is_depth) {
 		ret = ds5_chrdev_init(c, state);
@@ -6874,24 +6641,23 @@ static int ds5_probe(struct i2c_client *c
 		msleep(200);
 	}
 
-	/* Verify communication with retries and delay.
-	 * After HW reset (done by the first probe instance), the camera
-	 * firmware may still be initializing and briefly NAK I2C requests.
-	 * Use the same retry pattern as the initial communication check.
+	/* Verify post-reset format-discovery readiness.
+	 * FW_VERSION becomes readable earlier than DS5_DEVICE_TYPE, while later
+	 * probe code depends on DEVICE_TYPE to pick the correct format tables.
 	 */
-	retry = 10;
-	do {
-		ret = ds5_read(state, 0x5020, &rec_state);
-		if (ret < 0)
-			msleep(50);
-	} while (retry-- && ret < 0);
+	ret = ds5_wait_device_type(state, &rec_state);
 	if (ret < 0) {
-		dev_err(&c->dev, "%s(): cannot communicate with D4XX: %d\n",
-				__func__, ret);
+		dev_err(&c->dev,
+			"%s(): device type not ready after reset: %d (last val 0x%x)\n",
+			__func__, ret, rec_state);
 		goto e_chardev;
 	}
 
-	if (rec_state == 0x201) {
+	ret = ds5_read(state, DS5_DFU_MAGIC_REG, &rec_state);
+	if (ret < 0)
+		rec_state = 0;
+
+	if (rec_state == DS5_DFU_MAGIC_LSW) {
 		dev_info(&c->dev, "%s(): D4XX recovery state\n", __func__);
 		state->dfu_dev.dfu_state_flag = DS5_DFU_RECOVERY;
 		/* Override I2C drvdata with state for use in remove function */

--- a/kernel/realsense/d4xx.c
+++ b/kernel/realsense/d4xx.c
@@ -2315,7 +2315,7 @@ static int ds5_get_hwmc(struct ds5 *state, unsigned char *data,
 
 static int ds5_hwmc_send(struct ds5 *state,
 			u16 cmdLen,
-			struct hwm_cmd *cmd)
+			const struct hwm_cmd *cmd)
 {
 	dev_dbg(&state->client->dev,
 			"%s(): HWMC header: 0x%x, magic: 0x%x, opcode: 0x%x, "
@@ -2331,7 +2331,7 @@ static int ds5_hwmc_send(struct ds5 *state,
 }
 
 static int ds5_set_calibration_data(struct ds5 *state,
-		struct hwm_cmd *cmd, u16 length)
+		const struct hwm_cmd *cmd, u16 length)
 {
 	int ret;
 
@@ -4098,6 +4098,7 @@ static int ds5_board_setup(struct ds5 *state)
 		.is_prim_ser = 1, // todo: configurable
 		.def_addr = 0x40, // todo: configurable
 	};
+
 	static struct max9296_pdata max9296_pdata = {
 		.max_src = 2,
 		.csi_mode = GMSL_CSI_2X4_MODE,
@@ -6548,10 +6549,7 @@ static int ds5_probe(struct i2c_client *c
 	state->reset_ref_ds5 = atomic_read(ds5_get_reset_gen(state));
 
 	// Verify communication
-	retry = 5;
-	do {
-		ret = ds5_read_poll(state, DS5_FW_VERSION, &state->fw_version);
-	} while (retry-- && ret < 0);
+	ret = ds5_read(state, DS5_FW_VERSION, &state->fw_version);
 	if (ret < 0) {
 		dev_err(&c->dev,
 			"%s(): cannot communicate with D4XX: %d on addr: 0x%x\n",
@@ -6706,10 +6704,12 @@ e_regulator:
 	if (state->vcc)
 		regulator_disable(state->vcc);
 #ifdef CONFIG_VIDEO_D4XX_SERDES
+#ifndef CONFIG_OF
 	if (state->ser_i2c)
 		i2c_unregister_device(state->ser_i2c);
 	if (state->dser_i2c && !state->aggregated)
 		i2c_unregister_device(state->dser_i2c);
+#endif
 #endif
 	return ret;
 }
@@ -6764,12 +6764,14 @@ static void ds5_remove(struct i2c_client *c)
 
 		mutex_unlock(&serdes_lock__);
 
-		if (state->ser_i2c)
-			i2c_unregister_device(state->ser_i2c);
-		if (state->dser_i2c && !state->aggregated)
-			i2c_unregister_device(state->dser_i2c);
 	}
+#ifndef CONFIG_OF
+	if (state->ser_i2c)
+		i2c_unregister_device(state->ser_i2c);
+	if (state->dser_i2c && !state->aggregated)
+		i2c_unregister_device(state->dser_i2c);
 #endif
+#endif /* CONFIG_VIDEO_D4XX_SERDES */
 #ifndef CONFIG_TEGRA_CAMERA_PLATFORM
 	state->is_depth = 1;
 #endif

--- a/kernel/realsense/d4xx.c
+++ b/kernel/realsense/d4xx.c
@@ -339,6 +339,12 @@ static const struct hwm_cmd cmd_hw_reset = {
 	.opcode = 0x20,  /* HW reset opcode */
 };
 
+static const struct hwm_cmd log_prepare = {
+	.header = 0x014,
+	.magic_word = 0xCDAB,
+	.opcode = 0xf,
+	.param1 = 0x400, .param2 = 0, .param3 = 0, .param4 = 0,
+};
 struct __fw_status {
 	uint32_t	spare1;
 	uint32_t	FW_lastVersion;
@@ -2225,7 +2231,7 @@ enum DS5_HWMC_ERR {
 	DS5_HWMC_ERR_LAST,
 };
 
-static int ds5_get_hwmc_status(struct ds5 *state)
+static int ds5_hwmc_wait(struct ds5 *state)
 {
 	int ret = 0;
 	u16 status = DS5_HWMC_STATUS_WIP;
@@ -2242,17 +2248,20 @@ static int ds5_get_hwmc_status(struct ds5 *state)
 		}
 	} while (retries-- && (ret || status == DS5_HWMC_STATUS_WIP));
 	dev_dbg(&state->client->dev,
-			"%s(): ret: 0x%x, status: 0x%x\n",
-			__func__, ret, status);
-	if (ret || status != DS5_HWMC_STATUS_OK) {
+		"%s(): ret: 0x%x, status: 0x%x\n",
+		__func__, ret, status);
+	if (!ret) {
 		if (status == DS5_HWMC_STATUS_ERR) {
 			ds5_raw_read(state, DS5_HWMC_DATA, &errorCode, sizeof(errorCode));
-			return errorCode;
+			ret = errorCode;
+		} else if (status == DS5_HWMC_STATUS_WIP) {
+			ret = -ETIMEDOUT;
+			dev_warn(&state->client->dev,
+				"%s(): HWMC command timed out\n", __func__);
 		}
-	}
-	if (!ret && (status != DS5_HWMC_STATUS_OK))
+	} else {
 		ret = DS5_HWMC_ERR_LAST;
-
+	}
 	return ret;
 }
 
@@ -2266,7 +2275,7 @@ static int ds5_get_hwmc(struct ds5 *state, unsigned char *data,
 		return -ENOBUFS;
 
 	memset(data, 0, cmdDataLen);
-	ret = ds5_get_hwmc_status(state);
+	ret = ds5_hwmc_wait(state);
 	if (ret) {
 		dev_dbg(&state->client->dev,
 			"%s(): HWMC status not clear, ret: %d\n",
@@ -2304,7 +2313,7 @@ static int ds5_get_hwmc(struct ds5 *state, unsigned char *data,
 	return ret;
 }
 
-static int ds5_send_hwmc(struct ds5 *state,
+static int ds5_hwmc_send(struct ds5 *state,
 			u16 cmdLen,
 			struct hwm_cmd *cmd)
 {
@@ -2326,16 +2335,15 @@ static int ds5_set_calibration_data(struct ds5 *state,
 {
 	int ret;
 
-	ret = ds5_send_hwmc(state, length, cmd);
+	ret = ds5_hwmc_send(state, length, cmd);
 	if (ret)
 		return ret;
 
-	ret = ds5_get_hwmc_status(state);
+	ret = ds5_hwmc_wait(state);
 	if (ret) {
 		dev_err(&state->client->dev,
-				"%s(): Failed to set calibration table %d,"
-				"ret: %d, fw error: %x\n",
-				__func__, cmd->param1, ret, ret);
+				"%s(): Failed to set calibration table %d, error: %d\n",
+				__func__, cmd->param1, ret);
 	}
 
 	return ret;
@@ -2789,7 +2797,7 @@ static int ds5_hw_reset_with_recovery(struct ds5 *state)
 
 	/* 4. Send HW reset command */
 	memcpy(&reset_cmd, &cmd_hw_reset, sizeof(reset_cmd));
-	ret = ds5_send_hwmc(state, sizeof(reset_cmd), &reset_cmd);
+	ret = ds5_hwmc_send(state, sizeof(reset_cmd), &reset_cmd);
 	if (ret < 0) {
 		dev_err(&state->client->dev,
 			"%s(): Failed to send HW reset command: %d\n",
@@ -2827,6 +2835,11 @@ static int ds5_hw_reset_with_recovery(struct ds5 *state)
 	if (retry >= DS5_HW_RESET_MAX_RETRIES) {
 		u16 dfu_magic = 0;
 
+		dev_err(&state->client->dev,
+			"%s(): Device did not become ready after %d ms (last control-status: 0x%04x, i2c ret: %d)\n",
+			__func__, DS5_HW_RESET_INITIAL_DELAY_MS + DS5_HW_RESET_TIMEOUT_MS,
+			ready_status, ret);
+
 		ret = ds5_read_poll(state, DS5_DFU_MAGIC_REG, &dfu_magic);
 		if (!ret && dfu_magic == DS5_DFU_MAGIC_LSW) {
 			dev_warn(&state->client->dev,
@@ -2835,10 +2848,6 @@ static int ds5_hw_reset_with_recovery(struct ds5 *state)
 			return 0;
 		}
 
-		dev_err(&state->client->dev,
-			"%s(): Device did not become ready after %d ms (last control-status: 0x%04x, i2c ret: %d)\n",
-			__func__, DS5_HW_RESET_INITIAL_DELAY_MS + DS5_HW_RESET_TIMEOUT_MS,
-			ready_status, ret);
 		return -ETIMEDOUT;
 	}
 
@@ -3048,10 +3057,10 @@ static int ds5_s_ctrl(struct v4l2_ctrl *ctrl)
 			ae_roi_cmd.param2 = *((u16 *)ctrl->p_new.p_u16 + 1);
 			ae_roi_cmd.param3 = *((u16 *)ctrl->p_new.p_u16 + 2);
 			ae_roi_cmd.param4 = *((u16 *)ctrl->p_new.p_u16 + 3);
-			ret = ds5_send_hwmc(state, sizeof(struct hwm_cmd),
+			ret = ds5_hwmc_send(state, sizeof(struct hwm_cmd),
 				&ae_roi_cmd);
 			if (!ret)
-				ret = ds5_get_hwmc_status(state);
+				ret = ds5_hwmc_wait(state);
 		}
 		break;
 	case DS5_CAMERA_CID_AE_SETPOINT_SET:
@@ -3070,10 +3079,10 @@ static int ds5_s_ctrl(struct v4l2_ctrl *ctrl)
 			}
 			memcpy(ae_setpoint_cmd, &set_ae_setpoint, sizeof (set_ae_setpoint));
 			memcpy(ae_setpoint_cmd->Data, (u8 *)ctrl->p_new.p_s32, 4);
-			ret = ds5_send_hwmc(state, sizeof(struct hwm_cmd) + 4,
+			ret = ds5_hwmc_send(state, sizeof(struct hwm_cmd) + 4,
 					ae_setpoint_cmd);
 			if (!ret)
-				ret = ds5_get_hwmc_status(state);
+				ret = ds5_hwmc_wait(state);
 			devm_kfree(&state->client->dev, ae_setpoint_cmd);
 		}
 		break;
@@ -3103,7 +3112,7 @@ static int ds5_s_ctrl(struct v4l2_ctrl *ctrl)
 			memcpy(erb_cmd, &erb, sizeof(struct hwm_cmd));
 			erb_cmd->param1 = offset;
 			erb_cmd->param2 = size;
-			ret = ds5_send_hwmc(state, sizeof(struct hwm_cmd), erb_cmd);
+			ret = ds5_hwmc_send(state, sizeof(struct hwm_cmd), erb_cmd);
 			if (!ret)
 				ret = ds5_get_hwmc(state, erb_cmd->Data, len, &size);
 			if (ret) {
@@ -3162,9 +3171,9 @@ static int ds5_s_ctrl(struct v4l2_ctrl *ctrl)
 			ewb_cmd->param1 = offset; // start index
 			ewb_cmd->param2 = size; // size
 			memcpy(ewb_cmd->Data, (u8 *)ctrl->p_new.p_u8 + 4, size);
-			ret = ds5_send_hwmc(state, sizeof(struct hwm_cmd) + size, ewb_cmd);
+			ret = ds5_hwmc_send(state, sizeof(struct hwm_cmd) + size, ewb_cmd);
 			if (!ret)
-				ret = ds5_get_hwmc_status(state);
+				ret = ds5_hwmc_wait(state);
 			if (ret) {
 				dev_err(&state->client->dev,
 					"%s(): EWB cmd failed, ret: %d,"
@@ -3183,7 +3192,7 @@ static int ds5_s_ctrl(struct v4l2_ctrl *ctrl)
 			struct hwm_cmd *cmd = (struct hwm_cmd *)ctrl->p_new.p_u8;
 			size = *((u8 *)ctrl->p_new.p_u8 + 1) << 8;
 			size |= *((u8 *)ctrl->p_new.p_u8 + 0);
-			ret = ds5_send_hwmc(state, size + 4, cmd);
+			ret = ds5_hwmc_send(state, size + 4, cmd);
 			ret = ds5_get_hwmc(state, cmd->Data, ctrl->dims[0], &size);
 			if (ctrl->dims[0] < DS5_HWMC_BUFFER_SIZE) {
 				ret = -ENODATA;
@@ -3208,7 +3217,7 @@ static int ds5_s_ctrl(struct v4l2_ctrl *ctrl)
 					__func__);
 				ret = ds5_hw_reset_with_recovery(state);
 			} else {
-				ret = ds5_send_hwmc(state, size + 4, cmd);
+				ret = ds5_hwmc_send(state, size + 4, cmd);
 			}
 		}
 		break;
@@ -3253,17 +3262,17 @@ static int ds5_get_calibration_data(struct ds5 *state, enum table_id id,
 
 	memcpy(cmd, &get_calib_data, sizeof(get_calib_data));
 	cmd->param1 = id;
-	ret = ds5_send_hwmc(state, sizeof(struct hwm_cmd), cmd);
+	ret = ds5_hwmc_send(state, sizeof(struct hwm_cmd), cmd);
 	if (ret) {
 		devm_kfree(&state->client->dev, cmd);
 		return ret;
 	}
 
-	ret = ds5_get_hwmc_status(state);
+	ret = ds5_hwmc_wait(state);
 
 	if (ret) {
 		dev_err(&state->client->dev,
-				"%s(): Failed to get calibration table %d, fw error: %x\n",
+				"%s(): Failed to get calibration table %d, error: %d\n",
 				__func__, id, ret);
 		devm_kfree(&state->client->dev, cmd);
 		return ret;
@@ -3289,14 +3298,14 @@ static int ds5_gvd(struct ds5 *state, unsigned char *data)
 	u16 length = 0;
 
 	memcpy(&cmd, &gvd, sizeof(gvd));
-	ret = ds5_send_hwmc(state, sizeof(cmd), &cmd);
+	ret = ds5_hwmc_send(state, sizeof(cmd), &cmd);
 	if (ret)
 		return ret;
 
-	ret = ds5_get_hwmc_status(state);
+	ret = ds5_hwmc_wait(state);
 	if (ret) {
 		dev_err(&state->client->dev,
-			"%s(): Failed to read GVD, HWM cmd status ret: %d\n",
+			"%s(): Failed to read GVD, error: %d\n",
 			__func__, ret);
 		return -EIO;
 	}
@@ -3311,8 +3320,7 @@ static int ds5_g_volatile_ctrl(struct v4l2_ctrl *ctrl)
 {
 	struct ds5 *state = container_of(ctrl->handler, struct ds5,
 			ctrls.handler);
-	u16 log_prepare[] = {0x0014, 0xcdab, 0x000f, 0x0000, 0x0400, 0x0000,
-			0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000};
+			
 	u32 data;
 	int ret = 0;
 	struct ds5_sensor *sensor = (struct ds5_sensor *)ctrl->priv;
@@ -3390,12 +3398,11 @@ static int ds5_g_volatile_ctrl(struct v4l2_ctrl *ctrl)
 		break;
 
 	case DS5_CAMERA_CID_LOG:
-		ret = ds5_send_hwmc(state, sizeof(log_prepare),
-					    (struct hwm_cmd *)log_prepare);
+		ret = ds5_hwmc_send(state, sizeof(log_prepare), &log_prepare);
 		if (ret)
 			return ret;
 
-		ret = ds5_get_hwmc_status(state);
+		ret = ds5_hwmc_wait(state);
 		if (ret)
 			return ret;
 
@@ -3441,7 +3448,7 @@ static int ds5_g_volatile_ctrl(struct v4l2_ctrl *ctrl)
 				break;
 			}
 			memcpy(ae_roi_cmd, &get_ae_roi, sizeof(struct hwm_cmd));
-			ret = ds5_send_hwmc(state, sizeof(struct hwm_cmd), ae_roi_cmd);
+			ret = ds5_hwmc_send(state, sizeof(struct hwm_cmd), ae_roi_cmd);
 			if (ret) {
 				devm_kfree(&state->client->dev, ae_roi_cmd);
 				return ret;
@@ -3466,7 +3473,7 @@ static int ds5_g_volatile_ctrl(struct v4l2_ctrl *ctrl)
 			break;
 		}
 		memcpy(ae_setpoint_cmd, &get_ae_setpoint, sizeof(struct hwm_cmd));
-		ret = ds5_send_hwmc(state, sizeof(struct hwm_cmd), ae_setpoint_cmd);
+		ret = ds5_hwmc_send(state, sizeof(struct hwm_cmd), ae_setpoint_cmd);
 		if (ret) {		
 			devm_kfree(&state->client->dev, ae_setpoint_cmd);
 			return ret;
@@ -5806,7 +5813,7 @@ static int ds5_dfu_switch_to_dfu(struct ds5 *state)
 	int i = DS5_START_MAX_COUNT;
 	u16 status;
 
-	ret = ds5_send_hwmc(state, sizeof(cmd_switch_to_dfu),
+	ret = ds5_hwmc_send(state, sizeof(cmd_switch_to_dfu),
 			    (struct hwm_cmd *)&cmd_switch_to_dfu);
 	if (ret)
 		return ret;
@@ -6725,10 +6732,12 @@ static void ds5_remove(struct i2c_client *c)
 
 		mutex_lock(&serdes_lock__);
 		mutex_lock(&state->ds5_dev->lock);
+
 		if (state->ds5_dev->ds5_primary) {
 			state->ds5_dev->ds5_primary = NULL;
 			do_cleanup = true;
 		}
+
 		mutex_unlock(&state->ds5_dev->lock);
 
 		if (do_cleanup) {
@@ -6754,11 +6763,12 @@ static void ds5_remove(struct i2c_client *c)
 		}
 
 		mutex_unlock(&serdes_lock__);
+
+		if (state->ser_i2c)
+			i2c_unregister_device(state->ser_i2c);
+		if (state->dser_i2c && !state->aggregated)
+			i2c_unregister_device(state->dser_i2c);
 	}
-	if (state->ser_i2c)
-		i2c_unregister_device(state->ser_i2c);
-	if (state->dser_i2c && !state->aggregated)
-		i2c_unregister_device(state->dser_i2c);
 #endif
 #ifndef CONFIG_TEGRA_CAMERA_PLATFORM
 	state->is_depth = 1;
@@ -6767,7 +6777,6 @@ static void ds5_remove(struct i2c_client *c)
 			ds5_get_sensor_name(state));
 	if (state->vcc)
 		regulator_disable(state->vcc);
-//	gpio_free(state->pwdn_gpio);
 
 	if (state->dfu_dev.dfu_state_flag != DS5_DFU_RECOVERY && \
 		 state->mux.sd.subdev.v4l2_dev) {

--- a/scripts/generate_compile_commands.sh
+++ b/scripts/generate_compile_commands.sh
@@ -40,6 +40,42 @@ if [ -z "$RAW_CMD" ]; then
   exit 1
 fi
 
+# Try to locate the kernel source top under the same sources_* tree
+# 1) extract the sources_<ver> root folder from the .cmd path
+SOURCES_ROOT="$(echo "$CMD_FILE" | sed -n 's@\(.*sources_[^/]*\)/.*@\1@p' || true)"
+KERNEL_TOP=""
+if [ -n "$SOURCES_ROOT" ] && [ -d "$SOURCES_ROOT" ]; then
+  # First check for an immediate child like sources_*/kernel*/ that looks like the kernel tree
+  for d in "$SOURCES_ROOT"/*; do
+    if [ -d "$d" ] && [[ "$(basename "$d")" == kernel* ]] && [ -f "$d/include/linux/kconfig.h" ]; then
+      KERNEL_TOP="$d"
+      break
+    fi
+  done
+  # If not found, fall back to searching for any include/linux/kconfig.h
+  if [ -z "$KERNEL_TOP" ]; then
+    while IFS= read -r kp; do
+      maybe_top="$(dirname "$(dirname "$kp")")"  # parent of 'include'
+      if [ -f "$maybe_top/Makefile" ]; then
+        KERNEL_TOP="$maybe_top"
+        break
+      fi
+    done < <(find "$SOURCES_ROOT" -maxdepth 12 -type f -path '*/include/linux/kconfig.h' -print || true)
+  fi
+fi
+
+if [ -n "$KERNEL_TOP" ]; then
+  DIRECTORY="$KERNEL_TOP"
+else
+  # Fallback: use the object path recorded in the cmd_ key if available
+  OBJ_PATH="$(sed -n 's/^cmd_\([^ ]*\) := .*$/\1/p' "$CMD_FILE" | head -1 || true)"
+  if [ -n "$OBJ_PATH" ]; then
+    DIRECTORY="$(dirname "$OBJ_PATH")"
+  else
+    DIRECTORY="$REPO"
+  fi
+fi
+
 # ── rewrite the command for IDE use ───────────────────────────────────────────
 # 1. Strip -Wp,-MMD,... (generates .d dependency files, confuses clangd/cpptools)
 # 2. Replace the original source path with our repo's d4xx.c
@@ -55,13 +91,20 @@ if ! echo "$CLEAN_CMD" | grep -q "$SOURCE_FILE"; then
   CLEAN_CMD="$CLEAN_CMD $SOURCE_FILE"
 fi
 
+# If the kernel config indicates OF support, ensure CONFIG_OF is visible to the indexer
+if find "$REPO/sources_"* -path '*/include/config/OF' -print -quit | grep -q .; then
+  if ! echo "$CLEAN_CMD" | grep -q -- '-DCONFIG_OF'; then
+    CLEAN_CMD="$CLEAN_CMD -DCONFIG_OF"
+  fi
+fi
+
 # ── write compile_commands.json ───────────────────────────────────────────────
 mkdir -p "$REPO/.vscode"
-python3 - "$DEST" "$REPO" "$CLEAN_CMD" "$SOURCE_FILE" <<'PY'
+python3 - "$DEST" "$DIRECTORY" "$CLEAN_CMD" "$SOURCE_FILE" <<'PY'
 import sys, json
 dest, directory, command, src = sys.argv[1:]
 db = [{"directory": directory, "command": command, "file": src}]
 with open(dest, "w") as f:
-    json.dump(db, f, indent=2)
-print(f"Written {dest}")
+  json.dump(db, f, indent=2)
+print(f"Written {dest} (directory={directory})")
 PY

--- a/scripts/install_to_kernel.sh
+++ b/scripts/install_to_kernel.sh
@@ -43,6 +43,8 @@ if [ "${JETPACK_VERSION}" = "5.0.2" ]; then
           sudo cp videobuf-vmalloc.ko /lib/modules/$(uname -r)/updates/
 elif [ "${JETPACK_VERSION}" = "6.0" ] || [ "${JETPACK_VERSION}" = "6.1" ] || [ "${JETPACK_VERSION}" = "6.2" ] || [ "${JETPACK_VERSION}" = "6.2.1" ] || [ "${JETPACK_VERSION}" = "7.0" ] || [ "${JETPACK_VERSION}" = "7.1" ]; then
     tar xf rootfs.tar.gz
+    echo "sudo rm -rf /lib/modules/$(uname -r)"
+          sudo rm -rf /lib/modules/$(uname -r)
     echo "sudo cp -r lib/modules/$(uname -r) /lib/modules/."
           sudo cp -r lib/modules/$(uname -r) /lib/modules/.
     echo "sudo cp boot/tegra234-camera-d4xx-overlay*.dtbo /boot/."

--- a/scripts/install_to_kernel.sh
+++ b/scripts/install_to_kernel.sh
@@ -42,11 +42,26 @@ if [ "${JETPACK_VERSION}" = "5.0.2" ]; then
     echo "sudo cp videobuf-vmalloc.ko /lib/modules/$(uname -r)/updates/"
           sudo cp videobuf-vmalloc.ko /lib/modules/$(uname -r)/updates/
 elif [ "${JETPACK_VERSION}" = "6.0" ] || [ "${JETPACK_VERSION}" = "6.1" ] || [ "${JETPACK_VERSION}" = "6.2" ] || [ "${JETPACK_VERSION}" = "6.2.1" ] || [ "${JETPACK_VERSION}" = "7.0" ] || [ "${JETPACK_VERSION}" = "7.1" ]; then
-    tar xf rootfs.tar.gz
-    echo "sudo rm -rf /lib/modules/$(uname -r)"
-          sudo rm -rf /lib/modules/$(uname -r)
-    echo "sudo cp -r lib/modules/$(uname -r) /lib/modules/."
-          sudo cp -r lib/modules/$(uname -r) /lib/modules/.
+    MODULES_DIR="lib/modules/$(uname -r)"
+    echo "Extracting rootfs.tar.gz..."
+    if ! tar xf rootfs.tar.gz; then
+        echo "Error: Failed to extract rootfs.tar.gz; not modifying kernel modules."
+        exit 1
+    fi
+    if [ ! -d "${MODULES_DIR}" ] || [ -z "$(ls -A "${MODULES_DIR}" 2>/dev/null)" ]; then
+        echo "Error: Extracted modules directory '${MODULES_DIR}' is missing or empty; not modifying kernel modules."
+        exit 1
+    fi
+    echo "sudo rm -rf /${MODULES_DIR}"
+    if ! sudo rm -rf /${MODULES_DIR}; then
+        echo "Error: Failed to remove existing modules directory '${MODULES_DIR}', DON'T REBOOT"
+        exit 1
+    fi
+    echo "sudo cp -r ${MODULES_DIR} /lib/modules/."
+    if ! sudo cp -r ${MODULES_DIR} /lib/modules/.; then
+        echo "Error: Failed to copy modules to '/lib/modules/', DON'T REBOOT"
+        exit 1
+    fi
     echo "sudo cp boot/tegra234-camera-d4xx-overlay*.dtbo /boot/."
           sudo cp boot/tegra234-camera-d4xx-overlay*.dtbo /boot/.
     echo "sudo cp boot/dtb/tegra234-p3737-0000+p3701-0005-nv.dtb /boot/dtb/."


### PR DESCRIPTION
What changed:

Added a dedicated ds5_wait_device_type() helper in [d4xx.c:2379](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/ce099c1ed2/resources/app/out/vs/code/electron-browser/workbench/workbench.html) that:
* polls DS5_DEVICE_TYPE with ds5_read_poll()
* accepts only known D4XX device-type values
* stores the first valid result in state->ds5_dev->cached_device_type
* lets sibling probe instances reuse that cached value immediately

Updated the cached-type comment in [d4xx.c:514](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/ce099c1ed2/resources/app/out/vs/code/electron-browser/workbench/workbench.html) so it describes the current post-reset flow instead of the removed old “Step 8”.
Changed the reset path in [d4xx.c:2847](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/ce099c1ed2/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to wait for DS5_DEVICE_TYPE rather than treating FW_VERSION as the post-reset readiness signal.
Kept the final firmware/build reads, but now only after device type has become valid; the reset completion log reflects that in [d4xx.c:2915](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/ce099c1ed2/resources/app/out/vs/code/electron-browser/workbench/workbench.html).
Replaced the probe’s post-reset retry loop with the same device-type readiness check in [d4xx.c:6657](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/ce099c1ed2/resources/app/out/vs/code/electron-browser/workbench/workbench.html), which is the path that matters for format-table selection.

FW_VERSION remains useful as an early liveness indicator.
DS5_DEVICE_TYPE is now the gate for “firmware is ready enough for format/config-dependent paths”.
That removes the race where probe and post-reset code could proceed while FW_VERSION was readable but DEVICE_TYPE was still zero.