### PR TITLE
Advantech board orin support

### DIFF
--- a/hardware/nvidia/t23x/nv-public/6.x/0001-overlay-enable-d4xx-camera-for-Orin-jp6.patch
+++ b/hardware/nvidia/t23x/nv-public/6.x/0001-overlay-enable-d4xx-camera-for-Orin-jp6.patch
@@ -1,18 +1,18 @@
-From ed5946bc9eb94bd84b85b307409e783d05cb9a04 Mon Sep 17 00:00:00 2001
+From aa67f11e7fb33188f5e7e3fb78a5c5f35cd51164 Mon Sep 17 00:00:00 2001
 From: ejgoldik <ehud.joseph.goldik@realsenseai.com>
-Date: Wed, 25 Mar 2026 12:17:30 +0200
+Date: Tue, 31 Mar 2026 09:41:38 +0300
 Subject: [PATCH] overlay: enable d4xx camera for Orin jp6
 
 Signed-off-by: ejgoldik <ehud.joseph.goldik@realsenseai.com>
 ---
- overlay/Makefile | 16 ++++++++++++++++
- 1 file changed, 16 insertions(+)
+ overlay/Makefile | 17 +++++++++++++++++
+ 1 file changed, 17 insertions(+)
 
 diff --git a/overlay/Makefile b/overlay/Makefile
-index c88bbe2..2e24c2d 100644
+index c88bbe2..b1876c1 100644
 --- a/overlay/Makefile
 +++ b/overlay/Makefile
-@@ -60,6 +60,22 @@ dtbo-y += tegra234-p3767-camera-p3768-imx219-A.dtbo
+@@ -60,6 +60,23 @@ dtbo-y += tegra234-p3767-camera-p3768-imx219-A.dtbo
  dtbo-y += tegra234-p3767-camera-p3768-imx219-imx477.dtbo
  dtbo-y += tegra234-p3767-camera-p3768-imx477-C.dtbo
  dtbo-y += tegra234-p3767-camera-p3768-imx477-A.dtbo
@@ -26,6 +26,7 @@ index c88bbe2..2e24c2d 100644
 +dtbo-y += tegra234-camera-d4xx-overlay-fg12-16ch-cams-0-1-2-3.dtbo
 +dtbo-y += tegra234-camera-d4xx-overlay-fg12-16ch-cams-0-4.dtbo
 +dtbo-y += tegra234-camera-d4xx-overlay-fg12-16ch-cams-0-4-8-12.dtbo
++dtbo-y += tegra234-camera-d4xx-overlay-advantech.dtbo
 +dtbo-y += tegra234-camera-d4xx-overlay.calib.dtbo
 +dtbo-y += tegra234-camera-d4xx-overlay-dual.calib.dtbo
 +dtbo-y += tegra234-camera-d4xx-overlay-max96712-EVB.calib.dtbo

--- a/hardware/realsense/tegra234-camera-d4xx-overlay-advantech.dts
+++ b/hardware/realsense/tegra234-camera-d4xx-overlay-advantech.dts
@@ -201,6 +201,7 @@
 						csi-mode = "2x4";
 						channel = "a";
 						pwdn-gpios = <&gpio CAM2_PWDN GPIO_ACTIVE_HIGH>;
