### PR TITLE
RSDEV-6847: On-demand ESYNC GPIO tunneling for external sync

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -125,6 +125,7 @@ Build outputs go to `images/<version>/`.
 Camera variant flags: `--one-cam`, `--dual-cam`, `--max96712-EVB`, `--fg12-16ch`, `--fg12-16ch-dual` (only some apply to specific JetPack versions).
 
 - **Separate patches per kernel module**: when changes span different kernel modules (e.g. max9295, max9296, max96712, d4xx), each module must get its own patch file. Do not combine changes to different modules in a single patch.
+- **Signed-off-by in every patch**: every `.patch` file must include a `Signed-off-by:` trailer. When you modify a patch, add your own `Signed-off-by:` using the current `git config user.name` / `user.email`. Do not leave any patch without one.
 
 ## Key Directories
 

--- a/kernel/nvidia/5.0.2/0015-Add-max9295-GPIO-tunneling-for-the-external-sync-support.patch
+++ b/kernel/nvidia/5.0.2/0015-Add-max9295-GPIO-tunneling-for-the-external-sync-support.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Add max9295 GPIO tunneling for the external sync support
 Add MAX9295A serializer GPIO tunneling / ESYNC register configuration
 for MAX96712A external sync support.
 
-Includes max9295_setup_gpio_tunneling() export for MAX96712A usage.
+Includes max9295_enable_gpio_tunneling() export for MAX96712A usage.
 
 Signed-off-by: ejgoldik <ehud.joseph.goldik@realsenseai.com>
 ---
@@ -45,11 +45,11 @@ index 4b03b1ef8..d7226af6e 100644
  
  #define MAX9295_MAX_PIPES 0x4
  
-@@ -383,6 +395,61 @@ error:
+@@ -383,6 +395,92 @@ error:
  }
  EXPORT_SYMBOL(max9295_setup_control);
  
-+int max9295_setup_gpio_tunneling(struct device *dev)
++int max9295_enable_gpio_tunneling(struct device *dev)
 +{
 +	struct max9295 *priv = dev_get_drvdata(dev);
 +	int err = 0;
@@ -102,7 +102,38 @@ index 4b03b1ef8..d7226af6e 100644
 +
 +	return err;
 +}
-+EXPORT_SYMBOL(max9295_setup_gpio_tunneling);
++EXPORT_SYMBOL(max9295_enable_gpio_tunneling);
++
++int max9295_disable_gpio_tunneling(struct device *dev)
++{
++	struct max9295 *priv = dev_get_drvdata(dev);
++	int err = 0;
++	unsigned int readback = 0;
++
++	mutex_lock(&priv->lock);
++
++	max9295_write_reg(dev, MAX9295_SRC_PWDN_ADDR, MAX9295_PWDN_GPIO);
++	regmap_read(priv->regmap, MAX9295_SRC_PWDN_ADDR, &readback);
++	dev_info(dev, "%s: reg 0x%04x written 0x%02x readback 0x%02x %s\n",
++		__func__, MAX9295_SRC_PWDN_ADDR, MAX9295_PWDN_GPIO,
++		readback, (readback == MAX9295_PWDN_GPIO) ? "OK" : "MISMATCH");
++
++	max9295_write_reg(dev, MAX9295_SRC_CTRL_ADDR, MAX9295_RESET_SRC);
++	regmap_read(priv->regmap, MAX9295_SRC_CTRL_ADDR, &readback);
++	dev_info(dev, "%s: reg 0x%04x written 0x%02x readback 0x%02x %s\n",
++		__func__, MAX9295_SRC_CTRL_ADDR, MAX9295_RESET_SRC,
++		readback, (readback == MAX9295_RESET_SRC) ? "OK" : "MISMATCH");
++
++	max9295_write_reg(dev, MAX9295_2C0_ADDR, 0x00);
++	max9295_write_reg(dev, MAX9295_2C1_ADDR, 0x00);
++	max9295_write_reg(dev, MAX9295_2C2_ADDR, 0x00);
++	max9295_write_reg(dev, MAX9295_2C3_ADDR, 0x00);
++
++	mutex_unlock(&priv->lock);
++
++	return err;
++}
++EXPORT_SYMBOL(max9295_disable_gpio_tunneling);
 +
  int max9295_reset_control(struct device *dev)
  {
@@ -111,12 +142,13 @@ diff --git a/include/media/max9295.h b/include/media/max9295.h
 index bea15c414..6099859d2 100644
 --- a/include/media/max9295.h
 +++ b/include/media/max9295.h
-@@ -99,6 +99,9 @@ int max9295_sdev_unpair(struct device *dev, struct device *s_dev);
+@@ -99,6 +99,10 @@ int max9295_sdev_unpair(struct device *dev, struct device *s_dev);
  int max9295_setup_streaming(struct device *dev);
  
  int max9295_init_settings(struct device *dev);
 +
-+int max9295_setup_gpio_tunneling(struct device *dev);
++int max9295_enable_gpio_tunneling(struct device *dev);
++int max9295_disable_gpio_tunneling(struct device *dev);
 +
  /** @} */
  

--- a/kernel/nvidia/5.0.2/0015-Add-max9295-GPIO-tunneling-for-the-external-sync-support.patch
+++ b/kernel/nvidia/5.0.2/0015-Add-max9295-GPIO-tunneling-for-the-external-sync-support.patch
@@ -9,10 +9,11 @@ for MAX96712A external sync support.
 Includes max9295_enable_gpio_tunneling() export for MAX96712A usage.
 
 Signed-off-by: ejgoldik <ehud.joseph.goldik@realsenseai.com>
+Signed-off-by: ipilchin1 <inga.pilchin@realsenseai.com>
 ---
- drivers/media/i2c/max9295.c | 67 +++++++++++++++++++++++++++++++++++++++++++++
- include/media/max9295.h     |  3 +++
- 2 files changed, 70 insertions(+)
+ drivers/media/i2c/max9295.c | 69 +++++++++++++++++++++++++++++++++++++++++++++
+ include/media/max9295.h     |  4 +++
+ 2 files changed, 73 insertions(+)
 
 diff --git a/drivers/media/i2c/max9295.c b/drivers/media/i2c/max9295.c
 index 4b03b1ef8..d7226af6e 100644
@@ -45,58 +46,39 @@ index 4b03b1ef8..d7226af6e 100644
  
  #define MAX9295_MAX_PIPES 0x4
  
-@@ -383,6 +395,92 @@ error:
+@@ -383,6 +395,63 @@ error:
  }
  EXPORT_SYMBOL(max9295_setup_control);
  
