### PR TITLE
[RSDSO-20220][RSDSO-19683]Fix VI reordering by img_fmt mapping

### DIFF
--- a/kernel/nvidia/4.6.1/0079-Fix-vi-yuv422-tegra-format-mapping.patch
+++ b/kernel/nvidia/4.6.1/0079-Fix-vi-yuv422-tegra-format-mapping.patch
@@ -1,0 +1,46 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Pinquan Wang <pinquanw@realsenseai.com>
+Date: Thu, 17 Apr 2025 12:00:00 +0800
+Subject: [PATCH] Fix vi5/vi4 YUV422 1X16 Tegra format mapping
+
+Change YUYV8_1X16 and VYUY8_1X16 (Y8I) Tegra image format to
+T_U8_Y8__V8_Y8 to unify all YUV422 1X16 formats to use the same
+Tegra pixel format, fixing RGB (UYVY) and IR stereo (Y8I) stream
+color/channel issues on GMSL D4xx cameras.
+
+Signed-off-by: Pinquan Wang <pinquanw@realsenseai.com>
+---
+diff --git a/drivers/media/platform/tegra/camera/vi/vi4_formats.h b/drivers/media/platform/tegra/camera/vi/vi4_formats.h
+--- a/drivers/media/platform/tegra/camera/vi/vi4_formats.h
++++ b/drivers/media/platform/tegra/camera/vi/vi4_formats.h
+@@ -131,5 +131,5 @@
+ 	//TEGRA_VIDEO_FORMAT(YUV422, 16, VYUY8_1X16, 2, 1, T_V8_Y8__U8_Y8,
+ 	//			YUV422_8, VYUY, "YUV 4:2:2"),
+-	TEGRA_VIDEO_FORMAT(YUV422, 16, YUYV8_1X16, 2, 1, T_Y8_U8__Y8_V8,
++	TEGRA_VIDEO_FORMAT(YUV422, 16, YUYV8_1X16, 2, 1, T_U8_Y8__V8_Y8,
+ 				YUV422_8, YUYV, "YUV 4:2:2"),
+ 	TEGRA_VIDEO_FORMAT(YUV422, 16, YVYU8_1X16, 2, 1, T_Y8_V8__Y8_U8,
+@@ -150,4 +150,4 @@
+ 	TEGRA_VIDEO_FORMAT(YUV422, 16, UYVY8_1X16, 2, 1, T_U8_Y8__V8_Y8,
+ 				YUV422_8, Z16, "Depth 16"),
+-	TEGRA_VIDEO_FORMAT(YUV422, 16, VYUY8_1X16, 2, 1, T_V8_Y8__U8_Y8,
++	TEGRA_VIDEO_FORMAT(YUV422, 16, VYUY8_1X16, 2, 1, T_U8_Y8__V8_Y8,
+ 				YUV422_8, Y8I, "Y8I 16"),
+diff --git a/drivers/media/platform/tegra/camera/vi/vi5_formats.h b/drivers/media/platform/tegra/camera/vi/vi5_formats.h
+--- a/drivers/media/platform/tegra/camera/vi/vi5_formats.h
++++ b/drivers/media/platform/tegra/camera/vi/vi5_formats.h
+@@ -130,5 +130,5 @@
+ 	//TEGRA_VIDEO_FORMAT(YUV422, 16, VYUY8_1X16, 2, 1, T_V8_Y8__U8_Y8,
+ 	//			YUV422_8, VYUY, "YUV 4:2:2"),
+-	TEGRA_VIDEO_FORMAT(YUV422, 16, YUYV8_1X16, 2, 1, T_Y8_U8__Y8_V8,
++	TEGRA_VIDEO_FORMAT(YUV422, 16, YUYV8_1X16, 2, 1, T_U8_Y8__V8_Y8,
+ 				YUV422_8, YUYV, "YUV 4:2:2"),
+ 	TEGRA_VIDEO_FORMAT(YUV422, 16, YVYU8_1X16, 2, 1, T_Y8_V8__Y8_U8,
+@@ -149,4 +149,4 @@
+ 	TEGRA_VIDEO_FORMAT(YUV422, 16, UYVY8_1X16, 2, 1, T_U8_Y8__V8_Y8,
+ 				YUV422_8, Z16, "Depth 16"),
+-	TEGRA_VIDEO_FORMAT(YUV422, 16, VYUY8_1X16, 2, 1, T_V8_Y8__U8_Y8,
++	TEGRA_VIDEO_FORMAT(YUV422, 16, VYUY8_1X16, 2, 1, T_U8_Y8__V8_Y8,
+ 				YUV422_8, Y8I, "Y8I 16"),
+-- 
+2.34.1

--- a/kernel/nvidia/5.0.2/0021-Fix-vi5-yuv422-tegra-format-mapping.patch
+++ b/kernel/nvidia/5.0.2/0021-Fix-vi5-yuv422-tegra-format-mapping.patch
@@ -1,0 +1,30 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Pinquan Wang <pinquanw@realsenseai.com>
+Date: Thu, 17 Apr 2025 12:00:00 +0800
+Subject: [PATCH] Fix vi5/vi4 YUV422 1X16 Tegra format mapping
+
+Change YUYV8_1X16 and VYUY8_1X16 (Y8I) Tegra image format to
+T_U8_Y8__V8_Y8 to unify all YUV422 1X16 formats to use the same
+Tegra pixel format, fixing RGB (UYVY) and IR stereo (Y8I) stream
+color/channel issues on GMSL D4xx cameras.
+
+Signed-off-by: Pinquan Wang <pinquanw@realsenseai.com>
+---
+diff --git a/drivers/media/platform/tegra/camera/vi/vi5_formats.h b/drivers/media/platform/tegra/camera/vi/vi5_formats.h
+--- a/drivers/media/platform/tegra/camera/vi/vi5_formats.h
++++ b/drivers/media/platform/tegra/camera/vi/vi5_formats.h
+@@ -130,5 +130,5 @@
+ 	// TEGRA_VIDEO_FORMAT(YUV422, 16, VYUY8_1X16, 2, 1, T_V8_Y8__U8_Y8,
+ 	// 			YUV422_8, VYUY, "YUV 4:2:2"),
+-	TEGRA_VIDEO_FORMAT(YUV422, 16, YUYV8_1X16, 2, 1, T_Y8_U8__Y8_V8,
++	TEGRA_VIDEO_FORMAT(YUV422, 16, YUYV8_1X16, 2, 1, T_U8_Y8__V8_Y8,
+ 				YUV422_8, YUYV, "YUV 4:2:2"),
+ 	TEGRA_VIDEO_FORMAT(YUV422, 16, YVYU8_1X16, 2, 1, T_Y8_V8__Y8_U8,
+@@ -147,4 +147,4 @@
+ 	TEGRA_VIDEO_FORMAT(YUV422, 16, UYVY8_1X16, 2, 1, T_U8_Y8__V8_Y8,
+ 				YUV422_8, Z16, "Depth 16"),
+-	TEGRA_VIDEO_FORMAT(YUV422, 16, VYUY8_1X16, 2, 1, T_V8_Y8__U8_Y8,
++	TEGRA_VIDEO_FORMAT(YUV422, 16, VYUY8_1X16, 2, 1, T_U8_Y8__V8_Y8,
+ 				YUV422_8, Y8I, "Y8I 16"),
+-- 
+2.34.1

--- a/kernel/nvidia/5.1.2/0011-Fix-vi-yuv422-tegra-format-mapping.patch
+++ b/kernel/nvidia/5.1.2/0011-Fix-vi-yuv422-tegra-format-mapping.patch
@@ -1,0 +1,46 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Pinquan Wang <pinquanw@realsenseai.com>
+Date: Thu, 17 Apr 2025 12:00:00 +0800
+Subject: [PATCH] Fix vi5/vi4 YUV422 1X16 Tegra format mapping
+
+Change YUYV8_1X16 and VYUY8_1X16 (Y8I) Tegra image format to
+T_U8_Y8__V8_Y8 to unify all YUV422 1X16 formats to use the same
+Tegra pixel format, fixing RGB (UYVY) and IR stereo (Y8I) stream
+color/channel issues on GMSL D4xx cameras.
+
+Signed-off-by: Pinquan Wang <pinquanw@realsenseai.com>
+---
+diff --git a/drivers/media/platform/tegra/camera/vi/vi4_formats.h b/drivers/media/platform/tegra/camera/vi/vi4_formats.h
+--- a/drivers/media/platform/tegra/camera/vi/vi4_formats.h
++++ b/drivers/media/platform/tegra/camera/vi/vi4_formats.h
+@@ -131,5 +131,5 @@
+ 	// TEGRA_VIDEO_FORMAT(YUV422, 16, VYUY8_1X16, 2, 1, T_V8_Y8__U8_Y8,
+ 	// 			YUV422_8, VYUY, "YUV 4:2:2"),
+-	TEGRA_VIDEO_FORMAT(YUV422, 16, YUYV8_1X16, 2, 1, T_Y8_U8__Y8_V8,
++	TEGRA_VIDEO_FORMAT(YUV422, 16, YUYV8_1X16, 2, 1, T_U8_Y8__V8_Y8,
+ 				YUV422_8, YUYV, "YUV 4:2:2"),
+ 	TEGRA_VIDEO_FORMAT(YUV422, 16, YVYU8_1X16, 2, 1, T_Y8_V8__Y8_U8,
+@@ -148,4 +148,4 @@
+ 	TEGRA_VIDEO_FORMAT(YUV422, 16, UYVY8_1X16, 2, 1, T_U8_Y8__V8_Y8,
+ 				YUV422_8, Z16, "Depth 16"),
+-	TEGRA_VIDEO_FORMAT(YUV422, 16, VYUY8_1X16, 2, 1, T_V8_Y8__U8_Y8,
++	TEGRA_VIDEO_FORMAT(YUV422, 16, VYUY8_1X16, 2, 1, T_U8_Y8__V8_Y8,
+ 				YUV422_8, Y8I, "Y8I 16"),
+diff --git a/drivers/media/platform/tegra/camera/vi/vi5_formats.h b/drivers/media/platform/tegra/camera/vi/vi5_formats.h
+--- a/drivers/media/platform/tegra/camera/vi/vi5_formats.h
++++ b/drivers/media/platform/tegra/camera/vi/vi5_formats.h
+@@ -130,5 +130,5 @@
+ 	// TEGRA_VIDEO_FORMAT(YUV422, 16, VYUY8_1X16, 2, 1, T_V8_Y8__U8_Y8,
+ 	// 			YUV422_8, VYUY, "YUV 4:2:2"),
+-	TEGRA_VIDEO_FORMAT(YUV422, 16, YUYV8_1X16, 2, 1, T_Y8_U8__Y8_V8,
++	TEGRA_VIDEO_FORMAT(YUV422, 16, YUYV8_1X16, 2, 1, T_U8_Y8__V8_Y8,
+ 				YUV422_8, YUYV, "YUV 4:2:2"),
+ 	TEGRA_VIDEO_FORMAT(YUV422, 16, YVYU8_1X16, 2, 1, T_Y8_V8__Y8_U8,
+@@ -147,4 +147,4 @@
+ 	TEGRA_VIDEO_FORMAT(YUV422, 16, UYVY8_1X16, 2, 1, T_U8_Y8__V8_Y8,
+ 				YUV422_8, Z16, "Depth 16"),
+-	TEGRA_VIDEO_FORMAT(YUV422, 16, VYUY8_1X16, 2, 1, T_V8_Y8__U8_Y8,
++	TEGRA_VIDEO_FORMAT(YUV422, 16, VYUY8_1X16, 2, 1, T_U8_Y8__V8_Y8,
+ 				YUV422_8, Y8I, "Y8I 16"),
+-- 
+2.34.1

--- a/kernel/nvidia/5.1.6/0011-Fix-vi-yuv422-tegra-format-mapping.patch
+++ b/kernel/nvidia/5.1.6/0011-Fix-vi-yuv422-tegra-format-mapping.patch
@@ -1,0 +1,46 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Pinquan Wang <pinquanw@realsenseai.com>
+Date: Thu, 17 Apr 2025 12:00:00 +0800
+Subject: [PATCH] Fix vi5/vi4 YUV422 1X16 Tegra format mapping
+
+Change YUYV8_1X16 and VYUY8_1X16 (Y8I) Tegra image format to
+T_U8_Y8__V8_Y8 to unify all YUV422 1X16 formats to use the same
+Tegra pixel format, fixing RGB (UYVY) and IR stereo (Y8I) stream
+color/channel issues on GMSL D4xx cameras.
+
+Signed-off-by: Pinquan Wang <pinquanw@realsenseai.com>
+---
+diff --git a/drivers/media/platform/tegra/camera/vi/vi4_formats.h b/drivers/media/platform/tegra/camera/vi/vi4_formats.h
+--- a/drivers/media/platform/tegra/camera/vi/vi4_formats.h
++++ b/drivers/media/platform/tegra/camera/vi/vi4_formats.h
+@@ -131,5 +131,5 @@
+ 	// TEGRA_VIDEO_FORMAT(YUV422, 16, VYUY8_1X16, 2, 1, T_V8_Y8__U8_Y8,
+ 	// 			YUV422_8, VYUY, "YUV 4:2:2"),
+-	TEGRA_VIDEO_FORMAT(YUV422, 16, YUYV8_1X16, 2, 1, T_Y8_U8__Y8_V8,
++	TEGRA_VIDEO_FORMAT(YUV422, 16, YUYV8_1X16, 2, 1, T_U8_Y8__V8_Y8,
+ 				YUV422_8, YUYV, "YUV 4:2:2"),
+ 	TEGRA_VIDEO_FORMAT(YUV422, 16, YVYU8_1X16, 2, 1, T_Y8_V8__Y8_U8,
+@@ -148,4 +148,4 @@
+ 	TEGRA_VIDEO_FORMAT(YUV422, 16, UYVY8_1X16, 2, 1, T_U8_Y8__V8_Y8,
+ 				YUV422_8, Z16, "Depth 16"),
+-	TEGRA_VIDEO_FORMAT(YUV422, 16, VYUY8_1X16, 2, 1, T_V8_Y8__U8_Y8,
++	TEGRA_VIDEO_FORMAT(YUV422, 16, VYUY8_1X16, 2, 1, T_U8_Y8__V8_Y8,
+ 				YUV422_8, Y8I, "Y8I 16"),
+diff --git a/drivers/media/platform/tegra/camera/vi/vi5_formats.h b/drivers/media/platform/tegra/camera/vi/vi5_formats.h
+--- a/drivers/media/platform/tegra/camera/vi/vi5_formats.h
++++ b/drivers/media/platform/tegra/camera/vi/vi5_formats.h
+@@ -130,5 +130,5 @@
+ 	// TEGRA_VIDEO_FORMAT(YUV422, 16, VYUY8_1X16, 2, 1, T_V8_Y8__U8_Y8,
+ 	// 			YUV422_8, VYUY, "YUV 4:2:2"),
+-	TEGRA_VIDEO_FORMAT(YUV422, 16, YUYV8_1X16, 2, 1, T_Y8_U8__Y8_V8,
++	TEGRA_VIDEO_FORMAT(YUV422, 16, YUYV8_1X16, 2, 1, T_U8_Y8__V8_Y8,
+ 				YUV422_8, YUYV, "YUV 4:2:2"),
+ 	TEGRA_VIDEO_FORMAT(YUV422, 16, YVYU8_1X16, 2, 1, T_Y8_V8__Y8_U8,
+@@ -147,4 +147,4 @@
+ 	TEGRA_VIDEO_FORMAT(YUV422, 16, UYVY8_1X16, 2, 1, T_U8_Y8__V8_Y8,
+ 				YUV422_8, Z16, "Depth 16"),
+-	TEGRA_VIDEO_FORMAT(YUV422, 16, VYUY8_1X16, 2, 1, T_V8_Y8__U8_Y8,
++	TEGRA_VIDEO_FORMAT(YUV422, 16, VYUY8_1X16, 2, 1, T_U8_Y8__V8_Y8,
+ 				YUV422_8, Y8I, "Y8I 16"),
+-- 
+2.34.1

--- a/nvidia-oot/6.0/0010-Fix-vi5-yuv422-tegra-format-mapping.patch
+++ b/nvidia-oot/6.0/0010-Fix-vi5-yuv422-tegra-format-mapping.patch
@@ -1,0 +1,30 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Pinquan Wang <pinquanw@realsenseai.com>
+Date: Thu, 17 Apr 2025 12:00:00 +0800
+Subject: [PATCH] Fix vi5/vi4 YUV422 1X16 Tegra format mapping
+
+Change YUYV8_1X16 and VYUY8_1X16 (Y8I) Tegra image format to
+T_U8_Y8__V8_Y8 to unify all YUV422 1X16 formats to use the same
+Tegra pixel format, fixing RGB (UYVY) and IR stereo (Y8I) stream
+color/channel issues on GMSL D4xx cameras.
+
+Signed-off-by: Pinquan Wang <pinquanw@realsenseai.com>
+---
+diff --git a/drivers/media/platform/tegra/camera/vi/vi5_formats.h b/drivers/media/platform/tegra/camera/vi/vi5_formats.h
+--- a/drivers/media/platform/tegra/camera/vi/vi5_formats.h
++++ b/drivers/media/platform/tegra/camera/vi/vi5_formats.h
+@@ -130,5 +130,5 @@
+ 	// TEGRA_VIDEO_FORMAT(YUV422, 16, VYUY8_1X16, 2, 1, T_V8_Y8__U8_Y8,
+ 	// 			YUV422_8, VYUY, "YUV 4:2:2"),
+-	TEGRA_VIDEO_FORMAT(YUV422, 16, YUYV8_1X16, 2, 1, T_Y8_U8__Y8_V8,
++	TEGRA_VIDEO_FORMAT(YUV422, 16, YUYV8_1X16, 2, 1, T_U8_Y8__V8_Y8,
+ 				YUV422_8, YUYV, "YUV 4:2:2"),
+ 	TEGRA_VIDEO_FORMAT(YUV422, 16, YVYU8_1X16, 2, 1, T_Y8_V8__Y8_U8,
+@@ -147,4 +147,4 @@
+ 	TEGRA_VIDEO_FORMAT(YUV422, 16, UYVY8_1X16, 2, 1, T_U8_Y8__V8_Y8,
+ 				YUV422_8, Z16, "Depth 16"),
+-	TEGRA_VIDEO_FORMAT(YUV422, 16, VYUY8_1X16, 2, 1, T_V8_Y8__U8_Y8,
++	TEGRA_VIDEO_FORMAT(YUV422, 16, VYUY8_1X16, 2, 1, T_U8_Y8__V8_Y8,
+ 				YUV422_8, Y8I, "Y8I 16"),
+-- 
+2.34.1

--- a/nvidia-oot/6.2/0010-Fix-vi5-yuv422-tegra-format-mapping.patch
+++ b/nvidia-oot/6.2/0010-Fix-vi5-yuv422-tegra-format-mapping.patch
@@ -1,0 +1,30 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Pinquan Wang <pinquanw@realsenseai.com>
+Date: Thu, 17 Apr 2025 12:00:00 +0800
+Subject: [PATCH] Fix vi5/vi4 YUV422 1X16 Tegra format mapping
+
+Change YUYV8_1X16 and VYUY8_1X16 (Y8I) Tegra image format to
+T_U8_Y8__V8_Y8 to unify all YUV422 1X16 formats to use the same
+Tegra pixel format, fixing RGB (UYVY) and IR stereo (Y8I) stream
+color/channel issues on GMSL D4xx cameras.
+
+Signed-off-by: Pinquan Wang <pinquanw@realsenseai.com>
+---
+diff --git a/drivers/media/platform/tegra/camera/vi/vi5_formats.h b/drivers/media/platform/tegra/camera/vi/vi5_formats.h
+--- a/drivers/media/platform/tegra/camera/vi/vi5_formats.h
++++ b/drivers/media/platform/tegra/camera/vi/vi5_formats.h
+@@ -130,5 +130,5 @@
+ 	// TEGRA_VIDEO_FORMAT(YUV422, 16, VYUY8_1X16, 2, 1, T_V8_Y8__U8_Y8,
+ 	// 			YUV422_8, VYUY, "YUV 4:2:2"),
+-	TEGRA_VIDEO_FORMAT(YUV422, 16, YUYV8_1X16, 2, 1, T_Y8_U8__Y8_V8,
++	TEGRA_VIDEO_FORMAT(YUV422, 16, YUYV8_1X16, 2, 1, T_U8_Y8__V8_Y8,
+ 				YUV422_8, YUYV, "YUV 4:2:2"),
+ 	TEGRA_VIDEO_FORMAT(YUV422, 16, YVYU8_1X16, 2, 1, T_Y8_V8__Y8_U8,
+@@ -147,4 +147,4 @@
+ 	TEGRA_VIDEO_FORMAT(YUV422, 16, UYVY8_1X16, 2, 1, T_U8_Y8__V8_Y8,
+ 				YUV422_8, Z16, "Depth 16"),
+-	TEGRA_VIDEO_FORMAT(YUV422, 16, VYUY8_1X16, 2, 1, T_V8_Y8__U8_Y8,
++	TEGRA_VIDEO_FORMAT(YUV422, 16, VYUY8_1X16, 2, 1, T_U8_Y8__V8_Y8,
+ 				YUV422_8, Y8I, "Y8I 16"),
+-- 
+2.34.1

--- a/nvidia-oot/7.0/0009-Fix-vi5-yuv422-tegra-format-mapping.patch
+++ b/nvidia-oot/7.0/0009-Fix-vi5-yuv422-tegra-format-mapping.patch
@@ -1,0 +1,30 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Pinquan Wang <pinquanw@realsenseai.com>
+Date: Thu, 17 Apr 2025 12:00:00 +0800
+Subject: [PATCH] Fix vi5/vi4 YUV422 1X16 Tegra format mapping
+
+Change YUYV8_1X16 and VYUY8_1X16 (Y8I) Tegra image format to
+T_U8_Y8__V8_Y8 to unify all YUV422 1X16 formats to use the same
+Tegra pixel format, fixing RGB (UYVY) and IR stereo (Y8I) stream
+color/channel issues on GMSL D4xx cameras.
+
+Signed-off-by: Pinquan Wang <pinquanw@realsenseai.com>
+---
+diff --git a/drivers/media/platform/tegra/camera/vi/vi5_formats.h b/drivers/media/platform/tegra/camera/vi/vi5_formats.h
+--- a/drivers/media/platform/tegra/camera/vi/vi5_formats.h
++++ b/drivers/media/platform/tegra/camera/vi/vi5_formats.h
+@@ -130,5 +130,5 @@
+ 	// TEGRA_VIDEO_FORMAT(YUV422, 16, VYUY8_1X16, 2, 1, T_V8_Y8__U8_Y8,
+ 	// 			YUV422_8, VYUY, "YUV 4:2:2"),
+-	TEGRA_VIDEO_FORMAT(YUV422, 16, YUYV8_1X16, 2, 1, T_Y8_U8__Y8_V8,
++	TEGRA_VIDEO_FORMAT(YUV422, 16, YUYV8_1X16, 2, 1, T_U8_Y8__V8_Y8,
+ 				YUV422_8, YUYV, "YUV 4:2:2"),
+ 	TEGRA_VIDEO_FORMAT(YUV422, 16, YVYU8_1X16, 2, 1, T_Y8_V8__Y8_U8,
+@@ -147,4 +147,4 @@
+ 	TEGRA_VIDEO_FORMAT(YUV422, 16, UYVY8_1X16, 2, 1, T_U8_Y8__V8_Y8,
+ 				YUV422_8, Z16, "Depth 16"),
+-	TEGRA_VIDEO_FORMAT(YUV422, 16, VYUY8_1X16, 2, 1, T_V8_Y8__U8_Y8,
++	TEGRA_VIDEO_FORMAT(YUV422, 16, VYUY8_1X16, 2, 1, T_U8_Y8__V8_Y8,
+ 				YUV422_8, Y8I, "Y8I 16"),
+-- 
+2.34.1

--- a/nvidia-oot/7.1/0009-Fix-vi5-yuv422-tegra-format-mapping.patch
+++ b/nvidia-oot/7.1/0009-Fix-vi5-yuv422-tegra-format-mapping.patch
@@ -1,0 +1,30 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Pinquan Wang <pinquanw@realsenseai.com>
+Date: Thu, 17 Apr 2025 12:00:00 +0800
+Subject: [PATCH] Fix vi5/vi4 YUV422 1X16 Tegra format mapping
+
+Change YUYV8_1X16 and VYUY8_1X16 (Y8I) Tegra image format to
+T_U8_Y8__V8_Y8 to unify all YUV422 1X16 formats to use the same
+Tegra pixel format, fixing RGB (UYVY) and IR stereo (Y8I) stream
+color/channel issues on GMSL D4xx cameras.
+
+Signed-off-by: Pinquan Wang <pinquanw@realsenseai.com>
+---
+diff --git a/drivers/media/platform/tegra/camera/vi/vi5_formats.h b/drivers/media/platform/tegra/camera/vi/vi5_formats.h
+--- a/drivers/media/platform/tegra/camera/vi/vi5_formats.h
++++ b/drivers/media/platform/tegra/camera/vi/vi5_formats.h
+@@ -130,5 +130,5 @@
+ 	// TEGRA_VIDEO_FORMAT(YUV422, 16, VYUY8_1X16, 2, 1, T_V8_Y8__U8_Y8,
+ 	// 			YUV422_8, VYUY, "YUV 4:2:2"),
+-	TEGRA_VIDEO_FORMAT(YUV422, 16, YUYV8_1X16, 2, 1, T_Y8_U8__Y8_V8,
++	TEGRA_VIDEO_FORMAT(YUV422, 16, YUYV8_1X16, 2, 1, T_U8_Y8__V8_Y8,
+ 				YUV422_8, YUYV, "YUV 4:2:2"),
+ 	TEGRA_VIDEO_FORMAT(YUV422, 16, YVYU8_1X16, 2, 1, T_Y8_V8__Y8_U8,
+@@ -147,4 +147,4 @@
+ 	TEGRA_VIDEO_FORMAT(YUV422, 16, UYVY8_1X16, 2, 1, T_U8_Y8__V8_Y8,
+ 				YUV422_8, Z16, "Depth 16"),
+-	TEGRA_VIDEO_FORMAT(YUV422, 16, VYUY8_1X16, 2, 1, T_V8_Y8__U8_Y8,
++	TEGRA_VIDEO_FORMAT(YUV422, 16, VYUY8_1X16, 2, 1, T_U8_Y8__V8_Y8,
+ 				YUV422_8, Y8I, "Y8I 16"),
+-- 
+2.34.1


### PR DESCRIPTION
## Summary
Alternative approach to fix D4xx GMSL RGB color and IR stereo ordering.

This approach makes a minimal change: only modify the Tegra image format for `VYUY8_1X16` and `YUYV8_1X16` from their original values to `T_U8_Y8__V8_Y8`, matching the UYVY byte ordering that D4xx GMSL cameras actually produce.

## Changes
- `VYUY8_1X16`: `T_V8_Y8__U8_Y8` → `T_U8_Y8__V8_Y8`
- `YUYV8_1X16`: `T_Y8_U8__Y8_V8` → `T_U8_Y8__V8_Y8`
- All other format entries remain stock/unchanged
- No d4xx.c driver changes needed

## Versions covered
JP 4.6.1, 5.0.2, 5.1.2, 5.1.6, 6.0/6.1, 6.2/6.2.1/6.2.2, 7.0, 7.1

## Notes
- Symlinks: 6.1→6.0, 6.2.1/6.2.2→6.2
- JP4.6.1: also removed vi4/vi5 format hunks from patch 0041 (Y8I enabling) since the generic VYUY entry now handles Y8I correctly