+						force_clk0;
 					};
 
 					ser_a: max9295_a@40 {

--- a/hardware/realsense/tegra234-camera-d4xx-overlay-advantech.dts
+++ b/hardware/realsense/tegra234-camera-d4xx-overlay-advantech.dts
@@ -1,0 +1,453 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// SPDX-FileCopyrightText: Copyright (c) 2018-2023, INTEL CORPORATION.  All rights reserved.
+
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/clock/tegra234-clock.h>
+#include <dt-bindings/gpio/tegra234-gpio.h>
+#include <dt-bindings/tegra234-p3737-0000+p3701-0000.h>
+
+#define CAM0_PWDN	TEGRA234_MAIN_GPIO(H, 6)  //MAX96712_1 PWDN
+#define CAM1_PWDN	TEGRA234_MAIN_GPIO(H, 3)  //MAX96712_2 PWDN
+#define CAM2_PWDN	TEGRA234_MAIN_GPIO(AC, 0) //MAX96712_3 PWDN
+#define CAM3_PWDN	TEGRA234_MAIN_GPIO(AC, 1) //MAX96712_4 PWDN
+#define CAM12V_POC	TEGRA234_MAIN_GPIO(AC, 7)
+
+/* camera control gpio definitions */
+/ {
+	overlay-name = "Jetson RealSense Camera D4xx with max96712 for Orin Advantech";
+	jetson-header-name = "Jetson AGX CSI Connector";
+	compatible = JETSON_COMPATIBLE;
+
+	fragment@1 {
+		target-path = "/";
+		__overlay__ {
+			vdd_cam12v_poc: regulator-vdd-cam12v-poc {
+					compatible = "regulator-fixed";
+					regulator-name = "vdd-cam12v-poc";
+					regulator-min-microvolt = <12000000>;
+					regulator-max-microvolt = <12000000>;
+					gpio = <&gpio CAM12V_POC GPIO_ACTIVE_HIGH>;
+					enable-active-high;
+					regulator-always-on;
+					regulator-boot-on;
+			};
+			vdd_cam0_pwdn: regulator-vdd-cam0-pwdn {
+					compatible = "regulator-fixed";
+					regulator-name = "vdd-cam0-pwdn";
+					regulator-min-microvolt = <1800000>;
+					regulator-max-microvolt = <1800000>;
+					gpio = <&gpio CAM0_PWDN GPIO_ACTIVE_HIGH>;
+					enable-active-high;
+					regulator-always-on;
+					regulator-boot-on;
+			};
+			vdd_cam1_pwdn: regulator-vdd-cam1-pwdn {
+					compatible = "regulator-fixed";
+					regulator-name = "vdd-cam1-pwdn";
+					regulator-min-microvolt = <1800000>;
+					regulator-max-microvolt = <1800000>;
+					gpio = <&gpio CAM1_PWDN GPIO_ACTIVE_HIGH>;
+					enable-active-high;
+					regulator-always-on;
+					regulator-boot-on;
+			};
+			vdd_cam2_pwdn: regulator-vdd-cam2-pwdn {
+					compatible = "regulator-fixed";
+					regulator-name = "vdd-cam2-pwdn";
+					regulator-min-microvolt = <1800000>;
+					regulator-max-microvolt = <1800000>;
+					gpio = <&gpio CAM2_PWDN GPIO_ACTIVE_HIGH>;
+					enable-active-high;
+					regulator-always-on;
+					regulator-boot-on;
+			};
+			vdd_cam3_pwdn: regulator-vdd-cam3-pwdn {
+					compatible = "regulator-fixed";
+					regulator-name = "vdd-cam3-pwdn";
+					regulator-min-microvolt = <1800000>;
+					regulator-max-microvolt = <1800000>;
+					gpio = <&gpio CAM3_PWDN GPIO_ACTIVE_HIGH>;
+					enable-active-high;
+					regulator-always-on;
+					regulator-boot-on;
+			};
+		};
+	};
+	fragment@0 {
+		target-path = "/";
+		__overlay__ {
+			tegra-capture-vi {
+				num-channels = <4>;
+				ports {
+					status = "okay";
+					port@0 {
+						status = "okay";
+						reg = <0>;
+						d4xx_vi_in0: endpoint {
+							status = "okay";
+							vc-id = <0>;
+							port-index = <0>;
+							bus-width = <2>;
+							remote-endpoint = <&d4xx_csi_out0>;
+						};
+					};
+					port@1 {
+						status = "okay";
+						reg = <1>;
+						d4xx_vi_in1: endpoint {
+							status = "okay";
+							vc-id = <1>;
+							port-index = <0>;
+							bus-width = <2>;
+							remote-endpoint = <&d4xx_csi_out1>;
+						};
+					};
+					port@2 {
+						status = "okay";
+						reg = <2>;
+						d4xx_vi_in2: endpoint {
+							status = "okay";
+							vc-id = <2>;
+							port-index = <0>;
+							bus-width = <2>;
+							remote-endpoint = <&d4xx_csi_out2>;
+						};
+					};
+					port@3 {
+						status = "okay";
+						reg = <3>;
+						d4xx_vi_in3: endpoint {
+							status = "okay";
+							vc-id = <3>;
+							port-index = <0>;
+							bus-width = <2>;
+							remote-endpoint = <&d4xx_csi_out3>;
+						};
+					};
+				};
+			};
+
+			bus@0 {
+				host1x@13e00000 {
+					nvcsi@15a00000 {
+						num-channels = <4>;
+						channel@0 {
+							status = "okay";
+							reg = <0>;
+							ports {
+								status = "okay";
+								port@0 {
+									status = "okay";
+									reg = <0>;
+									d4xx_csi_in0: endpoint@0 {
+										status = "okay";
+										port-index = <0>;
+										bus-width = <2>;
+										remote-endpoint = <&ds5_0_out>;
+									};
+								};
+								port@1 {
+									status = "okay";
+									reg = <1>;
+									d4xx_csi_out0: endpoint@1 {
+										status = "okay";
+										remote-endpoint = <&d4xx_vi_in0>;
+									};
+								};
+							};
+						};
+						channel@1 {
+							status = "okay";
+							reg = <1>;
+							ports {
+								status = "okay";
+								port@0 {
+									status = "okay";
+									reg = <0>;
+									d4xx_csi_in1: endpoint@2 {
+										status = "okay";
+										port-index = <0>;
+										bus-width = <2>;
+										remote-endpoint = <&ds5_1_out>;
+									};
+								};
+								port@1 {
+									status = "okay";
+									reg = <1>;
+									d4xx_csi_out1: endpoint@3 {
+										status = "okay";
+										remote-endpoint = <&d4xx_vi_in1>;
+									};
+								};
+							};
+						};
+						channel@2 {
+							status = "okay";
+							reg = <2>;
+							ports {
+								status = "okay";
+								port@0 {
+									status = "okay";
+									reg = <0>;
+									d4xx_csi_in2: endpoint@4 {
+										status = "okay";
+										port-index = <0>;
+										bus-width = <2>;
+										remote-endpoint = <&ds5_2_out>;
+									};
+								};
+								port@1 {
+									status = "okay";
+									reg = <1>;
+									d4xx_csi_out2: endpoint@5 {
+										status = "okay";
+										remote-endpoint = <&d4xx_vi_in2>;
+									};
+								};
+							};
+						};
+						channel@3 {
+							status = "okay";
+							reg = <3>;
+							ports {
+								status = "okay";
+								port@0 {
+									status = "okay";
+									reg = <0>;
+									d4xx_csi_in3: endpoint@6 {
+										status = "okay";
+										port-index = <0>;
+										bus-width = <2>;
+										remote-endpoint = <&ds5_3_out>;
+									};
+								};
+								port@1 {
+									status = "okay";
+									reg = <1>;
+									d4xx_csi_out3: endpoint@7 {
+										status = "okay";
+										remote-endpoint = <&d4xx_vi_in3>;
+									};
+								};
+							};
+						};
+					};
+				};
+
+				i2c@3180000 {
+					clock-frequency = <100000>;
+
+					dser: max96712@29 {
+						status = "okay";
+						reg = <0x29>;
+						compatible = "maxim,max96712";
+						csi-mode = "2x4";
+						channel = "a";
+						//pwdn-gpios = <&gpio CAM0_PWDN GPIO_ACTIVE_HIGH>;
+					};
+
+					ser_a: max9295_a@40 {
+						status = "okay";
+						compatible = "maxim,max9295";
+						reg = <0x40>;
+						maxim,gmsl-dser-device = <&dser>;
+					};
+
+					ds5_3: ds5@1d {
+						status = "okay";
+						def-addr = <0x10>;
+						reg = <0x1d>;
+						override_reg = <0x1a>;
+						compatible = "intel,d4xx";
+						use_sensor_mode_id = "true";
+						//vcc-supply = <&vdd_cam12v_poc>;
+						cam-type = "IMU";
+						nvidia,gmsl-ser-device = <&ser_a>;
+						nvidia,gmsl-dser-device = <&dser>;
+						ports {
+							#address-cells = <1>;
+							#size-cells = <0>;
+
+							port@0 {
+								reg = <0>;
+								ds5_3_out: endpoint {
+									vc-id = <3>;
+									port-index = <3>;
+									bus-width = <2>;
+									remote-endpoint = <&d4xx_csi_in3>;
+								};
+							};
+						};
+						mode0 {
+							pixel_t = "grey_y16";
+							num_lanes = "2";
+							csi_pixel_bit_depth = "16";
+							active_w = "640";
+							active_h = "480";
+							tegra_sinterface = "serial_b";
+							mclk_khz = "24000";
+							pix_clk_hz = "74250000";
+							line_length = "1280"; /* 2200 */
+							embedded_metadata_height = "0";
+						};
+						gmsl-link {
+							src-csi-port = "b";
+							dst-csi-port = "a";
+							serdes-csi-link = "a";
+							csi-mode = "1x4";
+							st-vc = <0>;
+							vc-id = <3>;
+							num-lanes = <2>;
+						};
+					};
+
+					ds5_2: ds5@1c {
+						status = "okay";
+						def-addr = <0x10>;
+						reg = <0x1c>;
+						override_reg = <0x1a>;
+						compatible = "intel,d4xx";
+						use_sensor_mode_id = "true";
+						//vcc-supply = <&vdd_cam12v_poc>;
+						cam-type = "Y8";
+						nvidia,gmsl-ser-device = <&ser_a>;
+						nvidia,gmsl-dser-device = <&dser>;
+						ports {
+							#address-cells = <1>;
+							#size-cells = <0>;
+
+							port@0 {
+								reg = <0>;
+								ds5_2_out: endpoint {
+									vc-id = <2>;
+									port-index = <2>;
+									bus-width = <2>;
+									remote-endpoint = <&d4xx_csi_in2>;
+								};
+							};
+						};
+						/* mode0: Y8, mode1: depth D16 */
+						mode0 {
+							pixel_t = "grey_y16";
+							num_lanes = "2";
+							csi_pixel_bit_depth = "16";
+							active_w = "1280";
+							active_h = "720";
+							tegra_sinterface = "serial_b";
+							mclk_khz = "24000";
+							pix_clk_hz = "74250000";
+							line_length = "1280"; /* 2200 */
+							embedded_metadata_height = "1";
+						};
+						gmsl-link {
+							src-csi-port = "b";
+							dst-csi-port = "a";
+							serdes-csi-link = "a";
+							csi-mode = "1x4";
+							st-vc = <0>;
+							vc-id = <2>;
+							num-lanes = <2>;
+						};
+					};
+
+					ds5_1: ds5@1b {
+						status = "okay";
+						def-addr = <0x10>;
+						reg = <0x1b>;
+						override_reg = <0x1a>;
+						compatible = "intel,d4xx";
+						use_sensor_mode_id = "true";
+						//vcc-supply = <&vdd_cam12v_poc>;
+						cam-type = "RGB";
+						nvidia,gmsl-ser-device = <&ser_a>;
+						nvidia,gmsl-dser-device = <&dser>;
+						ports {
+							#address-cells = <1>;
+							#size-cells = <0>;
+
+							port@0 {
+								reg = <0>;
+								ds5_1_out: endpoint {
+									vc-id = <1>;
+									port-index = <1>;
+									bus-width = <2>;
+									remote-endpoint = <&d4xx_csi_in1>;
+								};
+							};
+						};
+						mode0 {
+							pixel_t = "grey_y16";
+							num_lanes = "2";
+							csi_pixel_bit_depth = "16";
+							active_w = "1920";
+							active_h = "1080";
+							tegra_sinterface = "serial_e";
+							mclk_khz = "24000";
+							pix_clk_hz = "74250000";
+							line_length = "1280"; /* 2200 */
+							embedded_metadata_height = "1";
+						};
+						gmsl-link {
+							src-csi-port = "b";
+							dst-csi-port = "a";
+							serdes-csi-link = "a";
+							csi-mode = "1x4";
+							st-vc = <0>;
+							vc-id = <1>;
+							num-lanes = <2>;
+						};
+					};
+
+					ds5_0: ds5@1a {
+						status = "okay";
+						def-addr = <0x10>;
+						reg = <0x1a>;
+						compatible = "intel,d4xx";
+						use_sensor_mode_id = "true";
+						//vcc-supply = <&vdd_cam12v_poc>;
+						cam-type = "Depth";
+						nvidia,gmsl-ser-device = <&ser_a>;
+						nvidia,gmsl-dser-device = <&dser>;
+						ports {
+							#address-cells = <1>;
+							#size-cells = <0>;
+
+							port@0 {
+								reg = <0>;
+								ds5_0_out: endpoint {
+									vc-id = <0>;
+									port-index = <0>;
+									bus-width = <2>;
+									remote-endpoint = <&d4xx_csi_in0>;
+								};
+							};
+						};
+						mode0 {
+							pixel_t = "grey_y16";
+							num_lanes = "2";
+							csi_pixel_bit_depth = "16";
+							active_w = "1280";
+							active_h = "720";
+							tegra_sinterface = "serial_a";
+							mclk_khz = "24000";
+							pix_clk_hz = "74250000";
+							line_length = "1280"; /* 2200 */
+							embedded_metadata_height = "1";
+						};
+						gmsl-link {
+							src-csi-port = "b";
+							dst-csi-port = "a";
+							serdes-csi-link = "a";
+							csi-mode = "1x4";
+							st-vc = <0>;
+							vc-id = <0>;
+							num-lanes = <2>;
+						};
+					};
+				};
+			};
+		};
+	};
+};

--- a/hardware/realsense/tegra234-camera-d4xx-overlay-advantech.dts
+++ b/hardware/realsense/tegra234-camera-d4xx-overlay-advantech.dts
@@ -8,10 +8,7 @@
 #include <dt-bindings/gpio/tegra234-gpio.h>
 #include <dt-bindings/tegra234-p3737-0000+p3701-0000.h>
 
-#define CAM0_PWDN	TEGRA234_MAIN_GPIO(H, 6)  //MAX96712_1 PWDN
-#define CAM1_PWDN	TEGRA234_MAIN_GPIO(H, 3)  //MAX96712_2 PWDN
 #define CAM2_PWDN	TEGRA234_MAIN_GPIO(AC, 0) //MAX96712_3 PWDN
-#define CAM3_PWDN	TEGRA234_MAIN_GPIO(AC, 1) //MAX96712_4 PWDN
 #define CAM12V_POC	TEGRA234_MAIN_GPIO(AC, 7)
 
 /* camera control gpio definitions */
@@ -30,48 +27,6 @@
 					regulator-max-microvolt = <12000000>;
 					gpio = <&gpio CAM12V_POC GPIO_ACTIVE_HIGH>;
 					enable-active-high;
-					regulator-always-on;
-					regulator-boot-on;
-			};
-			vdd_cam0_pwdn: regulator-vdd-cam0-pwdn {
-					compatible = "regulator-fixed";
-					regulator-name = "vdd-cam0-pwdn";
-					regulator-min-microvolt = <1800000>;
-					regulator-max-microvolt = <1800000>;
-					gpio = <&gpio CAM0_PWDN GPIO_ACTIVE_HIGH>;
-					enable-active-high;
-					regulator-always-on;
-					regulator-boot-on;
-			};
-			vdd_cam1_pwdn: regulator-vdd-cam1-pwdn {
-					compatible = "regulator-fixed";
-					regulator-name = "vdd-cam1-pwdn";
-					regulator-min-microvolt = <1800000>;
-					regulator-max-microvolt = <1800000>;
-					gpio = <&gpio CAM1_PWDN GPIO_ACTIVE_HIGH>;
-					enable-active-high;
-					regulator-always-on;
-					regulator-boot-on;
-			};
-			vdd_cam2_pwdn: regulator-vdd-cam2-pwdn {
-					compatible = "regulator-fixed";
-					regulator-name = "vdd-cam2-pwdn";
-					regulator-min-microvolt = <1800000>;
-					regulator-max-microvolt = <1800000>;
-					gpio = <&gpio CAM2_PWDN GPIO_ACTIVE_HIGH>;
-					enable-active-high;
-					regulator-always-on;
-					regulator-boot-on;
-			};
-			vdd_cam3_pwdn: regulator-vdd-cam3-pwdn {
-					compatible = "regulator-fixed";
-					regulator-name = "vdd-cam3-pwdn";
-					regulator-min-microvolt = <1800000>;
-					regulator-max-microvolt = <1800000>;
-					gpio = <&gpio CAM3_PWDN GPIO_ACTIVE_HIGH>;
-					enable-active-high;
-					regulator-always-on;
-					regulator-boot-on;
 			};
 		};
 	};
