### PR TITLE
Max96712 multicamera

### DIFF
--- a/hardware/nvidia/t23x/nv-public/6.x/0001-overlay-enable-d4xx-camera-for-Orin-jp6.patch
+++ b/hardware/nvidia/t23x/nv-public/6.x/0001-overlay-enable-d4xx-camera-for-Orin-jp6.patch
@@ -1,18 +1,18 @@
-From b7a19e2d92f5a4d66cb5ced66d3fb65ecbe2e720 Mon Sep 17 00:00:00 2001
+From ed5946bc9eb94bd84b85b307409e783d05cb9a04 Mon Sep 17 00:00:00 2001
 From: ejgoldik <ehud.joseph.goldik@realsenseai.com>
-Date: Thu, 19 Mar 2026 08:45:25 +0200
+Date: Wed, 25 Mar 2026 12:17:30 +0200
 Subject: [PATCH] overlay: enable d4xx camera for Orin jp6
 
 Signed-off-by: ejgoldik <ehud.joseph.goldik@realsenseai.com>
 ---
- overlay/Makefile | 15 +++++++++++++++
- 1 file changed, 15 insertions(+)
+ overlay/Makefile | 16 ++++++++++++++++
+ 1 file changed, 16 insertions(+)
 
 diff --git a/overlay/Makefile b/overlay/Makefile
-index c88bbe2..0446200 100644
+index c88bbe2..2e24c2d 100644
 --- a/overlay/Makefile
 +++ b/overlay/Makefile
-@@ -60,6 +60,21 @@ dtbo-y += tegra234-p3767-camera-p3768-imx219-A.dtbo
+@@ -60,6 +60,22 @@ dtbo-y += tegra234-p3767-camera-p3768-imx219-A.dtbo
  dtbo-y += tegra234-p3767-camera-p3768-imx219-imx477.dtbo
  dtbo-y += tegra234-p3767-camera-p3768-imx477-C.dtbo
  dtbo-y += tegra234-p3767-camera-p3768-imx477-A.dtbo
@@ -23,6 +23,7 @@ index c88bbe2..0446200 100644
 +dtbo-y += tegra234-camera-d4xx-overlay-fg12-16ch.dtbo
 +dtbo-y += tegra234-camera-d4xx-overlay-fg12-16ch-PWR-only.dtbo
 +dtbo-y += tegra234-camera-d4xx-overlay-fg12-16ch-cams-0-1.dtbo
++dtbo-y += tegra234-camera-d4xx-overlay-fg12-16ch-cams-0-1-2-3.dtbo
 +dtbo-y += tegra234-camera-d4xx-overlay-fg12-16ch-cams-0-4.dtbo
 +dtbo-y += tegra234-camera-d4xx-overlay-fg12-16ch-cams-0-4-8-12.dtbo
 +dtbo-y += tegra234-camera-d4xx-overlay.calib.dtbo

--- a/hardware/realsense/tegra234-camera-d4xx-overlay-fg12-16ch-cams-0-1-2-3.dts
+++ b/hardware/realsense/tegra234-camera-d4xx-overlay-fg12-16ch-cams-0-1-2-3.dts
@@ -20,7 +20,7 @@
 
 /* camera control gpio definitions */
 / {
-	overlay-name = "Jetson dual RealSense Camera D4xx with a single max96712 and tca9546 (fg12-16ch)";
+	overlay-name = "Jetson four RealSense Cameras D4xx with a single max96712 and tca9546 (fg12-16ch)";
 	jetson-header-name = "Jetson AGX CSI Connector";
 	compatible = JETSON_COMPATIBLE;
 
@@ -41,7 +41,7 @@
 		target-path = "/";
 		__overlay__ {
 			tegra-capture-vi {
-				num-channels = <8>;
+				num-channels = <16>;
 				ports {
 					status = "okay";
 					port@0 {
@@ -132,13 +132,101 @@
 							remote-endpoint = <&d4xx_csi_out7>;
 						};
 					};
+					port@8 {
+						status = "okay";
+						reg = <8>;
+						d4xx_vi_in8: endpoint {
+							status = "okay";
+							vc-id = <8>;
+							port-index = <0>;
+							bus-width = <2>;
+							remote-endpoint = <&d4xx_csi_out8>;
+						};
+					};
+					port@9 {
+						status = "okay";
+						reg = <9>;
+						d4xx_vi_in9: endpoint {
+							status = "okay";
+							vc-id = <9>;
+							port-index = <0>;
+							bus-width = <2>;
+							remote-endpoint = <&d4xx_csi_out9>;
+						};
+					};
+					port@10 {
+						status = "okay";
+						reg = <10>;
+						d4xx_vi_in10: endpoint {
+							status = "okay";
+							vc-id = <10>;
+							port-index = <0>;
+							bus-width = <2>;
+							remote-endpoint = <&d4xx_csi_out10>;
+						};
+					};
+					port@11 {
+						status = "okay";
+						reg = <11>;
+						d4xx_vi_in11: endpoint {
+							status = "okay";
+							vc-id = <11>;
+							port-index = <0>;
+							bus-width = <2>;
+							remote-endpoint = <&d4xx_csi_out11>;
+						};
+					};
+					port@12 {
+						status = "okay";
+						reg = <12>;
+						d4xx_vi_in12: endpoint {
+							status = "okay";
+							vc-id = <12>;
+							port-index = <0>;
+							bus-width = <2>;
+							remote-endpoint = <&d4xx_csi_out12>;
+						};
+					};
+					port@13 {
+						status = "okay";
+						reg = <13>;
+						d4xx_vi_in13: endpoint {
+							status = "okay";
+							vc-id = <13>;
+							port-index = <0>;
+							bus-width = <2>;
+							remote-endpoint = <&d4xx_csi_out13>;
+						};
+					};
+					port@14 {
+						status = "okay";
+						reg = <14>;
+						d4xx_vi_in14: endpoint {
+							status = "okay";
+							vc-id = <14>;
+							port-index = <0>;
+							bus-width = <2>;
+							remote-endpoint = <&d4xx_csi_out14>;
+						};
+					};
+					port@15 {
+						status = "okay";
+						reg = <15>;
+						d4xx_vi_in15: endpoint {
+							status = "okay";
+							vc-id = <15>;
+							port-index = <0>;
+							bus-width = <2>;
+							remote-endpoint = <&d4xx_csi_out15>;
+						};
+					};
 				};
 			};
 
 			bus@0 {
 				host1x@13e00000 {
 					nvcsi@15a00000 {
-						num-channels = <8>;
+						num-channels = <16>;
 						channel@0 {
 							status = "okay";
 							reg = <0>;
@@ -339,6 +427,206 @@
 								};
 							};
 						};
+						channel@8 {
+							status = "okay";
+							reg = <8>;
+							ports {
+								status = "okay";
+								port@0 {
+									status = "okay";
+									reg = <0>;
+									d4xx_csi_in8: endpoint@16 {
+										status = "okay";
+										port-index = <0>;
+										bus-width = <2>;
+										remote-endpoint = <&ds5_8_out>;
+									};
+								};
+								port@1 {
+									status = "okay";
+									reg = <1>;
+									d4xx_csi_out8: endpoint@17 {
+										status = "okay";
+										remote-endpoint = <&d4xx_vi_in8>;
+									};
+								};
+							};
+						};
+						channel@9 {
+							status = "okay";
+							reg = <9>;
+							ports {
+								status = "okay";
+								port@0 {
+									status = "okay";
+									reg = <0>;
+									d4xx_csi_in9: endpoint@18 {
+										status = "okay";
+										port-index = <0>;
+										bus-width = <2>;
+										remote-endpoint = <&ds5_9_out>;
+									};
+								};
+								port@1 {
+									status = "okay";
+									reg = <1>;
+									d4xx_csi_out9: endpoint@19 {
+										status = "okay";
+										remote-endpoint = <&d4xx_vi_in9>;
+									};
+								};
+							};
+						};
+						channel@10 {
+							status = "okay";
+							reg = <10>;
+							ports {
+								status = "okay";
+								port@0 {
+									status = "okay";
+									reg = <0>;
+									d4xx_csi_in10: endpoint@20 {
+										status = "okay";
+										port-index = <0>;
+										bus-width = <2>;
+										remote-endpoint = <&ds5_10_out>;
+									};
+								};
+								port@1 {
+									status = "okay";
+									reg = <1>;
+									d4xx_csi_out10: endpoint@21 {
+										status = "okay";
+										remote-endpoint = <&d4xx_vi_in10>;
+									};
+								};
+							};
+						};
+						channel@11 {
+							status = "okay";
+							reg = <11>;
+							ports {
+								status = "okay";
+								port@0 {
+									status = "okay";
+									reg = <0>;
+									d4xx_csi_in11: endpoint@22 {
+										status = "okay";
+										port-index = <0>;
+										bus-width = <2>;
+										remote-endpoint = <&ds5_11_out>;
+									};
+								};
+								port@1 {
+									status = "okay";
+									reg = <1>;
+									d4xx_csi_out11: endpoint@23 {
+										status = "okay";
+										remote-endpoint = <&d4xx_vi_in11>;
+									};
+								};
+							};
+						};
+						channel@12 {
+							status = "okay";
+							reg = <12>;
+							ports {
+								status = "okay";
+								port@0 {
+									status = "okay";
+									reg = <0>;
+									d4xx_csi_in12: endpoint@24 {
+										status = "okay";
+										port-index = <0>;
+										bus-width = <2>;
+										remote-endpoint = <&ds5_12_out>;
+									};
+								};
+								port@1 {
+									status = "okay";
+									reg = <1>;
+									d4xx_csi_out12: endpoint@25 {
+										status = "okay";
+										remote-endpoint = <&d4xx_vi_in12>;
+									};
+								};
+							};
+						};
+						channel@13 {
+							status = "okay";
+							reg = <13>;
+							ports {
+								status = "okay";
+								port@0 {
+									status = "okay";
+									reg = <0>;
+									d4xx_csi_in13: endpoint@26 {
+										status = "okay";
+										port-index = <0>;
+										bus-width = <2>;
+										remote-endpoint = <&ds5_13_out>;
+									};
+								};
+								port@1 {
+									status = "okay";
+									reg = <1>;
+									d4xx_csi_out13: endpoint@27 {
+										status = "okay";
+										remote-endpoint = <&d4xx_vi_in13>;
+									};
+								};
+							};
+						};
+						channel@14 {
+							status = "okay";
+							reg = <14>;
+							ports {
+								status = "okay";
+								port@0 {
+									status = "okay";
+									reg = <0>;
+									d4xx_csi_in14: endpoint@28 {
+										status = "okay";
+										port-index = <0>;
+										bus-width = <2>;
+										remote-endpoint = <&ds5_14_out>;
+									};
+								};
+								port@1 {
+									status = "okay";
+									reg = <1>;
+									d4xx_csi_out14: endpoint@29 {
+										status = "okay";
+										remote-endpoint = <&d4xx_vi_in14>;
+									};
+								};
+							};
+						};
+						channel@15 {
+							status = "okay";
+							reg = <15>;
+							ports {
+								status = "okay";
+								port@0 {
+									status = "okay";
+									reg = <0>;
+									d4xx_csi_in15: endpoint@30 {
+										status = "okay";
+										port-index = <0>;
+										bus-width = <2>;
+										remote-endpoint = <&ds5_15_out>;
+									};
+								};
+								port@1 {
+									status = "okay";
+									reg = <1>;
+									d4xx_csi_out15: endpoint@31 {
+										status = "okay";
+										remote-endpoint = <&d4xx_vi_in15>;
+									};
+								};
+							};
+						};
 					};
 				};
 
@@ -366,7 +654,7 @@
 								reg = <0x29>;
 								compatible = "maxim,max96712";
 								csi-mode = "2x4";
-								link-mask = <0x3>;
+								link-mask = <0xf>;
 								channel = "a";
 								pwdn-gpios = <&gpio CAM0_PWDN GPIO_ACTIVE_HIGH>;
 							};
@@ -385,6 +673,406 @@
 								reg = <0x41>;
 								maxim,gmsl-dser-device = <&dser>;
 								external_addr_reassign;
