### PR TITLE
Fix d4xx RGB UYVY mapping across JetPack versions

### DIFF
--- a/kernel/nvidia/4.6.1/0079-Fix-d4xx-rgb-uyvy-and-y8i-order.patch
+++ b/kernel/nvidia/4.6.1/0079-Fix-d4xx-rgb-uyvy-and-y8i-order.patch
@@ -1,0 +1,12 @@
+diff --git a/drivers/media/platform/tegra/camera/vi/vi5_formats.h b/drivers/media/platform/tegra/camera/vi/vi5_formats.h
+--- a/drivers/media/platform/tegra/camera/vi/vi5_formats.h
++++ b/drivers/media/platform/tegra/camera/vi/vi5_formats.h
+@@ -148,5 +148,7 @@
+ 	TEGRA_VIDEO_FORMAT(YUV422, 16, UYVY8_1X16, 2, 1, T_U8_Y8__V8_Y8,
+ 				YUV422_8, Z16, "Depth 16"),
+-	TEGRA_VIDEO_FORMAT(YUV422, 16, VYUY8_1X16, 2, 1, T_V8_Y8__U8_Y8,
++	TEGRA_VIDEO_FORMAT(YUV422, 16, VYUY8_1X16, 2, 1, T_U8_Y8__V8_Y8,
+ 				YUV422_8, Y8I, "Y8I 16"),
++	TEGRA_VIDEO_FORMAT(YUV422, 16, UYVY8_2X8, 2, 1, T_U8_Y8__V8_Y8,
++				YUV422_8, YUYV, "YUV 4:2:2"),
+ 	// TODO: RealSesne calibration format Y12I should be 3-byte,

--- a/kernel/nvidia/5.0.2/0021-Fix-d4xx-rgb-uyvy-and-y8i-order.patch
+++ b/kernel/nvidia/5.0.2/0021-Fix-d4xx-rgb-uyvy-and-y8i-order.patch
@@ -1,0 +1,26 @@
+diff --git a/drivers/media/platform/tegra/camera/vi/vi5_formats.h b/drivers/media/platform/tegra/camera/vi/vi5_formats.h
+--- a/drivers/media/platform/tegra/camera/vi/vi5_formats.h
++++ b/drivers/media/platform/tegra/camera/vi/vi5_formats.h
+@@ -135,8 +135,8 @@
+ 				YUV422_8, YVYU, "YUV 4:2:2"),
+ 	// TEGRA_VIDEO_FORMAT(YUV422, 16, UYVY8_1X16, 1, 1, T_Y8__V8U8_N422,
+ 	// 			YUV422_8, NV16, "NV16"),
+-	TEGRA_VIDEO_FORMAT(YUV422, 16, UYVY8_2X8, 2, 1, T_U8_Y8__V8_Y8,
+-				YUV422_8, UYVY, "YUV 4:2:2 UYVY"),
++	// TEGRA_VIDEO_FORMAT(YUV422, 16, UYVY8_2X8, 2, 1, T_U8_Y8__V8_Y8,
++	// 			YUV422_8, UYVY, "YUV 4:2:2 UYVY"),
+ 	TEGRA_VIDEO_FORMAT(YUV422, 16, VYUY8_2X8, 2, 1, T_V8_Y8__U8_Y8,
+ 				YUV422_8, VYUY, "YUV 4:2:2 VYUY"),
+ 	TEGRA_VIDEO_FORMAT(YUV422, 16, YUYV8_2X8, 2, 1, T_Y8_U8__Y8_V8,
+@@ -146,8 +146,10 @@
+ 
+ 	TEGRA_VIDEO_FORMAT(YUV422, 16, UYVY8_1X16, 2, 1, T_U8_Y8__V8_Y8,
+ 				YUV422_8, Z16, "Depth 16"),
+-	TEGRA_VIDEO_FORMAT(YUV422, 16, VYUY8_1X16, 2, 1, T_V8_Y8__U8_Y8,
++	TEGRA_VIDEO_FORMAT(YUV422, 16, VYUY8_1X16, 2, 1, T_U8_Y8__V8_Y8,
+ 				YUV422_8, Y8I, "Y8I 16"),
++	TEGRA_VIDEO_FORMAT(YUV422, 16, UYVY8_2X8, 2, 1, T_U8_Y8__V8_Y8,
++				YUV422_8, YUYV, "YUV 4:2:2"),
+ 	// TODO: RealSesne calibration format Y12I should be 3-byte,
+ 	// R[7:3]R[3:0] | L[3:0]R[11:8] | L[11:8]L[7:4]
+ 	// but, currently, it's 4-byte, one byte is added as alignment

--- a/kernel/nvidia/5.1.2/0011-Fix-d4xx-rgb-uyvy-and-y8i-order.patch
+++ b/kernel/nvidia/5.1.2/0011-Fix-d4xx-rgb-uyvy-and-y8i-order.patch
@@ -1,0 +1,26 @@
+diff --git a/drivers/media/platform/tegra/camera/vi/vi5_formats.h b/drivers/media/platform/tegra/camera/vi/vi5_formats.h
+--- a/drivers/media/platform/tegra/camera/vi/vi5_formats.h
++++ b/drivers/media/platform/tegra/camera/vi/vi5_formats.h
+@@ -135,8 +135,8 @@
+ 				YUV422_8, YVYU, "YUV 4:2:2"),
+ 	// TEGRA_VIDEO_FORMAT(YUV422, 16, UYVY8_1X16, 1, 1, T_Y8__V8U8_N422,
+ 	// 			YUV422_8, NV16, "NV16"),
+-	TEGRA_VIDEO_FORMAT(YUV422, 16, UYVY8_2X8, 2, 1, T_U8_Y8__V8_Y8,
+-				YUV422_8, UYVY, "YUV 4:2:2 UYVY"),
++	// TEGRA_VIDEO_FORMAT(YUV422, 16, UYVY8_2X8, 2, 1, T_U8_Y8__V8_Y8,
++	// 			YUV422_8, UYVY, "YUV 4:2:2 UYVY"),
+ 	TEGRA_VIDEO_FORMAT(YUV422, 16, VYUY8_2X8, 2, 1, T_V8_Y8__U8_Y8,
+ 				YUV422_8, VYUY, "YUV 4:2:2 VYUY"),
+ 	TEGRA_VIDEO_FORMAT(YUV422, 16, YUYV8_2X8, 2, 1, T_Y8_U8__Y8_V8,
+@@ -146,8 +146,10 @@
+ 
+ 	TEGRA_VIDEO_FORMAT(YUV422, 16, UYVY8_1X16, 2, 1, T_U8_Y8__V8_Y8,
+ 				YUV422_8, Z16, "Depth 16"),
+-	TEGRA_VIDEO_FORMAT(YUV422, 16, VYUY8_1X16, 2, 1, T_V8_Y8__U8_Y8,
++	TEGRA_VIDEO_FORMAT(YUV422, 16, VYUY8_1X16, 2, 1, T_U8_Y8__V8_Y8,
+ 				YUV422_8, Y8I, "Y8I 16"),
++	TEGRA_VIDEO_FORMAT(YUV422, 16, UYVY8_2X8, 2, 1, T_U8_Y8__V8_Y8,
++				YUV422_8, YUYV, "YUV 4:2:2"),
+ 	// TODO: RealSesne calibration format Y12I should be 3-byte,
+ 	// R[7:3]R[3:0] | L[3:0]R[11:8] | L[11:8]L[7:4]
+ 	// but, currently, it's 4-byte, one byte is added as alignment

--- a/kernel/nvidia/5.1.6/0011-Fix-d4xx-rgb-uyvy-and-y8i-order.patch
+++ b/kernel/nvidia/5.1.6/0011-Fix-d4xx-rgb-uyvy-and-y8i-order.patch
@@ -1,0 +1,26 @@
+diff --git a/drivers/media/platform/tegra/camera/vi/vi5_formats.h b/drivers/media/platform/tegra/camera/vi/vi5_formats.h
+--- a/drivers/media/platform/tegra/camera/vi/vi5_formats.h
++++ b/drivers/media/platform/tegra/camera/vi/vi5_formats.h
+@@ -135,8 +135,8 @@
+ 				YUV422_8, YVYU, "YUV 4:2:2"),
+ 	// TEGRA_VIDEO_FORMAT(YUV422, 16, UYVY8_1X16, 1, 1, T_Y8__V8U8_N422,
+ 	// 			YUV422_8, NV16, "NV16"),
+-	TEGRA_VIDEO_FORMAT(YUV422, 16, UYVY8_2X8, 2, 1, T_U8_Y8__V8_Y8,
+-				YUV422_8, UYVY, "YUV 4:2:2 UYVY"),
++	// TEGRA_VIDEO_FORMAT(YUV422, 16, UYVY8_2X8, 2, 1, T_U8_Y8__V8_Y8,
++	// 			YUV422_8, UYVY, "YUV 4:2:2 UYVY"),
+ 	TEGRA_VIDEO_FORMAT(YUV422, 16, VYUY8_2X8, 2, 1, T_V8_Y8__U8_Y8,
+ 				YUV422_8, VYUY, "YUV 4:2:2 VYUY"),
+ 	TEGRA_VIDEO_FORMAT(YUV422, 16, YUYV8_2X8, 2, 1, T_Y8_U8__Y8_V8,
+@@ -146,8 +146,10 @@
+ 
+ 	TEGRA_VIDEO_FORMAT(YUV422, 16, UYVY8_1X16, 2, 1, T_U8_Y8__V8_Y8,
+ 				YUV422_8, Z16, "Depth 16"),
+-	TEGRA_VIDEO_FORMAT(YUV422, 16, VYUY8_1X16, 2, 1, T_V8_Y8__U8_Y8,
++	TEGRA_VIDEO_FORMAT(YUV422, 16, VYUY8_1X16, 2, 1, T_U8_Y8__V8_Y8,
+ 				YUV422_8, Y8I, "Y8I 16"),
++	TEGRA_VIDEO_FORMAT(YUV422, 16, UYVY8_2X8, 2, 1, T_U8_Y8__V8_Y8,
++				YUV422_8, YUYV, "YUV 4:2:2"),
+ 	// TODO: RealSesne calibration format Y12I should be 3-byte,
+ 	// R[7:3]R[3:0] | L[3:0]R[11:8] | L[11:8]L[7:4]
+ 	// but, currently, it's 4-byte, one byte is added as alignment

--- a/kernel/realsense/d4xx.c
+++ b/kernel/realsense/d4xx.c
@@ -1414,21 +1414,21 @@ static const struct ds5_format ds5_y_formats_45x[] = {
 
 static const struct ds5_format ds5_41x_rgb_format = {
 	.data_type = GMSL_CSI_DT_YUV422_8,	/* UYVY */
-	.mbus_code = MEDIA_BUS_FMT_YUYV8_1X16,
+	.mbus_code = MEDIA_BUS_FMT_UYVY8_2X8,
 	.n_resolutions = ARRAY_SIZE(ds5_41x_rgb_sizes),
 	.resolutions = ds5_41x_rgb_sizes,
 };
 
 static const struct ds5_format ds5_40x_rgb_format = {
 	.data_type = GMSL_CSI_DT_YUV422_8,	/* UYVY */
-	.mbus_code = MEDIA_BUS_FMT_YUYV8_1X16,
+	.mbus_code = MEDIA_BUS_FMT_UYVY8_2X8,
 	.n_resolutions = ARRAY_SIZE(d40x_rgb_sizes),
 	.resolutions = d40x_rgb_sizes,
 };
 
 static const struct ds5_format ds5_rlt_rgb_format = {
 	.data_type = GMSL_CSI_DT_YUV422_8,	/* UYVY */
-	.mbus_code = MEDIA_BUS_FMT_YUYV8_1X16,
+	.mbus_code = MEDIA_BUS_FMT_UYVY8_2X8,
 	.n_resolutions = ARRAY_SIZE(ds5_rlt_rgb_sizes),
 	.resolutions = ds5_rlt_rgb_sizes,
 };
@@ -1436,7 +1436,7 @@ static const struct ds5_format ds5_rlt_rgb_format = {
 
 static const struct ds5_format ds5_onsemi_rgb_format = {
 	.data_type = GMSL_CSI_DT_YUV422_8,	/* UYVY */
-	.mbus_code = MEDIA_BUS_FMT_YUYV8_1X16,
+	.mbus_code = MEDIA_BUS_FMT_UYVY8_2X8,
 	.n_resolutions = ARRAY_SIZE(ds5_onsemi_rgb_sizes),
 	.resolutions = ds5_onsemi_rgb_sizes,
 };

--- a/nvidia-oot/6.0/0010-Fix-d4xx-rgb-uyvy-and-y8i-order.patch
+++ b/nvidia-oot/6.0/0010-Fix-d4xx-rgb-uyvy-and-y8i-order.patch
@@ -1,0 +1,26 @@
+diff --git a/drivers/media/platform/tegra/camera/vi/vi5_formats.h b/drivers/media/platform/tegra/camera/vi/vi5_formats.h
+--- a/drivers/media/platform/tegra/camera/vi/vi5_formats.h
++++ b/drivers/media/platform/tegra/camera/vi/vi5_formats.h
+@@ -135,8 +135,8 @@
+ 				YUV422_8, YVYU, "YUV 4:2:2"),
+ 	// TEGRA_VIDEO_FORMAT(YUV422, 16, UYVY8_1X16, 1, 1, T_Y8__V8U8_N422,
+ 	// 			YUV422_8, NV16, "NV16"),
+-	TEGRA_VIDEO_FORMAT(YUV422, 16, UYVY8_2X8, 2, 1, T_U8_Y8__V8_Y8,
+-				YUV422_8, UYVY, "YUV 4:2:2 UYVY"),
++	// TEGRA_VIDEO_FORMAT(YUV422, 16, UYVY8_2X8, 2, 1, T_U8_Y8__V8_Y8,
++	// 			YUV422_8, UYVY, "YUV 4:2:2 UYVY"),
+ 	TEGRA_VIDEO_FORMAT(YUV422, 16, VYUY8_2X8, 2, 1, T_V8_Y8__U8_Y8,
+ 				YUV422_8, VYUY, "YUV 4:2:2 VYUY"),
+ 	TEGRA_VIDEO_FORMAT(YUV422, 16, YUYV8_2X8, 2, 1, T_Y8_U8__Y8_V8,
+@@ -146,8 +146,10 @@
+ 
+ 	TEGRA_VIDEO_FORMAT(YUV422, 16, UYVY8_1X16, 2, 1, T_U8_Y8__V8_Y8,
+ 				YUV422_8, Z16, "Depth 16"),
+-	TEGRA_VIDEO_FORMAT(YUV422, 16, VYUY8_1X16, 2, 1, T_V8_Y8__U8_Y8,
++	TEGRA_VIDEO_FORMAT(YUV422, 16, VYUY8_1X16, 2, 1, T_U8_Y8__V8_Y8,
+ 				YUV422_8, Y8I, "Y8I 16"),
++	TEGRA_VIDEO_FORMAT(YUV422, 16, UYVY8_2X8, 2, 1, T_U8_Y8__V8_Y8,
++				YUV422_8, YUYV, "YUV 4:2:2"),
+ 	// TODO: RealSesne calibration format Y12I should be 3-byte,
+ 	// R[7:3]R[3:0] | L[3:0]R[11:8] | L[11:8]L[7:4]
+ 	// but, currently, it's 4-byte, one byte is added as alignment

--- a/nvidia-oot/6.2/0010-Fix-d4xx-rgb-uyvy-and-y8i-order.patch
+++ b/nvidia-oot/6.2/0010-Fix-d4xx-rgb-uyvy-and-y8i-order.patch
@@ -1,0 +1,26 @@
+diff --git a/drivers/media/platform/tegra/camera/vi/vi5_formats.h b/drivers/media/platform/tegra/camera/vi/vi5_formats.h
+--- a/drivers/media/platform/tegra/camera/vi/vi5_formats.h
++++ b/drivers/media/platform/tegra/camera/vi/vi5_formats.h
+@@ -135,8 +135,8 @@
+ 				YUV422_8, YVYU, "YUV 4:2:2"),
+ 	// TEGRA_VIDEO_FORMAT(YUV422, 16, UYVY8_1X16, 1, 1, T_Y8__V8U8_N422,
+ 	// 			YUV422_8, NV16, "NV16"),
+-	TEGRA_VIDEO_FORMAT(YUV422, 16, UYVY8_2X8, 2, 1, T_U8_Y8__V8_Y8,
+-				YUV422_8, UYVY, "YUV 4:2:2 UYVY"),
++	// TEGRA_VIDEO_FORMAT(YUV422, 16, UYVY8_2X8, 2, 1, T_U8_Y8__V8_Y8,
++	// 			YUV422_8, UYVY, "YUV 4:2:2 UYVY"),
+ 	TEGRA_VIDEO_FORMAT(YUV422, 16, VYUY8_2X8, 2, 1, T_V8_Y8__U8_Y8,
+ 				YUV422_8, VYUY, "YUV 4:2:2 VYUY"),
+ 	TEGRA_VIDEO_FORMAT(YUV422, 16, YUYV8_2X8, 2, 1, T_Y8_U8__Y8_V8,
+@@ -146,8 +146,10 @@
+ 
+ 	TEGRA_VIDEO_FORMAT(YUV422, 16, UYVY8_1X16, 2, 1, T_U8_Y8__V8_Y8,
+ 				YUV422_8, Z16, "Depth 16"),
+-	TEGRA_VIDEO_FORMAT(YUV422, 16, VYUY8_1X16, 2, 1, T_V8_Y8__U8_Y8,
++	TEGRA_VIDEO_FORMAT(YUV422, 16, VYUY8_1X16, 2, 1, T_U8_Y8__V8_Y8,
+ 				YUV422_8, Y8I, "Y8I 16"),
++	TEGRA_VIDEO_FORMAT(YUV422, 16, UYVY8_2X8, 2, 1, T_U8_Y8__V8_Y8,
++				YUV422_8, YUYV, "YUV 4:2:2"),
+ 	// TODO: RealSesne calibration format Y12I should be 3-byte,
+ 	// R[7:3]R[3:0] | L[3:0]R[11:8] | L[11:8]L[7:4]
+ 	// but, currently, it's 4-byte, one byte is added as alignment

--- a/nvidia-oot/7.0/0009-Fix-d4xx-rgb-uyvy-and-y8i-order.patch
+++ b/nvidia-oot/7.0/0009-Fix-d4xx-rgb-uyvy-and-y8i-order.patch
@@ -1,0 +1,26 @@
+diff --git a/drivers/media/platform/tegra/camera/vi/vi5_formats.h b/drivers/media/platform/tegra/camera/vi/vi5_formats.h
+--- a/drivers/media/platform/tegra/camera/vi/vi5_formats.h
++++ b/drivers/media/platform/tegra/camera/vi/vi5_formats.h
+@@ -135,8 +135,8 @@
+ 				YUV422_8, YVYU, "YUV 4:2:2"),
+ 	// TEGRA_VIDEO_FORMAT(YUV422, 16, UYVY8_1X16, 1, 1, T_Y8__V8U8_N422,
+ 	// 			YUV422_8, NV16, "NV16"),
+-	TEGRA_VIDEO_FORMAT(YUV422, 16, UYVY8_2X8, 2, 1, T_U8_Y8__V8_Y8,
+-				YUV422_8, UYVY, "YUV 4:2:2 UYVY"),
++	// TEGRA_VIDEO_FORMAT(YUV422, 16, UYVY8_2X8, 2, 1, T_U8_Y8__V8_Y8,
++	// 			YUV422_8, UYVY, "YUV 4:2:2 UYVY"),
+ 	TEGRA_VIDEO_FORMAT(YUV422, 16, VYUY8_2X8, 2, 1, T_V8_Y8__U8_Y8,
+ 				YUV422_8, VYUY, "YUV 4:2:2 VYUY"),
+ 	TEGRA_VIDEO_FORMAT(YUV422, 16, YUYV8_2X8, 2, 1, T_Y8_U8__Y8_V8,
+@@ -146,8 +146,10 @@
+ 
+ 	TEGRA_VIDEO_FORMAT(YUV422, 16, UYVY8_1X16, 2, 1, T_U8_Y8__V8_Y8,
+ 				YUV422_8, Z16, "Depth 16"),
+-	TEGRA_VIDEO_FORMAT(YUV422, 16, VYUY8_1X16, 2, 1, T_V8_Y8__U8_Y8,
++	TEGRA_VIDEO_FORMAT(YUV422, 16, VYUY8_1X16, 2, 1, T_U8_Y8__V8_Y8,
+ 				YUV422_8, Y8I, "Y8I 16"),
++	TEGRA_VIDEO_FORMAT(YUV422, 16, UYVY8_2X8, 2, 1, T_U8_Y8__V8_Y8,
++				YUV422_8, YUYV, "YUV 4:2:2"),
+ 	// TODO: RealSesne calibration format Y12I should be 3-byte,
+ 	// R[7:3]R[3:0] | L[3:0]R[11:8] | L[11:8]L[7:4]
+ 	// but, currently, it's 4-byte, one byte is added as alignment

--- a/nvidia-oot/7.1/0009-Fix-d4xx-rgb-uyvy-and-y8i-order.patch
+++ b/nvidia-oot/7.1/0009-Fix-d4xx-rgb-uyvy-and-y8i-order.patch
@@ -1,0 +1,26 @@
+diff --git a/drivers/media/platform/tegra/camera/vi/vi5_formats.h b/drivers/media/platform/tegra/camera/vi/vi5_formats.h
+--- a/drivers/media/platform/tegra/camera/vi/vi5_formats.h
++++ b/drivers/media/platform/tegra/camera/vi/vi5_formats.h
+@@ -135,8 +135,8 @@
+ 				YUV422_8, YVYU, "YUV 4:2:2"),
+ 	// TEGRA_VIDEO_FORMAT(YUV422, 16, UYVY8_1X16, 1, 1, T_Y8__V8U8_N422,
+ 	// 			YUV422_8, NV16, "NV16"),
+-	TEGRA_VIDEO_FORMAT(YUV422, 16, UYVY8_2X8, 2, 1, T_U8_Y8__V8_Y8,
+-				YUV422_8, UYVY, "YUV 4:2:2 UYVY"),
++	// TEGRA_VIDEO_FORMAT(YUV422, 16, UYVY8_2X8, 2, 1, T_U8_Y8__V8_Y8,
++	// 			YUV422_8, UYVY, "YUV 4:2:2 UYVY"),
+ 	TEGRA_VIDEO_FORMAT(YUV422, 16, VYUY8_2X8, 2, 1, T_V8_Y8__U8_Y8,
+ 				YUV422_8, VYUY, "YUV 4:2:2 VYUY"),
+ 	TEGRA_VIDEO_FORMAT(YUV422, 16, YUYV8_2X8, 2, 1, T_Y8_U8__Y8_V8,
+@@ -146,8 +146,10 @@
+ 
+ 	TEGRA_VIDEO_FORMAT(YUV422, 16, UYVY8_1X16, 2, 1, T_U8_Y8__V8_Y8,
+ 				YUV422_8, Z16, "Depth 16"),
+-	TEGRA_VIDEO_FORMAT(YUV422, 16, VYUY8_1X16, 2, 1, T_V8_Y8__U8_Y8,
++	TEGRA_VIDEO_FORMAT(YUV422, 16, VYUY8_1X16, 2, 1, T_U8_Y8__V8_Y8,
+ 				YUV422_8, Y8I, "Y8I 16"),
++	TEGRA_VIDEO_FORMAT(YUV422, 16, UYVY8_2X8, 2, 1, T_U8_Y8__V8_Y8,
++				YUV422_8, YUYV, "YUV 4:2:2"),
+ 	// TODO: RealSesne calibration format Y12I should be 3-byte,
+ 	// R[7:3]R[3:0] | L[3:0]R[11:8] | L[11:8]L[7:4]
+ 	// but, currently, it's 4-byte, one byte is added as alignment


### PR DESCRIPTION
## Summary
- fix the canonical d4xx RGB bus-code declaration to use UYVY for D400 GMSL RGB streams
- add per-version vi5 incremental patches so Y8I stereo ordering matches the buffer layout and UYVY RGB is exposed consistently
- cover the maintained JetPack patch stacks: 4.6.1, 5.0.2, 5.1.2, 5.1.6, 6.0/6.1, 6.2/6.2.1/6.2.2, 7.0, and 7.1

## Notes
- 6.1 reuses the 6.0 nvidia-oot patch directory via symlink
- 6.2.1 and 6.2.2 reuse the 6.2 nvidia-oot patch directory via symlink
- no unrelated workspace changes were included in this branch

## Testing
- not run (patch-stack update only)