@@ -88,7 +43,7 @@
 						d4xx_vi_in0: endpoint {
 							status = "okay";
 							vc-id = <0>;
-							port-index = <0>;
+							port-index = <4>;
 							bus-width = <2>;
 							remote-endpoint = <&d4xx_csi_out0>;
 						};
@@ -99,7 +54,7 @@
 						d4xx_vi_in1: endpoint {
 							status = "okay";
 							vc-id = <1>;
-							port-index = <0>;
+							port-index = <4>;
 							bus-width = <2>;
 							remote-endpoint = <&d4xx_csi_out1>;
 						};
@@ -110,7 +65,7 @@
 						d4xx_vi_in2: endpoint {
 							status = "okay";
 							vc-id = <2>;
-							port-index = <0>;
+							port-index = <4>;
 							bus-width = <2>;
 							remote-endpoint = <&d4xx_csi_out2>;
 						};
@@ -121,7 +76,7 @@
 						d4xx_vi_in3: endpoint {
 							status = "okay";
 							vc-id = <3>;
-							port-index = <0>;
+							port-index = <4>;
 							bus-width = <2>;
 							remote-endpoint = <&d4xx_csi_out3>;
 						};
@@ -143,7 +98,7 @@
 									reg = <0>;
 									d4xx_csi_in0: endpoint@0 {
 										status = "okay";
-										port-index = <0>;
+										port-index = <4>;
 										bus-width = <2>;
 										remote-endpoint = <&ds5_0_out>;
 									};
