### PR TITLE
MAX96712 increase lane data rate to 2500Mbps (JP6.x + JP7.x)

### DIFF
--- a/nvidia-oot/6.0/0006-Adding-max96712-support-for-D4xx.patch
+++ b/nvidia-oot/6.0/0006-Adding-max96712-support-for-D4xx.patch
@@ -513,8 +513,8 @@ index 8e237eef..188bb083 100644
 +		/* Put DPLL in reset before changing MIPI lane rates */
 +		{MAX96712_DPLL_0_ADDR, 0xF4}, //0x1D00
 +
-+		/* 1500Mbps/lane on port A */
-+		{MAX96712_BACKTOP25_ADDR, 0x2f}, //0x418
++		/* 2500Mbps/lane on port A */
++		{MAX96712_BACKTOP25_ADDR, 0x39}, //0x418
 +
 +		/* Release DPLL reset */
 +		{MAX96712_DPLL_0_ADDR, 0xF5}, //0x1D00


### PR DESCRIPTION
Needed in order to handle data bursts seen when running **Externally synced D401 cameras** with depth + rgb at resolution 848x480 and above