++static int max9295_write_acc(struct device *dev, struct regmap *regmap,
++			     u16 addr, u8 val, int *err)
++{
++	unsigned int readback = 0;
++
++	if (*err)
++		return *err;
++	*err = max9295_write_reg(dev, addr, val);
++	if (!*err)
++		regmap_read(regmap, addr, &readback);
++	dev_dbg(dev, "%s: reg 0x%04x written 0x%02x readback 0x%02x\n",
++		__func__, addr, val, readback);
++	return *err;
++}
++
 +int max9295_enable_gpio_tunneling(struct device *dev)
 +{
 +	struct max9295 *priv = dev_get_drvdata(dev);
 +	int err = 0;
-+	unsigned int readback = 0;
 +
 +	mutex_lock(&priv->lock);
 +
-+	dev_info(dev, "%s: writing GPIO tunneling registers\n", __func__);
-+
 +	/* Configure ESYNC registers for MAX96712A deserializer */
-+	max9295_write_reg(dev, MAX9295_SRC_PWDN_ADDR, MAX9295_PWDN_ESYNC_EXT);
-+	regmap_read(priv->regmap, MAX9295_SRC_PWDN_ADDR, &readback);
-+	dev_info(dev, "%s: reg 0x%04x written 0x%02x readback 0x%02x %s\n",
-+		__func__, MAX9295_SRC_PWDN_ADDR, MAX9295_PWDN_ESYNC_EXT,
-+		readback, (readback == MAX9295_PWDN_ESYNC_EXT) ? "OK" : "MISMATCH");
-+
-+	max9295_write_reg(dev, MAX9295_SRC_CTRL_ADDR, MAX9295_RESET_ESYNC);
-+	regmap_read(priv->regmap, MAX9295_SRC_CTRL_ADDR, &readback);
-+	dev_info(dev, "%s: reg 0x%04x written 0x%02x readback 0x%02x %s\n",
-+		__func__, MAX9295_SRC_CTRL_ADDR, MAX9295_RESET_ESYNC,
-+		readback, (readback == MAX9295_RESET_ESYNC) ? "OK" : "MISMATCH");
-+
-+	max9295_write_reg(dev, MAX9295_2C0_ADDR, MAX9295_2C0_ESYNC);
-+	regmap_read(priv->regmap, MAX9295_2C0_ADDR, &readback);
-+	dev_info(dev, "%s: reg 0x%04x written 0x%02x readback 0x%02x %s\n",
-+		__func__, MAX9295_2C0_ADDR, MAX9295_2C0_ESYNC,
-+		readback, (readback == MAX9295_2C0_ESYNC) ? "OK" : "MISMATCH");
-+
-+	max9295_write_reg(dev, MAX9295_2C1_ADDR, MAX9295_2C1_ESYNC);
-+	regmap_read(priv->regmap, MAX9295_2C1_ADDR, &readback);
-+	dev_info(dev, "%s: reg 0x%04x written 0x%02x readback 0x%02x %s\n",
-+		__func__, MAX9295_2C1_ADDR, MAX9295_2C1_ESYNC,
-+		readback, (readback == MAX9295_2C1_ESYNC) ? "OK" : "MISMATCH");
-+
-+	max9295_write_reg(dev, MAX9295_2C2_ADDR, MAX9295_2C2_ESYNC);
-+	regmap_read(priv->regmap, MAX9295_2C2_ADDR, &readback);
-+	dev_info(dev, "%s: reg 0x%04x written 0x%02x readback 0x%02x %s\n",
-+		__func__, MAX9295_2C2_ADDR, MAX9295_2C2_ESYNC,
-+		readback, (readback == MAX9295_2C2_ESYNC) ? "OK" : "MISMATCH");
-+
-+	max9295_write_reg(dev, MAX9295_2C3_ADDR, MAX9295_2C3_ESYNC);
-+	regmap_read(priv->regmap, MAX9295_2C3_ADDR, &readback);
-+	dev_info(dev, "%s: reg 0x%04x written 0x%02x readback 0x%02x %s\n",
-+		__func__, MAX9295_2C3_ADDR, MAX9295_2C3_ESYNC,
-+		readback, (readback == MAX9295_2C3_ESYNC) ? "OK" : "MISMATCH");
-+
-+	dev_info(dev, "%s: GPIO tunneling register config done\n", __func__);
++	max9295_write_acc(dev, priv->regmap, MAX9295_SRC_PWDN_ADDR, MAX9295_PWDN_ESYNC_EXT, &err);
++	max9295_write_acc(dev, priv->regmap, MAX9295_SRC_CTRL_ADDR, MAX9295_RESET_ESYNC, &err);
++	max9295_write_acc(dev, priv->regmap, MAX9295_2C0_ADDR, MAX9295_2C0_ESYNC, &err);
++	max9295_write_acc(dev, priv->regmap, MAX9295_2C1_ADDR, MAX9295_2C1_ESYNC, &err);
++	max9295_write_acc(dev, priv->regmap, MAX9295_2C2_ADDR, MAX9295_2C2_ESYNC, &err);
++	max9295_write_acc(dev, priv->regmap, MAX9295_2C3_ADDR, MAX9295_2C3_ESYNC, &err);
 +
 +	mutex_unlock(&priv->lock);
 +
@@ -108,26 +90,16 @@ index 4b03b1ef8..d7226af6e 100644
 +{
 +	struct max9295 *priv = dev_get_drvdata(dev);
 +	int err = 0;
-+	unsigned int readback = 0;
 +
 +	mutex_lock(&priv->lock);
 +
-+	max9295_write_reg(dev, MAX9295_SRC_PWDN_ADDR, MAX9295_PWDN_GPIO);
-+	regmap_read(priv->regmap, MAX9295_SRC_PWDN_ADDR, &readback);
-+	dev_info(dev, "%s: reg 0x%04x written 0x%02x readback 0x%02x %s\n",
-+		__func__, MAX9295_SRC_PWDN_ADDR, MAX9295_PWDN_GPIO,
-+		readback, (readback == MAX9295_PWDN_GPIO) ? "OK" : "MISMATCH");
-+
-+	max9295_write_reg(dev, MAX9295_SRC_CTRL_ADDR, MAX9295_RESET_SRC);
-+	regmap_read(priv->regmap, MAX9295_SRC_CTRL_ADDR, &readback);
-+	dev_info(dev, "%s: reg 0x%04x written 0x%02x readback 0x%02x %s\n",
-+		__func__, MAX9295_SRC_CTRL_ADDR, MAX9295_RESET_SRC,
-+		readback, (readback == MAX9295_RESET_SRC) ? "OK" : "MISMATCH");
-+
-+	max9295_write_reg(dev, MAX9295_2C0_ADDR, 0x00);
-+	max9295_write_reg(dev, MAX9295_2C1_ADDR, 0x00);
-+	max9295_write_reg(dev, MAX9295_2C2_ADDR, 0x00);
-+	max9295_write_reg(dev, MAX9295_2C3_ADDR, 0x00);
++	/* Restore default SRC pin function — plain GPIO, no ESYNC tunneling */
++	max9295_write_acc(dev, priv->regmap, MAX9295_SRC_PWDN_ADDR, MAX9295_PWDN_GPIO, &err);
++	max9295_write_acc(dev, priv->regmap, MAX9295_SRC_CTRL_ADDR, MAX9295_RESET_SRC, &err);
++	max9295_write_acc(dev, priv->regmap, MAX9295_2C0_ADDR, 0x00, &err);
++	max9295_write_acc(dev, priv->regmap, MAX9295_2C1_ADDR, 0x00, &err);
++	max9295_write_acc(dev, priv->regmap, MAX9295_2C2_ADDR, 0x00, &err);
++	max9295_write_acc(dev, priv->regmap, MAX9295_2C3_ADDR, 0x00, &err);
 +
 +	mutex_unlock(&priv->lock);
 +

--- a/kernel/nvidia/5.1.2/0005-Add-max9295-GPIO-tunneling-for-the-external-sync-support.patch
+++ b/kernel/nvidia/5.1.2/0005-Add-max9295-GPIO-tunneling-for-the-external-sync-support.patch
@@ -9,10 +9,11 @@ for MAX96712A external sync support.
 Includes max9295_enable_gpio_tunneling() export for MAX96712A usage.
 
 Signed-off-by: ejgoldik <ehud.joseph.goldik@realsenseai.com>
+Signed-off-by: ipilchin1 <inga.pilchin@realsenseai.com>
 ---
- drivers/media/i2c/max9295.c | 69 +++++++++++++++++++++++++++++++++++++++++++++
- include/media/max9295.h     |  3 +++
- 2 files changed, 72 insertions(+)
+ drivers/media/i2c/max9295.c | 71 +++++++++++++++++++++++++++++++++++++++++++++
+ include/media/max9295.h     |  4 +++
+ 2 files changed, 75 insertions(+)
 
 diff --git a/drivers/media/i2c/max9295.c b/drivers/media/i2c/max9295.c
 index 6311d97d7..d7226af6e 100644
@@ -45,58 +46,39 @@ index 6311d97d7..d7226af6e 100644
  
  #define MAX9295_MAX_PIPES 0x4
  
-@@ -383,6 +395,92 @@ error:
+@@ -383,6 +395,63 @@ error:
  }
  EXPORT_SYMBOL(max9295_setup_control);
  
++static int max9295_write_acc(struct device *dev, struct regmap *regmap,
++			     u16 addr, u8 val, int *err)
++{
++	unsigned int readback = 0;
++
++	if (*err)
++		return *err;
++	*err = max9295_write_reg(dev, addr, val);
++	if (!*err)
++		regmap_read(regmap, addr, &readback);
++	dev_dbg(dev, "%s: reg 0x%04x written 0x%02x readback 0x%02x\n",
++		__func__, addr, val, readback);
++	return *err;
++}
++
 +int max9295_enable_gpio_tunneling(struct device *dev)
 +{
 +	struct max9295 *priv = dev_get_drvdata(dev);
 +	int err = 0;
-+	unsigned int readback = 0;
 +
 +	mutex_lock(&priv->lock);
 +
-+	dev_info(dev, "%s: writing GPIO tunneling registers\n", __func__);
-+
 +	/* Configure ESYNC registers for MAX96712A deserializer */
-+	max9295_write_reg(dev, MAX9295_SRC_PWDN_ADDR, MAX9295_PWDN_ESYNC_EXT);
-+	regmap_read(priv->regmap, MAX9295_SRC_PWDN_ADDR, &readback);
-+	dev_info(dev, "%s: reg 0x%04x written 0x%02x readback 0x%02x %s\n",
-+		__func__, MAX9295_SRC_PWDN_ADDR, MAX9295_PWDN_ESYNC_EXT,
-+		readback, (readback == MAX9295_PWDN_ESYNC_EXT) ? "OK" : "MISMATCH");
-+
-+	max9295_write_reg(dev, MAX9295_SRC_CTRL_ADDR, MAX9295_RESET_ESYNC);
-+	regmap_read(priv->regmap, MAX9295_SRC_CTRL_ADDR, &readback);
-+	dev_info(dev, "%s: reg 0x%04x written 0x%02x readback 0x%02x %s\n",
-+		__func__, MAX9295_SRC_CTRL_ADDR, MAX9295_RESET_ESYNC,
-+		readback, (readback == MAX9295_RESET_ESYNC) ? "OK" : "MISMATCH");
-+
-+	max9295_write_reg(dev, MAX9295_2C0_ADDR, MAX9295_2C0_ESYNC);
-+	regmap_read(priv->regmap, MAX9295_2C0_ADDR, &readback);
-+	dev_info(dev, "%s: reg 0x%04x written 0x%02x readback 0x%02x %s\n",
-+		__func__, MAX9295_2C0_ADDR, MAX9295_2C0_ESYNC,
-+		readback, (readback == MAX9295_2C0_ESYNC) ? "OK" : "MISMATCH");
-+
-+	max9295_write_reg(dev, MAX9295_2C1_ADDR, MAX9295_2C1_ESYNC);
-+	regmap_read(priv->regmap, MAX9295_2C1_ADDR, &readback);
-+	dev_info(dev, "%s: reg 0x%04x written 0x%02x readback 0x%02x %s\n",
-+		__func__, MAX9295_2C1_ADDR, MAX9295_2C1_ESYNC,
-+		readback, (readback == MAX9295_2C1_ESYNC) ? "OK" : "MISMATCH");
-+
-+	max9295_write_reg(dev, MAX9295_2C2_ADDR, MAX9295_2C2_ESYNC);
-+	regmap_read(priv->regmap, MAX9295_2C2_ADDR, &readback);
-+	dev_info(dev, "%s: reg 0x%04x written 0x%02x readback 0x%02x %s\n",
-+		__func__, MAX9295_2C2_ADDR, MAX9295_2C2_ESYNC,
-+		readback, (readback == MAX9295_2C2_ESYNC) ? "OK" : "MISMATCH");
-+
-+	max9295_write_reg(dev, MAX9295_2C3_ADDR, MAX9295_2C3_ESYNC);
-+	regmap_read(priv->regmap, MAX9295_2C3_ADDR, &readback);
-+	dev_info(dev, "%s: reg 0x%04x written 0x%02x readback 0x%02x %s\n",
-+		__func__, MAX9295_2C3_ADDR, MAX9295_2C3_ESYNC,
-+		readback, (readback == MAX9295_2C3_ESYNC) ? "OK" : "MISMATCH");
-+
-+	dev_info(dev, "%s: GPIO tunneling register config done\n", __func__);
++	max9295_write_acc(dev, priv->regmap, MAX9295_SRC_PWDN_ADDR, MAX9295_PWDN_ESYNC_EXT, &err);
++	max9295_write_acc(dev, priv->regmap, MAX9295_SRC_CTRL_ADDR, MAX9295_RESET_ESYNC, &err);
++	max9295_write_acc(dev, priv->regmap, MAX9295_2C0_ADDR, MAX9295_2C0_ESYNC, &err);
++	max9295_write_acc(dev, priv->regmap, MAX9295_2C1_ADDR, MAX9295_2C1_ESYNC, &err);
++	max9295_write_acc(dev, priv->regmap, MAX9295_2C2_ADDR, MAX9295_2C2_ESYNC, &err);
++	max9295_write_acc(dev, priv->regmap, MAX9295_2C3_ADDR, MAX9295_2C3_ESYNC, &err);
 +
 +	mutex_unlock(&priv->lock);
 +
@@ -108,26 +90,16 @@ index 6311d97d7..d7226af6e 100644
 +{
 +	struct max9295 *priv = dev_get_drvdata(dev);
 +	int err = 0;
-+	unsigned int readback = 0;
 +
 +	mutex_lock(&priv->lock);
 +
-+	max9295_write_reg(dev, MAX9295_SRC_PWDN_ADDR, MAX9295_PWDN_GPIO);
-+	regmap_read(priv->regmap, MAX9295_SRC_PWDN_ADDR, &readback);
-+	dev_info(dev, "%s: reg 0x%04x written 0x%02x readback 0x%02x %s\n",
-+		__func__, MAX9295_SRC_PWDN_ADDR, MAX9295_PWDN_GPIO,
-+		readback, (readback == MAX9295_PWDN_GPIO) ? "OK" : "MISMATCH");
-+
-+	max9295_write_reg(dev, MAX9295_SRC_CTRL_ADDR, MAX9295_RESET_SRC);
-+	regmap_read(priv->regmap, MAX9295_SRC_CTRL_ADDR, &readback);
-+	dev_info(dev, "%s: reg 0x%04x written 0x%02x readback 0x%02x %s\n",
-+		__func__, MAX9295_SRC_CTRL_ADDR, MAX9295_RESET_SRC,
-+		readback, (readback == MAX9295_RESET_SRC) ? "OK" : "MISMATCH");
-+
-+	max9295_write_reg(dev, MAX9295_2C0_ADDR, 0x00);
-+	max9295_write_reg(dev, MAX9295_2C1_ADDR, 0x00);
-+	max9295_write_reg(dev, MAX9295_2C2_ADDR, 0x00);
-+	max9295_write_reg(dev, MAX9295_2C3_ADDR, 0x00);
++	/* Restore default SRC pin function — plain GPIO, no ESYNC tunneling */
++	max9295_write_acc(dev, priv->regmap, MAX9295_SRC_PWDN_ADDR, MAX9295_PWDN_GPIO, &err);
++	max9295_write_acc(dev, priv->regmap, MAX9295_SRC_CTRL_ADDR, MAX9295_RESET_SRC, &err);
++	max9295_write_acc(dev, priv->regmap, MAX9295_2C0_ADDR, 0x00, &err);
++	max9295_write_acc(dev, priv->regmap, MAX9295_2C1_ADDR, 0x00, &err);
++	max9295_write_acc(dev, priv->regmap, MAX9295_2C2_ADDR, 0x00, &err);
++	max9295_write_acc(dev, priv->regmap, MAX9295_2C3_ADDR, 0x00, &err);
 +
 +	mutex_unlock(&priv->lock);
 +
@@ -156,7 +128,7 @@ diff --git a/include/media/max9295.h b/include/media/max9295.h
 index bea15c414..6099859d2 100644
 --- a/include/media/max9295.h
 +++ b/include/media/max9295.h
-@@ -99,7 +99,10 @@ int max9295_sdev_unpair(struct device *dev, struct device *s_dev);
+@@ -99,6 +99,10 @@ int max9295_sdev_unpair(struct device *dev, struct device *s_dev);
  int max9295_setup_streaming(struct device *dev);
  
  int max9295_init_settings(struct device *dev);

--- a/kernel/nvidia/5.1.2/0005-Add-max9295-GPIO-tunneling-for-the-external-sync-support.patch
+++ b/kernel/nvidia/5.1.2/0005-Add-max9295-GPIO-tunneling-for-the-external-sync-support.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Add max9295 GPIO tunneling for the external sync support
 Add MAX9295A serializer GPIO tunneling / ESYNC register configuration
 for MAX96712A external sync support.
 
-Includes max9295_setup_gpio_tunneling() export for MAX96712A usage.
+Includes max9295_enable_gpio_tunneling() export for MAX96712A usage.
 
 Signed-off-by: ejgoldik <ehud.joseph.goldik@realsenseai.com>
 ---
@@ -45,11 +45,11 @@ index 6311d97d7..d7226af6e 100644
  
  #define MAX9295_MAX_PIPES 0x4
  
-@@ -383,6 +395,61 @@ error:
+@@ -383,6 +395,92 @@ error:
  }
  EXPORT_SYMBOL(max9295_setup_control);
  
-+int max9295_setup_gpio_tunneling(struct device *dev)
++int max9295_enable_gpio_tunneling(struct device *dev)
 +{
 +	struct max9295 *priv = dev_get_drvdata(dev);
 +	int err = 0;
@@ -102,7 +102,38 @@ index 6311d97d7..d7226af6e 100644
 +
 +	return err;
 +}
-+EXPORT_SYMBOL(max9295_setup_gpio_tunneling);
++EXPORT_SYMBOL(max9295_enable_gpio_tunneling);
++
++int max9295_disable_gpio_tunneling(struct device *dev)
++{
++	struct max9295 *priv = dev_get_drvdata(dev);
++	int err = 0;
++	unsigned int readback = 0;
++
++	mutex_lock(&priv->lock);
++
++	max9295_write_reg(dev, MAX9295_SRC_PWDN_ADDR, MAX9295_PWDN_GPIO);
++	regmap_read(priv->regmap, MAX9295_SRC_PWDN_ADDR, &readback);
++	dev_info(dev, "%s: reg 0x%04x written 0x%02x readback 0x%02x %s\n",
++		__func__, MAX9295_SRC_PWDN_ADDR, MAX9295_PWDN_GPIO,
++		readback, (readback == MAX9295_PWDN_GPIO) ? "OK" : "MISMATCH");
++
++	max9295_write_reg(dev, MAX9295_SRC_CTRL_ADDR, MAX9295_RESET_SRC);
++	regmap_read(priv->regmap, MAX9295_SRC_CTRL_ADDR, &readback);
++	dev_info(dev, "%s: reg 0x%04x written 0x%02x readback 0x%02x %s\n",
++		__func__, MAX9295_SRC_CTRL_ADDR, MAX9295_RESET_SRC,
++		readback, (readback == MAX9295_RESET_SRC) ? "OK" : "MISMATCH");
++
++	max9295_write_reg(dev, MAX9295_2C0_ADDR, 0x00);
++	max9295_write_reg(dev, MAX9295_2C1_ADDR, 0x00);
++	max9295_write_reg(dev, MAX9295_2C2_ADDR, 0x00);
++	max9295_write_reg(dev, MAX9295_2C3_ADDR, 0x00);
++
++	mutex_unlock(&priv->lock);
++
++	return err;
++}
++EXPORT_SYMBOL(max9295_disable_gpio_tunneling);
 +
  int max9295_reset_control(struct device *dev)
  {
@@ -125,12 +156,13 @@ diff --git a/include/media/max9295.h b/include/media/max9295.h
 index bea15c414..6099859d2 100644
 --- a/include/media/max9295.h
 +++ b/include/media/max9295.h
-@@ -99,6 +99,9 @@ int max9295_sdev_unpair(struct device *dev, struct device *s_dev);
+@@ -99,7 +99,10 @@ int max9295_sdev_unpair(struct device *dev, struct device *s_dev);
  int max9295_setup_streaming(struct device *dev);
  
  int max9295_init_settings(struct device *dev);
 +
-+int max9295_setup_gpio_tunneling(struct device *dev);
++int max9295_enable_gpio_tunneling(struct device *dev);
++int max9295_disable_gpio_tunneling(struct device *dev);
 +
  /** @} */
  

--- a/kernel/realsense/d4xx.c
+++ b/kernel/realsense/d4xx.c
@@ -2206,6 +2206,16 @@ static int ds5_hw_set_exposure(struct ds5 *state, u32 base, s32 val)
 #define DS5_CAMERA_CID_HWMC			(DS5_CAMERA_CID_BASE+15)
 #define DS5_CAMERA_CID_SYNC_MODE		(DS5_CAMERA_CID_BASE+16)
 
+/* Sync mode values — indices into sync_mode_menu_full[] */
+enum ds5_sync_mode {
+	DS5_SYNC_MODE_DEFAULT,
+	DS5_SYNC_MODE_MASTER,
+	DS5_SYNC_MODE_SLAVE,
+	DS5_SYNC_MODE_FULL_SLAVE,
+	DS5_SYNC_MODE_SUB_PREMASTER,
+	DS5_SYNC_MODE_FULL_MASTER,
+};
+
 #define DS5_CAMERA_CID_PWM			(DS5_CAMERA_CID_BASE+22)
 
 /* the HWMC will remain for legacy tools compatibility,
@@ -2426,23 +2436,21 @@ static int ds5_set_ser_esync_tunneling(struct ds5 *state, bool enable)
 	if (state->dser_ops != &max96712_interface)
 		return 0;
 
-	dev_info(&state->client->dev,
+	dev_dbg(&state->client->dev,
 		"%s(): serializer ESYNC %s requested\n",
 		__func__, enable ? "enable" : "disable");
 
-	mutex_lock(&serdes_lock__);
 	if (enable)
 		ret = max9295_enable_gpio_tunneling(state->ser_dev);
 	else
 		ret = max9295_disable_gpio_tunneling(state->ser_dev);
-	mutex_unlock(&serdes_lock__);
 
 	if (ret)
 		dev_warn(&state->client->dev,
 			"%s(): serializer ESYNC %s failed (%d)\n",
 			__func__, enable ? "enable" : "disable", ret);
 	else
-		dev_info(&state->client->dev,
+		dev_dbg(&state->client->dev,
 			"%s(): serializer ESYNC %s OK\n",
 			__func__, enable ? "enable" : "disable");
 
@@ -2659,13 +2667,18 @@ static int ds5_hw_reset_with_recovery(struct ds5 *state)
 		(state->fw_version >> 8) & 0xff, state->fw_version & 0xff,
 		(state->fw_build >> 8) & 0xff, state->fw_build & 0xff);
 
-	dev_info(&state->client->dev,
-		"%s(): disabling serializer ESYNC after HW reset\n", __func__);
-	ret = ds5_set_ser_esync_tunneling(state, false);
-	if (ret)
-		dev_warn(&state->client->dev,
-			"%s(): serializer ESYNC disable after HW reset failed (%d)\n",
-			__func__, ret);
+	/* Re-apply ESYNC tunneling to match cached sync_mode control */
+	if (state->ctrls.sync_mode) {
+		int sync_val = state->ctrls.sync_mode->cur.val;
+		bool need_esync = (sync_val == DS5_SYNC_MODE_SLAVE ||
+				   sync_val == DS5_SYNC_MODE_FULL_SLAVE);
+
+		ret = ds5_set_ser_esync_tunneling(state, need_esync);
+		if (ret)
+			dev_warn(&state->client->dev,
+				"%s(): serializer ESYNC %s after HW reset failed (%d)\n",
+				__func__, need_esync ? "enable" : "disable", ret);
+	}
 
 	WRITE_ONCE(state->ds5_dev->last_reset_jiffies, jiffies);
 
@@ -2973,9 +2986,10 @@ static int ds5_s_ctrl(struct v4l2_ctrl *ctrl)
 			dev_info(&state->client->dev, "%s(): SYNC_MODE command passed to FW, addr: 0x%x, value: %d, ret: %d\n",
 				__func__, base | DS5_CAMERA_SYNC_MODE, ctrl->val, ret);
 			if (!ret) {
-				bool need_esync = (ctrl->val == 2 || ctrl->val == 3);
+				bool need_esync = (ctrl->val == DS5_SYNC_MODE_SLAVE ||
+						   ctrl->val == DS5_SYNC_MODE_FULL_SLAVE);
 
-				dev_info(&state->client->dev,
+				dev_dbg(&state->client->dev,
 					"%s(): sync_mode=%d -> serializer ESYNC %s\n",
 					__func__, ctrl->val,
 					need_esync ? "enable" : "disable");
@@ -3486,12 +3500,12 @@ static const struct v4l2_ctrl_config ds5_ctrl_hw_reset = {
 
 /* Sync mode menu arrays for different camera platforms */
 static const char * const sync_mode_menu_full[] = {
-	"Default",           /* 0 */
-	"Master",            /* 1 */
-	"Slave",             /* 2 */
-	"Full Slave",        /* 3 */
-	"Sub Pre-Master",    /* 4 */
-	"Full Master",       /* 5 */
+	[DS5_SYNC_MODE_DEFAULT]       = "Default",
+	[DS5_SYNC_MODE_MASTER]        = "Master",
+	[DS5_SYNC_MODE_SLAVE]         = "Slave",
+	[DS5_SYNC_MODE_FULL_SLAVE]    = "Full Slave",
+	[DS5_SYNC_MODE_SUB_PREMASTER] = "Sub Pre-Master",
+	[DS5_SYNC_MODE_FULL_MASTER]   = "Full Master",
 };
 
 static const char * const sync_mode_menu_d401[] = {

--- a/kernel/realsense/d4xx.c
+++ b/kernel/realsense/d4xx.c
@@ -2416,6 +2416,42 @@ static void ds5_reset_streaming_flags(struct ds5_dev *ds5_dev)
 	mutex_unlock(&ds5_dev->lock);
 }
 
+static int ds5_set_ser_esync_tunneling(struct ds5 *state, bool enable)
+{
+#ifdef CONFIG_VIDEO_D4XX_SERDES
+	int ret;
+
+	if (!state || !state->ser_dev)
+		return -EINVAL;
+	if (state->dser_ops != &max96712_interface)
+		return 0;
+
+	dev_info(&state->client->dev,
+		"%s(): serializer ESYNC %s requested\n",
+		__func__, enable ? "enable" : "disable");
+
+	mutex_lock(&serdes_lock__);
+	if (enable)
+		ret = max9295_enable_gpio_tunneling(state->ser_dev);
+	else
+		ret = max9295_disable_gpio_tunneling(state->ser_dev);
+	mutex_unlock(&serdes_lock__);
+
+	if (ret)
+		dev_warn(&state->client->dev,
+			"%s(): serializer ESYNC %s failed (%d)\n",
+			__func__, enable ? "enable" : "disable", ret);
+	else
+		dev_info(&state->client->dev,
+			"%s(): serializer ESYNC %s OK\n",
+			__func__, enable ? "enable" : "disable");
+
+	return ret;
+#else
+	return 0;
+#endif
+}
+
 /*
  * ds5_hw_reset_with_recovery - Perform hardware reset with readiness polling
  * @state: Driver state structure
@@ -2622,6 +2658,14 @@ static int ds5_hw_reset_with_recovery(struct ds5 *state)
 		dev_type,
 		(state->fw_version >> 8) & 0xff, state->fw_version & 0xff,
 		(state->fw_build >> 8) & 0xff, state->fw_build & 0xff);
+
+	dev_info(&state->client->dev,
+		"%s(): disabling serializer ESYNC after HW reset\n", __func__);
+	ret = ds5_set_ser_esync_tunneling(state, false);
+	if (ret)
+		dev_warn(&state->client->dev,
+			"%s(): serializer ESYNC disable after HW reset failed (%d)\n",
+			__func__, ret);
 
 	WRITE_ONCE(state->ds5_dev->last_reset_jiffies, jiffies);
 
@@ -2928,6 +2972,15 @@ static int ds5_s_ctrl(struct v4l2_ctrl *ctrl)
 			ret = ds5_write(state, base | DS5_CAMERA_SYNC_MODE, ctrl->val);
 			dev_info(&state->client->dev, "%s(): SYNC_MODE command passed to FW, addr: 0x%x, value: %d, ret: %d\n",
 				__func__, base | DS5_CAMERA_SYNC_MODE, ctrl->val, ret);
+			if (!ret) {
+				bool need_esync = (ctrl->val == 2 || ctrl->val == 3);
+
+				dev_info(&state->client->dev,
+					"%s(): sync_mode=%d -> serializer ESYNC %s\n",
+					__func__, ctrl->val,
+					need_esync ? "enable" : "disable");
+				ret = ds5_set_ser_esync_tunneling(state, need_esync);
+			}
 		}
 		break;
 	case DS5_CAMERA_CID_PWM:
@@ -3950,13 +4003,6 @@ static int ds5_gmsl_serdes_setup(struct ds5 *state)
 	/* proceed even if ser setup failed, to setup deser correctly */
 	if (err)
 		dev_err(dev, "gmsl serializer setup failed\n");
-
-	/* Extended GPIO tunneling for MAX96712A deserializer */
-	if (state->dser_ops == &max96712_interface) {
-		int tun_err = max9295_setup_gpio_tunneling(state->ser_dev);
-		if (tun_err)
-			dev_err(dev, "gmsl serializer GPIO tunneling setup failed\n");
-	}
 
 	des_err = state->dser_ops->setup_control(state->dser_dev, &state->client->dev);
 	if (des_err) {

--- a/nvidia-oot/6.0/0004-Add-max9295-GPIO-tunneling-for-the-external-sync-support.patch
+++ b/nvidia-oot/6.0/0004-Add-max9295-GPIO-tunneling-for-the-external-sync-support.patch
@@ -8,10 +8,12 @@ for MAX96712A external sync support.
 
 Includes max9295_enable_gpio_tunneling() export for MAX96712A usage.
 
+Signed-off-by: ejgoldik <ehud.joseph.goldik@realsenseai.com>
+Signed-off-by: ipilchin1 <inga.pilchin@realsenseai.com>
 ---
- drivers/media/i2c/max9295.c | 33 +++++++++++++++++++++++++++++++++
- include/media/max9295.h     |  3 +++
- 2 files changed, 36 insertions(+)
+ drivers/media/i2c/max9295.c | 69 +++++++++++++++++++++++++++++++++++++++++++++
+ include/media/max9295.h     |  4 +++
+ 2 files changed, 73 insertions(+)
 
 diff --git a/drivers/media/i2c/max9295.c b/drivers/media/i2c/max9295.c
 index e7c77845..eff47e1d 100644
@@ -44,10 +46,25 @@ index e7c77845..eff47e1d 100644
  
  #define MAX9295_MAX_PIPES 0x4
  
-@@ -373,6 +385,47 @@ error:
+@@ -373,6 +385,63 @@ error:
  }
  EXPORT_SYMBOL(max9295_setup_control);
  
++static int max9295_write_acc(struct device *dev, struct regmap *regmap,
++			     u16 addr, u8 val, int *err)
++{
++	unsigned int readback = 0;
++
++	if (*err)
++		return *err;
++	*err = max9295_write_reg(dev, addr, val);
++	if (!*err)
++		regmap_read(regmap, addr, &readback);
++	dev_dbg(dev, "%s: reg 0x%04x written 0x%02x readback 0x%02x\n",
++		__func__, addr, val, readback);
++	return *err;
++}
++
 +int max9295_enable_gpio_tunneling(struct device *dev)
 +{
 +	struct max9295 *priv = dev_get_drvdata(dev);
@@ -56,12 +73,12 @@ index e7c77845..eff47e1d 100644
 +	mutex_lock(&priv->lock);
 +
 +	/* Configure ESYNC registers for MAX96712A deserializer */
-+	max9295_write_reg(dev, MAX9295_SRC_PWDN_ADDR, MAX9295_PWDN_ESYNC_EXT);
-+	max9295_write_reg(dev, MAX9295_SRC_CTRL_ADDR, MAX9295_RESET_ESYNC);
-+	max9295_write_reg(dev, MAX9295_2C0_ADDR, MAX9295_2C0_ESYNC);
-+	max9295_write_reg(dev, MAX9295_2C1_ADDR, MAX9295_2C1_ESYNC);
-+	max9295_write_reg(dev, MAX9295_2C2_ADDR, MAX9295_2C2_ESYNC);
-+	max9295_write_reg(dev, MAX9295_2C3_ADDR, MAX9295_2C3_ESYNC);
++	max9295_write_acc(dev, priv->regmap, MAX9295_SRC_PWDN_ADDR, MAX9295_PWDN_ESYNC_EXT, &err);
++	max9295_write_acc(dev, priv->regmap, MAX9295_SRC_CTRL_ADDR, MAX9295_RESET_ESYNC, &err);
++	max9295_write_acc(dev, priv->regmap, MAX9295_2C0_ADDR, MAX9295_2C0_ESYNC, &err);
++	max9295_write_acc(dev, priv->regmap, MAX9295_2C1_ADDR, MAX9295_2C1_ESYNC, &err);
++	max9295_write_acc(dev, priv->regmap, MAX9295_2C2_ADDR, MAX9295_2C2_ESYNC, &err);
++	max9295_write_acc(dev, priv->regmap, MAX9295_2C3_ADDR, MAX9295_2C3_ESYNC, &err);
 +
 +	mutex_unlock(&priv->lock);
 +
@@ -76,12 +93,13 @@ index e7c77845..eff47e1d 100644
 +
 +	mutex_lock(&priv->lock);
 +
-+	max9295_write_reg(dev, MAX9295_SRC_PWDN_ADDR, MAX9295_PWDN_GPIO);
-+	max9295_write_reg(dev, MAX9295_SRC_CTRL_ADDR, MAX9295_RESET_SRC);
-+	max9295_write_reg(dev, MAX9295_2C0_ADDR, 0x00);
-+	max9295_write_reg(dev, MAX9295_2C1_ADDR, 0x00);
-+	max9295_write_reg(dev, MAX9295_2C2_ADDR, 0x00);
-+	max9295_write_reg(dev, MAX9295_2C3_ADDR, 0x00);
++	/* Restore default SRC pin function — plain GPIO, no ESYNC tunneling */
++	max9295_write_acc(dev, priv->regmap, MAX9295_SRC_PWDN_ADDR, MAX9295_PWDN_GPIO, &err);
++	max9295_write_acc(dev, priv->regmap, MAX9295_SRC_CTRL_ADDR, MAX9295_RESET_SRC, &err);
++	max9295_write_acc(dev, priv->regmap, MAX9295_2C0_ADDR, 0x00, &err);
++	max9295_write_acc(dev, priv->regmap, MAX9295_2C1_ADDR, 0x00, &err);
++	max9295_write_acc(dev, priv->regmap, MAX9295_2C2_ADDR, 0x00, &err);
++	max9295_write_acc(dev, priv->regmap, MAX9295_2C3_ADDR, 0x00, &err);
 +
 +	mutex_unlock(&priv->lock);
 +

--- a/nvidia-oot/6.0/0004-Add-max9295-GPIO-tunneling-for-the-external-sync-support.patch
+++ b/nvidia-oot/6.0/0004-Add-max9295-GPIO-tunneling-for-the-external-sync-support.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Add max9295 GPIO tunneling for the external sync support
 Add MAX9295A serializer GPIO tunneling / ESYNC register configuration
 for MAX96712A external sync support.
 
-Includes max9295_setup_gpio_tunneling() export for MAX96712A usage.
+Includes max9295_enable_gpio_tunneling() export for MAX96712A usage.
 
 ---
  drivers/media/i2c/max9295.c | 33 +++++++++++++++++++++++++++++++++
@@ -44,11 +44,11 @@ index e7c77845..eff47e1d 100644
  
  #define MAX9295_MAX_PIPES 0x4
  
-@@ -373,6 +385,27 @@ error:
+@@ -373,6 +385,47 @@ error:
  }
  EXPORT_SYMBOL(max9295_setup_control);
  
-+int max9295_setup_gpio_tunneling(struct device *dev)
++int max9295_enable_gpio_tunneling(struct device *dev)
 +{
 +	struct max9295 *priv = dev_get_drvdata(dev);
 +	int err = 0;
@@ -67,7 +67,27 @@ index e7c77845..eff47e1d 100644
 +
 +	return err;
 +}
-+EXPORT_SYMBOL(max9295_setup_gpio_tunneling);
++EXPORT_SYMBOL(max9295_enable_gpio_tunneling);
++
++int max9295_disable_gpio_tunneling(struct device *dev)
++{
++	struct max9295 *priv = dev_get_drvdata(dev);
++	int err = 0;
++
++	mutex_lock(&priv->lock);
++
++	max9295_write_reg(dev, MAX9295_SRC_PWDN_ADDR, MAX9295_PWDN_GPIO);
++	max9295_write_reg(dev, MAX9295_SRC_CTRL_ADDR, MAX9295_RESET_SRC);
++	max9295_write_reg(dev, MAX9295_2C0_ADDR, 0x00);
++	max9295_write_reg(dev, MAX9295_2C1_ADDR, 0x00);
++	max9295_write_reg(dev, MAX9295_2C2_ADDR, 0x00);
++	max9295_write_reg(dev, MAX9295_2C3_ADDR, 0x00);
++
++	mutex_unlock(&priv->lock);
++
++	return err;
++}
++EXPORT_SYMBOL(max9295_disable_gpio_tunneling);
 +
  int max9295_reset_control(struct device *dev)
  {
@@ -76,12 +96,13 @@ diff --git a/include/media/max9295.h b/include/media/max9295.h
 index c576e3e5..1acfe0fe 100644
 --- a/include/media/max9295.h
 +++ b/include/media/max9295.h
-@@ -86,6 +86,9 @@ int max9295_sdev_unpair(struct device *dev, struct device *s_dev);
+@@ -86,6 +86,10 @@ int max9295_sdev_unpair(struct device *dev, struct device *s_dev);
  int max9295_setup_streaming(struct device *dev);
  
  int max9295_init_settings(struct device *dev);
 +
-+int max9295_setup_gpio_tunneling(struct device *dev);
++int max9295_enable_gpio_tunneling(struct device *dev);
++int max9295_disable_gpio_tunneling(struct device *dev);
 +
  /** @} */
  


### PR DESCRIPTION
Replace probe-time one-shot GPIO tunneling setup with on-demand enable/disable tied to the sync_mode V4L2 control.

Changes:

d4xx.c: 
Add ds5_set_ser_esync_tunneling() to enable/disable MAX9295A serializer GPIO tunneling.
Enable ESYNC when sync_mode is set to slave (2) or master (3), disable otherwise. 
Disable ESYNC after HW reset to ensure clean state. 
Remove probe-time max9295_setup_gpio_tunneling() call.

max9295 patches (JP 5.x.x, 5.1.2, 6.x.x, 7.x): 
Rename max9295_setup_gpio_tunneling() → max9295_enable_gpio_tunneling(), add max9295_disable_gpio_tunneling() to reset ESYNC registers, export both.

Why: GPIO tunneling was previously enabled unconditionally at probe and never disabled, which could interfere with cameras not using external sync. This makes ESYNC tunneling follow the actual sync mode requested by userspace.