@@ -168,7 +123,7 @@
 									reg = <0>;
 									d4xx_csi_in1: endpoint@2 {
 										status = "okay";
-										port-index = <0>;
+										port-index = <4>;
 										bus-width = <2>;
 										remote-endpoint = <&ds5_1_out>;
 									};
@@ -193,7 +148,7 @@
 									reg = <0>;
 									d4xx_csi_in2: endpoint@4 {
 										status = "okay";
-										port-index = <0>;
+										port-index = <4>;
 										bus-width = <2>;
 										remote-endpoint = <&ds5_2_out>;
 									};
@@ -218,7 +173,7 @@
 									reg = <0>;
 									d4xx_csi_in3: endpoint@6 {
 										status = "okay";
-										port-index = <0>;
+										port-index = <4>;
 										bus-width = <2>;
 										remote-endpoint = <&ds5_3_out>;
 									};
@@ -245,7 +200,7 @@
 						compatible = "maxim,max96712";
 						csi-mode = "2x4";
 						channel = "a";
-						//pwdn-gpios = <&gpio CAM0_PWDN GPIO_ACTIVE_HIGH>;
+						pwdn-gpios = <&gpio CAM2_PWDN GPIO_ACTIVE_HIGH>;
 					};
 
 					ser_a: max9295_a@40 {
@@ -262,7 +217,7 @@
 						override_reg = <0x1a>;
 						compatible = "intel,d4xx";
 						use_sensor_mode_id = "true";
-						//vcc-supply = <&vdd_cam12v_poc>;
+						vcc-supply = <&vdd_cam12v_poc>;
 						cam-type = "IMU";
 						nvidia,gmsl-ser-device = <&ser_a>;
 						nvidia,gmsl-dser-device = <&dser>;
@@ -310,7 +265,7 @@
 						override_reg = <0x1a>;
 						compatible = "intel,d4xx";
 						use_sensor_mode_id = "true";
-						//vcc-supply = <&vdd_cam12v_poc>;
+						vcc-supply = <&vdd_cam12v_poc>;
 						cam-type = "Y8";
 						nvidia,gmsl-ser-device = <&ser_a>;
 						nvidia,gmsl-dser-device = <&dser>;
@@ -359,7 +314,7 @@
 						override_reg = <0x1a>;
 						compatible = "intel,d4xx";
 						use_sensor_mode_id = "true";
-						//vcc-supply = <&vdd_cam12v_poc>;
+						vcc-supply = <&vdd_cam12v_poc>;
 						cam-type = "RGB";
 						nvidia,gmsl-ser-device = <&ser_a>;
 						nvidia,gmsl-dser-device = <&dser>;
@@ -406,7 +361,7 @@
 						reg = <0x1a>;
 						compatible = "intel,d4xx";
 						use_sensor_mode_id = "true";
-						//vcc-supply = <&vdd_cam12v_poc>;
+						vcc-supply = <&vdd_cam12v_poc>;
 						cam-type = "Depth";
 						nvidia,gmsl-ser-device = <&ser_a>;
 						nvidia,gmsl-dser-device = <&dser>;

--- a/kernel/nvidia/5.0.2/0017-Adding-max96712-support-for-D4xx.patch
+++ b/kernel/nvidia/5.0.2/0017-Adding-max96712-support-for-D4xx.patch
@@ -1,20 +1,20 @@
-From 285bd68575eed4f7ff2cac5be4c2c10f2939050f Mon Sep 17 00:00:00 2001
+From fc25f4abf2e8e2a692c1c0723d4974cca81334c4 Mon Sep 17 00:00:00 2001
 From: ejgoldik <ehud.joseph.goldik@realsenseai.com>
-Date: Thu, 26 Mar 2026 16:04:31 +0200
+Date: Sun, 5 Apr 2026 12:15:24 +0300
 Subject: [PATCH] Adding max96712 support for D4xx
 
 Add MAX96712 deserializer driver support for D4XX cameras.
 
 Signed-off-by: ejgoldik <ehud.joseph.goldik@realsenseai.com>
 ---
- drivers/media/i2c/max96712.c | 582 ++++++++++++++++++++++++++++++++++-
- 1 file changed, 578 insertions(+), 4 deletions(-)
+ drivers/media/i2c/max96712.c | 589 ++++++++++++++++++++++++++++++++++-
+ 1 file changed, 585 insertions(+), 4 deletions(-)
 
 diff --git a/drivers/media/i2c/max96712.c b/drivers/media/i2c/max96712.c
-index 8081385f0..f25dd824e 100644
+index 8081385f0..576fa46cd 100644
 --- a/drivers/media/i2c/max96712.c
 +++ b/drivers/media/i2c/max96712.c
-@@ -21,18 +21,85 @@
+@@ -21,18 +21,86 @@
  #include <linux/debugfs.h>
  #include <media/camera_common.h>
  #include <linux/module.h>
@@ -92,6 +92,7 @@ index 8081385f0..f25dd824e 100644
 +	int pwdn_gpio;
 +	int link_mask;
 +	bool video_pipe_alloc[MAX96712_MAX_PIPES];
++	bool force_clk0;
  };
  struct max96712 *global_priv[4] ;
  