+							};
+
+							ser_c: max9295_c@42 {
+								status = "okay";
+								compatible = "maxim,max9295";
+								reg = <0x42>;
+								maxim,gmsl-dser-device = <&dser>;
+								external_addr_reassign;
+							};
+
+							ser_d: max9295_d@43 {
+								status = "okay";
+								compatible = "maxim,max9295";
+								reg = <0x43>;
+								maxim,gmsl-dser-device = <&dser>;
+								external_addr_reassign;
+							};
+
+							ds5_15: ds5@4d {
+								status = "okay";
+								def-addr = <0x10>;
+								reg = <0x4d>;
+								override_reg = <0x4a>;
+								compatible = "intel,d4xx";
+								use_sensor_mode_id = "true";
+								vcc-supply = <&vdd_cam12v_poc>;
+								cam-type = "IMU";
+								nvidia,gmsl-ser-device = <&ser_d>;
+								nvidia,gmsl-dser-device = <&dser>;
+								ports {
+									#address-cells = <1>;
+									#size-cells = <0>;
+
+									port@0 {
+										reg = <0>;
+										ds5_15_out: endpoint {
+											vc-id = <15>;
+											port-index = <15>;
+											bus-width = <2>;
+											remote-endpoint = <&d4xx_csi_in15>;
+										};
+									};
+								};
+								mode0 {
+									pixel_t = "grey_y16";
+									num_lanes = "2";
+									csi_pixel_bit_depth = "16";
+									active_w = "640";
+									active_h = "480";
+									tegra_sinterface = "serial_b";
+									mclk_khz = "24000";
+									pix_clk_hz = "74250000";
+									line_length = "1280"; /* 2200 */
+									embedded_metadata_height = "0";
+								};
+								gmsl-link {
+									src-csi-port = "b";
+									dst-csi-port = "a";
+									serdes-csi-link = "a";
+									csi-mode = "1x4";
+									st-vc = <0>;
+									vc-id = <15>;
+									num-lanes = <2>;
+								};
+							};
+
+							ds5_14: ds5@4c {
+								status = "okay";
+								def-addr = <0x10>;
+								reg = <0x4c>;
+								override_reg = <0x4a>;
+								compatible = "intel,d4xx";
+								use_sensor_mode_id = "true";
+								vcc-supply = <&vdd_cam12v_poc>;
+								cam-type = "Y8";
+								nvidia,gmsl-ser-device = <&ser_d>;
+								nvidia,gmsl-dser-device = <&dser>;
+								ports {
+									#address-cells = <1>;
+									#size-cells = <0>;
+
+									port@0 {
+										reg = <0>;
+										ds5_14_out: endpoint {
+											vc-id = <14>;
+											port-index = <14>;
+											bus-width = <2>;
+											remote-endpoint = <&d4xx_csi_in14>;
+										};
+									};
+								};
+								/* mode0: Y8, mode1: depth D16 */
+								mode0 {
+									pixel_t = "grey_y16";
+									num_lanes = "2";
+									csi_pixel_bit_depth = "16";
+									active_w = "1280";
+									active_h = "720";
+									tegra_sinterface = "serial_b";
+									mclk_khz = "24000";
+									pix_clk_hz = "74250000";
+									line_length = "1280"; /* 2200 */
+									embedded_metadata_height = "1";
+								};
+								gmsl-link {
+									src-csi-port = "b";
+									dst-csi-port = "a";
+									serdes-csi-link = "a";
+									csi-mode = "1x4";
+									st-vc = <0>;
+									vc-id = <14>;
+									num-lanes = <2>;
+								};
+							};
+
+							ds5_13: ds5@4b {
+								status = "okay";
+								def-addr = <0x10>;
+								reg = <0x4b>;
+								override_reg = <0x4a>;
+								compatible = "intel,d4xx";
+								use_sensor_mode_id = "true";
+								vcc-supply = <&vdd_cam12v_poc>;
+								cam-type = "RGB";
+								nvidia,gmsl-ser-device = <&ser_d>;
+								nvidia,gmsl-dser-device = <&dser>;
+								ports {
+									#address-cells = <1>;
+									#size-cells = <0>;
+
+									port@0 {
+										reg = <0>;
+										ds5_13_out: endpoint {
+											vc-id = <13>;
+											port-index = <13>;
+											bus-width = <2>;
+											remote-endpoint = <&d4xx_csi_in13>;
+										};
+									};
+								};
+								mode0 {
+									pixel_t = "grey_y16";
+									num_lanes = "2";
+									csi_pixel_bit_depth = "16";
+									active_w = "1920";
+									active_h = "1080";
+									tegra_sinterface = "serial_e";
+									mclk_khz = "24000";
+									pix_clk_hz = "74250000";
+									line_length = "1280"; /* 2200 */
+									embedded_metadata_height = "1";
+								};
+								gmsl-link {
+									src-csi-port = "b";
+									dst-csi-port = "a";
+									serdes-csi-link = "a";
+									csi-mode = "1x4";
+									st-vc = <0>;
+									vc-id = <13>;
+									num-lanes = <2>;
+								};
+							};
+
+							ds5_12: ds5@4a {
+								status = "okay";
+								def-addr = <0x10>;
+								reg = <0x4a>;
+								compatible = "intel,d4xx";
+								use_sensor_mode_id = "true";
+								vcc-supply = <&vdd_cam12v_poc>;
+								cam-type = "Depth";
+								nvidia,gmsl-ser-device = <&ser_d>;
+								nvidia,gmsl-dser-device = <&dser>;
+								ports {
+									#address-cells = <1>;
+									#size-cells = <0>;
+
+									port@0 {
+										reg = <0>;
+										ds5_12_out: endpoint {
+											vc-id = <12>;
+											port-index = <12>;
+											bus-width = <2>;
+											remote-endpoint = <&d4xx_csi_in12>;
+										};
+									};
+								};
+								mode0 {
+									pixel_t = "grey_y16";
+									num_lanes = "2";
+									csi_pixel_bit_depth = "16";
+									active_w = "1280";
+									active_h = "720";
+									tegra_sinterface = "serial_a";
+									mclk_khz = "24000";
+									pix_clk_hz = "74250000";
+									line_length = "1280"; /* 2200 */
+									embedded_metadata_height = "1";
+								};
+								gmsl-link {
+									src-csi-port = "b";
+									dst-csi-port = "a";
+									serdes-csi-link = "a";
+									csi-mode = "1x4";
+									st-vc = <0>;
+									vc-id = <12>;
+									num-lanes = <2>;
+								};
+							};
+
+							ds5_11: ds5@3d {
+								status = "okay";
+								def-addr = <0x10>;
+								reg = <0x3d>;
+								override_reg = <0x3a>;
+								compatible = "intel,d4xx";
+								use_sensor_mode_id = "true";
+								vcc-supply = <&vdd_cam12v_poc>;
+								cam-type = "IMU";
+								nvidia,gmsl-ser-device = <&ser_c>;
+								nvidia,gmsl-dser-device = <&dser>;
+								ports {
+									#address-cells = <1>;
+									#size-cells = <0>;
+
+									port@0 {
+										reg = <0>;
+										ds5_11_out: endpoint {
+											vc-id = <11>;
+											port-index = <11>;
+											bus-width = <2>;
+											remote-endpoint = <&d4xx_csi_in11>;
+										};
+									};
+								};
+								mode0 {
+									pixel_t = "grey_y16";
+									num_lanes = "2";
+									csi_pixel_bit_depth = "16";
+									active_w = "640";
+									active_h = "480";
+									tegra_sinterface = "serial_b";
+									mclk_khz = "24000";
+									pix_clk_hz = "74250000";
+									line_length = "1280"; /* 2200 */
+									embedded_metadata_height = "0";
+								};
+								gmsl-link {
+									src-csi-port = "b";
+									dst-csi-port = "a";
+									serdes-csi-link = "a";
+									csi-mode = "1x4";
+									st-vc = <0>;
+									vc-id = <11>;
+									num-lanes = <2>;
+								};
+							};
+
+							ds5_10: ds5@3c {
+								status = "okay";
+								def-addr = <0x10>;
+								reg = <0x3c>;
+								override_reg = <0x3a>;
+								compatible = "intel,d4xx";
+								use_sensor_mode_id = "true";
+								vcc-supply = <&vdd_cam12v_poc>;
+								cam-type = "Y8";
+								nvidia,gmsl-ser-device = <&ser_c>;
+								nvidia,gmsl-dser-device = <&dser>;
+								ports {
+									#address-cells = <1>;
+									#size-cells = <0>;
+
+									port@0 {
+										reg = <0>;
+										ds5_10_out: endpoint {
+											vc-id = <10>;
+											port-index = <10>;
+											bus-width = <2>;
+											remote-endpoint = <&d4xx_csi_in10>;
+										};
+									};
+								};
+								/* mode0: Y8, mode1: depth D16 */
+								mode0 {
+									pixel_t = "grey_y16";
+									num_lanes = "2";
+									csi_pixel_bit_depth = "16";
+									active_w = "1280";
+									active_h = "720";
+									tegra_sinterface = "serial_b";
+									mclk_khz = "24000";
+									pix_clk_hz = "74250000";
+									line_length = "1280"; /* 2200 */
+									embedded_metadata_height = "1";
+								};
+								gmsl-link {
+									src-csi-port = "b";
+									dst-csi-port = "a";
+									serdes-csi-link = "a";
+									csi-mode = "1x4";
+									st-vc = <0>;
+									vc-id = <10>;
+									num-lanes = <2>;
+								};
+							};
+
+							ds5_9: ds5@3b {
+								status = "okay";
+								def-addr = <0x10>;
+								reg = <0x3b>;
+								override_reg = <0x3a>;
+								compatible = "intel,d4xx";
+								use_sensor_mode_id = "true";
+								vcc-supply = <&vdd_cam12v_poc>;
+								cam-type = "RGB";
+								nvidia,gmsl-ser-device = <&ser_c>;
+								nvidia,gmsl-dser-device = <&dser>;
+								ports {
+									#address-cells = <1>;
+									#size-cells = <0>;
+
+									port@0 {
+										reg = <0>;
+										ds5_9_out: endpoint {
+											vc-id = <9>;
+											port-index = <9>;
+											bus-width = <2>;
+											remote-endpoint = <&d4xx_csi_in9>;
+										};
+									};
+								};
+								mode0 {
+									pixel_t = "grey_y16";
+									num_lanes = "2";
+									csi_pixel_bit_depth = "16";
+									active_w = "1920";
+									active_h = "1080";
+									tegra_sinterface = "serial_e";
+									mclk_khz = "24000";
+									pix_clk_hz = "74250000";
+									line_length = "1280"; /* 2200 */
+									embedded_metadata_height = "1";
+								};
+								gmsl-link {
+									src-csi-port = "b";
+									dst-csi-port = "a";
+									serdes-csi-link = "a";
+									csi-mode = "1x4";
+									st-vc = <0>;
+									vc-id = <9>;
+									num-lanes = <2>;
+								};
+							};
+
+							ds5_8: ds5@3a {
+								status = "okay";
+								def-addr = <0x10>;
+								reg = <0x3a>;
+								compatible = "intel,d4xx";
+								use_sensor_mode_id = "true";
+								vcc-supply = <&vdd_cam12v_poc>;
+								cam-type = "Depth";
+								nvidia,gmsl-ser-device = <&ser_c>;
+								nvidia,gmsl-dser-device = <&dser>;
+								ports {
+									#address-cells = <1>;
+									#size-cells = <0>;
+
+									port@0 {
+										reg = <0>;
+										ds5_8_out: endpoint {
+											vc-id = <8>;
+											port-index = <8>;
+											bus-width = <2>;
+											remote-endpoint = <&d4xx_csi_in8>;
+										};
+									};
+								};
+								mode0 {
+									pixel_t = "grey_y16";
+									num_lanes = "2";
+									csi_pixel_bit_depth = "16";
+									active_w = "1280";
+									active_h = "720";
+									tegra_sinterface = "serial_a";
+									mclk_khz = "24000";
+									pix_clk_hz = "74250000";
+									line_length = "1280"; /* 2200 */
+									embedded_metadata_height = "1";
+								};
+								gmsl-link {
+									src-csi-port = "b";
+									dst-csi-port = "a";
+									serdes-csi-link = "a";
+									csi-mode = "1x4";
+									st-vc = <0>;
+									vc-id = <8>;
+									num-lanes = <2>;
+								};
 							};
 
 							ds5_7: ds5@2d {

--- a/kernel/nvidia/5.0.2/0017-Adding-max96712-support-for-D4xx.patch
+++ b/kernel/nvidia/5.0.2/0017-Adding-max96712-support-for-D4xx.patch
@@ -1,20 +1,20 @@
-From fc65304997a262d40428bc49dbde5d8e008dc781 Mon Sep 17 00:00:00 2001
-From: ipilchin1 <inga.pilchin@realsenseai.com>
-Date: Sun, 22 Mar 2026 14:15:30 +0200
+From 4c907e3cd7b94aea1497c94ab458cafb8fe0a77c Mon Sep 17 00:00:00 2001
+From: ejgoldik <ehud.joseph.goldik@realsenseai.com>
+Date: Wed, 25 Mar 2026 14:10:22 +0200
 Subject: [PATCH] Adding max96712 support for D4xx
 
 Add MAX96712 deserializer driver support for D4XX cameras.
 
 Signed-off-by: ejgoldik <ehud.joseph.goldik@realsenseai.com>
 ---
- drivers/media/i2c/max96712.c | 319 ++++++++++++++++++++++++++++++++++-
- 1 file changed, 317 insertions(+), 2 deletions(-)
+ drivers/media/i2c/max96712.c | 553 ++++++++++++++++++++++++++++++++++-
+ 1 file changed, 549 insertions(+), 4 deletions(-)
 
 diff --git a/drivers/media/i2c/max96712.c b/drivers/media/i2c/max96712.c
-index 8081385f0..52836c0d7 100644
+index 8081385f0..62b5f24c2 100644
 --- a/drivers/media/i2c/max96712.c
 +++ b/drivers/media/i2c/max96712.c
-@@ -21,17 +21,69 @@
+@@ -21,18 +21,83 @@
  #include <linux/debugfs.h>
  #include <media/camera_common.h>
  #include <linux/module.h>
@@ -43,11 +43,18 @@ index 8081385f0..52836c0d7 100644
 +
 +#define MAX96712_BACKTOP25_ADDR 0x418
 +
++#define MAX96712_MIPI_TX_EXT0_ADDR 0x800
++#define MAX96712_MIPI_TX_EXT1_ADDR 0x801
++#define MAX96712_MIPI_TX_EXT2_ADDR 0x802
++#define MAX96712_MIPI_TX_EXT3_ADDR 0x803
++
 +#define MAX96712_MIPI_PHY0_ADDR 0x8A0
 +#define MAX96712_MIPI_PHY2_ADDR 0x8A2
 +#define MAX96712_MIPI_PHY3_ADDR 0x8A3
 +#define MAX96712_VIDEO_PIPE_SEL_0_ADDR 0xF0
 +#define MAX96712_VIDEO_PIPE_SEL_1_ADDR 0xF1
++#define MAX96712_VIDEO_PIPE_SEL_2_ADDR 0xF2
++#define MAX96712_VIDEO_PIPE_SEL_3_ADDR 0xF3
 +#define MAX96712_VIDEO_PIPE_EN_ADDR 0xF4
 +#define MAX96712_BACKTOP12_CSI_OUT_EN_ADDR 0x40B
 +
@@ -68,8 +75,12 @@ index 8081385f0..52836c0d7 100644
 +
 +#define MAX96712_DPLL_0_ADDR 0x1D00
 +
++#define MAX9295_DEFAULT_ADDR 0x40
++
 +/* data defines */
-+#define MAX96712_MAX_PIPES 4
++#define MAX96712_MAX_LINKS 4
++#define MAX96712_MAX_PIPES 8
++#define MAX9295_MAX_STREAMS 4
  
  struct max96712 {
  	struct i2c_client *i2c_client;
@@ -77,16 +88,72 @@ index 8081385f0..52836c0d7 100644
  	const char *channel;
 +	struct mutex lock;
 +	int pwdn_gpio;
++	int link_mask;
++	bool video_pipe_alloc[MAX96712_MAX_PIPES];
  };
  struct max96712 *global_priv[4] ;
  
  
--int max96712_write_reg_Dser(int slaveAddr,int channel,
-+int max96712_write_reg_Dser(int slaveAddr, int channel,
- 			u16 addr, u8 val)
+ int max96712_write_reg_Dser(int slaveAddr,int channel,
+-			u16 addr, u8 val)
++				u16 addr, u8 val)
  {
  	struct i2c_client *i2c_client = NULL;
-@@ -99,6 +151,20 @@ static int max96712_read_reg(struct max96712 *priv,
+ 	int bak = 0;
+@@ -85,6 +150,52 @@ int max96712_read_reg_Dser(int slaveAddr,int channel,
+ 
+ EXPORT_SYMBOL(max96712_read_reg_Dser);
+ 
++static int max96712_read_slave_reg(struct max96712 *priv,
++			int ShortSlaveAddr, u16 addr, unsigned int *val)
++{
++	struct i2c_client *i2c_client = priv->i2c_client;
++	int err;
++	int bak = i2c_client->addr;
++	unsigned int value = 0;
++
++	mutex_lock(&priv->lock);
++	i2c_client->addr = ShortSlaveAddr;
++	err = regmap_read(priv->regmap, addr, &value);
++	i2c_client->addr = bak;
++
++	if (err)
++		dev_err(&i2c_client->dev, "%s:i2c read failed, 0x%x: 0x%x\n",
++			__func__, ShortSlaveAddr, addr);
++	usleep_range(100, 110);
++	*val = value;
++	mutex_unlock(&priv->lock);
++
++	return err;
++}
++
++static int max96712_write_slave_reg(struct max96712 *priv,
++			int ShortSlaveAddr, u16 addr, unsigned int val)
++{
++	struct i2c_client *i2c_client = priv->i2c_client;
++	int err;
++	int bak = i2c_client->addr;
++
++	mutex_lock(&priv->lock);
++	i2c_client->addr = ShortSlaveAddr;
++	err = regmap_write(priv->regmap, addr, val);
++	i2c_client->addr = bak;
++
++	if (err)
++		dev_err(&i2c_client->dev, "%s:i2c write failed, 0x%x: 0x%x = %x\n",
++			__func__, ShortSlaveAddr, addr, val);
++
++	/* delay before next i2c command as required for SERDES link */
++	usleep_range(100, 110);
++	mutex_unlock(&priv->lock);
++
++	return err;
++}
++
+ static int max96712_read_reg(struct max96712 *priv,
+ 			u16 addr, unsigned int *val)
+ {
+@@ -99,6 +210,20 @@ static int max96712_read_reg(struct max96712 *priv,
  	return err;
  }
  
@@ -107,7 +174,7 @@ index 8081385f0..52836c0d7 100644
  
  static int max96712_stats_show(struct seq_file *s, void *data)
  {
-@@ -169,7 +235,10 @@ static int max96712_debugfs_init(const char *dir_name,
+@@ -169,7 +294,10 @@ static int max96712_debugfs_init(const char *dir_name,
  	if (np) {
  		err = of_property_read_string(np, "channel", &priv->channel);
  		if (err)
@@ -118,15 +185,26 @@ index 8081385f0..52836c0d7 100644
  
  		err = snprintf(dev_name, sizeof(dev_name), "max96712_%s", priv->channel);
  		if (err < 0)
-@@ -216,6 +285,7 @@ static int max96712_probe(struct i2c_client *client,
+@@ -208,7 +336,8 @@ static int max96712_debugfs_init(const char *dir_name,
+ static  struct regmap_config max96712_regmap_config = {
+ 	.reg_bits = 16,
+ 	.val_bits = 8,
+-	.cache_type = REGCACHE_RBTREE,
++	/* As this driver remaps i2c addresses, the cache is unreliable */
++	.cache_type = REGCACHE_NONE,
+ };
+ 
+ static int max96712_probe(struct i2c_client *client,
+@@ -216,6 +345,8 @@ static int max96712_probe(struct i2c_client *client,
  {
  	struct max96712 *priv;
  	int err = 0;
 +	struct device_node *np = NULL;
++	int value;
  
  	dev_info(&client->dev, "%s: enter\n", __func__);
  
-@@ -228,10 +298,23 @@ static int max96712_probe(struct i2c_client *client,
+@@ -228,10 +359,36 @@ static int max96712_probe(struct i2c_client *client,
  			"regmap init failed: %ld\n", PTR_ERR(priv->regmap));
  		return -ENODEV;
  	}
@@ -139,7 +217,20 @@ index 8081385f0..52836c0d7 100644
 +			dev_err(&client->dev,"%s: Could not retrieve pwdn_gpio = %d\n",
 +				__func__, priv->pwdn_gpio);
 +		}
++		err = of_property_read_u32(np, "link-mask", &value);
++		if (err < 0) {
++			dev_warn(&client->dev, "%s: No link-mask specified, using default 0x1\n",
++				__func__);
++			priv->link_mask = 0x1;
++		} else if ((value > 0xf) || (value <= 0)) {
++			dev_warn(&client->dev, "%s: Illegal link-mask specified 0x%x (0x1 - 0xf supported), using default 0x1\n",
++				__func__, value);
++			priv->link_mask = 0x1;
++		} else {
++			priv->link_mask = value;
++		}
 +	}
++
 +	dev_set_drvdata(&client->dev, priv);
  
  	err = max96712_debugfs_init(NULL, NULL, NULL, priv);
@@ -150,7 +241,7 @@ index 8081385f0..52836c0d7 100644
  
  	/*set daymode by fault*/
  	dev_info(&client->dev, "%s:  success\n", __func__);
-@@ -243,8 +326,12 @@ static int max96712_probe(struct i2c_client *client,
+@@ -243,8 +400,12 @@ static int max96712_probe(struct i2c_client *client,
  static int
  max96712_remove(struct i2c_client *client)
  {
@@ -163,7 +254,7 @@ index 8081385f0..52836c0d7 100644
  		i2c_unregister_device(client);
  		client = NULL;
  	}
-@@ -252,13 +339,302 @@ max96712_remove(struct i2c_client *client)
+@@ -252,13 +413,396 @@ max96712_remove(struct i2c_client *client)
  	return 0;
  }
  
@@ -188,19 +279,50 @@ index 8081385f0..52836c0d7 100644
 +
 +int max96712_get_available_pipe_id(struct device *dev, int vc_id)
 +{
-+	/* TODO EHUD: Currently vc_id == pipe id but that's definitely
-+	 * not the end goal if we plan to support multiple cameras
-+	 */
-+	return vc_id;
++	int i;
++	int pipe_id = -ENOMEM;
++	struct max96712 *priv = dev_get_drvdata(dev);
++
++	mutex_lock(&priv->lock);
++	for (i = 0; i < MAX96712_MAX_PIPES; i++) {
++		if (priv->video_pipe_alloc[i] == false) {
++			priv->video_pipe_alloc[i] = true;
++			pipe_id = i;
++			break;
++		}
++	}
++	mutex_unlock(&priv->lock);
++
++	return pipe_id;
 +}
 +EXPORT_SYMBOL(max96712_get_available_pipe_id);
 +
 +int max96712_release_pipe(struct device *dev, int pipe_id)
 +{
-+	/* TODO EHUD: pipe id? */
++	struct max96712 *priv = dev_get_drvdata(dev);
++	unsigned int pipe_en_val = 0;
++
++	if (pipe_id < 0 || pipe_id >= MAX96712_MAX_PIPES)
++		return -EINVAL;
++
++	mutex_lock(&priv->lock);
++	priv->video_pipe_alloc[pipe_id] = false;
++
++	max96712_read_reg(priv, MAX96712_VIDEO_PIPE_EN_ADDR, &pipe_en_val);
++	max96712_write_reg(priv, MAX96712_VIDEO_PIPE_EN_ADDR, pipe_en_val &= ~(1 << pipe_id));
++	mutex_unlock(&priv->lock);
++
++	max96712_bind_ser_to_dser_pipe(dev, pipe_id, 0, 0);
 +	return 0;
 +}
 +EXPORT_SYMBOL(max96712_release_pipe);
++
++int max96712_get_ser_pipe_id(struct device *dev, int dser_pipe_id, int vc_id)
++{
++	/* When paired with max96712, max9295 has a 1:1 ser_vc_id to ser_pipe_id mapping */
++	return vc_id;
++}
++EXPORT_SYMBOL(max96712_get_ser_pipe_id);
 +
 +void max96712_reset_oneshot(struct device *dev)
 +{
@@ -215,55 +337,48 @@ index 8081385f0..52836c0d7 100644
 +{
 +	int err = 0;
 +	struct max96712 *priv = dev_get_drvdata(dev);
-+
-+	int i = 0;
++	int vc_id_lsb = vc_id & 0x3;
++	int vc_id_msb = vc_id >> 2;
++	unsigned int pipe_en_val = 0;
 +
 +	struct reg_pair map_pipe_control[] = {
-+		// Enable 4 mappings for Pipe X
-+		{MAX96712_MIPI_TX11_ADDR, 0x0F},
++		// Enable 3/4 mappings for video pipe (4 if metadata enabled)
++		{MAX96712_MIPI_TX11_ADDR + (0x40 * pipe_id), (data_type2 == 0) ? 0x07 : 0x0F},
 +		// Map data_type1 on vc_id
-+		{MAX96712_MIPI_TX13_SRC_0_MAP_ADDR, 0x1E},
-+		{MAX96712_MIPI_TX14_DST_0_MAP_ADDR, 0x1E},
++		{MAX96712_MIPI_TX13_SRC_0_MAP_ADDR + (0x40 * pipe_id), (vc_id_lsb << 6) | data_type1},
++		{MAX96712_MIPI_TX14_DST_0_MAP_ADDR + (0x40 * pipe_id), (vc_id_lsb << 6) | data_type1},
 +		// Map frame_start on vc_id
-+		{MAX96712_MIPI_TX15_SRC_1_MAP_ADDR, 0x00},
-+		{MAX96712_MIPI_TX16_DST_1_MAP_ADDR, 0x00},
++		{MAX96712_MIPI_TX15_SRC_1_MAP_ADDR + (0x40 * pipe_id), (vc_id_lsb << 6) | 0x00},
++		{MAX96712_MIPI_TX16_DST_1_MAP_ADDR + (0x40 * pipe_id), (vc_id_lsb << 6) | 0x00},
 +		// Map frame end on vc_id
-+		{MAX96712_MIPI_TX17_SRC_2_MAP_ADDR, 0x01},
-+		{MAX96712_MIPI_TX18_DST_2_MAP_ADDR, 0x01},
++		{MAX96712_MIPI_TX17_SRC_2_MAP_ADDR + (0x40 * pipe_id), (vc_id_lsb << 6) | 0x01},
++		{MAX96712_MIPI_TX18_DST_2_MAP_ADDR + (0x40 * pipe_id), (vc_id_lsb << 6) | 0x01},
 +		// Map data_type2 on vc_id
-+		{MAX96712_MIPI_TX19_SRC_3_MAP_ADDR, 0x12},
-+		{MAX96712_MIPI_TX20_DST_3_MAP_ADDR, 0x12},
++		{MAX96712_MIPI_TX19_SRC_3_MAP_ADDR + (0x40 * pipe_id), (vc_id_lsb << 6) | data_type2},
++		{MAX96712_MIPI_TX20_DST_3_MAP_ADDR + (0x40 * pipe_id), (vc_id_lsb << 6) | data_type2},
++		// Extended dst vc_id mapping 0
++		{MAX96712_MIPI_TX_EXT0_ADDR + (0x10 * pipe_id), vc_id_msb << 2},
++		// Extended dst vc_id mapping 1
++		{MAX96712_MIPI_TX_EXT1_ADDR + (0x10 * pipe_id), vc_id_msb << 2},
++		// Extended dst vc_id mapping 2
++		{MAX96712_MIPI_TX_EXT2_ADDR + (0x10 * pipe_id), vc_id_msb << 2},
++		// Extended dst vc_id mapping 3
++		{MAX96712_MIPI_TX_EXT3_ADDR + (0x10 * pipe_id), vc_id_msb << 2},
 +		// All mappings to PHY1 (master for port A)
-+		{MAX96712_MIPI_TX45_MAP_DPHY_DEST_ADDR, 0x55},
++		{MAX96712_MIPI_TX45_MAP_DPHY_DEST_ADDR + (0x40 * pipe_id), 0x55},
 +		// SEQ_MISS_EN: Disabled / DIS_PKT_DET: Disabled
-+		{MAX96712_VIDEO_RX0_ADDR, 0x23}, // pipe X
++		// This reg has inconsistent gaps between reg addresses per pipe:
++		// 0x100, 0x112, 0x124, 0x136, 0x148, *0x160*, 0x172, 0x184
++		{MAX96712_VIDEO_RX0_ADDR + (0x12 * pipe_id) + ((pipe_id >= 5) ? 6 : 0), 0x23},
 +	};
-+
-+	for (i = 0; i < (ARRAY_SIZE(map_pipe_control) - 1); i++) {
-+		map_pipe_control[i].addr += 0x40 * pipe_id;
-+	}
-+	map_pipe_control[(ARRAY_SIZE(map_pipe_control) - 1)].addr += 0x12 * pipe_id;
-+
-+	if (data_type2 == 0x0) {
-+		/* For IMU (which has no metadata) we override mapping
-+		* to enable only 3
-+		*/
-+		map_pipe_control[0].val = 0x07;
-+	}
-+	map_pipe_control[1].val = (vc_id << 6) | data_type1;
-+	map_pipe_control[2].val = (vc_id << 6) | data_type1;
-+	map_pipe_control[3].val = (vc_id << 6) | 0x00;
-+	map_pipe_control[4].val = (vc_id << 6) | 0x00;
-+	map_pipe_control[5].val = (vc_id << 6) | 0x01;
-+	map_pipe_control[6].val = (vc_id << 6) | 0x01;
-+	map_pipe_control[7].val = (vc_id << 6) | data_type2;
-+	map_pipe_control[8].val = (vc_id << 6) | data_type2;
 +
 +	err |= max96712_set_registers(priv, map_pipe_control,
 +				     ARRAY_SIZE(map_pipe_control));
 +
 +	max96712_reset_oneshot(dev);
-+	max96712_write_reg(priv, MAX96712_VIDEO_PIPE_EN_ADDR, 0xF);
++
++	max96712_read_reg(priv, MAX96712_VIDEO_PIPE_EN_ADDR, &pipe_en_val);
++	max96712_write_reg(priv, MAX96712_VIDEO_PIPE_EN_ADDR, pipe_en_val |= (1 << pipe_id));
 +
 +	return err;
 +}
@@ -274,18 +389,19 @@ index 8081385f0..52836c0d7 100644
 +	struct max96712 *priv = dev_get_drvdata(dev);
 +	struct reg_pair map_pipe_opt[] =
 +	{
-+		/* ----------Video pipes configure ----------------------*/
-+		{MAX96712_REG6_ADDR, 0xF1}, // Enable link - Why is this needed?
-+		{MAX96712_VIDEO_PIPE_SEL_0_ADDR, 0x10}, //0xF0, Link A ID 0 to pipe 0 , Link A ID 1 to pipe 1
-+		{MAX96712_VIDEO_PIPE_SEL_1_ADDR, 0x32}, //0xF1, Link A ID 2 to pipe 2 , Link A ID 3 to pipe 3
-+		{MAX96712_VIDEO_PIPE_EN_ADDR, 0x00}, //0xF4, Enable pipe 0-3, 0xFF
++		/* ----------Initial empty video pipe configure ----------------------*/
++		{MAX96712_VIDEO_PIPE_SEL_0_ADDR, 0x0},
++		{MAX96712_VIDEO_PIPE_SEL_1_ADDR, 0x0},
++		{MAX96712_VIDEO_PIPE_SEL_2_ADDR, 0x0},
++		{MAX96712_VIDEO_PIPE_SEL_3_ADDR, 0x0},
++		{MAX96712_VIDEO_PIPE_EN_ADDR, 0x00}, //0xF4, Disable all pipes for now
 +	};
 +
 +	struct reg_pair map_phy_opt[] =
 +	{
 +		/* MIPI D-PHY Config */
 +		{MAX96712_MIPI_PHY0_ADDR, 0x04}, //0x8A0
-+		{MAX96712_MIPI_TX10_ADDR, 0x40}, //0x94a - MIPI lane count
++		{MAX96712_MIPI_TX10_ADDR, 0x50}, //0x94a - 2 MIPI lanes (Master controller for PHYA), and enable extended VC
 +		{MAX96712_MIPI_PHY3_ADDR, 0xe4}, //0x8A3, Lower phys to lower lanes
 +
 +		/* Put DPLL in reset before changing MIPI lane rates */
@@ -315,6 +431,42 @@ index 8081385f0..52836c0d7 100644
 +}
 +EXPORT_SYMBOL(max96712_init_settings);
 +
++int max96712_bind_ser_to_dser_pipe(struct device *dev, int dser_pipe_id, int ser_pipe_id, u32 vc_id)
++{
++	struct max96712 *priv = dev_get_drvdata(dev);
++	unsigned int pipe_sel_val = 0;
++	u32 link_id = vc_id / MAX9295_MAX_STREAMS;
++	int err = 0;
++
++	/* dser_pipe_id will be connected to ser_pipe_id of link_id */
++	uint8_t map_pipe_val = link_id << 2 | ser_pipe_id;
++
++	/* Every pipe select reg handles two pipe mappings */
++	uint32_t dser_pipe_sel_addr = MAX96712_VIDEO_PIPE_SEL_0_ADDR + (dser_pipe_id / 2);
++	uint32_t dser_pipe_sel_offset = 4 * (dser_pipe_id % 2);
++	uint8_t dser_pipe_sel_mask = 0xF << dser_pipe_sel_offset;
++
++	if (dser_pipe_id < 0 || dser_pipe_id >= MAX96712_MAX_PIPES || link_id >= MAX96712_MAX_LINKS)
++		return -EINVAL;
++
++	mutex_lock(&priv->lock);
++
++	err = max96712_read_reg(priv, dser_pipe_sel_addr, &pipe_sel_val);
++	if (err == 0) {
++		/* Zero the pipe we are interested in */
++		pipe_sel_val &= ~(dser_pipe_sel_mask);
++		/* Input the new value */
++		pipe_sel_val |= (map_pipe_val << dser_pipe_sel_offset);
++
++		err = max96712_write_reg(priv, dser_pipe_sel_addr, pipe_sel_val);
++	}
++
++	mutex_unlock(&priv->lock);
++
++	return err;
++}
++EXPORT_SYMBOL(max96712_bind_ser_to_dser_pipe);
++
 +int max96712_set_pipe(struct device *dev, int pipe_id,
 +		     u8 data_type1, u8 data_type2, u32 vc_id)
 +{
@@ -342,7 +494,40 @@ index 8081385f0..52836c0d7 100644
 +
 +int max96712_setup_link(struct device *dev, struct device *s_dev)
 +{
-+	/* TODO EHUD: Is needed? */
++	struct max96712 *priv = dev_get_drvdata(dev);
++	uint8_t link_mask = priv->link_mask;
++	unsigned int reg_val = 0;
++	unsigned int dser_empty_link_mask_reg = 0xF0;
++	uint8_t link_id_iter = 0;
++	unsigned default_ser_addr = MAX9295_DEFAULT_ADDR;
++	int err = 0;
++
++	/* Iterating over the links and assigning unique serializer i2c addresses */
++	for (link_id_iter = 0; link_id_iter < MAX96712_MAX_LINKS ; link_id_iter++)
++	{
++		if (link_mask & (1 << link_id_iter))
++		{
++			/* Camera should be connected on this link */
++			unsigned int dst_ser_addr = default_ser_addr + link_id_iter;
++			unsigned int curr_map = dser_empty_link_mask_reg | (1 << link_id_iter);
++
++			/* Enable single link */
++			max96712_write_reg(priv, MAX96712_REG6_ADDR, curr_map);
++			msleep(20);
++			max96712_reset_oneshot(dev);
++
++			err = max96712_read_slave_reg(priv, dst_ser_addr, 0, &reg_val);
++			if ((err == 0) && (reg_val == (dst_ser_addr << 1)))
++			{
++				dev_dbg(dev, "%s Serializer already at 0x%x\n", __func__, dst_ser_addr);
++				continue;
++			}
++
++			/* Assign the new i2c address */
++			max96712_write_slave_reg(priv, default_ser_addr, 0, dst_ser_addr << 1);
++		}
++	}
++	max96712_write_reg(priv, MAX96712_REG6_ADDR, dser_empty_link_mask_reg | link_mask);
 +	return 0;
 +}
 +EXPORT_SYMBOL(max96712_setup_link);
@@ -467,7 +652,7 @@ index 8081385f0..52836c0d7 100644
  	{ },
  };
  
-@@ -268,6 +644,7 @@ static struct i2c_driver max96712_i2c_driver = {
+@@ -268,6 +812,7 @@ static struct i2c_driver max96712_i2c_driver = {
  	.driver = {
  		.name = "max96712",
  		.owner = THIS_MODULE,
@@ -475,6 +660,6 @@ index 8081385f0..52836c0d7 100644
  	},
  	.probe = max96712_probe,
  	.remove = max96712_remove,
-	.id_table = max96712_id,
 -- 
 2.43.0
+

--- a/kernel/nvidia/5.0.2/0017-Adding-max96712-support-for-D4xx.patch
+++ b/kernel/nvidia/5.0.2/0017-Adding-max96712-support-for-D4xx.patch
@@ -1,20 +1,20 @@
-From 117d51d36ef79577e7c5dc19a31b021f1bd29e79 Mon Sep 17 00:00:00 2001
+From 285bd68575eed4f7ff2cac5be4c2c10f2939050f Mon Sep 17 00:00:00 2001
 From: ejgoldik <ehud.joseph.goldik@realsenseai.com>
-Date: Wed, 25 Mar 2026 15:27:46 +0200
+Date: Thu, 26 Mar 2026 16:04:31 +0200
 Subject: [PATCH] Adding max96712 support for D4xx
 
 Add MAX96712 deserializer driver support for D4XX cameras.
 
 Signed-off-by: ejgoldik <ehud.joseph.goldik@realsenseai.com>
 ---
- drivers/media/i2c/max96712.c | 557 ++++++++++++++++++++++++++++++++++-
- 1 file changed, 553 insertions(+), 4 deletions(-)
+ drivers/media/i2c/max96712.c | 582 ++++++++++++++++++++++++++++++++++-
+ 1 file changed, 578 insertions(+), 4 deletions(-)
 
 diff --git a/drivers/media/i2c/max96712.c b/drivers/media/i2c/max96712.c
-index 8081385f0..ba4d06c9c 100644
+index 8081385f0..f25dd824e 100644
 --- a/drivers/media/i2c/max96712.c
 +++ b/drivers/media/i2c/max96712.c
-@@ -21,18 +21,84 @@
+@@ -21,18 +21,85 @@
  #include <linux/debugfs.h>
  #include <media/camera_common.h>
  #include <linux/module.h>
@@ -40,6 +40,7 @@ index 8081385f0..ba4d06c9c 100644
 +
 +#define MAX96712_REG6_ADDR 0x6
 +#define MAX96712_PWR1_ADDR 0x13
++#define MAX96712_PWR1_RESET_ALL_VAL 0x40
 +#define MAX96712_CTRL1_ADDR 0x18
 +
 +#define MAX96712_BACKTOP25_ADDR 0x418
@@ -101,7 +102,7 @@ index 8081385f0..ba4d06c9c 100644
  {
  	struct i2c_client *i2c_client = NULL;
  	int bak = 0;
-@@ -85,6 +151,52 @@ int max96712_read_reg_Dser(int slaveAddr,int channel,
+@@ -85,6 +152,52 @@ int max96712_read_reg_Dser(int slaveAddr,int channel,
  
  EXPORT_SYMBOL(max96712_read_reg_Dser);
  
@@ -154,7 +155,7 @@ index 8081385f0..ba4d06c9c 100644
  static int max96712_read_reg(struct max96712 *priv,
  			u16 addr, unsigned int *val)
  {
-@@ -99,6 +211,20 @@ static int max96712_read_reg(struct max96712 *priv,
+@@ -99,6 +212,20 @@ static int max96712_read_reg(struct max96712 *priv,
  	return err;
  }
  
@@ -175,7 +176,7 @@ index 8081385f0..ba4d06c9c 100644
  
  static int max96712_stats_show(struct seq_file *s, void *data)
  {
-@@ -169,7 +295,10 @@ static int max96712_debugfs_init(const char *dir_name,
+@@ -169,7 +296,10 @@ static int max96712_debugfs_init(const char *dir_name,
  	if (np) {
  		err = of_property_read_string(np, "channel", &priv->channel);
  		if (err)
@@ -186,7 +187,7 @@ index 8081385f0..ba4d06c9c 100644
  
  		err = snprintf(dev_name, sizeof(dev_name), "max96712_%s", priv->channel);
  		if (err < 0)
-@@ -208,7 +337,8 @@ static int max96712_debugfs_init(const char *dir_name,
+@@ -208,7 +338,8 @@ static int max96712_debugfs_init(const char *dir_name,
  static  struct regmap_config max96712_regmap_config = {
  	.reg_bits = 16,
  	.val_bits = 8,
@@ -196,7 +197,7 @@ index 8081385f0..ba4d06c9c 100644
  };
  
  static int max96712_probe(struct i2c_client *client,
-@@ -216,6 +346,8 @@ static int max96712_probe(struct i2c_client *client,
+@@ -216,6 +347,8 @@ static int max96712_probe(struct i2c_client *client,
  {
  	struct max96712 *priv;
  	int err = 0;
@@ -205,7 +206,7 @@ index 8081385f0..ba4d06c9c 100644
  
  	dev_info(&client->dev, "%s: enter\n", __func__);
  
-@@ -228,10 +360,36 @@ static int max96712_probe(struct i2c_client *client,
+@@ -228,10 +361,36 @@ static int max96712_probe(struct i2c_client *client,
  			"regmap init failed: %ld\n", PTR_ERR(priv->regmap));
  		return -ENODEV;
  	}
@@ -242,7 +243,7 @@ index 8081385f0..ba4d06c9c 100644
  
  	/*set daymode by fault*/
  	dev_info(&client->dev, "%s:  success\n", __func__);
-@@ -243,8 +401,12 @@ static int max96712_probe(struct i2c_client *client,
+@@ -243,8 +402,12 @@ static int max96712_probe(struct i2c_client *client,
  static int
  max96712_remove(struct i2c_client *client)
  {
@@ -255,7 +256,7 @@ index 8081385f0..ba4d06c9c 100644
  		i2c_unregister_device(client);
  		client = NULL;
  	}
-@@ -252,13 +414,399 @@ max96712_remove(struct i2c_client *client)
+@@ -252,13 +415,423 @@ max96712_remove(struct i2c_client *client)
  	return 0;
  }
  
@@ -281,7 +282,7 @@ index 8081385f0..ba4d06c9c 100644
 +int max96712_get_available_pipe_id(struct device *dev, int vc_id)
 +{
 +	int i;
-+	int pipe_id = -ENOMEM;
++	int pipe_id = -ENOSR;
 +	struct max96712 *priv = dev_get_drvdata(dev);
 +
 +	mutex_lock(&priv->lock);
@@ -298,10 +299,42 @@ index 8081385f0..ba4d06c9c 100644
 +}
 +EXPORT_SYMBOL(max96712_get_available_pipe_id);
 +
++static int __max96712_bind_ser_to_dser_pipe(struct device *dev, int dser_pipe_id, int ser_pipe_id, u32 vc_id)
++{
++	struct max96712 *priv = dev_get_drvdata(dev);
++	unsigned int pipe_sel_val = 0;
++	u32 link_id = vc_id / MAX9295_MAX_STREAMS;
++	int err = 0;
++
++	/* dser_pipe_id will be connected to ser_pipe_id of link_id */
++	uint8_t map_pipe_val = link_id << 2 | ser_pipe_id;
++
++	/* Every pipe select reg handles two pipe mappings */
++	uint32_t dser_pipe_sel_addr = MAX96712_VIDEO_PIPE_SEL_0_ADDR + (dser_pipe_id / 2);
++	uint32_t dser_pipe_sel_offset = 4 * (dser_pipe_id % 2);
++	uint8_t dser_pipe_sel_mask = 0xF << dser_pipe_sel_offset;
++
++	if (dser_pipe_id < 0 || dser_pipe_id >= MAX96712_MAX_PIPES || link_id >= MAX96712_MAX_LINKS)
++		return -EINVAL;
++
++	err = max96712_read_reg(priv, dser_pipe_sel_addr, &pipe_sel_val);
++	if (err == 0) {
++		/* Zero the pipe we are interested in */
++		pipe_sel_val &= ~(dser_pipe_sel_mask);
++		/* Input the new value */
++		pipe_sel_val |= (map_pipe_val << dser_pipe_sel_offset);
++
++		err = max96712_write_reg(priv, dser_pipe_sel_addr, pipe_sel_val);
++	}
++
++	return err;
++}
++
 +int max96712_release_pipe(struct device *dev, int pipe_id)
 +{
 +	struct max96712 *priv = dev_get_drvdata(dev);
 +	unsigned int pipe_en_val = 0;
++	int err = 0;
 +
 +	if (pipe_id < 0 || pipe_id >= MAX96712_MAX_PIPES)
 +		return -EINVAL;
@@ -309,12 +342,19 @@ index 8081385f0..ba4d06c9c 100644
 +	mutex_lock(&priv->lock);
 +	priv->video_pipe_alloc[pipe_id] = false;
 +
-+	max96712_read_reg(priv, MAX96712_VIDEO_PIPE_EN_ADDR, &pipe_en_val);
-+	max96712_write_reg(priv, MAX96712_VIDEO_PIPE_EN_ADDR, pipe_en_val &= ~(1 << pipe_id));
++	err = max96712_read_reg(priv, MAX96712_VIDEO_PIPE_EN_ADDR, &pipe_en_val);
++	if (err == 0) {
++		pipe_en_val &= ~(1 << pipe_id);
++		err = max96712_write_reg(priv, MAX96712_VIDEO_PIPE_EN_ADDR, pipe_en_val);
++	}
++
++	if (err == 0) {
++		err = __max96712_bind_ser_to_dser_pipe(dev, pipe_id, 0, 0);
++	}
++
 +	mutex_unlock(&priv->lock);
 +
-+	max96712_bind_ser_to_dser_pipe(dev, pipe_id, 0, 0);
-+	return 0;
++	return err;
 +}
 +EXPORT_SYMBOL(max96712_release_pipe);
 +
@@ -375,11 +415,16 @@ index 8081385f0..ba4d06c9c 100644
 +
 +	err |= max96712_set_registers(priv, map_pipe_control,
 +				     ARRAY_SIZE(map_pipe_control));
-+
++	if (err) {
++		return err;
++	}
 +	max96712_reset_oneshot(dev);
 +
-+	max96712_read_reg(priv, MAX96712_VIDEO_PIPE_EN_ADDR, &pipe_en_val);
-+	max96712_write_reg(priv, MAX96712_VIDEO_PIPE_EN_ADDR, pipe_en_val |= (1 << pipe_id));
++	err |= max96712_read_reg(priv, MAX96712_VIDEO_PIPE_EN_ADDR, &pipe_en_val);
++	if (err == 0) {
++		pipe_en_val |= (1 << pipe_id);
++		err |= max96712_write_reg(priv, MAX96712_VIDEO_PIPE_EN_ADDR, pipe_en_val);
++	}
 +
 +	return err;
 +}
@@ -435,32 +480,11 @@ index 8081385f0..ba4d06c9c 100644
 +int max96712_bind_ser_to_dser_pipe(struct device *dev, int dser_pipe_id, int ser_pipe_id, u32 vc_id)
 +{
 +	struct max96712 *priv = dev_get_drvdata(dev);
-+	unsigned int pipe_sel_val = 0;
-+	u32 link_id = vc_id / MAX9295_MAX_STREAMS;
 +	int err = 0;
-+
-+	/* dser_pipe_id will be connected to ser_pipe_id of link_id */
-+	uint8_t map_pipe_val = link_id << 2 | ser_pipe_id;
-+
-+	/* Every pipe select reg handles two pipe mappings */
-+	uint32_t dser_pipe_sel_addr = MAX96712_VIDEO_PIPE_SEL_0_ADDR + (dser_pipe_id / 2);
-+	uint32_t dser_pipe_sel_offset = 4 * (dser_pipe_id % 2);
-+	uint8_t dser_pipe_sel_mask = 0xF << dser_pipe_sel_offset;
-+
-+	if (dser_pipe_id < 0 || dser_pipe_id >= MAX96712_MAX_PIPES || link_id >= MAX96712_MAX_LINKS)
-+		return -EINVAL;
 +
 +	mutex_lock(&priv->lock);
 +
-+	err = max96712_read_reg(priv, dser_pipe_sel_addr, &pipe_sel_val);
-+	if (err == 0) {
-+		/* Zero the pipe we are interested in */
-+		pipe_sel_val &= ~(dser_pipe_sel_mask);
-+		/* Input the new value */
-+		pipe_sel_val |= (map_pipe_val << dser_pipe_sel_offset);
-+
-+		err = max96712_write_reg(priv, dser_pipe_sel_addr, pipe_sel_val);
-+	}
++	err = __max96712_bind_ser_to_dser_pipe(dev, dser_pipe_id, ser_pipe_id, vc_id);
 +
 +	mutex_unlock(&priv->lock);
 +
@@ -638,7 +662,8 @@ index 8081385f0..ba4d06c9c 100644
 +        gpio_set_value(priv->pwdn_gpio, 0);
 +        msleep(100);
 +    } else {
-+        max96712_write_reg(priv, MAX96712_PWR1_ADDR, 0x40);
++        /* If no power off GPIO exists, use reset all (self-clearing) */
++        max96712_write_reg(priv, MAX96712_PWR1_ADDR, MAX96712_PWR1_RESET_ALL_VAL);
 +        msleep(200);
 +    }
 +    return;
@@ -656,7 +681,7 @@ index 8081385f0..ba4d06c9c 100644
  	{ },
  };
  
-@@ -268,6 +816,7 @@ static struct i2c_driver max96712_i2c_driver = {
+@@ -268,6 +841,7 @@ static struct i2c_driver max96712_i2c_driver = {
  	.driver = {
  		.name = "max96712",
  		.owner = THIS_MODULE,

--- a/kernel/nvidia/5.0.2/0017-Adding-max96712-support-for-D4xx.patch
+++ b/kernel/nvidia/5.0.2/0017-Adding-max96712-support-for-D4xx.patch
@@ -1,20 +1,20 @@
-From 4c907e3cd7b94aea1497c94ab458cafb8fe0a77c Mon Sep 17 00:00:00 2001
+From 117d51d36ef79577e7c5dc19a31b021f1bd29e79 Mon Sep 17 00:00:00 2001
 From: ejgoldik <ehud.joseph.goldik@realsenseai.com>
-Date: Wed, 25 Mar 2026 14:10:22 +0200
+Date: Wed, 25 Mar 2026 15:27:46 +0200
 Subject: [PATCH] Adding max96712 support for D4xx
 
 Add MAX96712 deserializer driver support for D4XX cameras.
 
 Signed-off-by: ejgoldik <ehud.joseph.goldik@realsenseai.com>
 ---
- drivers/media/i2c/max96712.c | 553 ++++++++++++++++++++++++++++++++++-
- 1 file changed, 549 insertions(+), 4 deletions(-)
+ drivers/media/i2c/max96712.c | 557 ++++++++++++++++++++++++++++++++++-
+ 1 file changed, 553 insertions(+), 4 deletions(-)
 
 diff --git a/drivers/media/i2c/max96712.c b/drivers/media/i2c/max96712.c
-index 8081385f0..62b5f24c2 100644
+index 8081385f0..ba4d06c9c 100644
 --- a/drivers/media/i2c/max96712.c
 +++ b/drivers/media/i2c/max96712.c
-@@ -21,18 +21,83 @@
+@@ -21,18 +21,84 @@
  #include <linux/debugfs.h>
  #include <media/camera_common.h>
  #include <linux/module.h>
@@ -39,6 +39,7 @@ index 8081385f0..62b5f24c2 100644
 +#define MAX96712_315_ESYNC 0x07
 +
 +#define MAX96712_REG6_ADDR 0x6
++#define MAX96712_PWR1_ADDR 0x13
 +#define MAX96712_CTRL1_ADDR 0x18
 +
 +#define MAX96712_BACKTOP25_ADDR 0x418
@@ -100,7 +101,7 @@ index 8081385f0..62b5f24c2 100644
  {
  	struct i2c_client *i2c_client = NULL;
  	int bak = 0;
-@@ -85,6 +150,52 @@ int max96712_read_reg_Dser(int slaveAddr,int channel,
+@@ -85,6 +151,52 @@ int max96712_read_reg_Dser(int slaveAddr,int channel,
  
  EXPORT_SYMBOL(max96712_read_reg_Dser);
  
@@ -153,7 +154,7 @@ index 8081385f0..62b5f24c2 100644
  static int max96712_read_reg(struct max96712 *priv,
  			u16 addr, unsigned int *val)
  {
-@@ -99,6 +210,20 @@ static int max96712_read_reg(struct max96712 *priv,
+@@ -99,6 +211,20 @@ static int max96712_read_reg(struct max96712 *priv,
  	return err;
  }
  
@@ -174,7 +175,7 @@ index 8081385f0..62b5f24c2 100644
  
  static int max96712_stats_show(struct seq_file *s, void *data)
  {
-@@ -169,7 +294,10 @@ static int max96712_debugfs_init(const char *dir_name,
+@@ -169,7 +295,10 @@ static int max96712_debugfs_init(const char *dir_name,
  	if (np) {
  		err = of_property_read_string(np, "channel", &priv->channel);
  		if (err)
@@ -185,7 +186,7 @@ index 8081385f0..62b5f24c2 100644
  
  		err = snprintf(dev_name, sizeof(dev_name), "max96712_%s", priv->channel);
  		if (err < 0)
-@@ -208,7 +336,8 @@ static int max96712_debugfs_init(const char *dir_name,
+@@ -208,7 +337,8 @@ static int max96712_debugfs_init(const char *dir_name,
  static  struct regmap_config max96712_regmap_config = {
  	.reg_bits = 16,
  	.val_bits = 8,
@@ -195,7 +196,7 @@ index 8081385f0..62b5f24c2 100644
  };
  
  static int max96712_probe(struct i2c_client *client,
-@@ -216,6 +345,8 @@ static int max96712_probe(struct i2c_client *client,
+@@ -216,6 +346,8 @@ static int max96712_probe(struct i2c_client *client,
  {
  	struct max96712 *priv;
  	int err = 0;
@@ -204,7 +205,7 @@ index 8081385f0..62b5f24c2 100644
  
  	dev_info(&client->dev, "%s: enter\n", __func__);
  
-@@ -228,10 +359,36 @@ static int max96712_probe(struct i2c_client *client,
+@@ -228,10 +360,36 @@ static int max96712_probe(struct i2c_client *client,
  			"regmap init failed: %ld\n", PTR_ERR(priv->regmap));
  		return -ENODEV;
  	}
@@ -241,7 +242,7 @@ index 8081385f0..62b5f24c2 100644
  
  	/*set daymode by fault*/
  	dev_info(&client->dev, "%s:  success\n", __func__);
-@@ -243,8 +400,12 @@ static int max96712_probe(struct i2c_client *client,
+@@ -243,8 +401,12 @@ static int max96712_probe(struct i2c_client *client,
  static int
  max96712_remove(struct i2c_client *client)
  {
@@ -254,7 +255,7 @@ index 8081385f0..62b5f24c2 100644
  		i2c_unregister_device(client);
  		client = NULL;
  	}
-@@ -252,13 +413,396 @@ max96712_remove(struct i2c_client *client)
+@@ -252,13 +414,399 @@ max96712_remove(struct i2c_client *client)
  	return 0;
  }
  
@@ -636,6 +637,9 @@ index 8081385f0..62b5f24c2 100644
 +        gpio_direction_output(priv->pwdn_gpio, 1);
 +        gpio_set_value(priv->pwdn_gpio, 0);
 +        msleep(100);
++    } else {
++        max96712_write_reg(priv, MAX96712_PWR1_ADDR, 0x40);
++        msleep(200);
 +    }
 +    return;
 +}
@@ -652,7 +656,7 @@ index 8081385f0..62b5f24c2 100644
  	{ },
  };
  
-@@ -268,6 +812,7 @@ static struct i2c_driver max96712_i2c_driver = {
+@@ -268,6 +816,7 @@ static struct i2c_driver max96712_i2c_driver = {
  	.driver = {
  		.name = "max96712",
  		.owner = THIS_MODULE,

--- a/kernel/nvidia/5.0.2/0018-Allow-external-address-assignment-on-max9295.patch
+++ b/kernel/nvidia/5.0.2/0018-Allow-external-address-assignment-on-max9295.patch
@@ -1,0 +1,149 @@
+From 062a6765043e3ec63ca50aa73a0f9e3674a14138 Mon Sep 17 00:00:00 2001
+From: ejgoldik <ehud.joseph.goldik@realsenseai.com>
+Date: Wed, 25 Mar 2026 14:26:10 +0200
+Subject: [PATCH] Allow external address assignment on max9295
+
+Signed-off-by: ejgoldik <ehud.joseph.goldik@realsenseai.com>
+---
+ drivers/media/i2c/max9295.c | 87 +++++++++++++++++--------------------
+ 1 file changed, 41 insertions(+), 46 deletions(-)
+
+diff --git a/drivers/media/i2c/max9295.c b/drivers/media/i2c/max9295.c
+index 8dd593de7..2ea0ee461 100644
+--- a/drivers/media/i2c/max9295.c
++++ b/drivers/media/i2c/max9295.c
+@@ -120,6 +120,7 @@ struct max9295 {
+ 	struct regmap *regmap;
+ 	struct max9295_client_ctx g_client;
+ 	struct mutex lock;
++	bool external_addr_reassign;
+ 	/* primary serializer properties */
+ 	__u32 def_addr;
+ 	__u32 pst2_ref;
+@@ -323,50 +324,52 @@ int max9295_setup_control(struct device *dev)
+ 
+ 	g_ctx = priv->g_client.g_ctx;
+ 
+-	if (prim_priv__) {
+-		/* update address reassingment */
+-		max9295_write_reg(&prim_priv__->i2c_client->dev,
+-				MAX9295_DEV_ADDR, (g_ctx->ser_reg << 1));
+-	}
++	if (!priv->external_addr_reassign) {
++		if (prim_priv__) {
++			/* update address reassingment */
++			max9295_write_reg(&prim_priv__->i2c_client->dev,
++					MAX9295_DEV_ADDR, (g_ctx->ser_reg << 1));
++		}
+ 
+-	if (g_ctx->serdes_csi_link == GMSL_SERDES_CSI_LINK_A)
+-		err = max9295_write_reg(dev, MAX9295_CTRL0_ADDR, 0x21);
+-	else
+-		err = max9295_write_reg(dev, MAX9295_CTRL0_ADDR, 0x22);
++		if (g_ctx->serdes_csi_link == GMSL_SERDES_CSI_LINK_A)
++			err = max9295_write_reg(dev, MAX9295_CTRL0_ADDR, 0x21);
++		else
++			err = max9295_write_reg(dev, MAX9295_CTRL0_ADDR, 0x22);
+ 
+-	/* check if serializer device exists */
+-	if (err) {
+-		dev_err(dev, "%s: ERROR: ser device not found\n", __func__);
+-		goto error;
+-	}
++		/* check if serializer device exists */
++		if (err) {
++			dev_err(dev, "%s: ERROR: ser device not found\n", __func__);
++			goto error;
++		}
+ 
+-	/* delay to settle link */
+-	msleep(100);
++		/* delay to settle link */
++		msleep(100);
+ 
+-	for (i = 0; i < ARRAY_SIZE(addr_offset); i += 3) {
+-		if ((g_ctx->ser_reg << 1) == addr_offset[i]) {
+-			offset1 = addr_offset[i+1];
+-			offset2 = addr_offset[i+2];
+-			break;
++		for (i = 0; i < ARRAY_SIZE(addr_offset); i += 3) {
++			if ((g_ctx->ser_reg << 1) == addr_offset[i]) {
++				offset1 = addr_offset[i+1];
++				offset2 = addr_offset[i+2];
++				break;
++			}
+ 		}
+-	}
+ 
+-	if (i == ARRAY_SIZE(addr_offset)) {
+-		dev_err(dev, "%s: invalid ser slave address\n", __func__);
+-		err = -EINVAL;
+-		goto error;
+-	}
++		if (i == ARRAY_SIZE(addr_offset)) {
++			dev_err(dev, "%s: invalid ser slave address\n", __func__);
++			err = -EINVAL;
++			goto error;
++		}
+ 
+-	for (i = 0; i < ARRAY_SIZE(i2c_ovrd); i += 2) {
+-		/* update address overrides */
+-		i2c_ovrd[i+1] += (i < 4) ? offset1 : offset2;
++		for (i = 0; i < ARRAY_SIZE(i2c_ovrd); i += 2) {
++			/* update address overrides */
++			i2c_ovrd[i+1] += (i < 4) ? offset1 : offset2;
+ 
+-		/* i2c passthrough2 must be configured once for all devices */
+-		if ((i2c_ovrd[i] == 0x8B) && prim_priv__ &&
+-				prim_priv__->pst2_ref)
+-			continue;
++			/* i2c passthrough2 must be configured once for all devices */
++			if ((i2c_ovrd[i] == 0x8B) && prim_priv__ &&
++					prim_priv__->pst2_ref)
++				continue;
+ 
+-		max9295_write_reg(dev, i2c_ovrd[i], i2c_ovrd[i+1]);
++			max9295_write_reg(dev, i2c_ovrd[i], i2c_ovrd[i+1]);
++		}
+ 	}
+ 
+ 	/* dev addr pass-through2 ref */
+@@ -568,10 +571,6 @@ static int __max9295_set_pipe(struct device *dev, int pipe_id, u8 data_type1,
+ {
+ 	int err = 0;
+ 	u8 bpp = 0x30;
+-	static u8 pipe_x_val = 0x0;
+-	struct reg_pair map_multi_pipe_en[] = {
+-		{0x0315, 0x80},
+-	};
+ 	struct reg_pair map_bpp8dbl[] = {
+ 		{0x0312, 0x0F},
+ 	};
+@@ -605,21 +604,17 @@ static int __max9295_set_pipe(struct device *dev, int pipe_id, u8 data_type1,
+ 
+ 	map_pipe_control[0].val = 0x40 | data_type1;
+ 	map_pipe_control[1].val = 0x40 | data_type2;
++	if (pipe_id == 0) {
++		map_pipe_control[1].val |= 0x80;
++	}
+ 	map_pipe_control[2].val = 1 << vc_id;
+ 	map_pipe_control[3].val = 0x00;
+ 	map_pipe_control[4].val = bpp;
+ 	map_pipe_control[5].val = 0x0E;
+ 
+-	if (pipe_id == 0)
+-		pipe_x_val = map_pipe_control[1].val;
+-
+ 	err |= max9295_set_registers(dev, map_pipe_control,
+ 				     ARRAY_SIZE(map_pipe_control));
+ 
+-	map_multi_pipe_en[0].val = 0x80 | pipe_x_val;
+-	err |= max9295_set_registers(dev, map_multi_pipe_en,
+-				     ARRAY_SIZE(map_multi_pipe_en));
+-
+ 	return err;
+ }
+ 
+-- 
+2.43.0
+

--- a/kernel/nvidia/5.0.2/0019-Align-max9296-api-to-max96712.patch
+++ b/kernel/nvidia/5.0.2/0019-Align-max9296-api-to-max96712.patch
@@ -1,0 +1,78 @@
+From d06ea5f9a705a9d7bb410682e690f54c94a73149 Mon Sep 17 00:00:00 2001
+From: ejgoldik <ehud.joseph.goldik@realsenseai.com>
+Date: Wed, 25 Mar 2026 14:16:58 +0200
+Subject: [PATCH] Align max9296 api to max96712
+
+Signed-off-by: ejgoldik <ehud.joseph.goldik@realsenseai.com>
+---
+ drivers/media/i2c/max9296.c | 14 ++++++++++++++
+ include/media/max9296.h     | 14 ++++++++++++++
+ 2 files changed, 28 insertions(+)
+
+diff --git a/drivers/media/i2c/max9296.c b/drivers/media/i2c/max9296.c
+index 829657bca..b4a18c5a3 100644
+--- a/drivers/media/i2c/max9296.c
++++ b/drivers/media/i2c/max9296.c
+@@ -847,6 +847,13 @@ int max9296_release_pipe(struct device *dev, int pipe_id)
+ }
+ EXPORT_SYMBOL(max9296_release_pipe);
+ 
++int max9296_get_ser_pipe_id(struct device *dev, int dser_pipe_id, int vc_id)
++{
++	/* When paired with max9296, max9295 has a 1:1 dser_pipe_id to ser_pipe_id mapping */
++	return dser_pipe_id;
++}
++EXPORT_SYMBOL(max9296_get_ser_pipe_id);
++
+ void max9296_reset_oneshot(struct device *dev)
+ {
+ 	struct max9296 *priv = dev_get_drvdata(dev);
+@@ -955,6 +962,13 @@ int max9296_init_settings(struct device *dev)
+ }
+ EXPORT_SYMBOL(max9296_init_settings);
+ 
++int max9296_bind_ser_to_dser_pipe(struct device *dev, int dser_pipe_id, int ser_pipe_id, u32 vc_id)
++{
++	/* pipe id's are 1:1 in this deserializer */
++	return 0;
++}
++EXPORT_SYMBOL(max9296_bind_ser_to_dser_pipe);
++
+ int max9296_set_pipe(struct device *dev, int pipe_id,
+ 		     u8 data_type1, u8 data_type2, u32 vc_id)
+ {
+diff --git a/include/media/max9296.h b/include/media/max9296.h
+index 20f3a6657..5d12d3108 100644
+--- a/include/media/max9296.h
++++ b/include/media/max9296.h
+@@ -37,6 +37,7 @@
+  */
+ 
+ int max9296_get_available_pipe_id(struct device *dev, int vc_id);
++int max9296_get_ser_pipe_id(struct device *dev, int dser_pipe_id, int vc_id);
+ int max9296_set_pipe(struct device *dev, int pipe_id, u8 data_type1,
+ 		     u8 data_type2, u32 vc_id);
+ int max9296_release_pipe(struct device *dev, int pipe_id);
+@@ -167,6 +168,19 @@ int max9296_power_on(struct device *dev);
+ void max9296_power_off(struct device *dev);
+ 
+ int max9296_init_settings(struct device *dev);
++
++/**
++ * @brief  Maps dserializer to serializer pipe id
++ *
++ * Not a meaningful function in this deserializer as the mapping is 1:1
++ *
++ * @param [in]  dev             The deserializer device handle.
++ * @param [in]  dser_pipe_id    Deserializer pipe id.
++ * @param [in]  ser_pipe_id     Serializer pipe id.
++ * @param [in]  vc_id           vc_id associated with this pipe path.
++ */
++int max9296_bind_ser_to_dser_pipe(struct device *dev, int dser_pipe_id, int ser_pipe_id, u32 vc_id);
++
+ /** @} */
+ 
+ #endif  /* __MAX9296_H__ */
+-- 
+2.43.0
+

--- a/kernel/nvidia/5.1.2/0007-Adding-max96712-support-for-D4xx.patch
+++ b/kernel/nvidia/5.1.2/0007-Adding-max96712-support-for-D4xx.patch
@@ -1,20 +1,20 @@
-]633;E;{ sed -n '1,14p' "$OLD512" | sed 's/ with GPIO tunneling//'\x3b sed -n '106,657p' "$OLD512"\x3b printf -- '-- \\n2.43.0\\n'\x3b } > "$DIR512/0007-Adding-max96712-support-for-D4xx.patch";9f837e99-f379-474d-ad57-9b4f15cb39a7]633;CFrom 317b49f2e4e8838181ae1804547fa1c7662d350b Mon Sep 17 00:00:00 2001
+From 7ece021a29ef6fca745da6910ca41b3c987481db Mon Sep 17 00:00:00 2001
 From: ejgoldik <ehud.joseph.goldik@realsenseai.com>
-Date: Wed, 18 Feb 2026 16:30:47 +0200
+Date: Wed, 25 Mar 2026 14:51:32 +0200
 Subject: [PATCH] Adding max96712 support for D4xx
 
 Add MAX96712 deserializer driver support for D4XX cameras.
 
 Signed-off-by: ejgoldik <ehud.joseph.goldik@realsenseai.com>
 ---
- drivers/media/i2c/max96712.c | 319 ++++++++++++++++++++++++++++++++++-
- 1 file changed, 317 insertions(+), 2 deletions(-)
+ drivers/media/i2c/max96712.c | 594 ++++++++++++++++++++++++++++++++---
+ 1 file changed, 553 insertions(+), 41 deletions(-)
 
 diff --git a/drivers/media/i2c/max96712.c b/drivers/media/i2c/max96712.c
-index 329a10dfd..52836c0d7 100644
+index 329a10dfd..cc18184a3 100644
 --- a/drivers/media/i2c/max96712.c
 +++ b/drivers/media/i2c/max96712.c
-@@ -21,32 +21,78 @@
+@@ -21,32 +21,91 @@
  #include <linux/debugfs.h>
  #include <media/camera_common.h>
  #include <linux/module.h>
@@ -44,11 +44,18 @@ index 329a10dfd..52836c0d7 100644
 +
 +#define MAX96712_BACKTOP25_ADDR 0x418
 +
++#define MAX96712_MIPI_TX_EXT0_ADDR 0x800
++#define MAX96712_MIPI_TX_EXT1_ADDR 0x801
++#define MAX96712_MIPI_TX_EXT2_ADDR 0x802
++#define MAX96712_MIPI_TX_EXT3_ADDR 0x803
++
 +#define MAX96712_MIPI_PHY0_ADDR 0x8A0
 +#define MAX96712_MIPI_PHY2_ADDR 0x8A2
 +#define MAX96712_MIPI_PHY3_ADDR 0x8A3
 +#define MAX96712_VIDEO_PIPE_SEL_0_ADDR 0xF0
 +#define MAX96712_VIDEO_PIPE_SEL_1_ADDR 0xF1
++#define MAX96712_VIDEO_PIPE_SEL_2_ADDR 0xF2
++#define MAX96712_VIDEO_PIPE_SEL_3_ADDR 0xF3
 +#define MAX96712_VIDEO_PIPE_EN_ADDR 0xF4
 +#define MAX96712_BACKTOP12_CSI_OUT_EN_ADDR 0x40B
 +
@@ -69,8 +76,12 @@ index 329a10dfd..52836c0d7 100644
 +
 +#define MAX96712_DPLL_0_ADDR 0x1D00
 +
++#define MAX9295_DEFAULT_ADDR 0x40
++
 +/* data defines */
-+#define MAX96712_MAX_PIPES 4
++#define MAX96712_MAX_LINKS 4
++#define MAX96712_MAX_PIPES 8
++#define MAX9295_MAX_STREAMS 4
  
  struct max96712 {
  	struct i2c_client *i2c_client;
@@ -78,6 +89,8 @@ index 329a10dfd..52836c0d7 100644
  	const char *channel;
 +	struct mutex lock;
 +	int pwdn_gpio;
++	int link_mask;
++	bool video_pipe_alloc[MAX96712_MAX_PIPES];
  };
  struct max96712 *global_priv[4] ;
  
@@ -100,7 +113,7 @@ index 329a10dfd..52836c0d7 100644
  	i2c_client = global_priv[channel]->i2c_client;
  	bak = i2c_client->addr;
  
-@@ -58,9 +104,9 @@ int max96712_write_reg_Dser(int slaveAddr,int channel,
+@@ -58,9 +117,9 @@ int max96712_write_reg_Dser(int slaveAddr,int channel,
  	{
  		dev_err(&i2c_client->dev, "%s: addr = 0x%x, val = 0x%x\n",
  				__func__, addr, val);
@@ -112,7 +125,7 @@ index 329a10dfd..52836c0d7 100644
  }
  
  EXPORT_SYMBOL(max96712_write_reg_Dser);
-@@ -71,11 +117,9 @@ int max96712_read_reg_Dser(int slaveAddr,int channel,
+@@ -71,11 +130,9 @@ int max96712_read_reg_Dser(int slaveAddr,int channel,
  {
  	struct i2c_client *i2c_client = NULL;
  	int bak = 0;
@@ -125,7 +138,7 @@ index 329a10dfd..52836c0d7 100644
  	i2c_client = global_priv[channel]->i2c_client;
  	bak = i2c_client->addr;
  	i2c_client->addr = slaveAddr / 2;
-@@ -85,9 +129,10 @@ int max96712_read_reg_Dser(int slaveAddr,int channel,
+@@ -85,13 +142,60 @@ int max96712_read_reg_Dser(int slaveAddr,int channel,
  	{
  		dev_err(&i2c_client->dev, "%s: addr = 0x%x, val = 0x%x\n",
  				__func__, addr, *val);
@@ -138,7 +151,57 @@ index 329a10dfd..52836c0d7 100644
  }
  
  EXPORT_SYMBOL(max96712_read_reg_Dser);
-@@ -106,6 +151,20 @@ static int max96712_read_reg(struct max96712 *priv,
+ 
++static int max96712_read_slave_reg(struct max96712 *priv,
++			int ShortSlaveAddr, u16 addr, unsigned int *val)
++{
++	struct i2c_client *i2c_client = priv->i2c_client;
++	int err;
++	int bak = i2c_client->addr;
++	unsigned int value = 0;
++
++	mutex_lock(&priv->lock);
++	i2c_client->addr = ShortSlaveAddr;
++	err = regmap_read(priv->regmap, addr, &value);
++	i2c_client->addr = bak;
++
++	if (err)
++		dev_err(&i2c_client->dev, "%s:i2c read failed, 0x%x: 0x%x\n",
++			__func__, ShortSlaveAddr, addr);
++	usleep_range(100, 110);
++	*val = value;
++	mutex_unlock(&priv->lock);
++
++	return err;
++}
++
++static int max96712_write_slave_reg(struct max96712 *priv,
++			int ShortSlaveAddr, u16 addr, unsigned int val)
++{
++	struct i2c_client *i2c_client = priv->i2c_client;
++	int err;
++	int bak = i2c_client->addr;
++
++	mutex_lock(&priv->lock);
++	i2c_client->addr = ShortSlaveAddr;
++	err = regmap_write(priv->regmap, addr, val);
++	i2c_client->addr = bak;
++
++	if (err)
++		dev_err(&i2c_client->dev, "%s:i2c write failed, 0x%x: 0x%x = %x\n",
++			__func__, ShortSlaveAddr, addr, val);
++
++	/* delay before next i2c command as required for SERDES link */
++	usleep_range(100, 110);
++	mutex_unlock(&priv->lock);
++
++	return err;
++}
++
+ static int max96712_read_reg(struct max96712 *priv,
+ 			u16 addr, unsigned int *val)
+ {
+@@ -106,6 +210,20 @@ static int max96712_read_reg(struct max96712 *priv,
  	return err;
  }
  
@@ -159,7 +222,7 @@ index 329a10dfd..52836c0d7 100644
  
  static int max96712_stats_show(struct seq_file *s, void *data)
  {
-@@ -161,24 +220,6 @@ static const struct file_operations max96712_debugfs_fops = {
+@@ -161,24 +279,6 @@ static const struct file_operations max96712_debugfs_fops = {
  	.release = single_release,
  };
  
@@ -184,7 +247,7 @@ index 329a10dfd..52836c0d7 100644
  static int max96712_debugfs_init(const char *dir_name,
  				struct dentry **d_entry,
  				struct dentry **f_entry,
-@@ -194,7 +235,10 @@ static int max96712_debugfs_init(const char *dir_name,
+@@ -194,7 +294,10 @@ static int max96712_debugfs_init(const char *dir_name,
  	if (np) {
  		err = of_property_read_string(np, "channel", &priv->channel);
  		if (err)
@@ -195,11 +258,22 @@ index 329a10dfd..52836c0d7 100644
  
  		err = snprintf(dev_name, sizeof(dev_name), "max96712_%s", priv->channel);
  		if (err < 0)
-@@ -241,9 +285,10 @@ static int max96712_probe(struct i2c_client *client,
+@@ -233,7 +336,8 @@ static int max96712_debugfs_init(const char *dir_name,
+ static  struct regmap_config max96712_regmap_config = {
+ 	.reg_bits = 16,
+ 	.val_bits = 8,
+-	.cache_type = REGCACHE_RBTREE,
++	/* As this driver remaps i2c addresses, the cache is unreliable */
++	.cache_type = REGCACHE_NONE,
+ };
+ 
+ static int max96712_probe(struct i2c_client *client,
+@@ -241,9 +345,11 @@ static int max96712_probe(struct i2c_client *client,
  {
  	struct max96712 *priv;
  	int err = 0;
 +	struct device_node *np = NULL;
++	int value;
  
  	dev_info(&client->dev, "%s: enter\n", __func__);
 -	
@@ -207,7 +281,7 @@ index 329a10dfd..52836c0d7 100644
  	priv = devm_kzalloc(&client->dev, sizeof(*priv), GFP_KERNEL);
  	priv->i2c_client = client;
  	priv->regmap = devm_regmap_init_i2c(priv->i2c_client,
-@@ -253,18 +298,23 @@ static int max96712_probe(struct i2c_client *client,
+@@ -253,18 +359,36 @@ static int max96712_probe(struct i2c_client *client,
  			"regmap init failed: %ld\n", PTR_ERR(priv->regmap));
  		return -ENODEV;
  	}
@@ -226,9 +300,22 @@ index 329a10dfd..52836c0d7 100644
 +			dev_err(&client->dev,"%s: Could not retrieve pwdn_gpio = %d\n",
 +				__func__, priv->pwdn_gpio);
 +		}
++		err = of_property_read_u32(np, "link-mask", &value);
++		if (err < 0) {
++			dev_warn(&client->dev, "%s: No link-mask specified, using default 0x1\n",
++				__func__);
++			priv->link_mask = 0x1;
++		} else if ((value > 0xf) || (value <= 0)) {
++			dev_warn(&client->dev, "%s: Illegal link-mask specified 0x%x (0x1 - 0xf supported), using default 0x1\n",
++				__func__, value);
++			priv->link_mask = 0x1;
++		} else {
++			priv->link_mask = value;
++		}
  	}
-+	dev_set_drvdata(&client->dev, priv);
  
++	dev_set_drvdata(&client->dev, priv);
++
  	err = max96712_debugfs_init(NULL, NULL, NULL, priv);
  	if (err)
 +	{
@@ -237,7 +324,7 @@ index 329a10dfd..52836c0d7 100644
  
  	/*set daymode by fault*/
  	dev_info(&client->dev, "%s:  success\n", __func__);
-@@ -276,8 +326,12 @@ static int max96712_probe(struct i2c_client *client,
+@@ -276,8 +400,12 @@ static int max96712_probe(struct i2c_client *client,
  static int
  max96712_remove(struct i2c_client *client)
  {
@@ -250,7 +337,7 @@ index 329a10dfd..52836c0d7 100644
  		i2c_unregister_device(client);
  		client = NULL;
  	}
-@@ -285,13 +339,302 @@ max96712_remove(struct i2c_client *client)
+@@ -285,13 +413,396 @@ max96712_remove(struct i2c_client *client)
  	return 0;
  }
  
@@ -275,19 +362,50 @@ index 329a10dfd..52836c0d7 100644
 +
 +int max96712_get_available_pipe_id(struct device *dev, int vc_id)
 +{
-+	/* TODO EHUD: Currently vc_id == pipe id but that's definitely
-+	 * not the end goal if we plan to support multiple cameras
-+	 */
-+	return vc_id;
++	int i;
++	int pipe_id = -ENOMEM;
++	struct max96712 *priv = dev_get_drvdata(dev);
++
++	mutex_lock(&priv->lock);
++	for (i = 0; i < MAX96712_MAX_PIPES; i++) {
++		if (priv->video_pipe_alloc[i] == false) {
++			priv->video_pipe_alloc[i] = true;
++			pipe_id = i;
++			break;
++		}
++	}
++	mutex_unlock(&priv->lock);
++
++	return pipe_id;
 +}
 +EXPORT_SYMBOL(max96712_get_available_pipe_id);
 +
 +int max96712_release_pipe(struct device *dev, int pipe_id)
 +{
-+	/* TODO EHUD: pipe id? */
++	struct max96712 *priv = dev_get_drvdata(dev);
++	unsigned int pipe_en_val = 0;
++
++	if (pipe_id < 0 || pipe_id >= MAX96712_MAX_PIPES)
++		return -EINVAL;
++
++	mutex_lock(&priv->lock);
++	priv->video_pipe_alloc[pipe_id] = false;
++
++	max96712_read_reg(priv, MAX96712_VIDEO_PIPE_EN_ADDR, &pipe_en_val);
++	max96712_write_reg(priv, MAX96712_VIDEO_PIPE_EN_ADDR, pipe_en_val &= ~(1 << pipe_id));
++	mutex_unlock(&priv->lock);
++
++	max96712_bind_ser_to_dser_pipe(dev, pipe_id, 0, 0);
 +	return 0;
 +}
 +EXPORT_SYMBOL(max96712_release_pipe);
++
++int max96712_get_ser_pipe_id(struct device *dev, int dser_pipe_id, int vc_id)
++{
++	/* When paired with max96712, max9295 has a 1:1 ser_vc_id to ser_pipe_id mapping */
++	return vc_id;
++}
++EXPORT_SYMBOL(max96712_get_ser_pipe_id);
 +
 +void max96712_reset_oneshot(struct device *dev)
 +{
@@ -302,55 +420,48 @@ index 329a10dfd..52836c0d7 100644
 +{
 +	int err = 0;
 +	struct max96712 *priv = dev_get_drvdata(dev);
-+
-+	int i = 0;
++	int vc_id_lsb = vc_id & 0x3;
++	int vc_id_msb = vc_id >> 2;
++	unsigned int pipe_en_val = 0;
 +
 +	struct reg_pair map_pipe_control[] = {
-+		// Enable 4 mappings for Pipe X
-+		{MAX96712_MIPI_TX11_ADDR, 0x0F},
++		// Enable 3/4 mappings for video pipe (4 if metadata enabled)
++		{MAX96712_MIPI_TX11_ADDR + (0x40 * pipe_id), (data_type2 == 0) ? 0x07 : 0x0F},
 +		// Map data_type1 on vc_id
-+		{MAX96712_MIPI_TX13_SRC_0_MAP_ADDR, 0x1E},
-+		{MAX96712_MIPI_TX14_DST_0_MAP_ADDR, 0x1E},
++		{MAX96712_MIPI_TX13_SRC_0_MAP_ADDR + (0x40 * pipe_id), (vc_id_lsb << 6) | data_type1},
++		{MAX96712_MIPI_TX14_DST_0_MAP_ADDR + (0x40 * pipe_id), (vc_id_lsb << 6) | data_type1},
 +		// Map frame_start on vc_id
-+		{MAX96712_MIPI_TX15_SRC_1_MAP_ADDR, 0x00},
-+		{MAX96712_MIPI_TX16_DST_1_MAP_ADDR, 0x00},
++		{MAX96712_MIPI_TX15_SRC_1_MAP_ADDR + (0x40 * pipe_id), (vc_id_lsb << 6) | 0x00},
++		{MAX96712_MIPI_TX16_DST_1_MAP_ADDR + (0x40 * pipe_id), (vc_id_lsb << 6) | 0x00},
 +		// Map frame end on vc_id
-+		{MAX96712_MIPI_TX17_SRC_2_MAP_ADDR, 0x01},
-+		{MAX96712_MIPI_TX18_DST_2_MAP_ADDR, 0x01},
++		{MAX96712_MIPI_TX17_SRC_2_MAP_ADDR + (0x40 * pipe_id), (vc_id_lsb << 6) | 0x01},
++		{MAX96712_MIPI_TX18_DST_2_MAP_ADDR + (0x40 * pipe_id), (vc_id_lsb << 6) | 0x01},
 +		// Map data_type2 on vc_id
-+		{MAX96712_MIPI_TX19_SRC_3_MAP_ADDR, 0x12},
-+		{MAX96712_MIPI_TX20_DST_3_MAP_ADDR, 0x12},
++		{MAX96712_MIPI_TX19_SRC_3_MAP_ADDR + (0x40 * pipe_id), (vc_id_lsb << 6) | data_type2},
++		{MAX96712_MIPI_TX20_DST_3_MAP_ADDR + (0x40 * pipe_id), (vc_id_lsb << 6) | data_type2},
++		// Extended dst vc_id mapping 0
++		{MAX96712_MIPI_TX_EXT0_ADDR + (0x10 * pipe_id), vc_id_msb << 2},
++		// Extended dst vc_id mapping 1
++		{MAX96712_MIPI_TX_EXT1_ADDR + (0x10 * pipe_id), vc_id_msb << 2},
++		// Extended dst vc_id mapping 2
++		{MAX96712_MIPI_TX_EXT2_ADDR + (0x10 * pipe_id), vc_id_msb << 2},
++		// Extended dst vc_id mapping 3
++		{MAX96712_MIPI_TX_EXT3_ADDR + (0x10 * pipe_id), vc_id_msb << 2},
 +		// All mappings to PHY1 (master for port A)
-+		{MAX96712_MIPI_TX45_MAP_DPHY_DEST_ADDR, 0x55},
++		{MAX96712_MIPI_TX45_MAP_DPHY_DEST_ADDR + (0x40 * pipe_id), 0x55},
 +		// SEQ_MISS_EN: Disabled / DIS_PKT_DET: Disabled
-+		{MAX96712_VIDEO_RX0_ADDR, 0x23}, // pipe X
++		// This reg has inconsistent gaps between reg addresses per pipe:
++		// 0x100, 0x112, 0x124, 0x136, 0x148, *0x160*, 0x172, 0x184
++		{MAX96712_VIDEO_RX0_ADDR + (0x12 * pipe_id) + ((pipe_id >= 5) ? 6 : 0), 0x23},
 +	};
-+
-+	for (i = 0; i < (ARRAY_SIZE(map_pipe_control) - 1); i++) {
-+		map_pipe_control[i].addr += 0x40 * pipe_id;
-+	}
-+	map_pipe_control[(ARRAY_SIZE(map_pipe_control) - 1)].addr += 0x12 * pipe_id;
-+
-+	if (data_type2 == 0x0) {
-+		/* For IMU (which has no metadata) we override mapping
-+		* to enable only 3
-+		*/
-+		map_pipe_control[0].val = 0x07;
-+	}
-+	map_pipe_control[1].val = (vc_id << 6) | data_type1;
-+	map_pipe_control[2].val = (vc_id << 6) | data_type1;
-+	map_pipe_control[3].val = (vc_id << 6) | 0x00;
-+	map_pipe_control[4].val = (vc_id << 6) | 0x00;
-+	map_pipe_control[5].val = (vc_id << 6) | 0x01;
-+	map_pipe_control[6].val = (vc_id << 6) | 0x01;
-+	map_pipe_control[7].val = (vc_id << 6) | data_type2;
-+	map_pipe_control[8].val = (vc_id << 6) | data_type2;
 +
 +	err |= max96712_set_registers(priv, map_pipe_control,
 +				     ARRAY_SIZE(map_pipe_control));
 +
 +	max96712_reset_oneshot(dev);
-+	max96712_write_reg(priv, MAX96712_VIDEO_PIPE_EN_ADDR, 0xF);
++
++	max96712_read_reg(priv, MAX96712_VIDEO_PIPE_EN_ADDR, &pipe_en_val);
++	max96712_write_reg(priv, MAX96712_VIDEO_PIPE_EN_ADDR, pipe_en_val |= (1 << pipe_id));
 +
 +	return err;
 +}
@@ -361,18 +472,19 @@ index 329a10dfd..52836c0d7 100644
 +	struct max96712 *priv = dev_get_drvdata(dev);
 +	struct reg_pair map_pipe_opt[] =
 +	{
-+		/* ----------Video pipes configure ----------------------*/
-+		{MAX96712_REG6_ADDR, 0xF1}, // Enable link - Why is this needed?
-+		{MAX96712_VIDEO_PIPE_SEL_0_ADDR, 0x10}, //0xF0, Link A ID 0 to pipe 0 , Link A ID 1 to pipe 1
-+		{MAX96712_VIDEO_PIPE_SEL_1_ADDR, 0x32}, //0xF1, Link A ID 2 to pipe 2 , Link A ID 3 to pipe 3
-+		{MAX96712_VIDEO_PIPE_EN_ADDR, 0x00}, //0xF4, Enable pipe 0-3, 0xFF
++		/* ----------Initial empty video pipe configure ----------------------*/
++		{MAX96712_VIDEO_PIPE_SEL_0_ADDR, 0x0},
++		{MAX96712_VIDEO_PIPE_SEL_1_ADDR, 0x0},
++		{MAX96712_VIDEO_PIPE_SEL_2_ADDR, 0x0},
++		{MAX96712_VIDEO_PIPE_SEL_3_ADDR, 0x0},
++		{MAX96712_VIDEO_PIPE_EN_ADDR, 0x00}, //0xF4, Disable all pipes for now
 +	};
 +
 +	struct reg_pair map_phy_opt[] =
 +	{
 +		/* MIPI D-PHY Config */
 +		{MAX96712_MIPI_PHY0_ADDR, 0x04}, //0x8A0
-+		{MAX96712_MIPI_TX10_ADDR, 0x40}, //0x94a - MIPI lane count
++		{MAX96712_MIPI_TX10_ADDR, 0x50}, //0x94a - 2 MIPI lanes (Master controller for PHYA), and enable extended VC
 +		{MAX96712_MIPI_PHY3_ADDR, 0xe4}, //0x8A3, Lower phys to lower lanes
 +
 +		/* Put DPLL in reset before changing MIPI lane rates */
@@ -402,6 +514,42 @@ index 329a10dfd..52836c0d7 100644
 +}
 +EXPORT_SYMBOL(max96712_init_settings);
 +
++int max96712_bind_ser_to_dser_pipe(struct device *dev, int dser_pipe_id, int ser_pipe_id, u32 vc_id)
++{
++	struct max96712 *priv = dev_get_drvdata(dev);
++	unsigned int pipe_sel_val = 0;
++	u32 link_id = vc_id / MAX9295_MAX_STREAMS;
++	int err = 0;
++
++	/* dser_pipe_id will be connected to ser_pipe_id of link_id */
++	uint8_t map_pipe_val = link_id << 2 | ser_pipe_id;
++
++	/* Every pipe select reg handles two pipe mappings */
++	uint32_t dser_pipe_sel_addr = MAX96712_VIDEO_PIPE_SEL_0_ADDR + (dser_pipe_id / 2);
++	uint32_t dser_pipe_sel_offset = 4 * (dser_pipe_id % 2);
++	uint8_t dser_pipe_sel_mask = 0xF << dser_pipe_sel_offset;
++
++	if (dser_pipe_id < 0 || dser_pipe_id >= MAX96712_MAX_PIPES || link_id >= MAX96712_MAX_LINKS)
++		return -EINVAL;
++
++	mutex_lock(&priv->lock);
++
++	err = max96712_read_reg(priv, dser_pipe_sel_addr, &pipe_sel_val);
++	if (err == 0) {
++		/* Zero the pipe we are interested in */
++		pipe_sel_val &= ~(dser_pipe_sel_mask);
++		/* Input the new value */
++		pipe_sel_val |= (map_pipe_val << dser_pipe_sel_offset);
++
++		err = max96712_write_reg(priv, dser_pipe_sel_addr, pipe_sel_val);
++	}
++
++	mutex_unlock(&priv->lock);
++
++	return err;
++}
++EXPORT_SYMBOL(max96712_bind_ser_to_dser_pipe);
++
 +int max96712_set_pipe(struct device *dev, int pipe_id,
 +		     u8 data_type1, u8 data_type2, u32 vc_id)
 +{
@@ -429,7 +577,40 @@ index 329a10dfd..52836c0d7 100644
 +
 +int max96712_setup_link(struct device *dev, struct device *s_dev)
 +{
-+	/* TODO EHUD: Is needed? */
++	struct max96712 *priv = dev_get_drvdata(dev);
++	uint8_t link_mask = priv->link_mask;
++	unsigned int reg_val = 0;
++	unsigned int dser_empty_link_mask_reg = 0xF0;
++	uint8_t link_id_iter = 0;
++	unsigned default_ser_addr = MAX9295_DEFAULT_ADDR;
++	int err = 0;
++
++	/* Iterating over the links and assigning unique serializer i2c addresses */
++	for (link_id_iter = 0; link_id_iter < MAX96712_MAX_LINKS ; link_id_iter++)
++	{
++		if (link_mask & (1 << link_id_iter))
++		{
++			/* Camera should be connected on this link */
++			unsigned int dst_ser_addr = default_ser_addr + link_id_iter;
++			unsigned int curr_map = dser_empty_link_mask_reg | (1 << link_id_iter);
++
++			/* Enable single link */
++			max96712_write_reg(priv, MAX96712_REG6_ADDR, curr_map);
++			msleep(20);
++			max96712_reset_oneshot(dev);
++
++			err = max96712_read_slave_reg(priv, dst_ser_addr, 0, &reg_val);
++			if ((err == 0) && (reg_val == (dst_ser_addr << 1)))
++			{
++				dev_dbg(dev, "%s Serializer already at 0x%x\n", __func__, dst_ser_addr);
++				continue;
++			}
++
++			/* Assign the new i2c address */
++			max96712_write_slave_reg(priv, default_ser_addr, 0, dst_ser_addr << 1);
++		}
++	}
++	max96712_write_reg(priv, MAX96712_REG6_ADDR, dser_empty_link_mask_reg | link_mask);
 +	return 0;
 +}
 +EXPORT_SYMBOL(max96712_setup_link);
@@ -554,7 +735,7 @@ index 329a10dfd..52836c0d7 100644
  	{ },
  };
  
-@@ -301,6 +644,7 @@ static struct i2c_driver max96712_i2c_driver = {
+@@ -301,6 +812,7 @@ static struct i2c_driver max96712_i2c_driver = {
  	.driver = {
  		.name = "max96712",
  		.owner = THIS_MODULE,
@@ -564,3 +745,4 @@ index 329a10dfd..52836c0d7 100644
  	.remove = max96712_remove,
 -- 
 2.43.0
+

--- a/kernel/nvidia/5.1.2/0007-Adding-max96712-support-for-D4xx.patch
+++ b/kernel/nvidia/5.1.2/0007-Adding-max96712-support-for-D4xx.patch
@@ -1,20 +1,20 @@
-From 7ece021a29ef6fca745da6910ca41b3c987481db Mon Sep 17 00:00:00 2001
+From a68f3e1de301cbc9d43388b4ca4879be1d915678 Mon Sep 17 00:00:00 2001
 From: ejgoldik <ehud.joseph.goldik@realsenseai.com>
-Date: Wed, 25 Mar 2026 14:51:32 +0200
+Date: Wed, 25 Mar 2026 15:23:18 +0200
 Subject: [PATCH] Adding max96712 support for D4xx
 
 Add MAX96712 deserializer driver support for D4XX cameras.
 
 Signed-off-by: ejgoldik <ehud.joseph.goldik@realsenseai.com>
 ---
- drivers/media/i2c/max96712.c | 594 ++++++++++++++++++++++++++++++++---
- 1 file changed, 553 insertions(+), 41 deletions(-)
+ drivers/media/i2c/max96712.c | 598 ++++++++++++++++++++++++++++++++---
+ 1 file changed, 557 insertions(+), 41 deletions(-)
 
 diff --git a/drivers/media/i2c/max96712.c b/drivers/media/i2c/max96712.c
-index 329a10dfd..cc18184a3 100644
+index 329a10dfd..5e30d88d8 100644
 --- a/drivers/media/i2c/max96712.c
 +++ b/drivers/media/i2c/max96712.c
-@@ -21,32 +21,91 @@
+@@ -21,32 +21,92 @@
  #include <linux/debugfs.h>
  #include <media/camera_common.h>
  #include <linux/module.h>
@@ -40,6 +40,7 @@ index 329a10dfd..cc18184a3 100644
 +#define MAX96712_315_ESYNC 0x07
 +
 +#define MAX96712_REG6_ADDR 0x6
++#define MAX96712_PWR1_ADDR 0x13
 +#define MAX96712_CTRL1_ADDR 0x18
 +
 +#define MAX96712_BACKTOP25_ADDR 0x418
@@ -113,7 +114,7 @@ index 329a10dfd..cc18184a3 100644
  	i2c_client = global_priv[channel]->i2c_client;
  	bak = i2c_client->addr;
  
-@@ -58,9 +117,9 @@ int max96712_write_reg_Dser(int slaveAddr,int channel,
+@@ -58,9 +118,9 @@ int max96712_write_reg_Dser(int slaveAddr,int channel,
  	{
  		dev_err(&i2c_client->dev, "%s: addr = 0x%x, val = 0x%x\n",
  				__func__, addr, val);
@@ -125,7 +126,7 @@ index 329a10dfd..cc18184a3 100644
  }
  
  EXPORT_SYMBOL(max96712_write_reg_Dser);
-@@ -71,11 +130,9 @@ int max96712_read_reg_Dser(int slaveAddr,int channel,
+@@ -71,11 +131,9 @@ int max96712_read_reg_Dser(int slaveAddr,int channel,
  {
  	struct i2c_client *i2c_client = NULL;
  	int bak = 0;
@@ -138,7 +139,7 @@ index 329a10dfd..cc18184a3 100644
  	i2c_client = global_priv[channel]->i2c_client;
  	bak = i2c_client->addr;
  	i2c_client->addr = slaveAddr / 2;
-@@ -85,13 +142,60 @@ int max96712_read_reg_Dser(int slaveAddr,int channel,
+@@ -85,13 +143,60 @@ int max96712_read_reg_Dser(int slaveAddr,int channel,
  	{
  		dev_err(&i2c_client->dev, "%s: addr = 0x%x, val = 0x%x\n",
  				__func__, addr, *val);
@@ -201,7 +202,7 @@ index 329a10dfd..cc18184a3 100644
  static int max96712_read_reg(struct max96712 *priv,
  			u16 addr, unsigned int *val)
  {
-@@ -106,6 +210,20 @@ static int max96712_read_reg(struct max96712 *priv,
+@@ -106,6 +211,20 @@ static int max96712_read_reg(struct max96712 *priv,
  	return err;
  }
  
@@ -222,7 +223,7 @@ index 329a10dfd..cc18184a3 100644
  
  static int max96712_stats_show(struct seq_file *s, void *data)
  {
-@@ -161,24 +279,6 @@ static const struct file_operations max96712_debugfs_fops = {
+@@ -161,24 +280,6 @@ static const struct file_operations max96712_debugfs_fops = {
  	.release = single_release,
  };
  
@@ -247,7 +248,7 @@ index 329a10dfd..cc18184a3 100644
  static int max96712_debugfs_init(const char *dir_name,
  				struct dentry **d_entry,
  				struct dentry **f_entry,
-@@ -194,7 +294,10 @@ static int max96712_debugfs_init(const char *dir_name,
+@@ -194,7 +295,10 @@ static int max96712_debugfs_init(const char *dir_name,
  	if (np) {
  		err = of_property_read_string(np, "channel", &priv->channel);
  		if (err)
@@ -258,7 +259,7 @@ index 329a10dfd..cc18184a3 100644
  
  		err = snprintf(dev_name, sizeof(dev_name), "max96712_%s", priv->channel);
  		if (err < 0)
-@@ -233,7 +336,8 @@ static int max96712_debugfs_init(const char *dir_name,
+@@ -233,7 +337,8 @@ static int max96712_debugfs_init(const char *dir_name,
  static  struct regmap_config max96712_regmap_config = {
  	.reg_bits = 16,
  	.val_bits = 8,
@@ -268,7 +269,7 @@ index 329a10dfd..cc18184a3 100644
  };
  
  static int max96712_probe(struct i2c_client *client,
-@@ -241,9 +345,11 @@ static int max96712_probe(struct i2c_client *client,
+@@ -241,9 +346,11 @@ static int max96712_probe(struct i2c_client *client,
  {
  	struct max96712 *priv;
  	int err = 0;
@@ -281,7 +282,7 @@ index 329a10dfd..cc18184a3 100644
  	priv = devm_kzalloc(&client->dev, sizeof(*priv), GFP_KERNEL);
  	priv->i2c_client = client;
  	priv->regmap = devm_regmap_init_i2c(priv->i2c_client,
-@@ -253,18 +359,36 @@ static int max96712_probe(struct i2c_client *client,
+@@ -253,18 +360,36 @@ static int max96712_probe(struct i2c_client *client,
  			"regmap init failed: %ld\n", PTR_ERR(priv->regmap));
  		return -ENODEV;
  	}
@@ -324,7 +325,7 @@ index 329a10dfd..cc18184a3 100644
  
  	/*set daymode by fault*/
  	dev_info(&client->dev, "%s:  success\n", __func__);
-@@ -276,8 +400,12 @@ static int max96712_probe(struct i2c_client *client,
+@@ -276,8 +401,12 @@ static int max96712_probe(struct i2c_client *client,
  static int
  max96712_remove(struct i2c_client *client)
  {
@@ -337,7 +338,7 @@ index 329a10dfd..cc18184a3 100644
  		i2c_unregister_device(client);
  		client = NULL;
  	}
-@@ -285,13 +413,396 @@ max96712_remove(struct i2c_client *client)
+@@ -285,13 +414,399 @@ max96712_remove(struct i2c_client *client)
  	return 0;
  }
  
@@ -719,6 +720,9 @@ index 329a10dfd..cc18184a3 100644
 +        gpio_direction_output(priv->pwdn_gpio, 1);
 +        gpio_set_value(priv->pwdn_gpio, 0);
 +        msleep(100);
++    } else {
++        max96712_write_reg(priv, MAX96712_PWR1_ADDR, 0x40);
++        msleep(200);
 +    }
 +    return;
 +}
@@ -735,7 +739,7 @@ index 329a10dfd..cc18184a3 100644
  	{ },
  };
  
-@@ -301,6 +812,7 @@ static struct i2c_driver max96712_i2c_driver = {
+@@ -301,6 +816,7 @@ static struct i2c_driver max96712_i2c_driver = {
  	.driver = {
  		.name = "max96712",
  		.owner = THIS_MODULE,

--- a/kernel/nvidia/5.1.2/0007-Adding-max96712-support-for-D4xx.patch
+++ b/kernel/nvidia/5.1.2/0007-Adding-max96712-support-for-D4xx.patch
@@ -1,20 +1,20 @@
-From a68f3e1de301cbc9d43388b4ca4879be1d915678 Mon Sep 17 00:00:00 2001
+From ee9521bccd1ba105c52e35c849c99545f875cbcd Mon Sep 17 00:00:00 2001
 From: ejgoldik <ehud.joseph.goldik@realsenseai.com>
-Date: Wed, 25 Mar 2026 15:23:18 +0200
+Date: Thu, 26 Mar 2026 16:12:51 +0200
 Subject: [PATCH] Adding max96712 support for D4xx
 
 Add MAX96712 deserializer driver support for D4XX cameras.
 
 Signed-off-by: ejgoldik <ehud.joseph.goldik@realsenseai.com>
 ---
- drivers/media/i2c/max96712.c | 598 ++++++++++++++++++++++++++++++++---
- 1 file changed, 557 insertions(+), 41 deletions(-)
+ drivers/media/i2c/max96712.c | 623 ++++++++++++++++++++++++++++++++---
+ 1 file changed, 582 insertions(+), 41 deletions(-)
 
 diff --git a/drivers/media/i2c/max96712.c b/drivers/media/i2c/max96712.c
-index 329a10dfd..5e30d88d8 100644
+index 329a10dfd..ebc6a1dfc 100644
 --- a/drivers/media/i2c/max96712.c
 +++ b/drivers/media/i2c/max96712.c
-@@ -21,32 +21,92 @@
+@@ -21,32 +21,93 @@
  #include <linux/debugfs.h>
  #include <media/camera_common.h>
  #include <linux/module.h>
@@ -41,6 +41,7 @@ index 329a10dfd..5e30d88d8 100644
 +
 +#define MAX96712_REG6_ADDR 0x6
 +#define MAX96712_PWR1_ADDR 0x13
++#define MAX96712_PWR1_RESET_ALL_VAL 0x40
 +#define MAX96712_CTRL1_ADDR 0x18
 +
 +#define MAX96712_BACKTOP25_ADDR 0x418
@@ -114,7 +115,7 @@ index 329a10dfd..5e30d88d8 100644
  	i2c_client = global_priv[channel]->i2c_client;
  	bak = i2c_client->addr;
  
-@@ -58,9 +118,9 @@ int max96712_write_reg_Dser(int slaveAddr,int channel,
+@@ -58,9 +119,9 @@ int max96712_write_reg_Dser(int slaveAddr,int channel,
  	{
  		dev_err(&i2c_client->dev, "%s: addr = 0x%x, val = 0x%x\n",
  				__func__, addr, val);
@@ -126,7 +127,7 @@ index 329a10dfd..5e30d88d8 100644
  }
  
  EXPORT_SYMBOL(max96712_write_reg_Dser);
-@@ -71,11 +131,9 @@ int max96712_read_reg_Dser(int slaveAddr,int channel,
+@@ -71,11 +132,9 @@ int max96712_read_reg_Dser(int slaveAddr,int channel,
  {
  	struct i2c_client *i2c_client = NULL;
  	int bak = 0;
@@ -139,7 +140,7 @@ index 329a10dfd..5e30d88d8 100644
  	i2c_client = global_priv[channel]->i2c_client;
  	bak = i2c_client->addr;
  	i2c_client->addr = slaveAddr / 2;
-@@ -85,13 +143,60 @@ int max96712_read_reg_Dser(int slaveAddr,int channel,
+@@ -85,13 +144,60 @@ int max96712_read_reg_Dser(int slaveAddr,int channel,
  	{
  		dev_err(&i2c_client->dev, "%s: addr = 0x%x, val = 0x%x\n",
  				__func__, addr, *val);
@@ -202,7 +203,7 @@ index 329a10dfd..5e30d88d8 100644
  static int max96712_read_reg(struct max96712 *priv,
  			u16 addr, unsigned int *val)
  {
-@@ -106,6 +211,20 @@ static int max96712_read_reg(struct max96712 *priv,
+@@ -106,6 +212,20 @@ static int max96712_read_reg(struct max96712 *priv,
  	return err;
  }
  
@@ -223,7 +224,7 @@ index 329a10dfd..5e30d88d8 100644
  
  static int max96712_stats_show(struct seq_file *s, void *data)
  {
-@@ -161,24 +280,6 @@ static const struct file_operations max96712_debugfs_fops = {
+@@ -161,24 +281,6 @@ static const struct file_operations max96712_debugfs_fops = {
  	.release = single_release,
  };
  
@@ -248,7 +249,7 @@ index 329a10dfd..5e30d88d8 100644
  static int max96712_debugfs_init(const char *dir_name,
  				struct dentry **d_entry,
  				struct dentry **f_entry,
-@@ -194,7 +295,10 @@ static int max96712_debugfs_init(const char *dir_name,
+@@ -194,7 +296,10 @@ static int max96712_debugfs_init(const char *dir_name,
  	if (np) {
  		err = of_property_read_string(np, "channel", &priv->channel);
  		if (err)
@@ -259,7 +260,7 @@ index 329a10dfd..5e30d88d8 100644
  
  		err = snprintf(dev_name, sizeof(dev_name), "max96712_%s", priv->channel);
  		if (err < 0)
-@@ -233,7 +337,8 @@ static int max96712_debugfs_init(const char *dir_name,
+@@ -233,7 +338,8 @@ static int max96712_debugfs_init(const char *dir_name,
  static  struct regmap_config max96712_regmap_config = {
  	.reg_bits = 16,
  	.val_bits = 8,
@@ -269,7 +270,7 @@ index 329a10dfd..5e30d88d8 100644
  };
  
  static int max96712_probe(struct i2c_client *client,
-@@ -241,9 +346,11 @@ static int max96712_probe(struct i2c_client *client,
+@@ -241,9 +347,11 @@ static int max96712_probe(struct i2c_client *client,
  {
  	struct max96712 *priv;
  	int err = 0;
@@ -282,7 +283,7 @@ index 329a10dfd..5e30d88d8 100644
  	priv = devm_kzalloc(&client->dev, sizeof(*priv), GFP_KERNEL);
  	priv->i2c_client = client;
  	priv->regmap = devm_regmap_init_i2c(priv->i2c_client,
-@@ -253,18 +360,36 @@ static int max96712_probe(struct i2c_client *client,
+@@ -253,18 +361,36 @@ static int max96712_probe(struct i2c_client *client,
  			"regmap init failed: %ld\n", PTR_ERR(priv->regmap));
  		return -ENODEV;
  	}
@@ -325,7 +326,7 @@ index 329a10dfd..5e30d88d8 100644
  
  	/*set daymode by fault*/
  	dev_info(&client->dev, "%s:  success\n", __func__);
-@@ -276,8 +401,12 @@ static int max96712_probe(struct i2c_client *client,
+@@ -276,8 +402,12 @@ static int max96712_probe(struct i2c_client *client,
  static int
  max96712_remove(struct i2c_client *client)
  {
@@ -338,7 +339,7 @@ index 329a10dfd..5e30d88d8 100644
  		i2c_unregister_device(client);
  		client = NULL;
  	}
-@@ -285,13 +414,399 @@ max96712_remove(struct i2c_client *client)
+@@ -285,13 +415,423 @@ max96712_remove(struct i2c_client *client)
  	return 0;
  }
  
@@ -364,7 +365,7 @@ index 329a10dfd..5e30d88d8 100644
 +int max96712_get_available_pipe_id(struct device *dev, int vc_id)
 +{
 +	int i;
-+	int pipe_id = -ENOMEM;
++	int pipe_id = -ENOSR;
 +	struct max96712 *priv = dev_get_drvdata(dev);
 +
 +	mutex_lock(&priv->lock);
@@ -381,10 +382,42 @@ index 329a10dfd..5e30d88d8 100644
 +}
 +EXPORT_SYMBOL(max96712_get_available_pipe_id);
 +
++static int __max96712_bind_ser_to_dser_pipe(struct device *dev, int dser_pipe_id, int ser_pipe_id, u32 vc_id)
++{
++	struct max96712 *priv = dev_get_drvdata(dev);
++	unsigned int pipe_sel_val = 0;
++	u32 link_id = vc_id / MAX9295_MAX_STREAMS;
++	int err = 0;
++
++	/* dser_pipe_id will be connected to ser_pipe_id of link_id */
++	uint8_t map_pipe_val = link_id << 2 | ser_pipe_id;
++
++	/* Every pipe select reg handles two pipe mappings */
++	uint32_t dser_pipe_sel_addr = MAX96712_VIDEO_PIPE_SEL_0_ADDR + (dser_pipe_id / 2);
++	uint32_t dser_pipe_sel_offset = 4 * (dser_pipe_id % 2);
++	uint8_t dser_pipe_sel_mask = 0xF << dser_pipe_sel_offset;
++
++	if (dser_pipe_id < 0 || dser_pipe_id >= MAX96712_MAX_PIPES || link_id >= MAX96712_MAX_LINKS)
++		return -EINVAL;
++
++	err = max96712_read_reg(priv, dser_pipe_sel_addr, &pipe_sel_val);
++	if (err == 0) {
++		/* Zero the pipe we are interested in */
++		pipe_sel_val &= ~(dser_pipe_sel_mask);
++		/* Input the new value */
++		pipe_sel_val |= (map_pipe_val << dser_pipe_sel_offset);
++
++		err = max96712_write_reg(priv, dser_pipe_sel_addr, pipe_sel_val);
++	}
++
++	return err;
++}
++
 +int max96712_release_pipe(struct device *dev, int pipe_id)
 +{
 +	struct max96712 *priv = dev_get_drvdata(dev);
 +	unsigned int pipe_en_val = 0;
++	int err = 0;
 +
 +	if (pipe_id < 0 || pipe_id >= MAX96712_MAX_PIPES)
 +		return -EINVAL;
@@ -392,12 +425,19 @@ index 329a10dfd..5e30d88d8 100644
 +	mutex_lock(&priv->lock);
 +	priv->video_pipe_alloc[pipe_id] = false;
 +
-+	max96712_read_reg(priv, MAX96712_VIDEO_PIPE_EN_ADDR, &pipe_en_val);
-+	max96712_write_reg(priv, MAX96712_VIDEO_PIPE_EN_ADDR, pipe_en_val &= ~(1 << pipe_id));
++	err = max96712_read_reg(priv, MAX96712_VIDEO_PIPE_EN_ADDR, &pipe_en_val);
++	if (err == 0) {
++		pipe_en_val &= ~(1 << pipe_id);
++		err = max96712_write_reg(priv, MAX96712_VIDEO_PIPE_EN_ADDR, pipe_en_val);
++	}
++
++	if (err == 0) {
++		err = __max96712_bind_ser_to_dser_pipe(dev, pipe_id, 0, 0);
++	}
++
 +	mutex_unlock(&priv->lock);
 +
-+	max96712_bind_ser_to_dser_pipe(dev, pipe_id, 0, 0);
-+	return 0;
++	return err;
 +}
 +EXPORT_SYMBOL(max96712_release_pipe);
 +
@@ -458,11 +498,16 @@ index 329a10dfd..5e30d88d8 100644
 +
 +	err |= max96712_set_registers(priv, map_pipe_control,
 +				     ARRAY_SIZE(map_pipe_control));
-+
++	if (err) {
++		return err;
++	}
 +	max96712_reset_oneshot(dev);
 +
-+	max96712_read_reg(priv, MAX96712_VIDEO_PIPE_EN_ADDR, &pipe_en_val);
-+	max96712_write_reg(priv, MAX96712_VIDEO_PIPE_EN_ADDR, pipe_en_val |= (1 << pipe_id));
++	err |= max96712_read_reg(priv, MAX96712_VIDEO_PIPE_EN_ADDR, &pipe_en_val);
++	if (err == 0) {
++		pipe_en_val |= (1 << pipe_id);
++		err |= max96712_write_reg(priv, MAX96712_VIDEO_PIPE_EN_ADDR, pipe_en_val);
++	}
 +
 +	return err;
 +}
@@ -518,32 +563,11 @@ index 329a10dfd..5e30d88d8 100644
 +int max96712_bind_ser_to_dser_pipe(struct device *dev, int dser_pipe_id, int ser_pipe_id, u32 vc_id)
 +{
 +	struct max96712 *priv = dev_get_drvdata(dev);
-+	unsigned int pipe_sel_val = 0;
-+	u32 link_id = vc_id / MAX9295_MAX_STREAMS;
 +	int err = 0;
-+
-+	/* dser_pipe_id will be connected to ser_pipe_id of link_id */
-+	uint8_t map_pipe_val = link_id << 2 | ser_pipe_id;
-+
-+	/* Every pipe select reg handles two pipe mappings */
-+	uint32_t dser_pipe_sel_addr = MAX96712_VIDEO_PIPE_SEL_0_ADDR + (dser_pipe_id / 2);
-+	uint32_t dser_pipe_sel_offset = 4 * (dser_pipe_id % 2);
-+	uint8_t dser_pipe_sel_mask = 0xF << dser_pipe_sel_offset;
-+
-+	if (dser_pipe_id < 0 || dser_pipe_id >= MAX96712_MAX_PIPES || link_id >= MAX96712_MAX_LINKS)
-+		return -EINVAL;
 +
 +	mutex_lock(&priv->lock);
 +
-+	err = max96712_read_reg(priv, dser_pipe_sel_addr, &pipe_sel_val);
-+	if (err == 0) {
-+		/* Zero the pipe we are interested in */
-+		pipe_sel_val &= ~(dser_pipe_sel_mask);
-+		/* Input the new value */
-+		pipe_sel_val |= (map_pipe_val << dser_pipe_sel_offset);
-+
-+		err = max96712_write_reg(priv, dser_pipe_sel_addr, pipe_sel_val);
-+	}
++	err = __max96712_bind_ser_to_dser_pipe(dev, dser_pipe_id, ser_pipe_id, vc_id);
 +
 +	mutex_unlock(&priv->lock);
 +
@@ -721,7 +745,8 @@ index 329a10dfd..5e30d88d8 100644
 +        gpio_set_value(priv->pwdn_gpio, 0);
 +        msleep(100);
 +    } else {
-+        max96712_write_reg(priv, MAX96712_PWR1_ADDR, 0x40);
++        /* If no power off GPIO exists, use reset all (self-clearing) */
++        max96712_write_reg(priv, MAX96712_PWR1_ADDR, MAX96712_PWR1_RESET_ALL_VAL);
 +        msleep(200);
 +    }
 +    return;
@@ -739,7 +764,7 @@ index 329a10dfd..5e30d88d8 100644
  	{ },
  };
  
-@@ -301,6 +816,7 @@ static struct i2c_driver max96712_i2c_driver = {
+@@ -301,6 +841,7 @@ static struct i2c_driver max96712_i2c_driver = {
  	.driver = {
  		.name = "max96712",
  		.owner = THIS_MODULE,

--- a/kernel/nvidia/5.1.2/0008-Allow-external-address-assignment-on-max9295.patch
+++ b/kernel/nvidia/5.1.2/0008-Allow-external-address-assignment-on-max9295.patch
@@ -1,0 +1,1 @@
+../5.0.2/0018-Allow-external-address-assignment-on-max9295.patch

--- a/kernel/nvidia/5.1.2/0009-Align-max9296-api-to-max96712.patch
+++ b/kernel/nvidia/5.1.2/0009-Align-max9296-api-to-max96712.patch
@@ -1,0 +1,1 @@
+../5.0.2/0019-Align-max9296-api-to-max96712.patch

--- a/kernel/nvidia/5.1.6/0008-Allow-external-address-assignment-on-max9295.patch
+++ b/kernel/nvidia/5.1.6/0008-Allow-external-address-assignment-on-max9295.patch
@@ -1,0 +1,1 @@
+../5.0.2/0018-Allow-external-address-assignment-on-max9295.patch

--- a/kernel/nvidia/5.1.6/0009-Align-max9296-api-to-max96712.patch
+++ b/kernel/nvidia/5.1.6/0009-Align-max9296-api-to-max96712.patch
@@ -1,0 +1,1 @@
+../5.0.2/0019-Align-max9296-api-to-max96712.patch

--- a/kernel/nvidia/max96712.h
+++ b/kernel/nvidia/max96712.h
@@ -37,6 +37,7 @@
  */
 
 int max96712_get_available_pipe_id(struct device *dev, int vc_id);
+int max96712_get_ser_pipe_id(struct device *dev, int dser_pipe_id, int vc_id);
 int max96712_set_pipe(struct device *dev, int pipe_id, u8 data_type1,
 		     u8 data_type2, u32 vc_id);
 int max96712_release_pipe(struct device *dev, int pipe_id);
@@ -49,5 +50,14 @@ int max96712_sdev_unregister(struct device *dev, struct device *s_dev);
 int max96712_power_on(struct device *dev);
 void max96712_power_off(struct device *dev);
 int max96712_init_settings(struct device *dev);
+/**
+ * @brief  Maps dserializer to serializer pipe id
+ *
+ * @param [in]  dev             The deserializer device handle.
+ * @param [in]  dser_pipe_id    Deserializer pipe id.
+ * @param [in]  ser_pipe_id     Serializer pipe id.
+ * @param [in]  vc_id           vc_id associated with this pipe path.
+ */
+int max96712_bind_ser_to_dser_pipe(struct device *dev, int dser_pipe_id, int ser_pipe_id, u32 vc_id);
 
 #endif  /* __MAX96712_H__ */

--- a/kernel/realsense/d4xx.c
+++ b/kernel/realsense/d4xx.c
@@ -569,7 +569,7 @@ struct dser_control {
 };
 static struct dser_control dser_inited[MAX_DSER_NUM];
 
-#define MAX_DS5_NUM (MAX_DSER_NUM * 4) /* assuming max 2 DS5 cameras per deserializer */
+#define MAX_DS5_NUM (MAX_DSER_NUM * 4) /* assuming max 4 DS5 cameras per deserializer (true for max96712) */
 static struct ds5_dev ds5_inited[MAX_DS5_NUM];
 
 static void ds5_init_global_slots_once(void)
@@ -1825,12 +1825,9 @@ static int ds5_setup_pipeline(struct ds5 *state, u8 data_type1, u8 data_type2,
 	 * The ser_pipe to dser_pipe mapping depends on the deserializer.
 	 */
 	int ser_vc_id = vc_id % DS5_MAX_STREAMS;
-	int ser_pipe_id = state->dser_ops->get_ser_pipe_id(state->dser_dev, pipe_id, ser_vc_id);;
+	int ser_pipe_id = state->dser_ops->get_ser_pipe_id(state->dser_dev, pipe_id, ser_vc_id);
 
-	if (state->dser_ops->bind_ser_to_dser_pipe != NULL)
-	{
-		ret |= state->dser_ops->bind_ser_to_dser_pipe(state->dser_dev, pipe_id, ser_pipe_id, vc_id);
-	}
+	ret |= state->dser_ops->bind_ser_to_dser_pipe(state->dser_dev, pipe_id, ser_pipe_id, vc_id);
 	dev_dbg(&state->client->dev,
 			"set ser pipe %d, dser pipe %d, data_type1: 0x%x, data_type2: 0x%x, ser_vc_id: %u, vc_id: %u\n",
 			ser_pipe_id, pipe_id, data_type1, data_type2, ser_vc_id, vc_id);

--- a/kernel/realsense/d4xx.c
+++ b/kernel/realsense/d4xx.c
@@ -46,6 +46,9 @@
 struct dser_interface {
 	/* Pipeline management */
 	int (*get_available_pipe_id)(struct device *dev, int vc_id);
+	int (*get_ser_pipe_id)(struct device *dev, int dser_pipe_id, int vc_id);
+	int (*bind_ser_to_dser_pipe)(struct device *dev, int dser_pipe_id, int ser_pipe_id, u32 vc_id);
+
 	int (*set_pipe)(struct device *dev, int pipe_id, u8 data_type1, u8 data_type2, u32 vc_id);
 	int (*release_pipe)(struct device *dev, int pipe_id);
 	void (*reset_oneshot)(struct device *dev);
@@ -63,7 +66,7 @@ struct dser_interface {
 	int (*power_on)(struct device *dev);
 	void (*power_off)(struct device *dev);
 	int (*init_settings)(struct device *dev);
-	
+
 	/* Identification */
 	const char *name;
 };
@@ -566,7 +569,7 @@ struct dser_control {
 };
 static struct dser_control dser_inited[MAX_DSER_NUM];
 
-#define MAX_DS5_NUM (MAX_DSER_NUM * 2) /* assuming max 2 DS5 cameras per deserializer */
+#define MAX_DS5_NUM (MAX_DSER_NUM * 4) /* assuming max 2 DS5 cameras per deserializer */
 static struct ds5_dev ds5_inited[MAX_DS5_NUM];
 
 static void ds5_init_global_slots_once(void)
@@ -599,6 +602,8 @@ static inline atomic_t *dser_get_reset_gen(struct ds5 *state)
 /* MAX9296 deserializer interface implementation */
 static const struct dser_interface max9296_interface = {
 	.get_available_pipe_id = max9296_get_available_pipe_id,
+	.get_ser_pipe_id = max9296_get_ser_pipe_id,
+	.bind_ser_to_dser_pipe = max9296_bind_ser_to_dser_pipe,
 	.set_pipe = max9296_set_pipe,
 	.release_pipe = max9296_release_pipe,
 	.reset_oneshot = max9296_reset_oneshot,
@@ -616,6 +621,8 @@ static const struct dser_interface max9296_interface = {
 /* MAX96712 deserializer interface implementation */
 static const struct dser_interface max96712_interface = {
 	.get_available_pipe_id = max96712_get_available_pipe_id,
+	.get_ser_pipe_id = max96712_get_ser_pipe_id,
+	.bind_ser_to_dser_pipe = max96712_bind_ser_to_dser_pipe,
 	.set_pipe = max96712_set_pipe,
 	.release_pipe = max96712_release_pipe,
 	.reset_oneshot = max96712_reset_oneshot,
@@ -1813,12 +1820,17 @@ static int ds5_setup_pipeline(struct ds5 *state, u8 data_type1, u8 data_type2,
 	int ret = 0;
 	/* While some deserializers can support up to 8 pipes, the serializer only supports
 	 * four pipes and four vc_ids (0 - 3).
-	 * In this case, a second camera connected to a deserializer, will have its pipes 0 - 3
-	 * with vc_id 0 - 3 connected to the deserializer's pipes 4 - 7 and vc_ids 4 - 7
+	 * To use multiple cameras under this restriction, a second camera connected
+	 * to a deserializer will have its vc_id 0 - 3 mapped to outside vc_id 4 - 7 etc.
+	 * The ser_pipe to dser_pipe mapping depends on the deserializer.
 	 */
-	int ser_pipe_id = pipe_id % DS5_MAX_STREAMS;
 	int ser_vc_id = vc_id % DS5_MAX_STREAMS;
+	int ser_pipe_id = state->dser_ops->get_ser_pipe_id(state->dser_dev, pipe_id, ser_vc_id);;
 
+	if (state->dser_ops->bind_ser_to_dser_pipe != NULL)
+	{
+		ret |= state->dser_ops->bind_ser_to_dser_pipe(state->dser_dev, pipe_id, ser_pipe_id, vc_id);
+	}
 	dev_dbg(&state->client->dev,
 			"set ser pipe %d, dser pipe %d, data_type1: 0x%x, data_type2: 0x%x, ser_vc_id: %u, vc_id: %u\n",
 			ser_pipe_id, pipe_id, data_type1, data_type2, ser_vc_id, vc_id);
@@ -5183,6 +5195,10 @@ retry_after_serdes_recovery:
 		if (!ds5_config_done) {
 			ret = ds5_configure(state);
 			if (ret < 0) {
+				if (ret == -ENOSR) {
+					/* No recovery can help if no resources are available */
+					return ret;
+				}
 				dev_warn(&state->client->dev, "stream %d config failed, retry %d\n",
 					stream_id, i);
 				continue;

--- a/nvidia-oot/6.0/0006-Adding-max96712-support-for-D4xx.patch
+++ b/nvidia-oot/6.0/0006-Adding-max96712-support-for-D4xx.patch
@@ -1,16 +1,20 @@
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: RealSense MIPI <realsense-mipi@intel.com>
-Date: Sat, 15 Mar 2025 10:00:00 +0200
+From d573187d3232bc64ec399d309ef363d32a1dafe8 Mon Sep 17 00:00:00 2001
+From: ejgoldik <ehud.joseph.goldik@realsenseai.com>
+Date: Wed, 25 Mar 2026 11:59:22 +0200
 Subject: [PATCH] Adding max96712 support for D4xx
 
 Add MAX96712 deserializer driver support for D4XX cameras.
 
+Signed-off-by: ejgoldik <ehud.joseph.goldik@realsenseai.com>
 ---
+ drivers/media/i2c/max96712.c | 534 ++++++++++++++++++++++++++++++++---
+ 1 file changed, 497 insertions(+), 37 deletions(-)
+
 diff --git a/drivers/media/i2c/max96712.c b/drivers/media/i2c/max96712.c
-index 8e237eef..33646ace 100644
+index 8e237eef..01cdd28a 100644
 --- a/drivers/media/i2c/max96712.c
 +++ b/drivers/media/i2c/max96712.c
-@@ -16,32 +16,89 @@
+@@ -16,32 +16,91 @@
  #include <linux/gpio.h>
  #include <linux/of.h>
  #include <linux/of_gpio.h>
@@ -75,6 +79,7 @@ index 8e237eef..33646ace 100644
 +/* data defines */
 +#define MAX96712_MAX_LINKS 4
 +#define MAX96712_MAX_PIPES 8
++#define MAX9295_MAX_STREAMS 4
  
  struct max96712 {
  	struct i2c_client *i2c_client;
@@ -83,6 +88,7 @@ index 8e237eef..33646ace 100644
 +	struct mutex lock;
 +	int pwdn_gpio;
 +	int link_mask;
++	bool video_pipe_alloc[MAX96712_MAX_PIPES];
  };
  static struct max96712 *global_priv[4];
  
@@ -106,7 +112,7 @@ index 8e237eef..33646ace 100644
  	i2c_client = global_priv[channel]->i2c_client;
  	bak = i2c_client->addr;
  
-@@ -53,7 +110,6 @@ int max96712_write_reg_Dser(int slaveAddr, int channel,
+@@ -53,7 +112,6 @@ int max96712_write_reg_Dser(int slaveAddr, int channel,
  		dev_err(&i2c_client->dev, "%s: addr = 0x%x, val = 0x%x\n",
  				__func__, addr, val);
  	}
@@ -114,7 +120,7 @@ index 8e237eef..33646ace 100644
  	return err;
  }
  EXPORT_SYMBOL(max96712_write_reg_Dser);
-@@ -68,8 +124,6 @@ int max96712_read_reg_Dser(int slaveAddr, int channel,
+@@ -68,8 +126,6 @@ int max96712_read_reg_Dser(int slaveAddr, int channel,
  
  	if (channel > 3 || channel < 0 || global_priv[channel] == NULL)
  		return -1;
@@ -123,7 +129,7 @@ index 8e237eef..33646ace 100644
  	i2c_client = global_priv[channel]->i2c_client;
  	bak = i2c_client->addr;
  	i2c_client->addr = slaveAddr / 2;
-@@ -80,11 +134,56 @@ int max96712_read_reg_Dser(int slaveAddr, int channel,
+@@ -80,11 +136,56 @@ int max96712_read_reg_Dser(int slaveAddr, int channel,
  		dev_err(&i2c_client->dev, "%s: addr = 0x%x, val = 0x%x\n",
  				__func__, addr, *val);
  	}
@@ -146,8 +152,8 @@ index 8e237eef..33646ace 100644
 +	i2c_client->addr = bak;
 +
 +	if (err)
-+		dev_err(&i2c_client->dev, "%s:i2c read failed, 0x%x = %x\n",
-+			__func__, addr, value);
++		dev_err(&i2c_client->dev, "%s:i2c read failed, 0x%x: 0x%x\n",
++			__func__, ShortSlaveAddr, addr);
 +	usleep_range(100, 110);
 +	*val = value;
 +	mutex_unlock(&priv->lock);
@@ -168,8 +174,8 @@ index 8e237eef..33646ace 100644
 +	i2c_client->addr = bak;
 +
 +	if (err)
-+		dev_err(&i2c_client->dev, "%s:i2c write failed, 0x%x = %x\n",
-+			__func__, addr, val);
++		dev_err(&i2c_client->dev, "%s:i2c write failed, 0x%x: 0x%x = %x\n",
++			__func__, ShortSlaveAddr, addr, val);
 +
 +	/* delay before next i2c command as required for SERDES link */
 +	usleep_range(100, 110);
@@ -181,7 +187,7 @@ index 8e237eef..33646ace 100644
  static int max96712_read_reg(struct max96712 *priv,
  			u16 addr, unsigned int *val)
  {
-@@ -99,6 +198,20 @@ static int max96712_read_reg(struct max96712 *priv,
+@@ -99,6 +200,20 @@ static int max96712_read_reg(struct max96712 *priv,
  	return err;
  }
  
@@ -202,7 +208,7 @@ index 8e237eef..33646ace 100644
  
  static int max96712_stats_show(struct seq_file *s, void *data)
  {
-@@ -153,24 +266,6 @@ static const struct file_operations max96712_debugfs_fops = {
+@@ -153,24 +268,6 @@ static const struct file_operations max96712_debugfs_fops = {
  	.release = single_release,
  };
  
@@ -227,7 +233,7 @@ index 8e237eef..33646ace 100644
  static int max96712_debugfs_init(const char *dir_name,
  				struct dentry **d_entry,
  				struct dentry **f_entry,
-@@ -225,7 +320,8 @@ static int max96712_debugfs_init(const char *dir_name,
+@@ -225,7 +322,8 @@ static int max96712_debugfs_init(const char *dir_name,
  static  struct regmap_config max96712_regmap_config = {
  	.reg_bits = 16,
  	.val_bits = 8,
@@ -237,7 +243,7 @@ index 8e237eef..33646ace 100644
  };
  
  #if defined(NV_I2C_DRIVER_STRUCT_PROBE_WITHOUT_I2C_DEVICE_ID_ARG) /* Linux 6.3 */
-@@ -237,6 +333,8 @@ static int max96712_probe(struct i2c_client *client,
+@@ -237,6 +335,8 @@ static int max96712_probe(struct i2c_client *client,
  {
  	struct max96712 *priv;
  	int err = 0;
@@ -246,7 +252,7 @@ index 8e237eef..33646ace 100644
  
  	dev_info(&client->dev, "%s: enter\n", __func__);
  
-@@ -249,15 +347,31 @@ static int max96712_probe(struct i2c_client *client,
+@@ -249,15 +349,31 @@ static int max96712_probe(struct i2c_client *client,
  			"regmap init failed: %ld\n", PTR_ERR(priv->regmap));
  		return -ENODEV;
  	}
@@ -284,7 +290,7 @@ index 8e237eef..33646ace 100644
  	err = max96712_debugfs_init(NULL, NULL, NULL, priv);
  	if (err)
  		return err;
-@@ -274,8 +388,11 @@ static int max96712_remove(struct i2c_client *client)
+@@ -274,8 +390,11 @@ static int max96712_remove(struct i2c_client *client)
  static void max96712_remove(struct i2c_client *client)
  #endif
  {
@@ -297,7 +303,7 @@ index 8e237eef..33646ace 100644
  		i2c_unregister_device(client);
  		client = NULL;
  	}
-@@ -284,13 +401,283 @@ static void max96712_remove(struct i2c_client *client)
+@@ -284,13 +403,353 @@ static void max96712_remove(struct i2c_client *client)
  #endif
  }
  
@@ -322,19 +328,50 @@ index 8e237eef..33646ace 100644
 +
 +int max96712_get_available_pipe_id(struct device *dev, int vc_id)
 +{
-+	/* TODO EHUD: Currently vc_id == pipe id but that's definitely
-+	 * not the end goal if we plan to support more than two cameras
-+	 */
-+	return vc_id;
++	int i;
++	int pipe_id = -ENOMEM;
++	struct max96712 *priv = dev_get_drvdata(dev);
++
++	mutex_lock(&priv->lock);
++	for (i = 0; i < MAX96712_MAX_PIPES; i++) {
++		if (priv->video_pipe_alloc[i] == false) {
++			priv->video_pipe_alloc[i] = true;
++			pipe_id = i;
++			break;
++		}
++	}
++	mutex_unlock(&priv->lock);
++
++	return pipe_id;
 +}
 +EXPORT_SYMBOL(max96712_get_available_pipe_id);
 +
 +int max96712_release_pipe(struct device *dev, int pipe_id)
 +{
-+	/* TODO EHUD: once pipe allocation is added, free here */
++	struct max96712 *priv = dev_get_drvdata(dev);
++	unsigned int pipe_en_val = 0;
++
++	if (pipe_id < 0 || pipe_id >= MAX96712_MAX_PIPES)
++		return -EINVAL;
++
++	mutex_lock(&priv->lock);
++	priv->video_pipe_alloc[pipe_id] = false;
++
++	max96712_read_reg(priv, MAX96712_VIDEO_PIPE_EN_ADDR, &pipe_en_val);
++	max96712_write_reg(priv, MAX96712_VIDEO_PIPE_EN_ADDR, pipe_en_val &= ~(1 << pipe_id));
++	mutex_unlock(&priv->lock);
++
++	max96712_bind_ser_to_dser_pipe(dev, pipe_id, 0, 0);
 +	return 0;
 +}
 +EXPORT_SYMBOL(max96712_release_pipe);
++
++int max96712_get_ser_pipe_id(struct device *dev, int dser_pipe_id, int vc_id)
++{
++	/* When paired with max96712, max9295 has a 1:1 ser_vc_id to ser_pipe_id mapping */
++	return vc_id;
++}
++EXPORT_SYMBOL(max96712_get_ser_pipe_id);
 +
 +void max96712_reset_oneshot(struct device *dev)
 +{
@@ -351,6 +388,7 @@ index 8e237eef..33646ace 100644
 +	struct max96712 *priv = dev_get_drvdata(dev);
 +	int vc_id_lsb = vc_id & 0x3;
 +	int vc_id_msb = vc_id >> 2;
++	unsigned int pipe_en_val = 0;
 +
 +	struct reg_pair map_pipe_control[] = {
 +		// Enable 3/4 mappings for video pipe (4 if metadata enabled)
@@ -387,7 +425,9 @@ index 8e237eef..33646ace 100644
 +				     ARRAY_SIZE(map_pipe_control));
 +
 +	max96712_reset_oneshot(dev);
-+	max96712_write_reg(priv, MAX96712_VIDEO_PIPE_EN_ADDR, 0xFF);
++
++	max96712_read_reg(priv, MAX96712_VIDEO_PIPE_EN_ADDR, &pipe_en_val);
++	max96712_write_reg(priv, MAX96712_VIDEO_PIPE_EN_ADDR, pipe_en_val |= (1 << pipe_id));
 +
 +	return err;
 +}
@@ -398,11 +438,11 @@ index 8e237eef..33646ace 100644
 +	struct max96712 *priv = dev_get_drvdata(dev);
 +	struct reg_pair map_pipe_opt[] =
 +	{
-+		/* ----------Video pipes configure ----------------------*/
-+		{MAX96712_VIDEO_PIPE_SEL_0_ADDR, 0x10}, //0xF0, LINK A ID X to pipe 0 , Link A ID Y to pipe 1
-+		{MAX96712_VIDEO_PIPE_SEL_1_ADDR, 0x32}, //0xF1, LINK A ID Z to pipe 2 , Link A ID U to pipe 3
-+		{MAX96712_VIDEO_PIPE_SEL_2_ADDR, 0x54}, //0xF2, LINK B ID X to pipe 4 , Link B ID Y to pipe 5
-+		{MAX96712_VIDEO_PIPE_SEL_3_ADDR, 0x76}, //0xF3, LINK B ID Z to pipe 6 , Link B ID U to pipe 7
++		/* ----------Initial empty video pipe configure ----------------------*/
++		{MAX96712_VIDEO_PIPE_SEL_0_ADDR, 0x0},
++		{MAX96712_VIDEO_PIPE_SEL_1_ADDR, 0x0},
++		{MAX96712_VIDEO_PIPE_SEL_2_ADDR, 0x0},
++		{MAX96712_VIDEO_PIPE_SEL_3_ADDR, 0x0},
 +		{MAX96712_VIDEO_PIPE_EN_ADDR, 0x00}, //0xF4, Disable all pipes for now
 +	};
 +
@@ -439,6 +479,42 @@ index 8e237eef..33646ace 100644
 +	return err;
 +}
 +EXPORT_SYMBOL(max96712_init_settings);
++
++int max96712_bind_ser_to_dser_pipe(struct device *dev, int dser_pipe_id, int ser_pipe_id, u32 vc_id)
++{
++	struct max96712 *priv = dev_get_drvdata(dev);
++	unsigned int pipe_sel_val = 0;
++	u32 link_id = vc_id / MAX9295_MAX_STREAMS;
++	int err = 0;
++
++	/* dser_pipe_id will be connected to ser_pipe_id of link_id */
++	uint8_t map_pipe_val = link_id << 2 | ser_pipe_id;
++
++	/* Every pipe select reg handles two pipe mappings */
++	uint32_t dser_pipe_sel_addr = MAX96712_VIDEO_PIPE_SEL_0_ADDR + (dser_pipe_id / 2);
++	uint32_t dser_pipe_sel_offset = 4 * (dser_pipe_id % 2);
++	uint8_t dser_pipe_sel_mask = 0xF << dser_pipe_sel_offset;
++
++	if (dser_pipe_id < 0 || dser_pipe_id >= MAX96712_MAX_PIPES || link_id >= MAX96712_MAX_LINKS)
++		return -EINVAL;
++
++	mutex_lock(&priv->lock);
++
++	err = max96712_read_reg(priv, dser_pipe_sel_addr, &pipe_sel_val);
++	if (err == 0) {
++		/* Zero the pipe we are interested in */
++		pipe_sel_val &= ~(dser_pipe_sel_mask);
++		/* Input the new value */
++		pipe_sel_val |= (map_pipe_val << dser_pipe_sel_offset);
++
++		err = max96712_write_reg(priv, dser_pipe_sel_addr, pipe_sel_val);
++	}
++
++	mutex_unlock(&priv->lock);
++
++	return err;
++}
++EXPORT_SYMBOL(max96712_bind_ser_to_dser_pipe);
 +
 +int max96712_set_pipe(struct device *dev, int pipe_id,
 +		     u8 data_type1, u8 data_type2, u32 vc_id)
@@ -486,7 +562,7 @@ index 8e237eef..33646ace 100644
 +
 +			/* Enable single link */
 +			max96712_write_reg(priv, MAX96712_REG6_ADDR, curr_map);
-+			msleep(10);
++			msleep(20);
 +			max96712_reset_oneshot(dev);
 +
 +			err = max96712_read_slave_reg(priv, dst_ser_addr, 0, &reg_val);
@@ -582,7 +658,7 @@ index 8e237eef..33646ace 100644
  	{ },
  };
  
-@@ -300,6 +687,7 @@ static struct i2c_driver max96712_i2c_driver = {
+@@ -300,6 +759,7 @@ static struct i2c_driver max96712_i2c_driver = {
  	.driver = {
  		.name = "max96712",
  		.owner = THIS_MODULE,
@@ -592,3 +668,4 @@ index 8e237eef..33646ace 100644
  	.remove = max96712_remove,
 -- 
 2.43.0
+

--- a/nvidia-oot/6.0/0006-Adding-max96712-support-for-D4xx.patch
+++ b/nvidia-oot/6.0/0006-Adding-max96712-support-for-D4xx.patch
@@ -1,20 +1,20 @@
-From d573187d3232bc64ec399d309ef363d32a1dafe8 Mon Sep 17 00:00:00 2001
+From eb98093f83475f9d16abb29f1a30899ebf924292 Mon Sep 17 00:00:00 2001
 From: ejgoldik <ehud.joseph.goldik@realsenseai.com>
-Date: Wed, 25 Mar 2026 11:59:22 +0200
+Date: Wed, 25 Mar 2026 15:36:14 +0200
 Subject: [PATCH] Adding max96712 support for D4xx
 
 Add MAX96712 deserializer driver support for D4XX cameras.
 
 Signed-off-by: ejgoldik <ehud.joseph.goldik@realsenseai.com>
 ---
- drivers/media/i2c/max96712.c | 534 ++++++++++++++++++++++++++++++++---
- 1 file changed, 497 insertions(+), 37 deletions(-)
+ drivers/media/i2c/max96712.c | 538 ++++++++++++++++++++++++++++++++---
+ 1 file changed, 501 insertions(+), 37 deletions(-)
 
 diff --git a/drivers/media/i2c/max96712.c b/drivers/media/i2c/max96712.c
-index 8e237eef..01cdd28a 100644
+index 8e237eef..1dca25e5 100644
 --- a/drivers/media/i2c/max96712.c
 +++ b/drivers/media/i2c/max96712.c
-@@ -16,32 +16,91 @@
+@@ -16,32 +16,92 @@
  #include <linux/gpio.h>
  #include <linux/of.h>
  #include <linux/of_gpio.h>
@@ -38,6 +38,7 @@ index 8e237eef..01cdd28a 100644
 +#define MAX96712_315_ESYNC 0x07
 +
 +#define MAX96712_REG6_ADDR 0x6
++#define MAX96712_PWR1_ADDR 0x13
 +#define MAX96712_CTRL1_ADDR 0x18
 +
 +#define MAX96712_BACKTOP25_ADDR 0x418
@@ -112,7 +113,7 @@ index 8e237eef..01cdd28a 100644
  	i2c_client = global_priv[channel]->i2c_client;
  	bak = i2c_client->addr;
  
-@@ -53,7 +112,6 @@ int max96712_write_reg_Dser(int slaveAddr, int channel,
+@@ -53,7 +113,6 @@ int max96712_write_reg_Dser(int slaveAddr, int channel,
  		dev_err(&i2c_client->dev, "%s: addr = 0x%x, val = 0x%x\n",
  				__func__, addr, val);
  	}
@@ -120,7 +121,7 @@ index 8e237eef..01cdd28a 100644
  	return err;
  }
  EXPORT_SYMBOL(max96712_write_reg_Dser);
-@@ -68,8 +126,6 @@ int max96712_read_reg_Dser(int slaveAddr, int channel,
+@@ -68,8 +127,6 @@ int max96712_read_reg_Dser(int slaveAddr, int channel,
  
  	if (channel > 3 || channel < 0 || global_priv[channel] == NULL)
  		return -1;
@@ -129,7 +130,7 @@ index 8e237eef..01cdd28a 100644
  	i2c_client = global_priv[channel]->i2c_client;
  	bak = i2c_client->addr;
  	i2c_client->addr = slaveAddr / 2;
-@@ -80,11 +136,56 @@ int max96712_read_reg_Dser(int slaveAddr, int channel,
+@@ -80,11 +137,56 @@ int max96712_read_reg_Dser(int slaveAddr, int channel,
  		dev_err(&i2c_client->dev, "%s: addr = 0x%x, val = 0x%x\n",
  				__func__, addr, *val);
  	}
@@ -187,7 +188,7 @@ index 8e237eef..01cdd28a 100644
  static int max96712_read_reg(struct max96712 *priv,
  			u16 addr, unsigned int *val)
  {
-@@ -99,6 +200,20 @@ static int max96712_read_reg(struct max96712 *priv,
+@@ -99,6 +201,20 @@ static int max96712_read_reg(struct max96712 *priv,
  	return err;
  }
  
@@ -208,7 +209,7 @@ index 8e237eef..01cdd28a 100644
  
  static int max96712_stats_show(struct seq_file *s, void *data)
  {
-@@ -153,24 +268,6 @@ static const struct file_operations max96712_debugfs_fops = {
+@@ -153,24 +269,6 @@ static const struct file_operations max96712_debugfs_fops = {
  	.release = single_release,
  };
  
@@ -233,7 +234,7 @@ index 8e237eef..01cdd28a 100644
  static int max96712_debugfs_init(const char *dir_name,
  				struct dentry **d_entry,
  				struct dentry **f_entry,
-@@ -225,7 +322,8 @@ static int max96712_debugfs_init(const char *dir_name,
+@@ -225,7 +323,8 @@ static int max96712_debugfs_init(const char *dir_name,
  static  struct regmap_config max96712_regmap_config = {
  	.reg_bits = 16,
  	.val_bits = 8,
@@ -243,7 +244,7 @@ index 8e237eef..01cdd28a 100644
  };
  
  #if defined(NV_I2C_DRIVER_STRUCT_PROBE_WITHOUT_I2C_DEVICE_ID_ARG) /* Linux 6.3 */
-@@ -237,6 +335,8 @@ static int max96712_probe(struct i2c_client *client,
+@@ -237,6 +336,8 @@ static int max96712_probe(struct i2c_client *client,
  {
  	struct max96712 *priv;
  	int err = 0;
@@ -252,7 +253,7 @@ index 8e237eef..01cdd28a 100644
  
  	dev_info(&client->dev, "%s: enter\n", __func__);
  
-@@ -249,15 +349,31 @@ static int max96712_probe(struct i2c_client *client,
+@@ -249,15 +350,31 @@ static int max96712_probe(struct i2c_client *client,
  			"regmap init failed: %ld\n", PTR_ERR(priv->regmap));
  		return -ENODEV;
  	}
@@ -290,7 +291,7 @@ index 8e237eef..01cdd28a 100644
  	err = max96712_debugfs_init(NULL, NULL, NULL, priv);
  	if (err)
  		return err;
-@@ -274,8 +390,11 @@ static int max96712_remove(struct i2c_client *client)
+@@ -274,8 +391,11 @@ static int max96712_remove(struct i2c_client *client)
  static void max96712_remove(struct i2c_client *client)
  #endif
  {
@@ -303,7 +304,7 @@ index 8e237eef..01cdd28a 100644
  		i2c_unregister_device(client);
  		client = NULL;
  	}
-@@ -284,13 +403,353 @@ static void max96712_remove(struct i2c_client *client)
+@@ -284,13 +404,356 @@ static void max96712_remove(struct i2c_client *client)
  #endif
  }
  
@@ -642,6 +643,9 @@ index 8e237eef..01cdd28a 100644
 +        gpio_direction_output(priv->pwdn_gpio, 1);
 +        gpio_set_value(priv->pwdn_gpio, 0);
 +        msleep(100);
++    } else {
++        max96712_write_reg(priv, MAX96712_PWR1_ADDR, 0x40);
++        msleep(200);
 +    }
 +    return;
 +}
@@ -658,7 +662,7 @@ index 8e237eef..01cdd28a 100644
  	{ },
  };
  
-@@ -300,6 +759,7 @@ static struct i2c_driver max96712_i2c_driver = {
+@@ -300,6 +763,7 @@ static struct i2c_driver max96712_i2c_driver = {
  	.driver = {
  		.name = "max96712",
  		.owner = THIS_MODULE,

--- a/nvidia-oot/6.0/0006-Adding-max96712-support-for-D4xx.patch
+++ b/nvidia-oot/6.0/0006-Adding-max96712-support-for-D4xx.patch
@@ -1,20 +1,20 @@
-From eb98093f83475f9d16abb29f1a30899ebf924292 Mon Sep 17 00:00:00 2001
+From 0273a0938bb1e2242f8b68e0167175a0a99f17f9 Mon Sep 17 00:00:00 2001
 From: ejgoldik <ehud.joseph.goldik@realsenseai.com>
-Date: Wed, 25 Mar 2026 15:36:14 +0200
+Date: Thu, 26 Mar 2026 15:49:47 +0200
 Subject: [PATCH] Adding max96712 support for D4xx
 
 Add MAX96712 deserializer driver support for D4XX cameras.
 
 Signed-off-by: ejgoldik <ehud.joseph.goldik@realsenseai.com>
 ---
- drivers/media/i2c/max96712.c | 538 ++++++++++++++++++++++++++++++++---
- 1 file changed, 501 insertions(+), 37 deletions(-)
+ drivers/media/i2c/max96712.c | 563 ++++++++++++++++++++++++++++++++---
+ 1 file changed, 526 insertions(+), 37 deletions(-)
 
 diff --git a/drivers/media/i2c/max96712.c b/drivers/media/i2c/max96712.c
-index 8e237eef..1dca25e5 100644
+index 8e237eef..c4577bbb 100644
 --- a/drivers/media/i2c/max96712.c
 +++ b/drivers/media/i2c/max96712.c
-@@ -16,32 +16,92 @@
+@@ -16,32 +16,93 @@
  #include <linux/gpio.h>
  #include <linux/of.h>
  #include <linux/of_gpio.h>
@@ -39,6 +39,7 @@ index 8e237eef..1dca25e5 100644
 +
 +#define MAX96712_REG6_ADDR 0x6
 +#define MAX96712_PWR1_ADDR 0x13
++#define MAX96712_PWR1_RESET_ALL_VAL 0x40
 +#define MAX96712_CTRL1_ADDR 0x18
 +
 +#define MAX96712_BACKTOP25_ADDR 0x418
@@ -113,7 +114,7 @@ index 8e237eef..1dca25e5 100644
  	i2c_client = global_priv[channel]->i2c_client;
  	bak = i2c_client->addr;
  
-@@ -53,7 +113,6 @@ int max96712_write_reg_Dser(int slaveAddr, int channel,
+@@ -53,7 +114,6 @@ int max96712_write_reg_Dser(int slaveAddr, int channel,
  		dev_err(&i2c_client->dev, "%s: addr = 0x%x, val = 0x%x\n",
  				__func__, addr, val);
  	}
@@ -121,7 +122,7 @@ index 8e237eef..1dca25e5 100644
  	return err;
  }
  EXPORT_SYMBOL(max96712_write_reg_Dser);
-@@ -68,8 +127,6 @@ int max96712_read_reg_Dser(int slaveAddr, int channel,
+@@ -68,8 +128,6 @@ int max96712_read_reg_Dser(int slaveAddr, int channel,
  
  	if (channel > 3 || channel < 0 || global_priv[channel] == NULL)
  		return -1;
@@ -130,7 +131,7 @@ index 8e237eef..1dca25e5 100644
  	i2c_client = global_priv[channel]->i2c_client;
  	bak = i2c_client->addr;
  	i2c_client->addr = slaveAddr / 2;
-@@ -80,11 +137,56 @@ int max96712_read_reg_Dser(int slaveAddr, int channel,
+@@ -80,11 +138,56 @@ int max96712_read_reg_Dser(int slaveAddr, int channel,
  		dev_err(&i2c_client->dev, "%s: addr = 0x%x, val = 0x%x\n",
  				__func__, addr, *val);
  	}
@@ -188,7 +189,7 @@ index 8e237eef..1dca25e5 100644
  static int max96712_read_reg(struct max96712 *priv,
  			u16 addr, unsigned int *val)
  {
-@@ -99,6 +201,20 @@ static int max96712_read_reg(struct max96712 *priv,
+@@ -99,6 +202,20 @@ static int max96712_read_reg(struct max96712 *priv,
  	return err;
  }
  
@@ -209,7 +210,7 @@ index 8e237eef..1dca25e5 100644
  
  static int max96712_stats_show(struct seq_file *s, void *data)
  {
-@@ -153,24 +269,6 @@ static const struct file_operations max96712_debugfs_fops = {
+@@ -153,24 +270,6 @@ static const struct file_operations max96712_debugfs_fops = {
  	.release = single_release,
  };
  
@@ -234,7 +235,7 @@ index 8e237eef..1dca25e5 100644
  static int max96712_debugfs_init(const char *dir_name,
  				struct dentry **d_entry,
  				struct dentry **f_entry,
-@@ -225,7 +323,8 @@ static int max96712_debugfs_init(const char *dir_name,
+@@ -225,7 +324,8 @@ static int max96712_debugfs_init(const char *dir_name,
  static  struct regmap_config max96712_regmap_config = {
  	.reg_bits = 16,
  	.val_bits = 8,
@@ -244,7 +245,7 @@ index 8e237eef..1dca25e5 100644
  };
  
  #if defined(NV_I2C_DRIVER_STRUCT_PROBE_WITHOUT_I2C_DEVICE_ID_ARG) /* Linux 6.3 */
-@@ -237,6 +336,8 @@ static int max96712_probe(struct i2c_client *client,
+@@ -237,6 +337,8 @@ static int max96712_probe(struct i2c_client *client,
  {
  	struct max96712 *priv;
  	int err = 0;
@@ -253,7 +254,7 @@ index 8e237eef..1dca25e5 100644
  
  	dev_info(&client->dev, "%s: enter\n", __func__);
  
-@@ -249,15 +350,31 @@ static int max96712_probe(struct i2c_client *client,
+@@ -249,15 +351,31 @@ static int max96712_probe(struct i2c_client *client,
  			"regmap init failed: %ld\n", PTR_ERR(priv->regmap));
  		return -ENODEV;
  	}
@@ -291,7 +292,7 @@ index 8e237eef..1dca25e5 100644
  	err = max96712_debugfs_init(NULL, NULL, NULL, priv);
  	if (err)
  		return err;
-@@ -274,8 +391,11 @@ static int max96712_remove(struct i2c_client *client)
+@@ -274,8 +392,11 @@ static int max96712_remove(struct i2c_client *client)
  static void max96712_remove(struct i2c_client *client)
  #endif
  {
@@ -304,7 +305,7 @@ index 8e237eef..1dca25e5 100644
  		i2c_unregister_device(client);
  		client = NULL;
  	}
-@@ -284,13 +404,356 @@ static void max96712_remove(struct i2c_client *client)
+@@ -284,13 +405,380 @@ static void max96712_remove(struct i2c_client *client)
  #endif
  }
  
@@ -330,7 +331,7 @@ index 8e237eef..1dca25e5 100644
 +int max96712_get_available_pipe_id(struct device *dev, int vc_id)
 +{
 +	int i;
-+	int pipe_id = -ENOMEM;
++	int pipe_id = -ENOSR;
 +	struct max96712 *priv = dev_get_drvdata(dev);
 +
 +	mutex_lock(&priv->lock);
@@ -347,10 +348,42 @@ index 8e237eef..1dca25e5 100644
 +}
 +EXPORT_SYMBOL(max96712_get_available_pipe_id);
 +
++static int __max96712_bind_ser_to_dser_pipe(struct device *dev, int dser_pipe_id, int ser_pipe_id, u32 vc_id)
++{
++	struct max96712 *priv = dev_get_drvdata(dev);
++	unsigned int pipe_sel_val = 0;
++	u32 link_id = vc_id / MAX9295_MAX_STREAMS;
++	int err = 0;
++
++	/* dser_pipe_id will be connected to ser_pipe_id of link_id */
++	uint8_t map_pipe_val = link_id << 2 | ser_pipe_id;
++
++	/* Every pipe select reg handles two pipe mappings */
++	uint32_t dser_pipe_sel_addr = MAX96712_VIDEO_PIPE_SEL_0_ADDR + (dser_pipe_id / 2);
++	uint32_t dser_pipe_sel_offset = 4 * (dser_pipe_id % 2);
++	uint8_t dser_pipe_sel_mask = 0xF << dser_pipe_sel_offset;
++
++	if (dser_pipe_id < 0 || dser_pipe_id >= MAX96712_MAX_PIPES || link_id >= MAX96712_MAX_LINKS)
++		return -EINVAL;
++
++	err = max96712_read_reg(priv, dser_pipe_sel_addr, &pipe_sel_val);
++	if (err == 0) {
++		/* Zero the pipe we are interested in */
++		pipe_sel_val &= ~(dser_pipe_sel_mask);
++		/* Input the new value */
++		pipe_sel_val |= (map_pipe_val << dser_pipe_sel_offset);
++
++		err = max96712_write_reg(priv, dser_pipe_sel_addr, pipe_sel_val);
++	}
++
++	return err;
++}
++
 +int max96712_release_pipe(struct device *dev, int pipe_id)
 +{
 +	struct max96712 *priv = dev_get_drvdata(dev);
 +	unsigned int pipe_en_val = 0;
++	int err = 0;
 +
 +	if (pipe_id < 0 || pipe_id >= MAX96712_MAX_PIPES)
 +		return -EINVAL;
@@ -358,12 +391,19 @@ index 8e237eef..1dca25e5 100644
 +	mutex_lock(&priv->lock);
 +	priv->video_pipe_alloc[pipe_id] = false;
 +
-+	max96712_read_reg(priv, MAX96712_VIDEO_PIPE_EN_ADDR, &pipe_en_val);
-+	max96712_write_reg(priv, MAX96712_VIDEO_PIPE_EN_ADDR, pipe_en_val &= ~(1 << pipe_id));
++	err = max96712_read_reg(priv, MAX96712_VIDEO_PIPE_EN_ADDR, &pipe_en_val);
++	if (err == 0) {
++		pipe_en_val &= ~(1 << pipe_id);
++		err = max96712_write_reg(priv, MAX96712_VIDEO_PIPE_EN_ADDR, pipe_en_val);
++	}
++
++	if (err == 0) {
++		err = __max96712_bind_ser_to_dser_pipe(dev, pipe_id, 0, 0);
++	}
++
 +	mutex_unlock(&priv->lock);
 +
-+	max96712_bind_ser_to_dser_pipe(dev, pipe_id, 0, 0);
-+	return 0;
++	return err;
 +}
 +EXPORT_SYMBOL(max96712_release_pipe);
 +
@@ -424,11 +464,16 @@ index 8e237eef..1dca25e5 100644
 +
 +	err |= max96712_set_registers(priv, map_pipe_control,
 +				     ARRAY_SIZE(map_pipe_control));
-+
++	if (err) {
++		return err;
++	}
 +	max96712_reset_oneshot(dev);
 +
-+	max96712_read_reg(priv, MAX96712_VIDEO_PIPE_EN_ADDR, &pipe_en_val);
-+	max96712_write_reg(priv, MAX96712_VIDEO_PIPE_EN_ADDR, pipe_en_val |= (1 << pipe_id));
++	err |= max96712_read_reg(priv, MAX96712_VIDEO_PIPE_EN_ADDR, &pipe_en_val);
++	if (err == 0) {
++		pipe_en_val |= (1 << pipe_id);
++		err |= max96712_write_reg(priv, MAX96712_VIDEO_PIPE_EN_ADDR, pipe_en_val);
++	}
 +
 +	return err;
 +}
@@ -484,32 +529,11 @@ index 8e237eef..1dca25e5 100644
 +int max96712_bind_ser_to_dser_pipe(struct device *dev, int dser_pipe_id, int ser_pipe_id, u32 vc_id)
 +{
 +	struct max96712 *priv = dev_get_drvdata(dev);
-+	unsigned int pipe_sel_val = 0;
-+	u32 link_id = vc_id / MAX9295_MAX_STREAMS;
 +	int err = 0;
-+
-+	/* dser_pipe_id will be connected to ser_pipe_id of link_id */
-+	uint8_t map_pipe_val = link_id << 2 | ser_pipe_id;
-+
-+	/* Every pipe select reg handles two pipe mappings */
-+	uint32_t dser_pipe_sel_addr = MAX96712_VIDEO_PIPE_SEL_0_ADDR + (dser_pipe_id / 2);
-+	uint32_t dser_pipe_sel_offset = 4 * (dser_pipe_id % 2);
-+	uint8_t dser_pipe_sel_mask = 0xF << dser_pipe_sel_offset;
-+
-+	if (dser_pipe_id < 0 || dser_pipe_id >= MAX96712_MAX_PIPES || link_id >= MAX96712_MAX_LINKS)
-+		return -EINVAL;
 +
 +	mutex_lock(&priv->lock);
 +
-+	err = max96712_read_reg(priv, dser_pipe_sel_addr, &pipe_sel_val);
-+	if (err == 0) {
-+		/* Zero the pipe we are interested in */
-+		pipe_sel_val &= ~(dser_pipe_sel_mask);
-+		/* Input the new value */
-+		pipe_sel_val |= (map_pipe_val << dser_pipe_sel_offset);
-+
-+		err = max96712_write_reg(priv, dser_pipe_sel_addr, pipe_sel_val);
-+	}
++	err = __max96712_bind_ser_to_dser_pipe(dev, dser_pipe_id, ser_pipe_id, vc_id);
 +
 +	mutex_unlock(&priv->lock);
 +
@@ -644,7 +668,8 @@ index 8e237eef..1dca25e5 100644
 +        gpio_set_value(priv->pwdn_gpio, 0);
 +        msleep(100);
 +    } else {
-+        max96712_write_reg(priv, MAX96712_PWR1_ADDR, 0x40);
++        /* If no power off GPIO exists, use reset all (self-clearing) */
++        max96712_write_reg(priv, MAX96712_PWR1_ADDR, MAX96712_PWR1_RESET_ALL_VAL);
 +        msleep(200);
 +    }
 +    return;
@@ -662,7 +687,7 @@ index 8e237eef..1dca25e5 100644
  	{ },
  };
  
-@@ -300,6 +763,7 @@ static struct i2c_driver max96712_i2c_driver = {
+@@ -300,6 +788,7 @@ static struct i2c_driver max96712_i2c_driver = {
  	.driver = {
  		.name = "max96712",
  		.owner = THIS_MODULE,

--- a/nvidia-oot/6.0/0007-Allow-external-address-assignment-on-max9295.patch
+++ b/nvidia-oot/6.0/0007-Allow-external-address-assignment-on-max9295.patch
@@ -1,59 +1,162 @@
-From 841e6f980e556bf451f9533e6f3e56f5e8474bf1 Mon Sep 17 00:00:00 2001
+From 9b5ee1e40b07c70f6b960914894bdd829e52c402 Mon Sep 17 00:00:00 2001
 From: ejgoldik <ehud.joseph.goldik@realsenseai.com>
-Date: Thu, 19 Mar 2026 08:58:32 +0200
+Date: Wed, 25 Mar 2026 12:05:28 +0200
 Subject: [PATCH] Allow external address assignment on max9295
 
 Signed-off-by: ejgoldik <ehud.joseph.goldik@realsenseai.com>
 ---
- drivers/media/i2c/max9295.c | 25 +++++++++++++------------
- 1 file changed, 13 insertions(+), 12 deletions(-)
+ drivers/media/i2c/max9295.c | 93 +++++++++++++++++++------------------
+ 1 file changed, 47 insertions(+), 46 deletions(-)
 
 diff --git a/drivers/media/i2c/max9295.c b/drivers/media/i2c/max9295.c
-index 40568147..937d4d42 100644
+index 0c86332d..12b5db00 100644
 --- a/drivers/media/i2c/max9295.c
 +++ b/drivers/media/i2c/max9295.c
-@@ -277,6 +277,7 @@ int max9295_setup_control(struct device *dev)
- 	u32 offset1 = 0;
- 	u32 offset2 = 0;
- 	u32 i;
-+	bool skip_addr_reassign = false;
+@@ -110,6 +110,7 @@ struct max9295 {
+ 	struct regmap *regmap;
+ 	struct max9295_client_ctx g_client;
+ 	struct mutex lock;
++	bool external_addr_reassign;
+ 	/* primary serializer properties */
+ 	__u32 def_addr;
+ 	__u32 pst2_ref;
+@@ -313,50 +314,52 @@ int max9295_setup_control(struct device *dev)
  
- 	u8 i2c_ovrd[] = {
- 		0x6B, 0x10,
-@@ -336,21 +337,21 @@ int max9295_setup_control(struct device *dev)
- 	}
+ 	g_ctx = priv->g_client.g_ctx;
  
- 	if (i == ARRAY_SIZE(addr_offset)) {
+-	if (prim_priv__) {
+-		/* update address reassingment */
+-		max9295_write_reg(&prim_priv__->i2c_client->dev,
+-				MAX9295_DEV_ADDR, (g_ctx->ser_reg << 1));
+-	}
++	if (!priv->external_addr_reassign) {
++		if (prim_priv__) {
++			/* update address reassingment */
++			max9295_write_reg(&prim_priv__->i2c_client->dev,
++					MAX9295_DEV_ADDR, (g_ctx->ser_reg << 1));
++		}
+ 
+-	if (g_ctx->serdes_csi_link == GMSL_SERDES_CSI_LINK_A)
+-		err = max9295_write_reg(dev, MAX9295_CTRL0_ADDR, 0x21);
+-	else
+-		err = max9295_write_reg(dev, MAX9295_CTRL0_ADDR, 0x22);
++		if (g_ctx->serdes_csi_link == GMSL_SERDES_CSI_LINK_A)
++			err = max9295_write_reg(dev, MAX9295_CTRL0_ADDR, 0x21);
++		else
++			err = max9295_write_reg(dev, MAX9295_CTRL0_ADDR, 0x22);
+ 
+-	/* check if serializer device exists */
+-	if (err) {
+-		dev_err(dev, "%s: ERROR: ser device not found\n", __func__);
+-		goto error;
+-	}
++		/* check if serializer device exists */
++		if (err) {
++			dev_err(dev, "%s: ERROR: ser device not found\n", __func__);
++			goto error;
++		}
+ 
+-	/* delay to settle link */
+-	msleep(100);
++		/* delay to settle link */
++		msleep(100);
+ 
+-	for (i = 0; i < ARRAY_SIZE(addr_offset); i += 3) {
+-		if ((g_ctx->ser_reg << 1) == addr_offset[i]) {
+-			offset1 = addr_offset[i+1];
+-			offset2 = addr_offset[i+2];
+-			break;
++		for (i = 0; i < ARRAY_SIZE(addr_offset); i += 3) {
++			if ((g_ctx->ser_reg << 1) == addr_offset[i]) {
++				offset1 = addr_offset[i+1];
++				offset2 = addr_offset[i+2];
++				break;
++			}
+ 		}
+-	}
+ 
+-	if (i == ARRAY_SIZE(addr_offset)) {
 -		dev_err(dev, "%s: invalid ser slave address\n", __func__);
 -		err = -EINVAL;
 -		goto error;
-+		dev_dbg(dev, "%s: invalid ser slave address\n", __func__);
-+		skip_addr_reassign = true;
- 	}
-+	if (!skip_addr_reassign) {
-+		for (i = 0; i < ARRAY_SIZE(i2c_ovrd); i += 2) {
-+			/* update address overrides */
-+			i2c_ovrd[i+1] += (i < 4) ? offset1 : offset2;
+-	}
++		if (i == ARRAY_SIZE(addr_offset)) {
++			dev_err(dev, "%s: invalid ser slave address\n", __func__);
++			err = -EINVAL;
++			goto error;
++		}
  
 -	for (i = 0; i < ARRAY_SIZE(i2c_ovrd); i += 2) {
 -		/* update address overrides */
 -		i2c_ovrd[i+1] += (i < 4) ? offset1 : offset2;
-+			/* i2c passthrough2 must be configured once for all devices */
-+			if ((i2c_ovrd[i] == 0x8B) && prim_priv__ &&
-+					prim_priv__->pst2_ref)
-+				continue;
++		for (i = 0; i < ARRAY_SIZE(i2c_ovrd); i += 2) {
++			/* update address overrides */
++			i2c_ovrd[i+1] += (i < 4) ? offset1 : offset2;
  
 -		/* i2c passthrough2 must be configured once for all devices */
 -		if ((i2c_ovrd[i] == 0x8B) && prim_priv__ &&
 -				prim_priv__->pst2_ref)
 -			continue;
--
++			/* i2c passthrough2 must be configured once for all devices */
++			if ((i2c_ovrd[i] == 0x8B) && prim_priv__ &&
++					prim_priv__->pst2_ref)
++				continue;
+ 
 -		max9295_write_reg(dev, i2c_ovrd[i], i2c_ovrd[i+1]);
 +			max9295_write_reg(dev, i2c_ovrd[i], i2c_ovrd[i+1]);
 +		}
  	}
  
  	/* dev addr pass-through2 ref */
+@@ -524,10 +527,6 @@ static int __max9295_set_pipe(struct device *dev, int pipe_id, u8 data_type1,
+ {
+ 	int err = 0;
+ 	u8 bpp = 0x30;
+-	static u8 pipe_x_val = 0x0;
+-	struct reg_pair map_multi_pipe_en[] = {
+-		{0x0315, 0x80},
+-	};
+ 	struct reg_pair map_bpp8dbl[] = {
+ 		{0x0312, 0x0F},
+ 	};
+@@ -561,21 +560,17 @@ static int __max9295_set_pipe(struct device *dev, int pipe_id, u8 data_type1,
+ 
+ 	map_pipe_control[0].val = 0x40 | data_type1;
+ 	map_pipe_control[1].val = 0x40 | data_type2;
++	if (pipe_id == 0) {
++		map_pipe_control[1].val |= 0x80;
++	}
+ 	map_pipe_control[2].val = 1 << vc_id;
+ 	map_pipe_control[3].val = 0x00;
+ 	map_pipe_control[4].val = bpp;
+ 	map_pipe_control[5].val = 0x0E;
+ 
+-	if (pipe_id == 0)
+-		pipe_x_val = map_pipe_control[1].val;
+-
+ 	err |= max9295_set_registers(dev, map_pipe_control,
+ 				     ARRAY_SIZE(map_pipe_control));
+ 
+-	map_multi_pipe_en[0].val = 0x80 | pipe_x_val;
+-	err |= max9295_set_registers(dev, map_multi_pipe_en,
+-				     ARRAY_SIZE(map_multi_pipe_en));
+-
+ 	return err;
+ }
+ 
+@@ -678,6 +673,12 @@ static int max9295_probe(struct i2c_client *client,
+ 		prim_priv__ = priv;
+ 	}
+ 
++	if (of_get_property(node, "external_addr_reassign", NULL)) {
++		priv->external_addr_reassign = true;
++	} else {
++		priv->external_addr_reassign = false;
++	}
++
+ 	dev_set_drvdata(&client->dev, priv);
+ 
+ 	/* dev communication gets validated when GMSL link setup is done */
 -- 
 2.43.0
 

--- a/nvidia-oot/6.0/0008-Align-max9296-api-to-max96712.patch
+++ b/nvidia-oot/6.0/0008-Align-max9296-api-to-max96712.patch
@@ -1,0 +1,78 @@
+From 8992bcc92a495b28e828736d94fc3325054669d9 Mon Sep 17 00:00:00 2001
+From: ejgoldik <ehud.joseph.goldik@realsenseai.com>
+Date: Wed, 25 Mar 2026 11:43:03 +0200
+Subject: [PATCH] Align max9296 api to max96712
+
+Signed-off-by: ejgoldik <ehud.joseph.goldik@realsenseai.com>
+---
+ drivers/media/i2c/max9296.c | 14 ++++++++++++++
+ include/media/max9296.h     | 14 ++++++++++++++
+ 2 files changed, 28 insertions(+)
+
+diff --git a/drivers/media/i2c/max9296.c b/drivers/media/i2c/max9296.c
+index d50bea51..92b483b6 100644
+--- a/drivers/media/i2c/max9296.c
++++ b/drivers/media/i2c/max9296.c
+@@ -836,6 +836,13 @@ int max9296_release_pipe(struct device *dev, int pipe_id)
+ }
+ EXPORT_SYMBOL(max9296_release_pipe);
+ 
++int max9296_get_ser_pipe_id(struct device *dev, int dser_pipe_id, int vc_id)
++{
++	/* When paired with max9296, max9295 has a 1:1 dser_pipe_id to ser_pipe_id mapping */
++	return dser_pipe_id;
++}
++EXPORT_SYMBOL(max9296_get_ser_pipe_id);
++
+ void max9296_reset_oneshot(struct device *dev)
+ {
+ 	struct max9296 *priv = dev_get_drvdata(dev);
+@@ -945,6 +952,13 @@ int max9296_init_settings(struct device *dev)
+ }
+ EXPORT_SYMBOL(max9296_init_settings);
+ 
++int max9296_bind_ser_to_dser_pipe(struct device *dev, int dser_pipe_id, int ser_pipe_id, u32 vc_id)
++{
++	/* pipe id's are 1:1 in this deserializer */
++	return 0;
++}
++EXPORT_SYMBOL(max9296_bind_ser_to_dser_pipe);
++
+ int max9296_set_pipe(struct device *dev, int pipe_id,
+ 		     u8 data_type1, u8 data_type2, u32 vc_id)
+ {
+diff --git a/include/media/max9296.h b/include/media/max9296.h
+index 6b4c796e..db7365d7 100644
+--- a/include/media/max9296.h
++++ b/include/media/max9296.h
+@@ -24,6 +24,7 @@
+  */
+ 
+ int max9296_get_available_pipe_id(struct device *dev, int vc_id);
++int max9296_get_ser_pipe_id(struct device *dev, int dser_pipe_id, int vc_id);
+ int max9296_set_pipe(struct device *dev, int pipe_id, u8 data_type1,
+ 		     u8 data_type2, u32 vc_id);
+ int max9296_release_pipe(struct device *dev, int pipe_id);
+@@ -154,6 +155,19 @@ int max9296_power_on(struct device *dev);
+ void max9296_power_off(struct device *dev);
+ 
+ int max9296_init_settings(struct device *dev);
++
++/**
++ * @brief  Maps dserializer to serializer pipe id
++ *
++ * Not a meaningful function in this deserializer as the mapping is 1:1
++ *
++ * @param [in]  dev             The deserializer device handle.
++ * @param [in]  dser_pipe_id    Deserializer pipe id.
++ * @param [in]  ser_pipe_id     Serializer pipe id.
++ * @param [in]  vc_id           vc_id associated with this pipe path.
++ */
++int max9296_bind_ser_to_dser_pipe(struct device *dev, int dser_pipe_id, int ser_pipe_id, u32 vc_id);
++
+ /** @} */
+ 
+ #endif  /* __MAX9296_H__ */
+-- 
+2.43.0
+

--- a/nvidia-oot/6.1/0008-Align-max9296-api-to-max96712.patch
+++ b/nvidia-oot/6.1/0008-Align-max9296-api-to-max96712.patch
@@ -1,0 +1,1 @@
+../6.0/0008-Align-max9296-api-to-max96712.patch

--- a/nvidia-oot/6.2.1/0008-Align-max9296-api-to-max96712.patch
+++ b/nvidia-oot/6.2.1/0008-Align-max9296-api-to-max96712.patch
@@ -1,0 +1,1 @@
+../6.0/0008-Align-max9296-api-to-max96712.patch

--- a/nvidia-oot/6.2/0008-Align-max9296-api-to-max96712.patch
+++ b/nvidia-oot/6.2/0008-Align-max9296-api-to-max96712.patch
@@ -1,0 +1,1 @@
+../6.0/0008-Align-max9296-api-to-max96712.patch

--- a/nvidia-oot/7.0/0007-Allow-external-address-assignment-on-max9295.patch
+++ b/nvidia-oot/7.0/0007-Allow-external-address-assignment-on-max9295.patch
@@ -1,0 +1,1 @@
+../6.0/0007-Allow-external-address-assignment-on-max9295.patch

--- a/nvidia-oot/7.0/0008-Align-max9296-api-to-max96712.patch
+++ b/nvidia-oot/7.0/0008-Align-max9296-api-to-max96712.patch
@@ -1,0 +1,1 @@
+../6.0/0008-Align-max9296-api-to-max96712.patch

--- a/nvidia-oot/7.1/0007-Allow-external-address-assignment-on-max9295.patch
+++ b/nvidia-oot/7.1/0007-Allow-external-address-assignment-on-max9295.patch
@@ -1,0 +1,1 @@
+../6.0/0007-Allow-external-address-assignment-on-max9295.patch

--- a/nvidia-oot/7.1/0008-Align-max9296-api-to-max96712.patch
+++ b/nvidia-oot/7.1/0008-Align-max9296-api-to-max96712.patch
@@ -1,0 +1,1 @@
+../6.0/0008-Align-max9296-api-to-max96712.patch

--- a/nvidia-oot/max96712.h
+++ b/nvidia-oot/max96712.h
@@ -24,6 +24,7 @@
  */
 
 int max96712_get_available_pipe_id(struct device *dev, int vc_id);
+int max96712_get_ser_pipe_id(struct device *dev, int dser_pipe_id, int vc_id);
 int max96712_set_pipe(struct device *dev, int pipe_id, u8 data_type1,
 		     u8 data_type2, u32 vc_id);
 int max96712_release_pipe(struct device *dev, int pipe_id);
@@ -36,5 +37,14 @@ int max96712_sdev_unregister(struct device *dev, struct device *s_dev);
 int max96712_power_on(struct device *dev);
 void max96712_power_off(struct device *dev);
 int max96712_init_settings(struct device *dev);
+/**
+ * @brief  Maps dserializer to serializer pipe id
+ *
+ * @param [in]  dev             The deserializer device handle.
+ * @param [in]  dser_pipe_id    Deserializer pipe id.
+ * @param [in]  ser_pipe_id     Serializer pipe id.
+ * @param [in]  vc_id           vc_id associated with this pipe path.
+ */
+int max96712_bind_ser_to_dser_pipe(struct device *dev, int dser_pipe_id, int ser_pipe_id, u32 vc_id);
 
 #endif  /* __MAX96712_H__ */


### PR DESCRIPTION
This enables up to four cameras connected at once to the same max96712 deserializer.
Note that as max96712 has 8 video pipes, the user can stream up to 8 streams at once from all cameras connected to the same deserializer (ir left + right count as 1)