### PR TITLE
Fix max9296 power_off underflow issue (boot time reg write failure)

### DIFF
--- a/kernel/nvidia/5.0.2/0008-Modify-SerDes-reset-control.patch
+++ b/kernel/nvidia/5.0.2/0008-Modify-SerDes-reset-control.patch
@@ -33,12 +33,15 @@ diff --git a/drivers/media/i2c/max9296.c b/drivers/media/i2c/max9296.c
 index a01445c8f..2a61c9c74 100644
 --- a/drivers/media/i2c/max9296.c
 +++ b/drivers/media/i2c/max9296.c
-@@ -260,6 +260,9 @@ void max9296_power_off(struct device *dev)
+@@ -260,6 +260,12 @@ void max9296_power_off(struct device *dev)
  	mutex_lock(&priv->lock);
  	priv->pw_ref--;
- 
-+	if (priv->pw_ref < 0)
+
++	if (priv->pw_ref < 0) {
 +		priv->pw_ref = 0;
++		mutex_unlock(&priv->lock);
++		return;
++	}
 +
  	if (priv->pw_ref == 0) {
  		/* enter reset mode: XCLR */

--- a/kernel/nvidia/5.1.2/0001-Porting-driver-patches-to-jetpack-5.1.2.patch
+++ b/kernel/nvidia/5.1.2/0001-Porting-driver-patches-to-jetpack-5.1.2.patch
@@ -241,12 +241,15 @@ index 5f48c9b9f..316e687a1 100644
  
  #define MAX9296_PIPE_X_ST_SEL_ADDR 0x50
  
-@@ -260,6 +262,9 @@ void max9296_power_off(struct device *dev)
+@@ -260,6 +262,12 @@ void max9296_power_off(struct device *dev)
  	mutex_lock(&priv->lock);
  	priv->pw_ref--;
- 
-+	if (priv->pw_ref < 0)
+
++	if (priv->pw_ref < 0) {
 +		priv->pw_ref = 0;
++		mutex_unlock(&priv->lock);
++		return;
++	}
 +
  	if (priv->pw_ref == 0) {
  		/* enter reset mode: XCLR */

--- a/kernel/nvidia/5.1.6/0001-Porting-driver-patches-to-jetpack-5.1.2.patch
+++ b/kernel/nvidia/5.1.6/0001-Porting-driver-patches-to-jetpack-5.1.2.patch
@@ -241,12 +241,15 @@ index 5f48c9b9f..316e687a1 100644
  
  #define MAX9296_PIPE_X_ST_SEL_ADDR 0x50
  
-@@ -260,6 +262,9 @@ void max9296_power_off(struct device *dev)
+@@ -260,6 +262,12 @@ void max9296_power_off(struct device *dev)
  	mutex_lock(&priv->lock);
  	priv->pw_ref--;
- 
-+	if (priv->pw_ref < 0)
+
++	if (priv->pw_ref < 0) {
 +		priv->pw_ref = 0;
++		mutex_unlock(&priv->lock);
++		return;
++	}
 +
  	if (priv->pw_ref == 0) {
  		/* enter reset mode: XCLR */

--- a/kernel/realsense/d4xx.c
+++ b/kernel/realsense/d4xx.c
@@ -4246,6 +4246,11 @@ static int ds5_gmsl_serdes_setup(struct ds5 *state)
 	state->dser_ops->power_off(state->dser_dev);
 	/* For now no separate power on required for serializer device */
 	state->dser_ops->power_on(state->dser_dev);
+	/* Allow deserializer to stabilize after power cycle before I2C access.
+	 * With REGCACHE_NONE the first register write goes straight to I2C;
+	 * if the chip is still booting after XCLR deassert the write fails.
+	 */
+	msleep(600);
 
 	dev_dbg(dev, "Setup SERDES addressing and control pipeline\n");
 	/* setup serdes addressing and control pipeline */

--- a/kernel/realsense/d4xx.c
+++ b/kernel/realsense/d4xx.c
@@ -6855,4 +6855,4 @@ MODULE_AUTHOR("Guennadi Liakhovetski <guennadi.liakhovetski@intel.com>,\n\
 				Shikun Ding <shikun.ding@intel.com>,\n\
 				Dmitry Perchanov <dmitry.perchanov@intel.com>");
 MODULE_LICENSE("GPL v2");
-MODULE_VERSION("1.0.2.26");
+MODULE_VERSION("1.0.2.27");

--- a/nvidia-oot/6.0/0001-Porting-nvidia-driver-patches-to-jetpack-6.0.patch
+++ b/nvidia-oot/6.0/0001-Porting-nvidia-driver-patches-to-jetpack-6.0.patch
@@ -198,12 +198,15 @@ index 1ceaf3cd..97559460 100644
  
  #define MAX9296_PIPE_X_ST_SEL_ADDR 0x50
  
-@@ -250,6 +252,9 @@ void max9296_power_off(struct device *dev)
+@@ -250,6 +252,12 @@ void max9296_power_off(struct device *dev)
  	mutex_lock(&priv->lock);
  	priv->pw_ref--;
- 
-+	if (priv->pw_ref < 0)
+
++	if (priv->pw_ref < 0) {
 +		priv->pw_ref = 0;
++		mutex_unlock(&priv->lock);
++		return;
++	}
 +
  	if (priv->pw_ref == 0) {
  		/* enter reset mode: XCLR */

--- a/nvidia-oot/6.2/0001-Porting-nvidia-driver-patches-to-jetpack-6.0.patch
+++ b/nvidia-oot/6.2/0001-Porting-nvidia-driver-patches-to-jetpack-6.0.patch
@@ -198,12 +198,15 @@ index 1ceaf3cd..97559460 100644
  
  #define MAX9296_PIPE_X_ST_SEL_ADDR 0x50
  
-@@ -250,6 +252,9 @@ void max9296_power_off(struct device *dev)
+@@ -250,6 +252,12 @@ void max9296_power_off(struct device *dev)
  	mutex_lock(&priv->lock);
  	priv->pw_ref--;
- 
-+	if (priv->pw_ref < 0)
+
++	if (priv->pw_ref < 0) {
 +		priv->pw_ref = 0;
++		mutex_unlock(&priv->lock);
++		return;
++	}
 +
  	if (priv->pw_ref == 0) {
  		/* enter reset mode: XCLR */

--- a/nvidia-oot/7.0/0001-Porting-nvidia-driver-patches-to-jetpack-6.0.patch
+++ b/nvidia-oot/7.0/0001-Porting-nvidia-driver-patches-to-jetpack-6.0.patch
@@ -198,12 +198,15 @@ index 1ceaf3cd..97559460 100644
  
  #define MAX9296_PIPE_X_ST_SEL_ADDR 0x50
  
-@@ -250,6 +252,9 @@ void max9296_power_off(struct device *dev)
+@@ -250,6 +252,12 @@ void max9296_power_off(struct device *dev)
  	mutex_lock(&priv->lock);
  	priv->pw_ref--;
- 
-+	if (priv->pw_ref < 0)
+
++	if (priv->pw_ref < 0) {
 +		priv->pw_ref = 0;
++		mutex_unlock(&priv->lock);
++		return;
++	}
 +
  	if (priv->pw_ref == 0) {
  		/* enter reset mode: XCLR */

--- a/nvidia-oot/7.1/0001-Porting-nvidia-driver-patches-to-jetpack-6.0.patch
+++ b/nvidia-oot/7.1/0001-Porting-nvidia-driver-patches-to-jetpack-6.0.patch
@@ -198,12 +198,15 @@ index 1ceaf3cd..97559460 100644
  
  #define MAX9296_PIPE_X_ST_SEL_ADDR 0x50
  
-@@ -250,6 +252,9 @@ void max9296_power_off(struct device *dev)
+@@ -250,6 +252,12 @@ void max9296_power_off(struct device *dev)
  	mutex_lock(&priv->lock);
  	priv->pw_ref--;
- 
-+	if (priv->pw_ref < 0)
+
++	if (priv->pw_ref < 0) {
 +		priv->pw_ref = 0;
++		mutex_unlock(&priv->lock);
++		return;
++	}
 +
  	if (priv->pw_ref == 0) {
  		/* enter reset mode: XCLR */


### PR DESCRIPTION
Address a latent bug in max9296_power_off that caused spurious XCLR resets during probe by preventing underflow of pw_ref. Implement an early return when pw_ref underflows and add a settling delay to ensure proper stabilization after power cycles.