@@ -102,7 +103,7 @@ index 8081385f0..f25dd824e 100644
  {
  	struct i2c_client *i2c_client = NULL;
  	int bak = 0;
-@@ -85,6 +152,52 @@ int max96712_read_reg_Dser(int slaveAddr,int channel,
+@@ -85,6 +153,52 @@ int max96712_read_reg_Dser(int slaveAddr,int channel,
  
  EXPORT_SYMBOL(max96712_read_reg_Dser);
  
@@ -155,7 +156,7 @@ index 8081385f0..f25dd824e 100644
  static int max96712_read_reg(struct max96712 *priv,
  			u16 addr, unsigned int *val)
  {
-@@ -99,6 +212,20 @@ static int max96712_read_reg(struct max96712 *priv,
+@@ -99,6 +213,20 @@ static int max96712_read_reg(struct max96712 *priv,
  	return err;
  }
  
@@ -176,7 +177,7 @@ index 8081385f0..f25dd824e 100644
  
  static int max96712_stats_show(struct seq_file *s, void *data)
  {
-@@ -169,7 +296,10 @@ static int max96712_debugfs_init(const char *dir_name,
+@@ -169,7 +297,10 @@ static int max96712_debugfs_init(const char *dir_name,
  	if (np) {
  		err = of_property_read_string(np, "channel", &priv->channel);
  		if (err)
@@ -187,7 +188,7 @@ index 8081385f0..f25dd824e 100644
  
  		err = snprintf(dev_name, sizeof(dev_name), "max96712_%s", priv->channel);
  		if (err < 0)
-@@ -208,7 +338,8 @@ static int max96712_debugfs_init(const char *dir_name,
+@@ -208,7 +339,8 @@ static int max96712_debugfs_init(const char *dir_name,
  static  struct regmap_config max96712_regmap_config = {
  	.reg_bits = 16,
  	.val_bits = 8,
@@ -197,7 +198,7 @@ index 8081385f0..f25dd824e 100644
  };
  
  static int max96712_probe(struct i2c_client *client,
-@@ -216,6 +347,8 @@ static int max96712_probe(struct i2c_client *client,
+@@ -216,6 +348,8 @@ static int max96712_probe(struct i2c_client *client,
  {
  	struct max96712 *priv;
  	int err = 0;
@@ -206,7 +207,7 @@ index 8081385f0..f25dd824e 100644
  
  	dev_info(&client->dev, "%s: enter\n", __func__);
  
-@@ -228,10 +361,36 @@ static int max96712_probe(struct i2c_client *client,
+@@ -228,10 +362,42 @@ static int max96712_probe(struct i2c_client *client,
  			"regmap init failed: %ld\n", PTR_ERR(priv->regmap));
  		return -ENODEV;
  	}
@@ -231,6 +232,12 @@ index 8081385f0..f25dd824e 100644
 +		} else {
 +			priv->link_mask = value;
 +		}
++
++		if (of_get_property(np, "force_clk0", NULL)) {
++			priv->force_clk0 = true;
++		} else {
++			priv->force_clk0 = false;
++		}
 +	}
 +
 +	dev_set_drvdata(&client->dev, priv);
@@ -243,7 +250,7 @@ index 8081385f0..f25dd824e 100644
  
  	/*set daymode by fault*/
  	dev_info(&client->dev, "%s:  success\n", __func__);
-@@ -243,8 +402,12 @@ static int max96712_probe(struct i2c_client *client,
+@@ -243,8 +409,12 @@ static int max96712_probe(struct i2c_client *client,
  static int
  max96712_remove(struct i2c_client *client)
  {
@@ -256,7 +263,7 @@ index 8081385f0..f25dd824e 100644
  		i2c_unregister_device(client);
  		client = NULL;
  	}
-@@ -252,13 +415,423 @@ max96712_remove(struct i2c_client *client)
+@@ -252,13 +422,423 @@ max96712_remove(struct i2c_client *client)
  	return 0;
  }
  
@@ -446,7 +453,7 @@ index 8081385f0..f25dd824e 100644
 +	struct reg_pair map_phy_opt[] =
 +	{
 +		/* MIPI D-PHY Config */
-+		{MAX96712_MIPI_PHY0_ADDR, 0x24}, //0x8A0
++		{MAX96712_MIPI_PHY0_ADDR, (priv->force_clk0 ? 0x20 : 0x0) | 0x04}, //0x8A0
 +		{MAX96712_MIPI_TX10_ADDR, 0x50}, //0x94a - 2 MIPI lanes (Master controller for PHYA), and enable extended VC
 +		{MAX96712_MIPI_PHY3_ADDR, 0xe4}, //0x8A3, Lower phys to lower lanes
 +
@@ -681,7 +688,7 @@ index 8081385f0..f25dd824e 100644
  	{ },
  };
  
-@@ -268,6 +841,7 @@ static struct i2c_driver max96712_i2c_driver = {
+@@ -268,6 +848,7 @@ static struct i2c_driver max96712_i2c_driver = {
  	.driver = {
  		.name = "max96712",
  		.owner = THIS_MODULE,

--- a/kernel/nvidia/5.0.2/0017-Adding-max96712-support-for-D4xx.patch
+++ b/kernel/nvidia/5.0.2/0017-Adding-max96712-support-for-D4xx.patch
@@ -446,7 +446,7 @@ index 8081385f0..f25dd824e 100644
 +	struct reg_pair map_phy_opt[] =
 +	{
 +		/* MIPI D-PHY Config */
-+		{MAX96712_MIPI_PHY0_ADDR, 0x04}, //0x8A0
++		{MAX96712_MIPI_PHY0_ADDR, 0x24}, //0x8A0
 +		{MAX96712_MIPI_TX10_ADDR, 0x50}, //0x94a - 2 MIPI lanes (Master controller for PHYA), and enable extended VC
 +		{MAX96712_MIPI_PHY3_ADDR, 0xe4}, //0x8A3, Lower phys to lower lanes
 +

--- a/kernel/nvidia/5.1.2/0007-Adding-max96712-support-for-D4xx.patch
+++ b/kernel/nvidia/5.1.2/0007-Adding-max96712-support-for-D4xx.patch
@@ -529,7 +529,7 @@ index 329a10dfd..ebc6a1dfc 100644
 +	struct reg_pair map_phy_opt[] =
 +	{
 +		/* MIPI D-PHY Config */
-+		{MAX96712_MIPI_PHY0_ADDR, 0x04}, //0x8A0
++		{MAX96712_MIPI_PHY0_ADDR, 0x24}, //0x8A0
 +		{MAX96712_MIPI_TX10_ADDR, 0x50}, //0x94a - 2 MIPI lanes (Master controller for PHYA), and enable extended VC
 +		{MAX96712_MIPI_PHY3_ADDR, 0xe4}, //0x8A3, Lower phys to lower lanes
 +

--- a/kernel/nvidia/5.1.2/0007-Adding-max96712-support-for-D4xx.patch
+++ b/kernel/nvidia/5.1.2/0007-Adding-max96712-support-for-D4xx.patch
@@ -1,20 +1,20 @@
-From ee9521bccd1ba105c52e35c849c99545f875cbcd Mon Sep 17 00:00:00 2001
+From ea9bfb07096f7f51f79adce80a1a2d6aefb84df7 Mon Sep 17 00:00:00 2001
 From: ejgoldik <ehud.joseph.goldik@realsenseai.com>
-Date: Thu, 26 Mar 2026 16:12:51 +0200
+Date: Sun, 5 Apr 2026 12:20:09 +0300
 Subject: [PATCH] Adding max96712 support for D4xx
 
 Add MAX96712 deserializer driver support for D4XX cameras.
 
 Signed-off-by: ejgoldik <ehud.joseph.goldik@realsenseai.com>
 ---
- drivers/media/i2c/max96712.c | 623 ++++++++++++++++++++++++++++++++---
- 1 file changed, 582 insertions(+), 41 deletions(-)
+ drivers/media/i2c/max96712.c | 630 ++++++++++++++++++++++++++++++++---
+ 1 file changed, 589 insertions(+), 41 deletions(-)
 
 diff --git a/drivers/media/i2c/max96712.c b/drivers/media/i2c/max96712.c
-index 329a10dfd..ebc6a1dfc 100644
+index 329a10dfd..fa96cf6c5 100644
 --- a/drivers/media/i2c/max96712.c
 +++ b/drivers/media/i2c/max96712.c
-@@ -21,32 +21,93 @@
+@@ -21,32 +21,94 @@
  #include <linux/debugfs.h>
  #include <media/camera_common.h>
  #include <linux/module.h>
@@ -93,6 +93,7 @@ index 329a10dfd..ebc6a1dfc 100644
 +	int pwdn_gpio;
 +	int link_mask;
 +	bool video_pipe_alloc[MAX96712_MAX_PIPES];
++	bool force_clk0;
  };
  struct max96712 *global_priv[4] ;
  
@@ -115,7 +116,7 @@ index 329a10dfd..ebc6a1dfc 100644
  	i2c_client = global_priv[channel]->i2c_client;
  	bak = i2c_client->addr;
  
-@@ -58,9 +119,9 @@ int max96712_write_reg_Dser(int slaveAddr,int channel,
+@@ -58,9 +120,9 @@ int max96712_write_reg_Dser(int slaveAddr,int channel,
  	{
  		dev_err(&i2c_client->dev, "%s: addr = 0x%x, val = 0x%x\n",
  				__func__, addr, val);
@@ -127,7 +128,7 @@ index 329a10dfd..ebc6a1dfc 100644
  }
  
  EXPORT_SYMBOL(max96712_write_reg_Dser);
-@@ -71,11 +132,9 @@ int max96712_read_reg_Dser(int slaveAddr,int channel,
+@@ -71,11 +133,9 @@ int max96712_read_reg_Dser(int slaveAddr,int channel,
  {
  	struct i2c_client *i2c_client = NULL;
  	int bak = 0;
@@ -140,7 +141,7 @@ index 329a10dfd..ebc6a1dfc 100644
  	i2c_client = global_priv[channel]->i2c_client;
  	bak = i2c_client->addr;
  	i2c_client->addr = slaveAddr / 2;
-@@ -85,13 +144,60 @@ int max96712_read_reg_Dser(int slaveAddr,int channel,
+@@ -85,13 +145,60 @@ int max96712_read_reg_Dser(int slaveAddr,int channel,
  	{
  		dev_err(&i2c_client->dev, "%s: addr = 0x%x, val = 0x%x\n",
  				__func__, addr, *val);
@@ -203,7 +204,7 @@ index 329a10dfd..ebc6a1dfc 100644
  static int max96712_read_reg(struct max96712 *priv,
  			u16 addr, unsigned int *val)
  {
-@@ -106,6 +212,20 @@ static int max96712_read_reg(struct max96712 *priv,
+@@ -106,6 +213,20 @@ static int max96712_read_reg(struct max96712 *priv,
  	return err;
  }
  
@@ -224,7 +225,7 @@ index 329a10dfd..ebc6a1dfc 100644
  
  static int max96712_stats_show(struct seq_file *s, void *data)
  {
-@@ -161,24 +281,6 @@ static const struct file_operations max96712_debugfs_fops = {
+@@ -161,24 +282,6 @@ static const struct file_operations max96712_debugfs_fops = {
  	.release = single_release,
  };
  
@@ -249,7 +250,7 @@ index 329a10dfd..ebc6a1dfc 100644
  static int max96712_debugfs_init(const char *dir_name,
  				struct dentry **d_entry,
  				struct dentry **f_entry,
-@@ -194,7 +296,10 @@ static int max96712_debugfs_init(const char *dir_name,
+@@ -194,7 +297,10 @@ static int max96712_debugfs_init(const char *dir_name,
  	if (np) {
  		err = of_property_read_string(np, "channel", &priv->channel);
  		if (err)
@@ -260,7 +261,7 @@ index 329a10dfd..ebc6a1dfc 100644
  
  		err = snprintf(dev_name, sizeof(dev_name), "max96712_%s", priv->channel);
  		if (err < 0)
-@@ -233,7 +338,8 @@ static int max96712_debugfs_init(const char *dir_name,
+@@ -233,7 +339,8 @@ static int max96712_debugfs_init(const char *dir_name,
  static  struct regmap_config max96712_regmap_config = {
  	.reg_bits = 16,
  	.val_bits = 8,
@@ -270,7 +271,7 @@ index 329a10dfd..ebc6a1dfc 100644
  };
  
  static int max96712_probe(struct i2c_client *client,
-@@ -241,9 +347,11 @@ static int max96712_probe(struct i2c_client *client,
+@@ -241,9 +348,11 @@ static int max96712_probe(struct i2c_client *client,
  {
  	struct max96712 *priv;
  	int err = 0;
@@ -283,7 +284,7 @@ index 329a10dfd..ebc6a1dfc 100644
  	priv = devm_kzalloc(&client->dev, sizeof(*priv), GFP_KERNEL);
  	priv->i2c_client = client;
  	priv->regmap = devm_regmap_init_i2c(priv->i2c_client,
-@@ -253,18 +361,36 @@ static int max96712_probe(struct i2c_client *client,
+@@ -253,18 +362,42 @@ static int max96712_probe(struct i2c_client *client,
  			"regmap init failed: %ld\n", PTR_ERR(priv->regmap));
  		return -ENODEV;
  	}
@@ -314,6 +315,12 @@ index 329a10dfd..ebc6a1dfc 100644
 +		} else {
 +			priv->link_mask = value;
 +		}
++
++		if (of_get_property(np, "force_clk0", NULL)) {
++			priv->force_clk0 = true;
++		} else {
++			priv->force_clk0 = false;
++		}
  	}
  
 +	dev_set_drvdata(&client->dev, priv);
@@ -326,7 +333,7 @@ index 329a10dfd..ebc6a1dfc 100644
  
  	/*set daymode by fault*/
  	dev_info(&client->dev, "%s:  success\n", __func__);
-@@ -276,8 +402,12 @@ static int max96712_probe(struct i2c_client *client,
+@@ -276,8 +409,12 @@ static int max96712_probe(struct i2c_client *client,
  static int
  max96712_remove(struct i2c_client *client)
  {
@@ -339,7 +346,7 @@ index 329a10dfd..ebc6a1dfc 100644
  		i2c_unregister_device(client);
  		client = NULL;
  	}
-@@ -285,13 +415,423 @@ max96712_remove(struct i2c_client *client)
+@@ -285,13 +422,423 @@ max96712_remove(struct i2c_client *client)
  	return 0;
  }
  
@@ -529,7 +536,7 @@ index 329a10dfd..ebc6a1dfc 100644
 +	struct reg_pair map_phy_opt[] =
 +	{
 +		/* MIPI D-PHY Config */
-+		{MAX96712_MIPI_PHY0_ADDR, 0x24}, //0x8A0
++		{MAX96712_MIPI_PHY0_ADDR, (priv->force_clk0 ? 0x20 : 0x0) | 0x04}, //0x8A0
 +		{MAX96712_MIPI_TX10_ADDR, 0x50}, //0x94a - 2 MIPI lanes (Master controller for PHYA), and enable extended VC
 +		{MAX96712_MIPI_PHY3_ADDR, 0xe4}, //0x8A3, Lower phys to lower lanes
 +
@@ -764,7 +771,7 @@ index 329a10dfd..ebc6a1dfc 100644
  	{ },
  };
  
-@@ -301,6 +841,7 @@ static struct i2c_driver max96712_i2c_driver = {
+@@ -301,6 +848,7 @@ static struct i2c_driver max96712_i2c_driver = {
  	.driver = {
  		.name = "max96712",
  		.owner = THIS_MODULE,

--- a/nvidia-oot/6.0/0006-Adding-max96712-support-for-D4xx.patch
+++ b/nvidia-oot/6.0/0006-Adding-max96712-support-for-D4xx.patch
@@ -495,7 +495,7 @@ index 8e237eef..c4577bbb 100644
 +	struct reg_pair map_phy_opt[] =
 +	{
 +		/* MIPI D-PHY Config */
-+		{MAX96712_MIPI_PHY0_ADDR, 0x04}, //0x8A0
++		{MAX96712_MIPI_PHY0_ADDR, 0x24}, //0x8A0
 +		{MAX96712_MIPI_TX10_ADDR, 0x50}, //0x94a - 2 MIPI lanes (Master controller for PHYA), and enable extended VC
 +		{MAX96712_MIPI_PHY3_ADDR, 0xe4}, //0x8A3, Lower phys to lower lanes
 +

--- a/nvidia-oot/6.0/0006-Adding-max96712-support-for-D4xx.patch
+++ b/nvidia-oot/6.0/0006-Adding-max96712-support-for-D4xx.patch
@@ -1,20 +1,20 @@
-From 0273a0938bb1e2242f8b68e0167175a0a99f17f9 Mon Sep 17 00:00:00 2001
+From dc06b3300426ab0cc1543a1949955d79ebea46bd Mon Sep 17 00:00:00 2001
 From: ejgoldik <ehud.joseph.goldik@realsenseai.com>
-Date: Thu, 26 Mar 2026 15:49:47 +0200
+Date: Sun, 5 Apr 2026 12:02:47 +0300
 Subject: [PATCH] Adding max96712 support for D4xx
 
 Add MAX96712 deserializer driver support for D4XX cameras.
 
 Signed-off-by: ejgoldik <ehud.joseph.goldik@realsenseai.com>
 ---
- drivers/media/i2c/max96712.c | 563 ++++++++++++++++++++++++++++++++---
- 1 file changed, 526 insertions(+), 37 deletions(-)
+ drivers/media/i2c/max96712.c | 570 ++++++++++++++++++++++++++++++++---
+ 1 file changed, 533 insertions(+), 37 deletions(-)
 
 diff --git a/drivers/media/i2c/max96712.c b/drivers/media/i2c/max96712.c
-index 8e237eef..c4577bbb 100644
+index 8e237eef..4fdc5cf5 100644
 --- a/drivers/media/i2c/max96712.c
 +++ b/drivers/media/i2c/max96712.c
-@@ -16,32 +16,93 @@
+@@ -16,32 +16,94 @@
  #include <linux/gpio.h>
  #include <linux/of.h>
  #include <linux/of_gpio.h>
@@ -91,6 +91,7 @@ index 8e237eef..c4577bbb 100644
 +	int pwdn_gpio;
 +	int link_mask;
 +	bool video_pipe_alloc[MAX96712_MAX_PIPES];
++	bool force_clk0;
  };
  static struct max96712 *global_priv[4];
  
@@ -114,7 +115,7 @@ index 8e237eef..c4577bbb 100644
  	i2c_client = global_priv[channel]->i2c_client;
  	bak = i2c_client->addr;
  
-@@ -53,7 +114,6 @@ int max96712_write_reg_Dser(int slaveAddr, int channel,
+@@ -53,7 +115,6 @@ int max96712_write_reg_Dser(int slaveAddr, int channel,
  		dev_err(&i2c_client->dev, "%s: addr = 0x%x, val = 0x%x\n",
  				__func__, addr, val);
  	}
@@ -122,7 +123,7 @@ index 8e237eef..c4577bbb 100644
  	return err;
  }
  EXPORT_SYMBOL(max96712_write_reg_Dser);
-@@ -68,8 +128,6 @@ int max96712_read_reg_Dser(int slaveAddr, int channel,
+@@ -68,8 +129,6 @@ int max96712_read_reg_Dser(int slaveAddr, int channel,
  
  	if (channel > 3 || channel < 0 || global_priv[channel] == NULL)
  		return -1;
@@ -131,7 +132,7 @@ index 8e237eef..c4577bbb 100644
  	i2c_client = global_priv[channel]->i2c_client;
  	bak = i2c_client->addr;
  	i2c_client->addr = slaveAddr / 2;
-@@ -80,11 +138,56 @@ int max96712_read_reg_Dser(int slaveAddr, int channel,
+@@ -80,11 +139,56 @@ int max96712_read_reg_Dser(int slaveAddr, int channel,
  		dev_err(&i2c_client->dev, "%s: addr = 0x%x, val = 0x%x\n",
  				__func__, addr, *val);
  	}
@@ -189,7 +190,7 @@ index 8e237eef..c4577bbb 100644
  static int max96712_read_reg(struct max96712 *priv,
  			u16 addr, unsigned int *val)
  {
-@@ -99,6 +202,20 @@ static int max96712_read_reg(struct max96712 *priv,
+@@ -99,6 +203,20 @@ static int max96712_read_reg(struct max96712 *priv,
  	return err;
  }
  
@@ -210,7 +211,7 @@ index 8e237eef..c4577bbb 100644
  
  static int max96712_stats_show(struct seq_file *s, void *data)
  {
-@@ -153,24 +270,6 @@ static const struct file_operations max96712_debugfs_fops = {
+@@ -153,24 +271,6 @@ static const struct file_operations max96712_debugfs_fops = {
  	.release = single_release,
  };
  
@@ -235,7 +236,7 @@ index 8e237eef..c4577bbb 100644
  static int max96712_debugfs_init(const char *dir_name,
  				struct dentry **d_entry,
  				struct dentry **f_entry,
-@@ -225,7 +324,8 @@ static int max96712_debugfs_init(const char *dir_name,
+@@ -225,7 +325,8 @@ static int max96712_debugfs_init(const char *dir_name,
  static  struct regmap_config max96712_regmap_config = {
  	.reg_bits = 16,
  	.val_bits = 8,
@@ -245,7 +246,7 @@ index 8e237eef..c4577bbb 100644
  };
  
  #if defined(NV_I2C_DRIVER_STRUCT_PROBE_WITHOUT_I2C_DEVICE_ID_ARG) /* Linux 6.3 */
-@@ -237,6 +337,8 @@ static int max96712_probe(struct i2c_client *client,
+@@ -237,6 +338,8 @@ static int max96712_probe(struct i2c_client *client,
  {
  	struct max96712 *priv;
  	int err = 0;
@@ -254,7 +255,7 @@ index 8e237eef..c4577bbb 100644
  
  	dev_info(&client->dev, "%s: enter\n", __func__);
  
-@@ -249,15 +351,31 @@ static int max96712_probe(struct i2c_client *client,
+@@ -249,15 +352,37 @@ static int max96712_probe(struct i2c_client *client,
  			"regmap init failed: %ld\n", PTR_ERR(priv->regmap));
  		return -ENODEV;
  	}
@@ -285,6 +286,12 @@ index 8e237eef..c4577bbb 100644
 +		} else {
 +			priv->link_mask = value;
 +		}
++
++		if (of_get_property(np, "force_clk0", NULL)) {
++			priv->force_clk0 = true;
++		} else {
++			priv->force_clk0 = false;
++		}
  	}
  
 +	dev_set_drvdata(&client->dev, priv);
@@ -292,7 +299,7 @@ index 8e237eef..c4577bbb 100644
  	err = max96712_debugfs_init(NULL, NULL, NULL, priv);
  	if (err)
  		return err;
-@@ -274,8 +392,11 @@ static int max96712_remove(struct i2c_client *client)
+@@ -274,8 +399,11 @@ static int max96712_remove(struct i2c_client *client)
  static void max96712_remove(struct i2c_client *client)
  #endif
  {
@@ -305,7 +312,7 @@ index 8e237eef..c4577bbb 100644
  		i2c_unregister_device(client);
  		client = NULL;
  	}
-@@ -284,13 +405,380 @@ static void max96712_remove(struct i2c_client *client)
+@@ -284,13 +412,380 @@ static void max96712_remove(struct i2c_client *client)
  #endif
  }
  
@@ -495,7 +502,7 @@ index 8e237eef..c4577bbb 100644
 +	struct reg_pair map_phy_opt[] =
 +	{
 +		/* MIPI D-PHY Config */
-+		{MAX96712_MIPI_PHY0_ADDR, 0x24}, //0x8A0
++		{MAX96712_MIPI_PHY0_ADDR, (priv->force_clk0 ? 0x20 : 0x0) | 0x04}, //0x8A0
 +		{MAX96712_MIPI_TX10_ADDR, 0x50}, //0x94a - 2 MIPI lanes (Master controller for PHYA), and enable extended VC
 +		{MAX96712_MIPI_PHY3_ADDR, 0xe4}, //0x8A3, Lower phys to lower lanes
 +
@@ -687,7 +694,7 @@ index 8e237eef..c4577bbb 100644
  	{ },
  };
  
-@@ -300,6 +788,7 @@ static struct i2c_driver max96712_i2c_driver = {
+@@ -300,6 +795,7 @@ static struct i2c_driver max96712_i2c_driver = {
  	.driver = {
  		.name = "max96712",
  		.owner = THIS_MODULE,


### PR DESCRIPTION
Added support for Advantech.
According to the vendor, this is for camera 0, but according to the device tree, this seems to be camera 4.

In a followup PR we will create another device tree for camera 0 and this device tree will either be removed or renamed to _4.dts