### PR TITLE
Add support for D5xx cameras with MAX96717/MAX96724

### DIFF
--- a/hardware/realsense/tegra234-camera-d5xx-overlay.dts
+++ b/hardware/realsense/tegra234-camera-d5xx-overlay.dts
@@ -1,0 +1,577 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// SPDX-FileCopyrightText: Copyright (c) 2026, RealSense CORPORATION.  All rights reserved.
+
+/*
+ * Device tree overlay for RealSense D585-3C depth camera with:
+ *   Serializer:   MAX96717
+ *   Deserializer: MAX96724
+ *   Camera SoC:   HKR
+ *   I2C Mux:      TCA9548
+ *
+ * VC assignment
+ *   VC0 = Depth  (Z16,  1280x720  @60fps)
+ *   VC1 = RGB    (YUY2, 1920x1080 @30fps)
+ *   VC2 = IR     (Y8/Y8I/Y12I, 1280x720 @60fps)
+ *   VC3 = IMU    (RAW8)
+ *
+ * GMSL link:
+ *   GMSL2 Tunnel Mode, 6 Gbps
+ *   HKR MIPI Tx → MAX96717: 4-lane CSI-2
+ *   MAX96724 → Orin NVCSI:  2-lane CSI-2 (SC20190112 board routes only D0/D1)
+ *
+ * I2C address map (7-bit):
+ *   TCA9548  mux:    0x72  (same as D4xx deser board)
+ *   MAX96724 deser:  0x27  (user-confirmed)
+ *   MAX96717 ser:    0x40  (default), 0x60 (aliased, user-confirmed)
+ *   HKR camera SoC:  0x42  (def-addr, user-confirmed)
+ *   Sensor aliases:   0x1a (Depth), 0x1b (RGB), 0x1c (IR), 0x1d (IMU)
+ *
+ * The four logical streams follow the D5xx driver stream model:
+ * Depth=0, RGB=1, IR=2, IMU=3.
+ */
+
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/clock/tegra234-clock.h>
+#include <dt-bindings/gpio/tegra234-gpio.h>
+#include <dt-bindings/tegra234-p3737-0000+p3701-0000.h>
+
+#define CAM0_RST_L	TEGRA234_MAIN_GPIO(H, 3)
+#define CAMERA_I2C_MUX_BUS(x) (0x1E + x)
+
+/ {
+	overlay-name = "Jetson RealSense Camera D5xx with max96724 and tca9548";
+	jetson-header-name = "Jetson AGX CSI Connector";
+	compatible = JETSON_COMPATIBLE;
+
+	fragment@0 {
+		target-path = "/";
+		__overlay__ {
+			tegra-capture-vi {
+				/* 4 channels: Depth(VC0), RGB(VC1), IR(VC2), IMU(VC3) */
+				num-channels = <4>;
+				ports {
+					status = "okay";
+
+					/* VC0: Depth — Z16 1280x720 @60fps */
+					port@0 {
+						status = "okay";
+						reg = <0>;
+						d5xx_vi_in0: endpoint {
+							status = "okay";
+							vc-id = <0>;
+							port-index = <0>;
+							bus-width = <2>; /* 2-lane CSI from MAX96724 (SC20190112: only D0/D1 routed) */
+							remote-endpoint = <&d5xx_csi_out0>;
+						};
+					};
+
+					/* VC1: RGB — YUY2 1920x1080 @30fps */
+					port@1 {
+						status = "okay";
+						reg = <1>;
+						d5xx_vi_in1: endpoint {
+							status = "okay";
+							vc-id = <1>;
+							port-index = <0>;
+							bus-width = <2>;
+							remote-endpoint = <&d5xx_csi_out1>;
+						};
+					};
+
+					/* VC2: IR — Y8/Y8I/Y12I 1280x720 @60fps */
+					port@2 {
+						status = "okay";
+						reg = <2>;
+						d5xx_vi_in2: endpoint {
+							status = "okay";
+							vc-id = <2>;
+							port-index = <0>;
+							bus-width = <2>;
+							remote-endpoint = <&d5xx_csi_out2>;
+						};
+					};
+
+					/* VC3: IMU — RAW8 */
+					port@3 {
+						status = "okay";
+						reg = <3>;
+						d5xx_vi_in3: endpoint {
+							status = "okay";
+							vc-id = <3>;
+							port-index = <0>;
+							bus-width = <2>;
+							remote-endpoint = <&d5xx_csi_out3>;
+						};
+					};
+				};
+			};
+
+			bus@0 {
+				host1x@13e00000 {
+					nvcsi@15a00000 {
+						num-channels = <4>;
+
+						/* NVCSI channel 0: Depth (VC0) */
+						channel@0 {
+							status = "okay";
+							reg = <0>;
+							ports {
+								status = "okay";
+								port@0 {
+									status = "okay";
+									reg = <0>;
+									d5xx_csi_in0: endpoint@0 {
+										status = "okay";
+										port-index = <0>;
+									bus-width = <2>;
+										vc-id = <0>;
+
+										remote-endpoint = <&d5xx_depth_out>;
+									};
+								};
+								port@1 {
+									status = "okay";
+									reg = <1>;
+									d5xx_csi_out0: endpoint@1 {
+										status = "okay";
+										remote-endpoint = <&d5xx_vi_in0>;
+									};
+								};
+							};
+						};
+
+						/* NVCSI channel 1: RGB (VC1) */
+						channel@1 {
+							status = "okay";
+							reg = <1>;
+							ports {
+								status = "okay";
+								port@0 {
+									status = "okay";
+									reg = <0>;
+									d5xx_csi_in1: endpoint@2 {
+										status = "okay";
+										port-index = <0>;
+									bus-width = <2>;
+										vc-id = <1>;
+
+										remote-endpoint = <&d5xx_rgb_out>;
+									};
+								};
+								port@1 {
+									status = "okay";
+									reg = <1>;
+									d5xx_csi_out1: endpoint@3 {
+										status = "okay";
+										remote-endpoint = <&d5xx_vi_in1>;
+									};
+								};
+							};
+						};
+
+						/* NVCSI channel 2: IR (VC2) */
+						channel@2 {
+							status = "okay";
+							reg = <2>;
+							ports {
+								status = "okay";
+								port@0 {
+									status = "okay";
+									reg = <0>;
+									d5xx_csi_in2: endpoint@4 {
+										status = "okay";
+										port-index = <0>;
+									bus-width = <2>;
+										vc-id = <2>;
+									remote-endpoint = <&d5xx_ir_out>;
+									};
+								};
+								port@1 {
+									status = "okay";
+									reg = <1>;
+									d5xx_csi_out2: endpoint@5 {
+										status = "okay";
+										remote-endpoint = <&d5xx_vi_in2>;
+									};
+								};
+							};
+						};
+
+						/* NVCSI channel 3: IMU (VC3) */
+						channel@3 {
+							status = "okay";
+							reg = <3>;
+							ports {
+								status = "okay";
+								port@0 {
+									status = "okay";
+									reg = <0>;
+									d5xx_csi_in3: endpoint@6 {
+										status = "okay";
+										port-index = <0>;
+									bus-width = <2>;
+										vc-id = <3>;
+									remote-endpoint = <&d5xx_imu_out>;
+									};
+								};
+								port@1 {
+									status = "okay";
+									reg = <1>;
+									d5xx_csi_out3: endpoint@7 {
+										status = "okay";
+										remote-endpoint = <&d5xx_vi_in3>;
+									};
+								};
+							};
+						};
+					};
+				};
+
+				i2c@3180000 {
+					clock-frequency = <400000>;
+					tca9548@72 {
+						status = "okay";
+						reg = <0x72>;
+						compatible = "nxp,pca9548";
+						#address-cells = <1>;
+						#size-cells = <0>;
+						skip_mux_detect = "yes";
+						vcc-supply = <&vdd_1v8_ls>;
+						force_bus_start = <CAMERA_I2C_MUX_BUS(0)>;
+						vcc_lp = "vcc";
+
+						i2c@0 {
+							status = "okay";
+							reg = <0>;
+							i2c-mux,deselect-on-exit;
+							#address-cells = <1>;
+							#size-cells = <0>;
+
+							/*
+							 * MAX96724 Deserializer
+							 * [DS2] MAX96724 Datasheet rev4
+							 * I2C addr: 0x27 (7-bit, user-confirmed)
+							 * csi-mode: "1x4" — 2-lane D-PHY output (SC20190112: only 2 lanes to Orin)
+							 * max-src: 1 — single D585 camera on link B
+							 * gmsl-link-speed: 6 — 6Gbps (matching XML reference)
+							 * csi-mode: "2x4" — phy_1x4a mode, Controller1→PortA, only PHY0(2 lane) enabled
+							 */
+							dser: max96724@27 {
+								status = "okay";
+								reg = <0x27>;
+								compatible = "adi,max96724";
+								csi-mode = "1x4";
+								max-src = <1>;
+								gmsl-link-speed = <6>;
+								reset-gpios = <&gpio CAM0_RST_L GPIO_ACTIVE_HIGH>;
+							};
+
+							/*
+							 * MAX96717 primary serializer node at power-on address.
+							 * max96717_setup_control() uses this handle to move
+							 * the serializer from 0x40 to the aliased 0x60 address.
+							 */
+							ser_prim: max96717_prim@40 {
+								status = "okay";
+								compatible = "adi,max96717";
+								reg = <0x40>;
+								is-prim-ser;
+							};
+
+							/*
+							 * MAX96717 Serializer alias used after address reassignment.
+							 * [DS1] MAX96717 Datasheet rev6
+							 * [HAS] Section 1.2: "GMSL serializer (MAX96717)"
+							 * I2C alias addr: 0x60 (7-bit, user-confirmed)
+							 * MAX96717 has single 4-lane CSI-2 D-PHY input
+							 */
+							ser_a: max96717_a@60 {
+								status = "okay";
+								compatible = "adi,max96717";
+								reg = <0x60>;
+								maxim,gmsl-dser-device = <&dser>;
+							};
+
+							/*
+							 * D585 Depth stream — VC0
+							 * [HAS] Table 3-5: Depth, Z16, 1280x720, 60fps, VC0
+							 * [HAS] Section 4.1: "HKR assigns output streams to
+							 *        MIPI VC: Depth→VC0"
+							 *
+							 * def-addr: 0x42 = HKR SoC I2C base (user-confirmed)
+							 * reg: 0x1a = primary aliased address (user-confirmed)
+							 */
+							d5xx_depth: d5xx@1a {
+								status = "okay";
+								def-addr = <0x42>;
+								reg = <0x1a>;
+								compatible = "realsense,d5xx";
+								use_sensor_mode_id = "true";
+								vcc-supply = <&vdd_1v8_ls>;
+								cam-type = "Depth";
+								nvidia,gmsl-ser-device = <&ser_a>;
+								nvidia,gmsl-dser-device = <&dser>;
+
+								ports {
+									#address-cells = <1>;
+									#size-cells = <0>;
+
+									port@0 {
+										reg = <0>;
+										d5xx_depth_out: endpoint {
+											vc-id = <0>;
+											port-index = <0>;
+										bus-width = <2>;
+											remote-endpoint = <&d5xx_csi_in0>;
+										};
+									};
+								};
+
+								/*
+								 * Depth mode: Z16 (16bpp), 1280x720
+								 * [HAS] Table 3-5: "Z16 (16-bit depth), 1280×720, 60fps"
+								 * [FAS] Table 4-1: "Depth - VC0, DT 0x1E (YUV422), 16bpp"
+								 * num_lanes: 2 — MAX96724 outputs 2 CSI lanes via SC20190112
+								 * embedded_metadata_height: 1 — depth metadata row
+								 */
+								mode0 {
+									pixel_t = "grey_y16";
+									num_lanes = "2";
+									csi_pixel_bit_depth = "16";
+									active_w = "1280";
+									active_h = "720";
+									tegra_sinterface = "serial_a";
+									phy_mode = "DPHY";
+									discontinuous_clk = "no";
+									mclk_khz = "24000";
+									pix_clk_hz = "175000000";
+									line_length = "1280";
+									embedded_metadata_height = "1";
+								};
+
+								/*
+								 * GMSL link config for Depth stream
+								 * src-csi-port: "a" — MAX96717 single CSI input port
+								 *   [DS1] MAX96717 has one 4-lane D-PHY CSI-2 input (Port A)
+								 * dst-csi-port: "a" — MAX96724 CSI output port A
+								 * serdes-csi-link: "b" — GMSL Link B (cable on port B)
+								 * csi-mode: "1x4" — single link, 4 video pipes
+								 * st-vc: 0 — starting VC offset
+								 * vc-id: 0 — [HAS] Table 3-5: Depth → VC0
+								 * num-lanes: 2 — SC20190112 only routes 2 CSI lanes to Orin
+								 */
+								gmsl-link {
+									src-csi-port = "a";
+									dst-csi-port = "a";
+									serdes-csi-link = "a";
+									csi-mode = "1x4";
+									st-vc = <0>;
+									vc-id = <0>;
+									num-lanes = <2>;
+								};
+							};
+
+							/*
+							 * D585 RGB stream — VC1
+							 * RGB follows the D5xx stream model as stream 1 / VC1.
+							 *
+							 * def-addr: 0x42 = HKR SoC I2C base
+							 * reg: 0x1b = aliased address
+							 * override_reg: 0x1a = redirect to primary node
+							 */
+							d5xx_rgb: d5xx@1b {
+								status = "okay";
+								def-addr = <0x42>;
+								reg = <0x1b>;
+								override_reg = <0x1a>;
+								compatible = "realsense,d5xx";
+								use_sensor_mode_id = "true";
+								vcc-supply = <&vdd_1v8_ls>;
+								cam-type = "RGB";
+								nvidia,gmsl-ser-device = <&ser_a>;
+								nvidia,gmsl-dser-device = <&dser>;
+
+								ports {
+									#address-cells = <1>;
+									#size-cells = <0>;
+
+									port@0 {
+										reg = <0>;
+										d5xx_rgb_out: endpoint {
+											vc-id = <1>;
+											port-index = <0>;
+										bus-width = <2>;
+											remote-endpoint = <&d5xx_csi_in1>;
+										};
+									};
+								};
+
+								/*
+								 * RGB mode: YUY2 (16bpp), 1920x1080
+								 * embedded_metadata_height: 1 — RGB metadata row
+								 */
+								mode0 {
+									pixel_t = "grey_y16";
+									num_lanes = "2";
+									csi_pixel_bit_depth = "16";
+									active_w = "1920";
+									active_h = "1080";
+									tegra_sinterface = "serial_a";
+									phy_mode = "DPHY";
+									discontinuous_clk = "no";
+									mclk_khz = "24000";
+									pix_clk_hz = "175000000";
+									line_length = "1920";
+									embedded_metadata_height = "1";
+								};
+
+								gmsl-link {
+									src-csi-port = "a";
+									dst-csi-port = "a";
+									serdes-csi-link = "a";
+									csi-mode = "1x4";
+									st-vc = <1>;
+									vc-id = <1>;
+									num-lanes = <2>;
+								};
+							};
+
+							/*
+							 * D585 IR stream — VC2
+							 * Y8, Y8I, and Y12I are mutually exclusive formats on
+							 * one logical IR stream, not separate left/right nodes.
+							 *
+							 * def-addr: 0x42 = HKR SoC I2C base
+							 * reg: 0x1c = aliased address
+							 * override_reg: 0x1a = redirect to primary node
+							 */
+							d5xx_ir: d5xx@1c {
+								status = "okay";
+								def-addr = <0x42>;
+								reg = <0x1c>;
+								override_reg = <0x1a>;
+								compatible = "realsense,d5xx";
+								use_sensor_mode_id = "true";
+								vcc-supply = <&vdd_1v8_ls>;
+								cam-type = "Y8";
+								nvidia,gmsl-ser-device = <&ser_a>;
+								nvidia,gmsl-dser-device = <&dser>;
+
+								ports {
+									#address-cells = <1>;
+									#size-cells = <0>;
+
+									port@0 {
+										reg = <0>;
+										d5xx_ir_out: endpoint {
+											vc-id = <2>;
+											port-index = <0>;
+										bus-width = <2>;
+											remote-endpoint = <&d5xx_csi_in2>;
+										};
+									};
+								};
+
+								/*
+								 * IR mode: Y8/Y8I/Y12I, 1280x720
+								 * embedded_metadata_height: 1 — IR metadata row
+								 */
+								mode0 {
+									pixel_t = "grey_y16";
+									num_lanes = "2";
+									csi_pixel_bit_depth = "16";
+									active_w = "1280";
+									active_h = "720";
+									tegra_sinterface = "serial_a";
+									phy_mode = "DPHY";
+									discontinuous_clk = "no";
+									mclk_khz = "24000";
+									pix_clk_hz = "175000000";
+									line_length = "1280";
+									embedded_metadata_height = "1";
+								};
+
+								gmsl-link {
+									src-csi-port = "a";
+									dst-csi-port = "a";
+									serdes-csi-link = "a";
+									csi-mode = "1x4";
+									st-vc = <2>;
+									vc-id = <2>;
+									num-lanes = <2>;
+								};
+							};
+
+							/*
+							 * D585 IMU stream — VC3
+							 * IMU follows the D5xx stream model as stream 3 / VC3.
+							 *
+							 * def-addr: 0x42 = HKR SoC I2C base
+							 * reg: 0x1d = aliased address
+							 * override_reg: 0x1a = redirect to primary node
+							 */
+							d5xx_imu: d5xx@1d {
+								status = "okay";
+								def-addr = <0x42>;
+								reg = <0x1d>;
+								override_reg = <0x1a>;
+								compatible = "realsense,d5xx";
+								use_sensor_mode_id = "true";
+								vcc-supply = <&vdd_1v8_ls>;
+								cam-type = "IMU";
+								nvidia,gmsl-ser-device = <&ser_a>;
+								nvidia,gmsl-dser-device = <&dser>;
+
+								ports {
+									#address-cells = <1>;
+									#size-cells = <0>;
+
+									port@0 {
+										reg = <0>;
+										d5xx_imu_out: endpoint {
+											vc-id = <3>;
+											port-index = <0>;
+										bus-width = <2>;
+											remote-endpoint = <&d5xx_csi_in3>;
+										};
+									};
+								};
+
+								/*
+								 * IMU mode: RAW8 logical stream on VC3.
+								 * embedded_metadata_height: 0 — IMU has no metadata row.
+								 */
+								mode0 {
+									pixel_t = "grey_y16";
+									num_lanes = "2";
+									csi_pixel_bit_depth = "16";
+									active_w = "640";
+									active_h = "480";
+									tegra_sinterface = "serial_a";
+									phy_mode = "DPHY";
+									discontinuous_clk = "no";
+									mclk_khz = "24000";
+									pix_clk_hz = "175000000";
+									line_length = "1280";
+									embedded_metadata_height = "0";
+								};
+
+								gmsl-link {
+									src-csi-port = "a";
+									dst-csi-port = "a";
+									serdes-csi-link = "a";
+									csi-mode = "1x4";
+									st-vc = <3>;
+									vc-id = <3>;
+									num-lanes = <2>;
+								};
+							};
+						};
+					};
+				};
+			};
+		};
+	};
+};

--- a/kernel/realsense/d5xx.c
+++ b/kernel/realsense/d5xx.c
@@ -1,0 +1,6113 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * RealSense D5XX camera driver
+ *
+ * Copyright (c) 2026, RealSense, Inc. All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms and conditions of the GNU General Public License,
+ * version 2, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <linux/delay.h>
+#include <linux/gpio.h>
+#include <linux/i2c.h>
+#include <linux/kernel.h>
+#include <linux/media.h>
+#include <linux/module.h>
+#include <linux/of_gpio.h>
+#include <linux/regmap.h>
+#include <linux/regulator/consumer.h>
+#include <linux/slab.h>
+#include <linux/string.h>
+#include <linux/videodev2.h>
+#include <linux/version.h>
+#include <linux/mutex.h>
+#include <media/media-entity.h>
+#include <media/v4l2-ctrls.h>
+#include <media/v4l2-device.h>
+#include <media/v4l2-subdev.h>
+#include <media/v4l2-mediabus.h>
+
+#ifdef CONFIG_VIDEO_D5XX_SERDES
+#include <media/max96717.h>
+#include <media/max96724.h>
+
+/* Deserializer interface structure for abstraction */
+struct dser_interface {
+	/* Pipeline management */
+	int (*get_available_pipe_id)(struct device *dev, int vc_id);
+	int (*get_ser_pipe_id)(struct device *dev, int dser_pipe_id, int vc_id);
+	int (*bind_ser_to_dser_pipe)(struct device *dev, int dser_pipe_id, int ser_pipe_id, u32 vc_id);
+
+	int (*set_pipe)(struct device *dev, int pipe_id, u8 data_type1, u8 data_type2, u32 vc_id);
+	int (*release_pipe)(struct device *dev, int pipe_id);
+	void (*reset_oneshot)(struct device *dev);
+	
+	/* Setup and control */
+	int (*setup_link)(struct device *dev, struct device *s_dev);
+	int (*setup_control)(struct device *dev, struct device *s_dev);
+	int (*reset_control)(struct device *dev, struct device *s_dev);
+	
+	/* Device registration */
+	int (*sdev_register)(struct device *dev, struct gmsl_link_ctx *g_ctx);
+	int (*sdev_unregister)(struct device *dev, struct device *s_dev);
+	
+	/* Power management */
+	int (*power_on)(struct device *dev);
+	void (*power_off)(struct device *dev);
+	int (*init_settings)(struct device *dev);
+
+	/* Identification */
+	const char *name;
+};
+
+#else
+#include <media/gmsl-link.h>
+#define GMSL_CSI_DT_YUV422_8 0x1E
+#define GMSL_CSI_DT_RGB_888 0x24
+#define GMSL_CSI_DT_RAW_8 0x2A
+#define GMSL_CSI_DT_EMBED 0x12
+#endif
+
+/*
+ * DS5_BYPASS_CAMERA_I2C: Bypass all I2C communication to the D5XX camera
+ * sensor while keeping GMSL SERDES (MAX96717/MAX96724) fully operational.
+ * Use this when the camera is already streaming MIPI data independently
+ * and only the SERDES link + V4L2 registration is needed on the Orin side.
+ */
+#define DS5_BYPASS_CAMERA_I2C 0   // Comment out to enable camera I2C control
+
+//#define DS5_DRIVER_NAME "DS5 RealSense camera driver"
+#define DS5_DRIVER_NAME "d5xx"
+#define DS5_DRIVER_NAME_AWG "d5xx-awg"
+#define DS5_DRIVER_NAME_ASR "d5xx-asr"
+#define DS5_DRIVER_NAME_CLASS "d5xx-class"
+#define DS5_DRIVER_NAME_DFU "d5xx-dfu"
+
+#define DS5_MIPI_SUPPORT_LINES		0x0300
+#define DS5_MIPI_SUPPORT_PHY		0x0304
+#define DS5_MIPI_DATARATE_MIN		0x0308
+#define DS5_MIPI_DATARATE_MAX		0x030A
+#define DS5_FW_VERSION			0x030C
+#define DS5_FW_BUILD			0x030E
+#define DS5_DEVICE_TYPE			0x0310
+#define DS5_DEVICE_TYPE_D58X		9
+#define DS5_DEVICE_TYPE_UNKNOWN		0
+
+#define DS5_MIPI_LANE_NUMS		0x0400
+#define DS5_MIPI_LANE_DATARATE		0x0402
+#define DS5_MIPI_CONF_STATUS		0x0500
+
+#define DS5_START_STOP_STREAM		0x1000
+#define DS5_DEPTH_STREAM_STATUS		0x1004
+#define DS5_RGB_STREAM_STATUS		0x1008
+#define DS5_IMU_STREAM_STATUS		0x100C
+#define DS5_IR_STREAM_STATUS		0x1014
+
+#define DS5_STREAM_DEPTH		0x0
+#define DS5_STREAM_RGB			0x1
+#define DS5_STREAM_IMU			0x2
+#define DS5_STREAM_IR			0x4
+#define DS5_STREAM_STOP			0x100
+#define DS5_STREAM_START		0x200
+#define DS5_STREAM_IDLE			0x1
+#define DS5_STREAM_STREAMING		0x2
+
+#define DS5_DEPTH_STREAM_DT		 0x4000
+#define DS5_DEPTH_STREAM_MD		 0x4002
+#define DS5_DEPTH_RES_WIDTH		 0x4004
+#define DS5_DEPTH_RES_HEIGHT	 0x4008
+#define DS5_DEPTH_FPS			 0x400C
+#define DS5_DEPTH_OVERRIDE		 0x401C
+#define DS5_DEPTH_CONTROL_STATUS 0x401E
+
+#define DS5_RGB_STREAM_DT		0x4020
+#define DS5_RGB_STREAM_MD		0x4022
+#define DS5_RGB_RES_WIDTH		0x4024
+#define DS5_RGB_RES_HEIGHT		0x4028
+#define DS5_RGB_FPS				0x402C
+#define DS5_RGB_CONTROL_STATUS 	0x402E
+
+#define DS5_IMU_STREAM_DT		0x4040
+#define DS5_IMU_STREAM_MD		0x4042
+#define DS5_IMU_RES_WIDTH		0x4044
+#define DS5_IMU_RES_HEIGHT		0x4048
+#define DS5_IMU_FPS				0x404C
+#define DS5_IMU_CONTROL_STATUS 	0x404E
+
+#define DS5_IR_STREAM_DT		0x4080
+#define DS5_IR_STREAM_MD		0x4082
+#define DS5_IR_RES_WIDTH		0x4084
+#define DS5_IR_RES_HEIGHT		0x4088
+#define DS5_IR_FPS				0x408C
+#define DS5_IR_OVERRIDE			0x409C
+#define DS5_IR_CONTROL_STATUS 	0x409E
+
+#define DS5_DEPTH_CONTROL_BASE		0x4100
+#define DS5_RGB_CONTROL_BASE		0x4200
+#define DS5_MANUAL_EXPOSURE_LSB		0x0000
+#define DS5_MANUAL_EXPOSURE_MSB		0x0002
+#define DS5_MANUAL_GAIN			0x0004
+#define DS5_LASER_POWER			0x0008
+#define DS5_AUTO_EXPOSURE_MODE		0x000C
+#define DS5_EXPOSURE_ROI_TOP		0x0010
+#define DS5_EXPOSURE_ROI_LEFT		0x0014
+#define DS5_EXPOSURE_ROI_BOTTOM		0x0018
+#define DS5_EXPOSURE_ROI_RIGHT		0x001C
+#define DS5_MANUAL_LASER_POWER		0x0024
+#define DS5_PWM_FREQUENCY		0x0028
+#define DS5_CAMERA_SYNC_MODE		0x002C
+
+#define DS5_DEPTH_CONFIG_STATUS		0x4800
+#define DS5_RGB_CONFIG_STATUS		0x4802
+#define DS5_IMU_CONFIG_STATUS		0x4804
+#define DS5_IR_CONFIG_STATUS		0x4808
+
+#define DS5_STATUS_STREAMING		0x1
+#define DS5_STATUS_INVALID_DT		0x2
+#define DS5_STATUS_INVALID_RES		0x4
+#define DS5_STATUS_INVALID_FPS		0x8
+
+#define MIPI_LANE_RATE			1000
+
+#define MAX_DEPTH_EXP			200000
+#define MAX_RGB_EXP			10000
+#define DEF_DEPTH_EXP			33000
+#define DEF_RGB_EXP			1660
+
+enum ds5_mux_pad {
+	DS5_MUX_PAD_EXTERNAL,
+	DS5_MUX_PAD_DEPTH,
+	DS5_MUX_PAD_RGB,
+	DS5_MUX_PAD_IR,
+	DS5_MUX_PAD_IMU,
+	DS5_MUX_PAD_COUNT,
+};
+
+#define DS5_N_CONTROLS			8
+
+#define DS5_MAX_STREAMS	4
+
+#define PIPE_NOT_CONFIGURED	-1
+
+#define DFU_WAIT_RET_LEN 6
+
+#define DS5_START_POLL_TIME	10
+#define DS5_START_MAX_TIME	2000
+#define DS5_START_MAX_COUNT	(DS5_START_MAX_TIME / DS5_START_POLL_TIME)
+#define MAX_DS5_CONFIG_RETRIES	5
+
+/* I2C retry configuration */
+#define DS5_I2C_RETRY_COUNT	5
+#define DS5_I2C_RETRY_DELAY_US	5000
+
+/* DFU definition section */
+#define DFU_MAGIC_NUMBER "/0x01/0x02/0x03/0x04"
+#define DFU_BLOCK_SIZE 1024
+#ifdef CONFIG_TEGRA_CAMERA_PLATFORM
+#define DFU_I2C_STANDARD_MODE		100000
+#define DFU_I2C_FAST_MODE			400000
+#define DFU_I2C_BUS_CLK_RATE		DFU_I2C_FAST_MODE
+#endif
+#define ds5_read_with_check(state, addr, val) {\
+	if (ds5_read(state, addr, val))	\
+		return -EINVAL; }
+#define ds5_raw_read_with_check(state, addr, buf, size)	{\
+	if (ds5_raw_read(state, addr, buf, size))	\
+		return -EINVAL; }
+#define ds5_write_with_check(state, addr, val) {\
+	if (ds5_write(state, addr, val))	\
+		return -EINVAL; }
+#define ds5_raw_write_with_check(state, addr, buf, size) {\
+	if (ds5_raw_write(state, addr, buf, size)) \
+		return -EINVAL; }
+
+enum dfu_fw_state {
+	appIDLE                = 0x0000,
+	appDETACH              = 0x0001,
+	dfuIDLE                = 0x0002,
+	dfuDNLOAD_SYNC         = 0x0003,
+	dfuDNBUSY              = 0x0004,
+	dfuDNLOAD_IDLE         = 0x0005,
+	dfuMANIFEST_SYNC       = 0x0006,
+	dfuMANIFEST            = 0x0007,
+	dfuMANIFEST_WAIT_RESET = 0x0008,
+	dfuUPLOAD_IDLE         = 0x0009,
+	dfuERROR               = 0x000a
+};
+
+enum dfu_state {
+	DS5_DFU_IDLE = 0,
+	DS5_DFU_RECOVERY,
+	DS5_DFU_OPEN,
+	DS5_DFU_IN_PROGRESS,
+	DS5_DFU_DONE,
+	DS5_DFU_ERROR
+} dfu_state_t;
+
+struct hwm_cmd {
+	u16 header;
+	u16 magic_word;
+	u32 opcode;
+	u32 param1;
+	u32 param2;
+	u32 param3;
+	u32 param4;
+	unsigned char Data[];
+};
+
+static const struct hwm_cmd cmd_switch_to_dfu = {
+	.header = 0x14,
+	.magic_word = 0xCDAB,
+	.opcode = 0x1e,
+	.param1 = 0x01,
+};
+
+enum table_id {
+	COEF_CALIBRATION_ID = 0x19,
+	DEPTH_CALIBRATION_ID = 0x1f,
+	RGB_CALIBRATION_ID = 0x20,
+	IMU_CALIBRATION_ID = 0x22
+} table_id_t;
+
+static const struct hwm_cmd get_calib_data = {
+	.header = 0x14,
+	.magic_word = 0xCDAB,
+	.opcode = 0x15,
+	.param1 = 0x00,	//table_id
+};
+
+static const struct hwm_cmd set_calib_data = {
+	.header = 0x0114,
+	.magic_word = 0xCDAB,
+	.opcode = 0x62,
+	.param1 = 0x00,	//table_id
+	.param2 = 0x02,	//region
+};
+
+static const struct hwm_cmd gvd = {
+	.header = 0x14,
+	.magic_word = 0xCDAB,
+	.opcode = 0x10,
+};
+
+static const struct hwm_cmd set_ae_roi = {
+	.header = 0x14,
+	.magic_word = 0xCDAB,
+	.opcode = 0x44,
+};
+
+static const struct hwm_cmd get_ae_roi = {
+	.header = 0x014,
+	.magic_word = 0xCDAB,
+	.opcode = 0x45,
+};
+
+static const struct hwm_cmd set_ae_setpoint = {
+	.header = 0x18,
+	.magic_word = 0xCDAB,
+	.opcode = 0x2B,
+	.param1 = 0xa, // AE control
+};
+
+static const struct hwm_cmd get_ae_setpoint = {
+	.header = 0x014,
+	.magic_word = 0xCDAB,
+	.opcode = 0x2C,
+	.param1 = 0xa, // AE control
+	.param2 = 0, // get current
+};
+
+static const struct hwm_cmd erb = {
+	.header = 0x14,
+	.magic_word = 0xCDAB,
+	.opcode = 0x17,
+};
+
+static const struct hwm_cmd ewb = {
+	.header = 0x14,
+	.magic_word = 0xCDAB,
+	.opcode = 0x18,
+};
+
+static const struct hwm_cmd cmd_hw_reset = {
+	.header = 0x14,
+	.magic_word = 0xCDAB,
+	.opcode = 0x20,  /* HW reset opcode */
+};
+
+static const struct hwm_cmd log_prepare = {
+	.header = 0x014,
+	.magic_word = 0xCDAB,
+	.opcode = 0xf,
+	.param1 = 0x400, .param2 = 0, .param3 = 0, .param4 = 0,
+};
+struct __fw_status {
+	uint32_t	spare1;
+	uint32_t	FW_lastVersion;
+	uint32_t	FW_highestVersion;
+	uint16_t	FW_DownloadStatus;
+	uint16_t	DFU_isLocked;
+	uint16_t	DFU_version;
+	uint8_t		ivcamSerialNum[8];
+	uint8_t		spare2[42];
+};
+
+/*************************/
+
+struct ds5_ctrls {
+	struct v4l2_ctrl_handler handler;
+	struct v4l2_ctrl_handler handler_depth;
+	struct v4l2_ctrl_handler handler_rgb;
+	struct v4l2_ctrl_handler handler_y8;
+	struct v4l2_ctrl_handler handler_imu;
+	struct {
+		struct v4l2_ctrl *log;
+		struct v4l2_ctrl *fw_version;
+		struct v4l2_ctrl *gvd;
+		struct v4l2_ctrl *get_depth_calib;
+		struct v4l2_ctrl *set_depth_calib;
+		struct v4l2_ctrl *get_coeff_calib;
+		struct v4l2_ctrl *set_coeff_calib;
+		struct v4l2_ctrl *ae_roi_get;
+		struct v4l2_ctrl *ae_roi_set;
+		struct v4l2_ctrl *ae_setpoint_get;
+		struct v4l2_ctrl *ae_setpoint_set;
+		struct v4l2_ctrl *erb;
+		struct v4l2_ctrl *ewb;
+		struct v4l2_ctrl *hwmc;
+		struct v4l2_ctrl *laser_power;
+		struct v4l2_ctrl *manual_laser_power;
+		struct v4l2_ctrl *auto_exp;
+		struct v4l2_ctrl *exposure;
+		/* in DS5 manual gain only works with manual exposure */
+		struct v4l2_ctrl *gain;
+		struct v4l2_ctrl *link_freq;
+		struct v4l2_ctrl *query_sub_stream;
+		struct v4l2_ctrl *set_sub_stream;
+		struct v4l2_ctrl *sync_mode;
+	};
+};
+
+struct ds5_resolution {
+	u16 width;
+	u16 height;
+	u8 n_framerates;
+	const u16 *framerates;
+};
+
+struct ds5_format {
+	unsigned int n_resolutions;
+	const struct ds5_resolution *resolutions;
+	u32 mbus_code;
+	u8 data_type;
+};
+
+struct ds5_sensor {
+	struct v4l2_subdev sd;
+	struct media_pad pad;
+	struct v4l2_mbus_framefmt format;
+	u16 mux_pad;
+	struct {
+		const struct ds5_format *format;
+		const struct ds5_resolution *resolution;
+		u16 framerate;
+	} config;
+	bool streaming;
+	const struct ds5_format *formats;
+	unsigned int n_formats;
+	int pipe_id;
+	u16 pipe_data_type1;
+	u16 pipe_data_type2;
+	u32 pipe_vc_id;
+	u16 cached_dt_value;
+	u16 cached_md_value;
+	u16 cached_override_value;
+	u16 cached_fps_value;
+	u16 cached_width_value;
+	u16 cached_height_value;
+};
+
+#ifdef CONFIG_TEGRA_CAMERA_PLATFORM
+#include <media/camera_common.h>
+#define ds5_mux_subdev camera_common_data
+#else
+struct ds5_mux_subdev {
+	struct v4l2_subdev subdev;
+};
+#endif
+
+struct ds5_variant {
+	const struct ds5_format *formats;
+	unsigned int n_formats;
+};
+
+struct ds5_dfu_dev {
+	struct cdev ds5_cdev;
+	struct class *ds5_class;
+	int device_open_count;
+	enum dfu_state dfu_state_flag;
+	unsigned char *dfu_msg;
+	u16 msg_write_once;
+	// unsigned char init_v4l_f; // need refactoring
+	u32 bus_clk_rate;
+};
+
+enum {
+	DS5_DS5U,
+	DS5_ASR,
+	DS5_AWG,
+};
+
+struct ds5 {
+	struct { struct ds5_sensor sensor; } depth;
+	struct { struct ds5_sensor sensor; } ir;
+	struct { struct ds5_sensor sensor; } rgb;
+	struct { struct ds5_sensor sensor; } imu;
+	struct {
+		struct ds5_mux_subdev sd;
+		struct media_pad pads[DS5_MUX_PAD_COUNT];
+		struct ds5_sensor *last_set;
+	} mux;
+	struct ds5_ctrls ctrls;
+	struct ds5_dfu_dev dfu_dev;
+	bool power;
+	struct i2c_client *client;
+	/* All below pointers are used for writing, cannot be const */
+	struct mutex lock;
+	struct regmap *regmap;
+	struct regulator *vcc;
+	const struct ds5_variant *variant;
+	int is_depth, is_y8, is_rgb, is_imu;
+	bool metadata_enabled;
+	int aggregated;
+	int reset_ref_ds5;
+	int reset_ref_dser;
+	u16 fw_version;
+	u16 fw_build;
+	u16 control_base;
+	u16 control_status_reg;
+#ifdef CONFIG_VIDEO_D5XX_SERDES
+	struct gmsl_link_ctx g_ctx;
+	struct device *ser_dev;
+	struct device *dser_dev;
+	struct i2c_client *ser_i2c;
+	struct i2c_client *dser_i2c;
+	const struct dser_interface *dser_ops;
+	bool serdes_primary; /* true for the instance that ran SERDES setup */
+#endif
+	struct ds5_dev *ds5_dev; /* pointer to DS5 device struct */
+};
+
+struct ds5_dev {
+	struct mutex lock;
+
+	/*
+	* Per-camera reset generation counter.
+	* Incremented whenever the camera undergoes a HW reset,
+	*  either from its own instance or a sibling's instance.
+	* Each instance stores the last seen generation count
+	*  and compares it on each access to detect if a reset has occurred
+	*  and invalidates its own state if so.
+	*/
+	atomic_t reset_gen;
+
+	/* Cached device type from post-reset device-type polling.
+	* During probe the first instance resets the camera, causing DS5_DEVICE_TYPE
+	* to temporarily return 0. The reset path polls until the register is valid
+	* and stores the result here so that all four probe instances (and any
+	* post-reset code path) can use the confirmed value even if the register
+	* read still returns 0.
+	*/
+	u16 cached_device_type;
+
+	/* Timestamp (jiffies) of last completed HW reset.
+	* Used to enforce DS5_HW_RESET_COOLDOWN_MS between consecutive resets
+	* and prevent GMSL link degradation from rapid reset cycles.
+	*/
+	unsigned long last_reset_jiffies;
+
+#ifdef CONFIG_VIDEO_D5XX_SERDES
+ 	/* Pointer to the deserializer dev */
+	struct dser_control *dser_control;
+#endif
+
+	/* Pointer to the primary DS5 struct */
+	struct ds5 *ds5_primary;
+
+	bool depth_streaming;
+	bool ir_streaming;
+	bool rgb_streaming;
+	bool imu_streaming;
+};
+
+#ifdef CONFIG_VIDEO_D5XX_SERDES
+static DEFINE_MUTEX(serdes_lock__);
+static bool ds5_slots_inited;
+
+#define MAX_DSER_NUM 4
+struct dser_control {
+	struct mutex lock;
+
+	/*
+	* Per-deserializer reset generation counter.
+	* Replaces the old global ds5_reset_gen for SERDES builds so that
+	* resetting camera A does not force camera B (on a different deserializer)
+	* to invalidate its state.  Cameras sharing the same deserializer still
+	* see each other's resets through the shared counter.
+	*/
+	atomic_t reset_gen;
+	struct device *dser_dev;
+};
+static struct dser_control dser_inited[MAX_DSER_NUM];
+
+#define MAX_DS5_NUM (MAX_DSER_NUM * 4) /* assuming max 4 DS5 cameras per deserializer (true for max96724) */
+static struct ds5_dev ds5_inited[MAX_DS5_NUM];
+
+static void ds5_init_global_slots_once(void)
+{
+	int i;
+
+	if (ds5_slots_inited) {
+		return;
+	}
+
+	for (i = 0; i < MAX_DS5_NUM; i++)
+		mutex_init(&ds5_inited[i].lock);
+
+	for (i = 0; i < MAX_DSER_NUM; i++)
+		mutex_init(&dser_inited[i].lock);
+
+	ds5_slots_inited = true;
+}
+
+static inline atomic_t *ds5_get_reset_gen(struct ds5 *state)
+{
+	return &state->ds5_dev->reset_gen;
+}
+
+static inline atomic_t *dser_get_reset_gen(struct ds5 *state)
+{
+	return &state->ds5_dev->dser_control->reset_gen;
+}
+
+/* MAX96724 deserializer interface implementation */
+static const struct dser_interface max96724_interface = {
+	.get_available_pipe_id = max96724_get_available_pipe_id,
+	.get_ser_pipe_id = max96724_get_ser_pipe_id,
+	.bind_ser_to_dser_pipe = max96724_bind_ser_to_dser_pipe,
+	.set_pipe = max96724_set_pipe,
+	.release_pipe = max96724_release_pipe,
+	.reset_oneshot = max96724_reset_oneshot,
+	.setup_link = max96724_setup_link,
+	.setup_control = max96724_setup_control,
+	.reset_control = max96724_reset_control,
+	.sdev_register = max96724_sdev_register,
+	.sdev_unregister = max96724_sdev_unregister,
+	.power_on = max96724_power_on,
+	.power_off = max96724_power_off,
+	.init_settings = max96724_init_settings,
+	.name = "max96724",
+};
+
+#else /* !CONFIG_VIDEO_D5XX_SERDES */
+
+static atomic_t ds5_reset_gen = ATOMIC_INIT(0);
+static inline atomic_t *ds5_get_reset_gen(struct ds5 *state)
+{
+	return &ds5_reset_gen;
+}
+
+#define MAX_DS5_NUM (1) /* assuming max 1 DS5 camera with RDK(?) */
+static struct ds5_dev ds5_inited[MAX_DS5_NUM];
+static bool ds5_slots_inited;
+static DEFINE_MUTEX(ds5_slots_lock__);
+
+static void ds5_init_global_slots_once(void)
+{
+	mutex_lock(&ds5_slots_lock__);
+	if (!ds5_slots_inited) {
+		mutex_init(&ds5_inited[0].lock);
+		ds5_slots_inited = true;
+	}
+	mutex_unlock(&ds5_slots_lock__);
+}
+
+#endif /* !CONFIG_VIDEO_D5XX_SERDES */
+
+static inline u16 ds5_dev_type(struct ds5 *state, u16 dev_type)
+{
+	if (dev_type == 0 && state->ds5_dev->cached_device_type != 0) {
+		dev_info(&state->client->dev,
+			"%s(): device type register returned 0, using cached type 0x%x\n",
+			__func__, state->ds5_dev->cached_device_type);
+		dev_type = state->ds5_dev->cached_device_type;
+	}
+	return dev_type;
+}
+
+static bool ds5_is_valid_device_type(u16 dev_type)
+{
+	switch (dev_type) {
+	case DS5_DEVICE_TYPE_D58X:
+		return true;
+	default:
+		return false;
+	}
+}
+
+#define ds5_from_depth_sd(sd) container_of(sd, struct ds5, depth.sd)
+#define ds5_from_ir_sd(sd) container_of(sd, struct ds5, ir.sd)
+#define ds5_from_rgb_sd(sd) container_of(sd, struct ds5, rgb.sd)
+#if LINUX_VERSION_CODE > KERNEL_VERSION(5, 15, 136)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 15, 148)
+static inline void msleep_range(unsigned int delay_base)
+{
+	usleep_range(delay_base * 1000, delay_base * 1000 + 500);
+}
+#endif
+#endif
+
+static int ds5_write(struct ds5 *state, u16 reg, u16 val)
+{
+	int ret;
+	int retry;
+	u8 value[2];
+
+	value[1] = val >> 8;
+	value[0] = val & 0x00FF;
+
+	dev_dbg(&state->client->dev,
+			"%s(): writing to register: 0x%04x, value1: 0x%x, value2:0x%x\n",
+			__func__, reg, value[1], value[0]);
+
+	for (retry = 0; retry < DS5_I2C_RETRY_COUNT; retry++) {
+		ret = regmap_raw_write(state->regmap, reg, value, sizeof(value));
+		if (ret == 0)
+			break;
+		if (retry < DS5_I2C_RETRY_COUNT - 1) {
+			dev_warn(&state->client->dev,
+				"%s(): i2c write retry %d, 0x%04x = 0x%x, err %d\n",
+				__func__, retry + 1, reg, val, ret);
+			usleep_range(DS5_I2C_RETRY_DELAY_US,
+				     DS5_I2C_RETRY_DELAY_US + 500);
+		}
+	}
+	if (ret < 0)
+		dev_err(&state->client->dev,
+			"%s(): i2c write failed after %d retries, 0x%04x = 0x%x, err %d\n",
+			__func__, DS5_I2C_RETRY_COUNT, reg, val, ret);
+	else if (state->dfu_dev.dfu_state_flag == DS5_DFU_IDLE)
+		dev_dbg(&state->client->dev, "%s(): i2c write 0x%04x: 0x%x\n",
+			__func__, reg, val);
+
+	return ret;
+}
+
+static int ds5_raw_write(struct ds5 *state, u16 reg,
+		const void *val, size_t val_len)
+{
+	int ret;
+	int retry;
+
+	for (retry = 0; retry < DS5_I2C_RETRY_COUNT; retry++) {
+		ret = regmap_raw_write(state->regmap, reg, val, val_len);
+		if (ret == 0)
+			break;
+		if (retry < DS5_I2C_RETRY_COUNT - 1) {
+			dev_warn(&state->client->dev,
+				"%s(): i2c raw write retry %d, 0x%04x size(%d), err %d\n",
+				__func__, retry + 1, reg, (int)val_len, ret);
+			usleep_range(DS5_I2C_RETRY_DELAY_US,
+				     DS5_I2C_RETRY_DELAY_US + 500);
+		}
+	}
+	if (ret < 0)
+		dev_err(&state->client->dev,
+			"%s(): i2c raw write failed after %d retries, 0x%04x size(%d), err %d\n",
+			__func__, DS5_I2C_RETRY_COUNT, reg, (int)val_len, ret);
+	else if (state->dfu_dev.dfu_state_flag == DS5_DFU_IDLE)
+		dev_dbg(&state->client->dev,
+			"%s(): i2c raw write 0x%04x: %d bytes\n",
+			__func__, reg, (int)val_len);
+
+	return ret;
+}
+
+static int ds5_read(struct ds5 *state, u16 reg, u16 *val)
+{
+	int ret;
+	int retry;
+
+	for (retry = 0; retry < DS5_I2C_RETRY_COUNT; retry++) {
+		ret = regmap_raw_read(state->regmap, reg, val, 2);
+		if (ret == 0)
+			break;
+		if (retry < DS5_I2C_RETRY_COUNT - 1) {
+			dev_warn(&state->client->dev,
+				"%s(): i2c read retry %d, 0x%04x, err %d\n",
+				__func__, retry + 1, reg, ret);
+			usleep_range(DS5_I2C_RETRY_DELAY_US,
+				     DS5_I2C_RETRY_DELAY_US + 500);
+		}
+	}
+	if (ret < 0)
+		dev_err(&state->client->dev,
+			"%s(): i2c read failed after %d retries, 0x%04x, err %d\n",
+			__func__, DS5_I2C_RETRY_COUNT, reg, ret);
+	else if (state->dfu_dev.dfu_state_flag == DS5_DFU_IDLE)
+		dev_dbg(&state->client->dev, "%s(): i2c read 0x%04x: 0x%x\n",
+			__func__, reg, *val);
+
+	return ret;
+}
+
+static int ds5_read_poll(struct ds5 *state, u16 reg, u16 *val)
+{
+	return regmap_raw_read(state->regmap, reg, val, 2);
+}
+
+static int ds5_raw_read(struct ds5 *state, u16 reg, void *val, size_t val_len)
+{
+	int ret;
+	int retry;
+
+	for (retry = 0; retry < DS5_I2C_RETRY_COUNT; retry++) {
+		ret = regmap_raw_read(state->regmap, reg, val, val_len);
+		if (ret == 0)
+			break;
+		if (retry < DS5_I2C_RETRY_COUNT - 1) {
+			dev_warn(&state->client->dev,
+				"%s(): i2c raw read retry %d, 0x%04x size(%d), err %d\n",
+				__func__, retry + 1, reg, (int)val_len, ret);
+			usleep_range(DS5_I2C_RETRY_DELAY_US,
+				     DS5_I2C_RETRY_DELAY_US + 500);
+		}
+	}
+	if (ret < 0)
+		dev_err(&state->client->dev,
+			"%s(): i2c raw read failed after %d retries, 0x%04x size(%d), err %d\n",
+			__func__, DS5_I2C_RETRY_COUNT, reg, (int)val_len, ret);
+
+	return ret;
+}
+
+/* Pad ops */
+
+static const u16 ds5_default_framerate = 30;
+
+#define DS5_FRAMERATE_DEFAULT_IDX 1
+
+static const u16 ds5_framerate_30 = 30;
+static const u16 ds5_depth_framerate_to_30[] = {5, 15, 30};
+static const u16 ds5_framerate_to_60[] = {5, 15, 30, 60};
+static const u16 ds5_framerate_15_30[] = {15, 30};
+static const u16 ds5_framerate_9_30[] = {9, 30};
+static const u16 ds5_imu_framerates[] = {100, 200, 400};
+
+/* Helper macro to define resolution entries concisely. */
+#define DS5_RES(w, h, fr) \
+    { .width = (w), .height = (h), .framerates = (fr), .n_framerates = ARRAY_SIZE(fr) },
+
+/* D58x depth resolutions: DEPTH (Z16) + DEPTH_RAW (Z16) */
+static const struct ds5_resolution d58x_depth_sizes[] = {
+	DS5_RES(640, 360, ds5_framerate_to_60)
+	DS5_RES(1280, 720, ds5_framerate_to_60)
+	DS5_RES(1280, 960, ds5_depth_framerate_to_30)
+};
+
+/* D58x IR/Y8 resolutions: IR (Y8) + IR_RAW (Y8) */
+static const struct ds5_resolution d58x_y8_sizes[] = {
+	DS5_RES(1280, 720, ds5_framerate_to_60)
+	DS5_RES(1280, 960, ds5_depth_framerate_to_30)
+};
+
+/* D58x calibration resolutions: IR_RAW Y16 */
+static const struct ds5_resolution d58x_calibration_sizes[] = {
+	DS5_RES(1600, 1300, ds5_framerate_15_30)
+};
+
+/* D58x RGB resolutions: COLOR (RGB8) */
+static const struct ds5_resolution d58x_rgb_sizes[] = {
+	DS5_RES(640, 360, ds5_depth_framerate_to_30)
+	DS5_RES(1280, 720, ds5_depth_framerate_to_30)
+};
+
+/* D58x COLOR_RAW resolutions: RAW16 */
+static const struct ds5_resolution d58x_rgb_raw_sizes[] = {
+	DS5_RES(1600, 1300, ds5_framerate_9_30)
+};
+
+static const struct ds5_resolution ds5_size_imu[] = {
+	{
+	.width = 32,
+	.height = 1,
+	.framerates = ds5_imu_framerates,
+	.n_framerates = ARRAY_SIZE(ds5_imu_framerates),
+	},
+};
+
+/* 32 bit IMU introduced with IMU sensitivity attribute Firmware */
+static const struct ds5_resolution ds5_size_imu_extended[] = {
+	{
+	.width = 38,
+	.height = 1,
+	.framerates = ds5_imu_framerates,
+	.n_framerates = ARRAY_SIZE(ds5_imu_framerates),
+	},
+};
+
+static const struct ds5_format ds5_depth_formats_d58x[] = {
+	{
+		.data_type = GMSL_CSI_DT_YUV422_8,	/* Z16 */
+		.mbus_code = MEDIA_BUS_FMT_UYVY8_1X16,
+		.n_resolutions = ARRAY_SIZE(d58x_depth_sizes),
+		.resolutions = d58x_depth_sizes,
+	}, {
+		.data_type = GMSL_CSI_DT_RAW_8,	/* Y8 */
+		.mbus_code = MEDIA_BUS_FMT_Y8_1X8,
+		.n_resolutions = ARRAY_SIZE(d58x_depth_sizes),
+		.resolutions = d58x_depth_sizes,
+	}, {
+		.data_type = GMSL_CSI_DT_RGB_888,	/* 24-bit Calibration */
+		.mbus_code = MEDIA_BUS_FMT_RGB888_1X24,
+		.n_resolutions = ARRAY_SIZE(d58x_calibration_sizes),
+		.resolutions = d58x_calibration_sizes,
+	},
+};
+
+#define DS5_DEPTH_N_FORMATS 1
+
+static const struct ds5_format ds5_y_formats_d58x[] = {
+	{
+		/* First format: default */
+		.data_type = GMSL_CSI_DT_RAW_8,	/* Y8 */
+		.mbus_code = MEDIA_BUS_FMT_Y8_1X8,
+		.n_resolutions = ARRAY_SIZE(d58x_y8_sizes),
+		.resolutions = d58x_y8_sizes,
+	}, {
+		.data_type = GMSL_CSI_DT_YUV422_8,	/* Y8I */
+		.mbus_code = MEDIA_BUS_FMT_VYUY8_1X16,
+		.n_resolutions = ARRAY_SIZE(d58x_y8_sizes),
+		.resolutions = d58x_y8_sizes,
+	}, {
+		.data_type = GMSL_CSI_DT_RGB_888,	/* Y12I, 24-bit Calibration */
+		.mbus_code = MEDIA_BUS_FMT_RGB888_1X24,
+		.n_resolutions = ARRAY_SIZE(d58x_calibration_sizes),
+		.resolutions = d58x_calibration_sizes,
+	},
+};
+
+static const struct ds5_format ds5_d58x_rgb_format = {
+	.data_type = GMSL_CSI_DT_YUV422_8,	/* UYVY */
+	.mbus_code = MEDIA_BUS_FMT_YUYV8_1X16,
+	.n_resolutions = ARRAY_SIZE(d58x_rgb_sizes),
+	.resolutions = d58x_rgb_sizes,
+};
+#define DS5_D58X_RGB_N_FORMATS 1
+
+static const struct ds5_variant ds5_variants[] = {
+	[DS5_DS5U] = {
+		.formats = ds5_y_formats_d58x,
+		.n_formats = ARRAY_SIZE(ds5_y_formats_d58x),
+	},
+};
+
+static const struct ds5_format ds5_imu_formats[] = {
+	{
+		/* First format: default */
+		.data_type = GMSL_CSI_DT_RAW_8,	/* IMU DT */
+		.mbus_code = MEDIA_BUS_FMT_Y8_1X8,
+		.n_resolutions = ARRAY_SIZE(ds5_size_imu),
+		.resolutions = ds5_size_imu,
+	},
+};
+
+static const struct ds5_format ds5_imu_formats_extended[] = {
+	{
+		/* First format: default */
+		.data_type = GMSL_CSI_DT_RAW_8,	/* IMU DT */
+		.mbus_code = MEDIA_BUS_FMT_Y8_1X8,
+		.n_resolutions = ARRAY_SIZE(ds5_size_imu_extended),
+		.resolutions = ds5_size_imu_extended,
+	},
+};
+
+static const struct v4l2_mbus_framefmt ds5_mbus_framefmt_template = {
+	.width = 0,
+	.height = 0,
+	.code = MEDIA_BUS_FMT_FIXED,
+	.field = V4L2_FIELD_NONE,
+	.colorspace = V4L2_COLORSPACE_DEFAULT,
+	.ycbcr_enc = V4L2_YCBCR_ENC_DEFAULT,
+	.quantization = V4L2_QUANTIZATION_DEFAULT,
+	.xfer_func = V4L2_XFER_FUNC_DEFAULT,
+};
+
+/* Get readable sensor name */
+static const char *ds5_get_sensor_name(struct ds5 *state)
+{
+	static const char *sensor_name[] = {"unknown", "RGB", "DEPTH", "Y8", "IMU"};
+	int sensor_id = state->is_rgb * 1 + state->is_depth * 2 + \
+			state->is_y8 * 3 + state->is_imu * 4;
+	if (sensor_id >= (sizeof(sensor_name)/sizeof(*sensor_name)))
+		sensor_id = 0;
+
+	return sensor_name[sensor_id];
+}
+
+static void ds5_set_state_last_set(struct ds5 *state)
+{
+	 dev_dbg(&state->client->dev, "%s(): %s\n",
+		__func__, ds5_get_sensor_name(state));
+
+	if (state->is_depth)
+		state->mux.last_set = &state->depth.sensor;
+	else if (state->is_rgb)
+		state->mux.last_set = &state->rgb.sensor;
+	else if (state->is_y8)
+		state->mux.last_set = &state->ir.sensor;
+	else
+		state->mux.last_set = &state->imu.sensor;
+}
+
+/* This is needed for .get_fmt()
+ * and if streaming is started without .set_fmt()
+ */
+static void ds5_sensor_format_init(struct ds5_sensor *sensor)
+{
+	const struct ds5_format *fmt;
+	struct v4l2_mbus_framefmt *ffmt;
+	unsigned int i;
+
+	if (sensor->config.format)
+		return;
+
+	dev_dbg(sensor->sd.dev, "%s(): on pad %u\n", __func__, sensor->mux_pad);
+
+	ffmt = &sensor->format;
+	*ffmt = ds5_mbus_framefmt_template;
+	/* Use the first format */
+	fmt = sensor->formats;
+	ffmt->code = fmt->mbus_code;
+	/* and the first resolution */
+	ffmt->width = fmt->resolutions->width;
+	ffmt->height = fmt->resolutions->height;
+
+	sensor->config.format = fmt;
+	sensor->config.resolution = fmt->resolutions;
+	/* Set default framerate to 30, or to 1st one if not supported */
+	for (i = 0; i < fmt->resolutions->n_framerates; i++) {
+		if (fmt->resolutions->framerates[i] == ds5_framerate_30 /* fps */) {
+			sensor->config.framerate = ds5_framerate_30;
+			return;
+		}
+	}
+	sensor->config.framerate = fmt->resolutions->framerates[0];
+}
+
+/* No locking needed for enumeration methods */
+static int ds5_sensor_enum_mbus_code(struct v4l2_subdev *sd,
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 15, 10)
+				     struct v4l2_subdev_pad_config *cfg,
+#else
+				     struct v4l2_subdev_state *v4l2_state,
+#endif
+				     struct v4l2_subdev_mbus_code_enum *mce)
+{
+	struct ds5_sensor *sensor = container_of(sd, struct ds5_sensor, sd);
+
+	dev_dbg(sensor->sd.dev, "%s(): sensor %s pad: %d index: %d\n",
+		__func__, sensor->sd.name, mce->pad, mce->index);
+	if (mce->pad)
+		return -EINVAL;
+
+	if (mce->index >= sensor->n_formats)
+		return -EINVAL;
+
+	mce->code = sensor->formats[mce->index].mbus_code;
+
+	return 0;
+}
+
+static int ds5_sensor_enum_frame_size(struct v4l2_subdev *sd,
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 15, 10)
+		struct v4l2_subdev_pad_config *cfg,
+#else
+		struct v4l2_subdev_state *v4l2_state,
+#endif
+		struct v4l2_subdev_frame_size_enum *fse)
+{
+	struct ds5_sensor *sensor = container_of(sd, struct ds5_sensor, sd);
+	struct ds5 *state = v4l2_get_subdevdata(sd);
+	const struct ds5_format *fmt;
+	unsigned int i;
+
+	dev_dbg(sensor->sd.dev, "%s(): sensor %s is %s\n",
+		__func__, sensor->sd.name, ds5_get_sensor_name(state));
+
+	for (i = 0, fmt = sensor->formats; i < sensor->n_formats; i++, fmt++)
+		if (fse->code == fmt->mbus_code)
+			break;
+
+	if (i == sensor->n_formats)
+		return -EINVAL;
+
+	if (fse->index >= fmt->n_resolutions)
+		return -EINVAL;
+
+	fse->min_width = fse->max_width = fmt->resolutions[fse->index].width;
+	fse->min_height = fse->max_height = fmt->resolutions[fse->index].height;
+
+	return 0;
+}
+
+static int ds5_sensor_enum_frame_interval(struct v4l2_subdev *sd,
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 15, 10)
+		struct v4l2_subdev_pad_config *cfg,
+#else
+		struct v4l2_subdev_state *v4l2_state,
+#endif
+		struct v4l2_subdev_frame_interval_enum *fie)
+{
+	struct ds5_sensor *sensor = container_of(sd, struct ds5_sensor, sd);
+	const struct ds5_format *fmt;
+	const struct ds5_resolution *res;
+	unsigned int i;
+
+	for (i = 0, fmt = sensor->formats; i < sensor->n_formats; i++, fmt++)
+		if (fie->code == fmt->mbus_code)
+			break;
+
+	if (i == sensor->n_formats)
+		return -EINVAL;
+
+	for (i = 0, res = fmt->resolutions; i < fmt->n_resolutions; i++, res++)
+		if (res->width == fie->width && res->height == fie->height)
+			break;
+
+	if (i == fmt->n_resolutions)
+		return -EINVAL;
+
+	if (fie->index >= res->n_framerates)
+		return -EINVAL;
+
+	fie->interval.numerator = 1;
+	fie->interval.denominator = res->framerates[fie->index];
+
+	return 0;
+}
+
+static int ds5_sensor_get_fmt(struct v4l2_subdev *sd,
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 15, 10)
+		struct v4l2_subdev_pad_config *cfg,
+#else
+		struct v4l2_subdev_state *v4l2_state,
+#endif
+		struct v4l2_subdev_format *fmt)
+{
+	struct ds5_sensor *sensor = container_of(sd, struct ds5_sensor, sd);
+	struct ds5 *state = v4l2_get_subdevdata(sd);
+	int ret = 0;
+
+	if (fmt->pad)
+		return -EINVAL;
+
+	mutex_lock(&state->lock);
+
+	if (fmt->which == V4L2_SUBDEV_FORMAT_TRY)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 15, 10)
+		fmt->format = *v4l2_subdev_get_try_format(sd, cfg, fmt->pad);
+#elif LINUX_VERSION_CODE < KERNEL_VERSION(6, 8, 0)
+		fmt->format = *v4l2_subdev_get_try_format(sd, v4l2_state, fmt->pad);
+#else
+	{
+		struct v4l2_mbus_framefmt* framefmt;
+		framefmt = v4l2_subdev_state_get_format(v4l2_state, fmt->pad);
+		if (framefmt)
+			fmt->format = *framefmt;
+		else
+			ret = -EINVAL;
+	}
+#endif
+	else
+		fmt->format = sensor->format;
+
+	mutex_unlock(&state->lock);
+
+	dev_dbg(sd->dev, "%s(): pad %x, code %x, res %ux%u\n",
+			__func__, fmt->pad, fmt->format.code,
+			fmt->format.width, fmt->format.height);
+
+	return ret;
+}
+
+/* Called with lock held */
+static const struct ds5_format *ds5_sensor_find_format(
+		struct ds5_sensor *sensor,
+		struct v4l2_mbus_framefmt *ffmt,
+		const struct ds5_resolution **best)
+{
+	const struct ds5_resolution *res;
+	const struct ds5_format *fmt;
+	unsigned long best_delta = ~0;
+	unsigned int i;
+
+	for (i = 0, fmt = sensor->formats; i < sensor->n_formats; i++, fmt++) {
+		if (fmt->mbus_code == ffmt->code)
+			break;
+	}
+	dev_dbg(sensor->sd.dev, "%s(): mbus_code = %x, code = %x \n",
+		__func__, fmt->mbus_code, ffmt->code);
+
+	if (i == sensor->n_formats) {
+		/* Not found, use default */
+		dev_dbg(sensor->sd.dev, "%s:%d Not found, use default\n",
+			__func__, __LINE__);
+		fmt = sensor->formats;
+	}
+	for (i = 0, res = fmt->resolutions; i < fmt->n_resolutions; i++, res++) {
+		unsigned long delta = abs(ffmt->width * ffmt->height -
+				res->width * res->height);
+		if (delta < best_delta) {
+			best_delta = delta;
+			*best = res;
+		}
+	}
+
+	ffmt->code = fmt->mbus_code;
+	ffmt->width = (*best)->width;
+	ffmt->height = (*best)->height;
+
+	ffmt->field = V4L2_FIELD_NONE;
+	/* Should we use V4L2_COLORSPACE_RAW for Y12I? */
+	ffmt->colorspace = V4L2_COLORSPACE_SRGB;
+
+	return fmt;
+}
+
+#define MIPI_CSI2_TYPE_NULL	0x10
+#define MIPI_CSI2_TYPE_BLANKING		0x11
+#define MIPI_CSI2_TYPE_EMBEDDED8	0x12
+#define MIPI_CSI2_TYPE_YUV422_8		0x1e
+#define MIPI_CSI2_TYPE_YUV422_10	0x1f
+#define MIPI_CSI2_TYPE_RGB565	0x22
+#define MIPI_CSI2_TYPE_RGB888	0x24
+#define MIPI_CSI2_TYPE_RAW6	0x28
+#define MIPI_CSI2_TYPE_RAW7	0x29
+#define MIPI_CSI2_TYPE_RAW8	0x2a
+#define MIPI_CSI2_TYPE_RAW10	0x2b
+#define MIPI_CSI2_TYPE_RAW12	0x2c
+#define MIPI_CSI2_TYPE_RAW14	0x2d
+/* 1-8 */
+#define MIPI_CSI2_TYPE_USER_DEF(i)	(0x30 + (i) - 1)
+
+static int __ds5_sensor_set_fmt(struct ds5 *state, struct ds5_sensor *sensor,
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 15, 10)
+		struct v4l2_subdev_pad_config *cfg,
+#else
+		struct v4l2_subdev_state *v4l2_state,
+#endif
+		struct v4l2_subdev_format *fmt)
+{
+	struct v4l2_mbus_framefmt *mf;// = &fmt->format;
+	int ret = 0;
+	//unsigned r;
+
+	dev_dbg(sensor->sd.dev, "%s(): state %p, "
+		"sensor %p, fmt %p, fmt->format %p\n",
+		__func__, state, sensor, fmt,  &fmt->format);
+
+	mf = &fmt->format;
+
+	if (fmt->pad)
+		return -EINVAL;
+
+	mutex_lock(&state->lock);
+
+	sensor->config.format = ds5_sensor_find_format(sensor, mf,
+						&sensor->config.resolution);
+	//r = DS5_FRAMERATE_DEFAULT_IDX < sensor->config.resolution->n_framerates ?
+	//	DS5_FRAMERATE_DEFAULT_IDX : 0;
+	/* FIXME: check if a framerate has been set */
+	//sensor->config.framerate = sensor->config.resolution->framerates[r];
+
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 15, 10)
+	if (cfg && fmt->which == V4L2_SUBDEV_FORMAT_TRY)
+		*v4l2_subdev_get_try_format(&sensor->sd, cfg, fmt->pad) = *mf;
+#else
+	if (v4l2_state && fmt->which == V4L2_SUBDEV_FORMAT_TRY)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 8, 0)
+		*v4l2_subdev_get_try_format(&sensor->sd, v4l2_state, fmt->pad) = *mf;
+#else
+	{
+		struct v4l2_mbus_framefmt* framefmt = v4l2_subdev_state_get_format(v4l2_state, fmt->pad);
+		if (framefmt)
+			*framefmt = *mf;
+		else
+			ret = -EINVAL;
+	}
+#endif
+#endif
+
+	else
+// FIXME: use this format in .s_stream()
+		sensor->format = *mf;
+
+	state->mux.last_set = sensor;
+
+	mutex_unlock(&state->lock);
+	return ret;
+}
+
+static int ds5_sensor_set_fmt(struct v4l2_subdev *sd,
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 15, 10)
+		struct v4l2_subdev_pad_config *cfg,
+#else
+		struct v4l2_subdev_state *v4l2_state,
+#endif
+		struct v4l2_subdev_format *fmt)
+{
+	struct ds5_sensor *sensor = container_of(sd, struct ds5_sensor, sd);
+	struct ds5 *state = v4l2_get_subdevdata(sd);
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 15, 10)
+	return __ds5_sensor_set_fmt(state, sensor, cfg, fmt);
+#else
+	return __ds5_sensor_set_fmt(state, sensor, v4l2_state, fmt);
+#endif
+}
+
+#ifdef CONFIG_VIDEO_D5XX_SERDES
+static int ds5_setup_pipeline(struct ds5 *state, u8 data_type1, u8 data_type2,
+			      int pipe_id, u32 vc_id)
+{
+	int ret = 0;
+	/* While some deserializers can support up to 8 pipes, the serializer only supports
+	 * four pipes and four vc_ids (0 - 3).
+	 * To use multiple cameras under this restriction, a second camera connected
+	 * to a deserializer will have its vc_id 0 - 3 mapped to outside vc_id 4 - 7 etc.
+	 * The ser_pipe to dser_pipe mapping depends on the deserializer.
+	 */
+	int ser_vc_id = vc_id % DS5_MAX_STREAMS;
+	int ser_pipe_id = state->dser_ops->get_ser_pipe_id(state->dser_dev, pipe_id, ser_vc_id);
+
+	ret |= state->dser_ops->bind_ser_to_dser_pipe(state->dser_dev, pipe_id, ser_pipe_id, vc_id);
+	dev_dbg(&state->client->dev,
+			"set ser pipe %d, dser pipe %d, data_type1: 0x%x, data_type2: 0x%x, ser_vc_id: %u, vc_id: %u\n",
+			ser_pipe_id, pipe_id, data_type1, data_type2, ser_vc_id, vc_id);
+	ret |= max96717_set_pipe(state->ser_dev, ser_pipe_id,
+				data_type1, data_type2, ser_vc_id);
+	ret |= state->dser_ops->set_pipe(state->dser_dev, pipe_id,
+				data_type1, data_type2, vc_id);
+	state->dser_ops->reset_oneshot(state->dser_dev);
+	/* DES ONESHOT resets the data path; SER must retrigger TX for
+	 * the DES to re-acquire the tunnel stream.
+	 */
+	max96717_retrigger_tx(state->ser_dev);
+	msleep(200);
+	if (ret)
+		dev_warn(&state->client->dev,
+			 "failed to set pipe %d, data_type1: 0x%x, data_type2: 0x%x, vc_id: %u\n",
+			 pipe_id, data_type1, data_type2, vc_id);
+
+	return ret;
+}
+#endif
+
+#ifndef DS5_BYPASS_CAMERA_I2C
+static void ds5_config_cache_clear(struct ds5_sensor *sensor)
+{
+	sensor->cached_dt_value = 0xFFFF;
+	sensor->cached_md_value = 0xFFFF;
+	sensor->cached_override_value = 0xFFFF;
+	sensor->cached_fps_value = 0xFFFF;
+	sensor->cached_width_value = 0xFFFF;
+	sensor->cached_height_value = 0xFFFF;
+}
+
+static void ds5_invalidate_sensor(struct ds5 *state, struct ds5_sensor *sensor)
+{
+	ds5_config_cache_clear(sensor);
+	/* Do NOT release SERDES pipes or clear pipe_id here.
+	 * Preserve the existing pipe_id so that ds5_configure() can
+	 * release-then-reallocate the pipe at stream-start time.
+	 * Clearing pipe_data_type forces ds5_configure() to enter the
+	 * re-allocation path (data_type mismatch triggers pipe setup).
+	 */
+	sensor->pipe_data_type1 = 0;
+	sensor->pipe_data_type2 = 0;
+	sensor->pipe_vc_id = 0xFFFF;
+}
+#endif /* !DS5_BYPASS_CAMERA_I2C */
+
+static int ds5_configure(struct ds5 *state)
+{
+	struct ds5_sensor *sensor;
+	u16 md_fmt, vc_id;
+#ifdef CONFIG_VIDEO_D5XX_SERDES
+	u16 data_type1, data_type2;
+	bool is_calib = 0;
+#endif
+#ifndef DS5_BYPASS_CAMERA_I2C
+	u16 dt_addr, md_addr, override_addr, fps_addr, width_addr, height_addr;
+	u16 dt_value = 0;
+	u16 md_value = 0;
+	u16 fps_value = 0;
+	u16 width_value = 0;
+	u16 height_value = 0;
+#endif
+	int ret;
+
+	if (state->is_depth) {
+		sensor = &state->depth.sensor;
+#ifndef DS5_BYPASS_CAMERA_I2C
+		dt_addr = DS5_DEPTH_STREAM_DT;
+		md_addr = DS5_DEPTH_STREAM_MD;
+		override_addr = DS5_DEPTH_OVERRIDE;
+		fps_addr = DS5_DEPTH_FPS;
+		width_addr = DS5_DEPTH_RES_WIDTH;
+		height_addr = DS5_DEPTH_RES_HEIGHT;
+#endif
+	} else if (state->is_rgb) {
+		sensor = &state->rgb.sensor;
+#ifndef DS5_BYPASS_CAMERA_I2C
+		dt_addr = DS5_RGB_STREAM_DT;
+		md_addr = DS5_RGB_STREAM_MD;
+		override_addr = 0;
+		fps_addr = DS5_RGB_FPS;
+		width_addr = DS5_RGB_RES_WIDTH;
+		height_addr = DS5_RGB_RES_HEIGHT;
+#endif
+	} else if (state->is_y8) {
+		sensor = &state->ir.sensor;
+#ifndef DS5_BYPASS_CAMERA_I2C
+		dt_addr = DS5_IR_STREAM_DT;
+		md_addr = DS5_IR_STREAM_MD;
+		override_addr = DS5_IR_OVERRIDE;
+		fps_addr = DS5_IR_FPS;
+		width_addr = DS5_IR_RES_WIDTH;
+		height_addr = DS5_IR_RES_HEIGHT;
+#endif
+	} else if (state->is_imu) {
+		sensor = &state->imu.sensor;
+#ifndef DS5_BYPASS_CAMERA_I2C
+		dt_addr = DS5_IMU_STREAM_DT;
+		md_addr = DS5_IMU_STREAM_MD;
+		override_addr = 0;
+		fps_addr = DS5_IMU_FPS;
+		width_addr = DS5_IMU_RES_WIDTH;
+		height_addr = DS5_IMU_RES_HEIGHT;
+#endif
+	} else {
+		return -EINVAL;
+	}
+
+	md_fmt = (state->metadata_enabled) ? GMSL_CSI_DT_EMBED : 0x00;
+
+#ifdef CONFIG_VIDEO_D5XX_SERDES
+	data_type1 = sensor->config.format->data_type;
+	data_type2 = md_fmt;
+	is_calib = (state->is_y8 && (data_type1 == GMSL_CSI_DT_RGB_888));
+
+	vc_id = state->g_ctx.dst_vc;
+	dev_info(&state->client->dev,
+		"ds5_configure: sensor=%s dt1=0x%x dt2=0x%x vc=%u pipe_id=%d\n",
+		ds5_get_sensor_name(state), data_type1, data_type2, vc_id, sensor->pipe_id);
+    if (PIPE_NOT_CONFIGURED == sensor->pipe_id ||
+			sensor->pipe_data_type1 != data_type1 ||
+			sensor->pipe_data_type2 != data_type2 ||
+			sensor->pipe_vc_id != vc_id) {
+		/* Release old pipe only if it changed and was valid */
+		if (sensor->pipe_id >= 0) {
+			mutex_lock(&serdes_lock__);
+			ret = state->dser_ops->release_pipe(state->dser_dev, sensor->pipe_id);
+			mutex_unlock(&serdes_lock__);
+			dev_warn(&state->client->dev, "release pipe %d (%d)\n", sensor->pipe_id, ret);
+		}
+		/*
+		* Serialize SERDES pipe allocation and configuration
+		* across all d4xx instances sharing the same GMSL link.
+		* Without this, concurrent pipe setups race on the shared
+		* Serializer/Deserializer hardware, causing I2C NACKs (-121) that
+		* take down the entire bus.
+		*/
+		mutex_lock(&serdes_lock__);
+		sensor->pipe_id =
+			state->dser_ops->get_available_pipe_id(state->dser_dev, (int)state->g_ctx.dst_vc);
+		mutex_unlock(&serdes_lock__);
+		if (sensor->pipe_id < 0) {
+			dev_err(&state->client->dev, "No free pipe in %s\n",state->dser_ops->name);
+			return -ENOSR;
+		}
+		mutex_lock(&serdes_lock__);
+		ret = ds5_setup_pipeline(state, data_type1, data_type2,
+					 sensor->pipe_id, vc_id);
+		// reset data path when switching to Y12I
+		if (is_calib)
+			state->dser_ops->reset_oneshot(state->dser_dev);
+		mutex_unlock(&serdes_lock__);
+		if (ret < 0) {
+			dev_err(&state->client->dev,
+				"pipe %d setup FAILED (dt1=0x%x dt2=0x%x vc=%u) ret=%d\n",
+				sensor->pipe_id, data_type1, data_type2, vc_id, ret);
+			return ret;
+		}
+		dev_info(&state->client->dev,
+				"pipe %d new  (dt1=0x%x dt2=0x%x vc=%u)\n",
+				sensor->pipe_id, data_type1, data_type2, vc_id);
+		sensor->pipe_data_type1 = data_type1;
+		sensor->pipe_data_type2 = data_type2;
+		sensor->pipe_vc_id = vc_id;
+	} else {
+		dev_info(&state->client->dev,
+				"pipe %d already configured (dt1=0x%x dt2=0x%x vc=%u)\n",
+				sensor->pipe_id, data_type1, data_type2, vc_id);
+	}
+#else /* Non-SERDES configuration */
+	vc_id = (state->is_depth) ? 0 : (state->is_rgb) ? 1 : (state->is_y8) ? 2 : 3;
+#endif
+
+#ifdef DS5_BYPASS_CAMERA_I2C
+	/* Skip camera I2C config writes - camera is already streaming */
+	return 0;
+#else
+	/* Determine desired data-type (special cases for depth/IR), then write
+	 * it only when it differs from cached value. This avoids overwriting a
+	 * correct DT with 0 (which caused INVALID_DT on subsequent attempts).
+	 */
+	dt_value = sensor->config.format->data_type;
+	if (state->is_depth && dt_value != 0)
+		dt_value = 0x31;
+	else if (state->is_y8 && dt_value == GMSL_CSI_DT_YUV422_8)
+		dt_value = 0x32;
+
+	dev_dbg(&state->client->dev,
+		"sensor %p: dt_value=0x%x, cached_dt_value=0x%x, cached_fps_value=%u, framerate=%u\n",
+		sensor, dt_value, sensor->cached_dt_value, sensor->cached_fps_value, sensor->config.framerate);
+
+	if (sensor->cached_dt_value != dt_value) {
+		ret = ds5_write(state, dt_addr, dt_value);
+		if (ret < 0)
+			return ret;
+		sensor->cached_dt_value = dt_value;
+	}
+
+	md_value = (vc_id << 8) | md_fmt;
+	if (sensor->cached_md_value != md_value) {
+		ret = ds5_write(state, md_addr, md_value);
+		if (ret < 0)
+			return ret;
+		sensor->cached_md_value = md_value;
+	}
+
+	if (override_addr != 0) {
+		dt_value = sensor->config.format->data_type;
+		if (sensor->cached_override_value != dt_value) {
+			ret = ds5_write(state, override_addr, dt_value);
+			if (ret < 0)
+				return ret;
+			sensor->cached_override_value = dt_value;
+		}
+	}
+
+	fps_value = sensor->config.framerate;
+	if (sensor->cached_fps_value != fps_value) {
+		ret = ds5_write(state, fps_addr, fps_value);
+		if (ret < 0)
+			return ret;
+		sensor->cached_fps_value = fps_value;
+	}
+
+	width_value = sensor->config.resolution->width;
+	if (sensor->cached_width_value != width_value) {
+		ret = ds5_write(state, width_addr, width_value);
+		if (ret < 0)
+			return ret;
+		sensor->cached_width_value = width_value;
+	}
+
+	height_value = sensor->config.resolution->height;
+	if (sensor->cached_height_value != height_value) {
+		ret = ds5_write(state, height_addr, height_value);
+		if (ret < 0)
+			return ret;
+		sensor->cached_height_value = height_value;
+	}
+
+	return 0;
+#endif /* !DS5_BYPASS_CAMERA_I2C */
+}
+
+static int ds5_sensor_g_frame_interval(struct v4l2_subdev *sd,
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 8, 0)
+		struct v4l2_subdev_state *state,
+#endif
+		struct v4l2_subdev_frame_interval *fi)
+{
+	struct ds5_sensor *sensor = container_of(sd, struct ds5_sensor, sd);
+
+	if (NULL == sd || NULL == fi)
+		return -EINVAL;
+
+	fi->interval.numerator = 1;
+	fi->interval.denominator = sensor->config.framerate;
+
+	dev_dbg(sd->dev, "%s(): %s %u\n", __func__, sd->name,
+			fi->interval.denominator);
+
+	return 0;
+}
+static u16 __ds5_probe_framerate(const struct ds5_resolution *res, u16 target);
+
+static int ds5_sensor_s_frame_interval(struct v4l2_subdev *sd,
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 8, 0)
+		struct v4l2_subdev_state *state,
+#endif
+		struct v4l2_subdev_frame_interval *fi)
+{
+	struct ds5_sensor *sensor = container_of(sd, struct ds5_sensor, sd);
+	u16 framerate = 1;
+
+	if (NULL == sd || NULL == fi || fi->interval.numerator == 0)
+		return -EINVAL;
+
+	framerate = fi->interval.denominator / fi->interval.numerator;
+	framerate = __ds5_probe_framerate(sensor->config.resolution, framerate);
+	sensor->config.framerate = framerate;
+	fi->interval.numerator = 1;
+	fi->interval.denominator = framerate;
+
+	dev_dbg(sd->dev, "%s(): %s %u\n", __func__, sd->name, framerate);
+
+	return 0;
+}
+
+static int ds5_sensor_s_stream(struct v4l2_subdev *sd, int on)
+{
+	struct ds5_sensor *sensor = container_of(sd, struct ds5_sensor, sd);
+
+	dev_dbg(sensor->sd.dev, "%s(): sensor: name=%s state=%d\n",
+		__func__, sensor->sd.name, on);
+
+	sensor->streaming = on;
+
+	return 0;
+}
+
+static const struct v4l2_subdev_video_ops ds5_sensor_video_ops = {
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 8, 0)
+	.g_frame_interval	= ds5_sensor_g_frame_interval,
+	.s_frame_interval	= ds5_sensor_s_frame_interval,
+#endif
+	.s_stream		= ds5_sensor_s_stream,
+};
+
+static const struct v4l2_subdev_pad_ops ds5_pad_ops = {
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 8, 0)
+	.get_frame_interval	= ds5_sensor_g_frame_interval,
+	.set_frame_interval	= ds5_sensor_s_frame_interval,
+#endif
+	.enum_mbus_code		= ds5_sensor_enum_mbus_code,
+	.enum_frame_size	= ds5_sensor_enum_frame_size,
+	.enum_frame_interval	= ds5_sensor_enum_frame_interval,
+	.get_fmt		= ds5_sensor_get_fmt,
+	.set_fmt		= ds5_sensor_set_fmt,
+};
+
+static const struct v4l2_subdev_ops ds5_subdev_ops = {
+	.pad = &ds5_pad_ops,
+	.video = &ds5_sensor_video_ops,
+};
+
+/* InfraRed stream Y8/Y16 */
+
+static int ds5_hw_set_auto_exposure(struct ds5 *state, u32 base, s32 val)
+{
+	if (val != V4L2_EXPOSURE_APERTURE_PRIORITY &&
+		val != V4L2_EXPOSURE_MANUAL)
+		return -EINVAL;
+
+	/*
+	 * In firmware color auto exposure setting follow the uvc_menu_info
+	 * exposure_auto_controls numbers, in drivers/media/usb/uvc/uvc_ctrl.c.
+	 */
+	if (state->is_rgb && val == V4L2_EXPOSURE_APERTURE_PRIORITY)
+		val = 8;
+
+	/*
+	 * In firmware depth auto exposure on: 1, off: 0.
+	 */
+	if (!state->is_rgb) {
+		if (val == V4L2_EXPOSURE_APERTURE_PRIORITY)
+			val = 1;
+		else if (val == V4L2_EXPOSURE_MANUAL)
+			val = 0;
+	}
+
+	return ds5_write(state, base | DS5_AUTO_EXPOSURE_MODE, (u16)val);
+}
+
+/*
+ * Manual exposure in us
+ * Depth/Y8: between 100 and 200000 (200ms)
+ * Color: between 100 and 1000000 (1s)
+ */
+static int ds5_hw_set_exposure(struct ds5 *state, u32 base, s32 val)
+{
+	int ret = -1;
+
+	if (val < 1)
+		val = 1;
+	if ((state->is_depth || state->is_y8) && val > MAX_DEPTH_EXP)
+		val = MAX_DEPTH_EXP;
+	if (state->is_rgb && val > MAX_RGB_EXP)
+		val = MAX_RGB_EXP;
+
+	/*
+	 * Color and depth uses different unit:
+	 *	Color: 1 is 100 us
+	 *	Depth: 1 is 1 us
+	 */
+
+	ret = ds5_write(state, base | DS5_MANUAL_EXPOSURE_MSB, (u16)(val >> 16));
+	if (!ret)
+		ret = ds5_write(state, base | DS5_MANUAL_EXPOSURE_LSB,
+				(u16)(val & 0xffff));
+
+	return ret;
+}
+
+#define DS5_MAX_LOG_WAIT 200
+#define DS5_MAX_LOG_SLEEP 10
+#define DS5_MAX_LOG_POLL (DS5_MAX_LOG_WAIT / DS5_MAX_LOG_SLEEP)
+
+// TODO: why to use DS5_DEPTH_Y_STREAMS_DT?
+#define DS5_CAMERA_CID_BASE	(V4L2_CTRL_CLASS_CAMERA | DS5_DEPTH_STREAM_DT)
+
+#define DS5_CAMERA_CID_LOG			(DS5_CAMERA_CID_BASE+0)
+#define DS5_CAMERA_CID_LASER_POWER		(DS5_CAMERA_CID_BASE+1)
+#define DS5_CAMERA_CID_MANUAL_LASER_POWER	(DS5_CAMERA_CID_BASE+2)
+#define DS5_CAMERA_DEPTH_CALIBRATION_TABLE_GET	(DS5_CAMERA_CID_BASE+3)
+#define DS5_CAMERA_DEPTH_CALIBRATION_TABLE_SET	(DS5_CAMERA_CID_BASE+4)
+#define DS5_CAMERA_COEFF_CALIBRATION_TABLE_GET	(DS5_CAMERA_CID_BASE+5)
+#define DS5_CAMERA_COEFF_CALIBRATION_TABLE_SET	(DS5_CAMERA_CID_BASE+6)
+#define DS5_CAMERA_CID_FW_VERSION		(DS5_CAMERA_CID_BASE+7)
+#define DS5_CAMERA_CID_GVD			(DS5_CAMERA_CID_BASE+8)
+#define DS5_CAMERA_CID_AE_ROI_GET		(DS5_CAMERA_CID_BASE+9)
+#define DS5_CAMERA_CID_AE_ROI_SET		(DS5_CAMERA_CID_BASE+10)
+#define DS5_CAMERA_CID_AE_SETPOINT_GET		(DS5_CAMERA_CID_BASE+11)
+#define DS5_CAMERA_CID_AE_SETPOINT_SET		(DS5_CAMERA_CID_BASE+12)
+#define DS5_CAMERA_CID_ERB			(DS5_CAMERA_CID_BASE+13)
+#define DS5_CAMERA_CID_EWB			(DS5_CAMERA_CID_BASE+14)
+#define DS5_CAMERA_CID_HWMC			(DS5_CAMERA_CID_BASE+15)
+#define DS5_CAMERA_CID_SYNC_MODE		(DS5_CAMERA_CID_BASE+16)
+
+/* Sync mode values — indices into sync_mode_menu_full[] */
+enum ds5_sync_mode {
+	DS5_SYNC_MODE_DEFAULT,
+	DS5_SYNC_MODE_MASTER,
+	DS5_SYNC_MODE_SLAVE,
+	DS5_SYNC_MODE_FULL_SLAVE,
+	DS5_SYNC_MODE_SUB_PREMASTER,
+	DS5_SYNC_MODE_FULL_MASTER,
+};
+
+#define DS5_CAMERA_CID_PWM			(DS5_CAMERA_CID_BASE+22)
+
+/* the HWMC will remain for legacy tools compatibility,
+ * HWMC_RW used for UVC compatibility
+ */
+#define DS5_CAMERA_CID_HWMC_RW		(DS5_CAMERA_CID_BASE+32)
+
+/* HW reset with recovery for GMSL connections */
+#define DS5_CAMERA_CID_HW_RESET		(DS5_CAMERA_CID_BASE+33)
+
+#define DS5_HWMC_DATA			0x4900
+#define DS5_HWMC_STATUS			0x4904
+#define DS5_HWMC_RESP_LEN		0x4908
+#define DS5_HWMC_EXEC			0x490C
+
+#define DS5_HWMC_STATUS_OK		0
+#define DS5_HWMC_STATUS_ERR		1
+#define DS5_HWMC_STATUS_WIP		2
+#define DS5_HWMC_BUFFER_SIZE	1024
+
+enum DS5_HWMC_ERR {
+	DS5_HWMC_ERR_SUCCESS = 0,
+	DS5_HWMC_ERR_CMD     = -1,
+	DS5_HWMC_ERR_PARAM   = -6,
+	DS5_HWMC_ERR_NODATA  = -21,
+	DS5_HWMC_ERR_UNKNOWN = -64,
+	DS5_HWMC_ERR_LAST,
+};
+
+static int ds5_hwmc_wait(struct ds5 *state)
+{
+	int ret = 0;
+	u16 status = DS5_HWMC_STATUS_WIP;
+	int retries = 100;
+	int errorCode;
+	do {
+		if (retries != 100)
+			msleep_range(1);
+		ret = ds5_read_poll(state, DS5_HWMC_STATUS, &status);
+		if (ret) {
+			dev_dbg(&state->client->dev,
+				"%s(): I2C read failed (%d), retries left: %d\n",
+				__func__, ret, retries);
+		}
+	} while (retries-- && (ret || status == DS5_HWMC_STATUS_WIP));
+	dev_dbg(&state->client->dev,
+		"%s(): ret: 0x%x, status: 0x%x\n",
+		__func__, ret, status);
+	if (!ret) {
+		if (status == DS5_HWMC_STATUS_ERR) {
+			ds5_raw_read(state, DS5_HWMC_DATA, &errorCode, sizeof(errorCode));
+			ret = errorCode;
+		} else if (status == DS5_HWMC_STATUS_WIP) {
+			ret = -ETIMEDOUT;
+			dev_warn(&state->client->dev,
+				"%s(): HWMC command timed out\n", __func__);
+		}
+	} else {
+		ret = DS5_HWMC_ERR_LAST;
+	}
+	return ret;
+}
+
+static int ds5_get_hwmc(struct ds5 *state, unsigned char *data,
+		u16 cmdDataLen, u16 *dataLen)
+{
+	int ret = 0;
+	u16 tmp_len = 0;
+
+	if (!data)
+		return -ENOBUFS;
+
+	memset(data, 0, cmdDataLen);
+	ret = ds5_hwmc_wait(state);
+	if (ret) {
+		dev_dbg(&state->client->dev,
+			"%s(): HWMC status not clear, ret: %d\n",
+			__func__, ret);
+		if (ret != DS5_HWMC_ERR_LAST) {
+			int *p = (int *)data;
+			*p = ret;
+			return 0;
+		} else {
+			return ret;
+		}
+	}
+
+	ret = ds5_raw_read(state, DS5_HWMC_RESP_LEN,
+			&tmp_len, sizeof(tmp_len)); /* Read response length */
+	if (ret)
+		return -EBADMSG;
+
+	if (tmp_len > cmdDataLen)
+		return -ENOBUFS;
+
+	if (tmp_len == 0) {
+		dev_err(&state->client->dev,
+			"%s(): HWMC response length is 0\n", __func__);
+		return -ENODATA;
+	}
+
+	dev_dbg(&state->client->dev,
+			"%s(): HWMC read len: %d, lrs_len: %d\n",
+			__func__, tmp_len, tmp_len - 4);
+
+	ds5_raw_read_with_check(state, DS5_HWMC_DATA, data, tmp_len); /* Read response data */
+	if (dataLen)
+		*dataLen = tmp_len;
+	return ret;
+}
+
+static int ds5_hwmc_send(struct ds5 *state,
+			u16 cmdLen,
+			const struct hwm_cmd *cmd)
+{
+	dev_dbg(&state->client->dev,
+			"%s(): HWMC header: 0x%x, magic: 0x%x, opcode: 0x%x, "
+			"cmdLen: %d, param1: %d, param2: %d, param3: %d, param4: %d\n",
+			__func__, cmd->header, cmd->magic_word, cmd->opcode,
+			cmdLen,	cmd->param1, cmd->param2, cmd->param3, cmd->param4);
+
+	ds5_raw_write_with_check(state, DS5_HWMC_DATA, cmd, cmdLen); /* Write command data */
+
+	ds5_write_with_check(state, DS5_HWMC_EXEC, 0x01); /* execute cmd */
+
+	return 0;
+}
+
+static int ds5_set_calibration_data(struct ds5 *state,
+		const struct hwm_cmd *cmd, u16 length)
+{
+	int ret;
+
+	ret = ds5_hwmc_send(state, length, cmd);
+	if (ret)
+		return ret;
+
+	ret = ds5_hwmc_wait(state);
+	if (ret) {
+		dev_err(&state->client->dev,
+				"%s(): Failed to set calibration table %d, error: %d\n",
+				__func__, cmd->param1, ret);
+	}
+
+	return ret;
+}
+
+/* HW reset timeout and polling parameters */
+#define DS5_HW_RESET_INITIAL_DELAY_MS	500
+#define DS5_HW_RESET_POLL_INTERVAL_MS	200
+#define DS5_HW_RESET_TIMEOUT_MS		10000
+#define DS5_HW_RESET_MAX_RETRIES	(DS5_HW_RESET_TIMEOUT_MS / DS5_HW_RESET_POLL_INTERVAL_MS)
+
+/* Minimum interval between consecutive HW resets (ms).
+ * Rapid back-to-back resets degrade the GMSL link.
+ */
+#define DS5_HW_RESET_COOLDOWN_MS	2000
+
+/* Reset readiness handshake:
+ * 1) write scratch value before reset,
+ * 2) wait for FW to restore control-status registers to default 0.
+ */
+#define DS5_HW_RESET_READY_SCRATCH_VAL	0x00AD
+#define DS5_HW_RESET_READY_EXPECTED_VAL	0x0000
+
+/*
+ * Register holding DFU magic (0x5020).
+ * In non-DFU mode this register is not defined.
+ * - 0x04030201: Device in DFU mode (DFU magic bytes, little-endian)
+ */
+#define DS5_DFU_MAGIC_REG	0x5020
+#define DS5_DFU_MAGIC_LSW		0x0201  /* Lower 16 bits of 0x04030201 */
+
+static int ds5_wait_device_type(struct ds5 *state, u16 *dev_type)
+{
+	int ret = -ETIMEDOUT;
+	int retry;
+	u16 cached_type;
+	u16 probed_type = DS5_DEVICE_TYPE_UNKNOWN;
+
+	for (retry = 0; retry < DS5_HW_RESET_MAX_RETRIES;
+	     retry++, msleep(DS5_HW_RESET_POLL_INTERVAL_MS)) {
+		cached_type = READ_ONCE(state->ds5_dev->cached_device_type);
+		if (ds5_is_valid_device_type(cached_type)) {
+			*dev_type = cached_type;
+			return 0;
+		}
+
+		ret = ds5_read_poll(state, DS5_DEVICE_TYPE, &probed_type);
+		if (!ret && ds5_is_valid_device_type(probed_type)) {
+			WRITE_ONCE(state->ds5_dev->cached_device_type, probed_type);
+			*dev_type = probed_type;
+			return 0;
+		}
+	}
+
+	*dev_type = probed_type;
+	return ret ? ret : -ETIMEDOUT;
+}
+
+static void ds5_reset_streaming_flags(struct ds5_dev *ds5_dev)
+{
+	mutex_lock(&ds5_dev->lock);
+	ds5_dev->depth_streaming = false;
+	ds5_dev->ir_streaming = false;
+	ds5_dev->rgb_streaming = false;
+	ds5_dev->imu_streaming = false;
+	mutex_unlock(&ds5_dev->lock);
+}
+
+static int ds5_set_ser_esync_tunneling(struct ds5 *state, bool enable)
+{
+#ifdef CONFIG_VIDEO_D5XX_SERDES
+	int ret;
+
+	if (!state || !state->ser_dev)
+		return -EINVAL;
+	if (state->dser_ops != &max96724_interface)
+		return 0;
+
+	dev_dbg(&state->client->dev,
+		"%s(): serializer ESYNC %s requested\n",
+		__func__, enable ? "enable" : "disable");
+
+	if (enable)
+		ret = max96717_setup_gpio_tunneling(state->ser_dev);
+	else
+		ret = 0; /* MAX96717 GPIO tunneling has no disable */
+
+	if (ret)
+		dev_warn(&state->client->dev,
+			"%s(): serializer ESYNC %s failed (%d)\n",
+			__func__, enable ? "enable" : "disable", ret);
+	else
+		dev_dbg(&state->client->dev,
+			"%s(): serializer ESYNC %s OK\n",
+			__func__, enable ? "enable" : "disable");
+
+	return ret;
+#else
+	return 0;
+#endif
+}
+
+/*
+ * ds5_hw_reset_with_recovery - Perform hardware reset with readiness polling
+ * @state: Driver state structure
+ *
+ * Sends a hardware reset command to the D4XX device and waits for it to
+ * come back online.  Before resetting, stops active streams and invalidates
+ * all driver-side sensor state (streaming flags, SERDES pipes, config cache).
+ * After the device responds, waits for DEVICE_TYPE to become valid (GMSL
+ * link recovery).  Per-pipe SERDES reconfiguration is deferred to
+ * ds5_configure() at the next stream start.
+ *
+ * Returns 0 on success, negative error code on failure.
+ */
+static int ds5_hw_reset_with_recovery(struct ds5 *state)
+{
+	int ret;
+	int retry;
+	u16 dev_type = DS5_DEVICE_TYPE_UNKNOWN;
+	u16 ready_status = 0;
+	u16 ready_reg = state->control_status_reg;
+	struct hwm_cmd reset_cmd;
+	bool depth_streaming;
+	bool rgb_streaming;
+	bool ir_streaming;
+	bool imu_streaming;
+	unsigned long ds5_last_reset_jiffies = READ_ONCE(state->ds5_dev->last_reset_jiffies);
+	unsigned long ts, timeout;
+
+	dev_info(&state->client->dev, "%s(): Initiating HW reset with recovery\n",
+		__func__);
+
+	/* 0. Reset cooldown — prevent rapid consecutive resets.
+	 *    Repeated HW resets without sufficient recovery time
+	 *    progressively degrade the GMSL link.  Enforce a minimum
+	 *    interval between resets.
+	 *    Skip check on the very first reset (ds5_last_reset_jiffies == 0).
+	 */
+	if (ds5_last_reset_jiffies) {
+		unsigned long elapsed = jiffies - ds5_last_reset_jiffies;
+		unsigned long cooldown = msecs_to_jiffies(DS5_HW_RESET_COOLDOWN_MS);
+
+		if (time_before(jiffies, ds5_last_reset_jiffies + cooldown)) {
+			unsigned long remaining = cooldown - elapsed;
+
+			dev_info(&state->client->dev,
+				"%s(): Reset cooldown — last reset %u ms ago, waiting %u ms\n",
+				__func__, jiffies_to_msecs(elapsed),
+				jiffies_to_msecs(remaining));
+			msleep(jiffies_to_msecs(remaining));
+		}
+	}
+
+	/* 1. Stop active streams on the device before reset.
+	 *    This ensures FW and SERDES are in a clean state.
+	 *
+	 *    In the D4XX architecture each physical camera has 4 driver
+	 *    instances (Depth, RGB, IR, IMU) sharing the same ser_dev.
+	 *    HW reset kills all streams on the camera ASIC, so we must
+	 *    stop and invalidate all peer instances of the same camera.
+	 */
+	dev_info(&state->client->dev, "%s(): stopping streams before reset\n", __func__);
+	mutex_lock(&state->ds5_dev->lock);
+	depth_streaming = state->ds5_dev->depth_streaming;
+	rgb_streaming = state->ds5_dev->rgb_streaming;
+	ir_streaming = state->ds5_dev->ir_streaming;
+	imu_streaming = state->ds5_dev->imu_streaming;
+	mutex_unlock(&state->ds5_dev->lock);
+
+	if (depth_streaming)
+		ds5_write(state, DS5_START_STOP_STREAM,	DS5_STREAM_STOP | DS5_STREAM_DEPTH);
+	if (rgb_streaming)
+		ds5_write(state, DS5_START_STOP_STREAM,	DS5_STREAM_STOP | DS5_STREAM_RGB);
+	if (ir_streaming)
+		ds5_write(state, DS5_START_STOP_STREAM,	DS5_STREAM_STOP | DS5_STREAM_IR);
+	if (imu_streaming)
+		ds5_write(state, DS5_START_STOP_STREAM,	DS5_STREAM_STOP | DS5_STREAM_IMU);
+
+	/* 2. Increment DS5 reset generation.
+	 *    After HW reset the device loses all configuration, so driver
+	 *    state must be brought in sync, like clearing streaming flags so that
+	 *    ds5_mux_s_stream() won't silently skip the next stream-start.
+	 *    Also clear cached device type so post-reset readiness polling
+	 *    cannot be satisfied by stale pre-reset values.
+	 *    Covers this instance AND all peer instances of the same camera.
+	 *
+	 *    Do NOT release SERDES pipes here — the D5XX FW may still
+	 *    reconfigure MAX96717 while reset completion propagates.
+	 *    Releasing + re-allocating pipes now would race with FW init.
+	 *    Instead, clear pipe_data_type to force ds5_configure() to
+	 *    release-then-reallocate at stream-start time, when the FW
+	 *    has long finished its init (matching v1.0.1.33 behavior).
+	 */
+	atomic_inc(ds5_get_reset_gen(state));
+	WRITE_ONCE(state->ds5_dev->cached_device_type, DS5_DEVICE_TYPE_UNKNOWN);
+	ds5_reset_streaming_flags(state->ds5_dev);
+
+	/* 3. Scratch one control-status register before reset.
+	 *    FW restores them to default 0x0000 only after reset completes.
+	 */
+	if (!ready_reg)
+		ready_reg = DS5_DEPTH_CONTROL_STATUS;
+
+	ret = ds5_write(state, ready_reg, DS5_HW_RESET_READY_SCRATCH_VAL);
+	if (ret) {
+		dev_err(&state->client->dev,
+			"%s(): scratch write failed reg 0x%04x (%d)\n",
+			__func__, ready_reg, ret);
+		return ret;
+	}
+
+	/* 4. Send HW reset command */
+	memcpy(&reset_cmd, &cmd_hw_reset, sizeof(reset_cmd));
+	ret = ds5_hwmc_send(state, sizeof(reset_cmd), &reset_cmd);
+	if (ret < 0) {
+		dev_err(&state->client->dev,
+			"%s(): Failed to send HW reset command: %d\n",
+			__func__, ret);
+		return ret;
+	}
+
+	dev_info(&state->client->dev, "%s(): HW reset command sent, waiting for device...\n",
+		__func__);
+
+	/* 5. Delay to allow reset to complete */
+	ts = jiffies;
+	msleep(DS5_HW_RESET_INITIAL_DELAY_MS);
+
+	/* 6. Poll for control-status defaults to confirm reset completion. */
+	for (retry = 0, timeout = ts + msecs_to_jiffies(DS5_HW_RESET_TIMEOUT_MS);
+			; retry++, msleep_range(DS5_HW_RESET_POLL_INTERVAL_MS)) {
+		if (!time_before(jiffies, timeout)) {
+			dev_err(&state->client->dev,
+				"%s(): Device isn't ready after %d ms (last control-status: 0x%04x, i2c ret: %d)\n",
+				__func__, jiffies_to_msecs(jiffies - ts), ready_status, ret);
+
+			return -ETIMEDOUT;
+		}
+
+		ret = ds5_read_poll(state, ready_reg, &ready_status);
+		if (ret < 0) {
+			dev_dbg(&state->client->dev,
+				"%s(): Device not responding (resetting), retry %d\n",
+				__func__, retry);
+			continue;
+		}
+		if (ready_status == DS5_HW_RESET_READY_EXPECTED_VAL) {
+			dev_info(&state->client->dev,
+				"%s(): Device ready after %d ms (control-status default restored)\n",
+				__func__, jiffies_to_msecs(jiffies - ts));
+			break;
+		}
+
+		ret = ds5_read_poll(state, DS5_DFU_MAGIC_REG, &ready_status);
+		if (!ret && ready_status == DS5_DFU_MAGIC_LSW) {
+			dev_warn(&state->client->dev,
+				"%s(): Device in DFU/recovery mode after reset\n", __func__);
+			state->dfu_dev.dfu_state_flag = DS5_DFU_RECOVERY;
+			return 0;
+		}
+	}
+
+
+	/* 7. Wait for DEVICE_TYPE to confirm GMSL link recovery.
+	 *    Step 6 confirmed reset completion via control-status defaults.
+	 *    Wait for DEVICE_TYPE: if the register becomes valid,
+	 *    the GMSL link recovered naturally and the firmware progressed
+	 *    far enough for format-dependent paths (the common case).
+	 *
+	 *    Do NOT call max96717_init_settings() here.  That function writes
+	 *    global serializer registers (0x02, 0x308, 0x311, 0x331) that
+	 *    disrupt the active GMSL link.  Per-pipe reconfiguration is
+	 *    handled by ds5_configure()->ds5_setup_pipeline()
+	 *    at the next STREAMON for each stream.
+	 */
+	ret = ds5_wait_device_type(state, &dev_type);
+	if (ret < 0) {
+		dev_err(&state->client->dev,
+			"%s(): device type not ready after reset (ret=%d, val=0x%x)\n",
+			__func__, ret, dev_type);
+		return ret;
+	}
+	dev_info(&state->client->dev,
+		"%s(): GMSL link recovered (device type 0x%04x)\n",
+		__func__, dev_type);
+
+	/* 8. Verify device is operational by reading firmware version */
+	ret = ds5_read(state, DS5_FW_VERSION, &state->fw_version);
+	if (ret < 0) {
+		dev_err(&state->client->dev,
+			"%s(): Failed to read firmware version: %d\n", __func__, ret);
+		return ret;
+	}
+
+	ret = ds5_read(state, DS5_FW_BUILD, &state->fw_build);
+	if (ret < 0) {
+		dev_err(&state->client->dev,
+			"%s(): Failed to read firmware build: %d\n", __func__, ret);
+		return ret;
+	}
+
+	dev_info(&state->client->dev,
+		"%s(): HW reset complete. Device type 0x%04x, firmware: %d.%d.%d.%d\n",
+		__func__,
+		dev_type,
+		(state->fw_version >> 8) & 0xff, state->fw_version & 0xff,
+		(state->fw_build >> 8) & 0xff, state->fw_build & 0xff);
+
+	/* Re-apply ESYNC tunneling to match cached sync_mode control */
+	if (state->ctrls.sync_mode) {
+		int sync_val = state->ctrls.sync_mode->cur.val;
+		bool need_esync = (sync_val == DS5_SYNC_MODE_SLAVE ||
+				   sync_val == DS5_SYNC_MODE_FULL_SLAVE);
+
+		ret = ds5_set_ser_esync_tunneling(state, need_esync);
+		if (ret)
+			dev_warn(&state->client->dev,
+				"%s(): serializer ESYNC %s after HW reset failed (%d)\n",
+				__func__, need_esync ? "enable" : "disable", ret);
+	}
+
+	WRITE_ONCE(state->ds5_dev->last_reset_jiffies, jiffies);
+
+	return 0;
+}
+
+static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on);
+
+static int ds5_s_ctrl(struct v4l2_ctrl *ctrl)
+{
+	struct ds5 *state = container_of(ctrl->handler, struct ds5,
+					 ctrls.handler);
+	struct v4l2_subdev *sd = &state->mux.sd.subdev;
+	struct ds5_sensor *sensor = (struct ds5_sensor *)ctrl->priv;
+	int ret = -EINVAL;
+	u16 base;
+
+	if (sensor) {
+		switch (sensor->mux_pad) {
+		case DS5_MUX_PAD_DEPTH:
+			state = container_of(ctrl->handler, struct ds5, ctrls.handler_depth);
+			break;
+		case DS5_MUX_PAD_RGB:
+			state = container_of(ctrl->handler, struct ds5, ctrls.handler_rgb);
+			break;
+		case DS5_MUX_PAD_IR:
+			state = container_of(ctrl->handler, struct ds5, ctrls.handler_y8);
+			break;
+		case DS5_MUX_PAD_IMU:
+			state = container_of(ctrl->handler, struct ds5, ctrls.handler_imu);
+			break;
+		default:
+			break;
+		}
+	}
+
+	base = state->control_base;
+	v4l2_dbg(3, 1, sd, "ctrl: %s, value: %d\n", ctrl->name, ctrl->val);
+	dev_dbg(&state->client->dev, "%s(): %s - ctrl: %s, value: %d\n",
+		__func__, ds5_get_sensor_name(state), ctrl->name, ctrl->val);
+
+	mutex_lock(&state->lock);
+
+	switch (ctrl->id) {
+	case V4L2_CID_ANALOGUE_GAIN:
+		ret = ds5_write(state, base | DS5_MANUAL_GAIN, ctrl->val);
+		break;
+
+	case V4L2_CID_EXPOSURE_AUTO:
+		ret = ds5_hw_set_auto_exposure(state, base, ctrl->val);
+		break;
+
+	case V4L2_CID_EXPOSURE_ABSOLUTE:
+		ret = ds5_hw_set_exposure(state, base, ctrl->val);
+		break;
+	case DS5_CAMERA_CID_LASER_POWER:
+		if (!state->is_rgb)
+			ret = ds5_write(state, base | DS5_LASER_POWER,
+					ctrl->val);
+		break;
+	case DS5_CAMERA_CID_MANUAL_LASER_POWER:
+		if (!state->is_rgb)
+			ret = ds5_write(state, base | DS5_MANUAL_LASER_POWER,
+					ctrl->val);
+		break;
+	case DS5_CAMERA_DEPTH_CALIBRATION_TABLE_SET:
+		dev_dbg(&state->client->dev,
+			"%s(): DS5_CAMERA_DEPTH_CALIBRATION_TABLE_SET \n",	__func__);
+		if (ctrl->p_new.p) {
+			struct hwm_cmd *calib_cmd;
+			dev_dbg(&state->client->dev,
+				"%s(): table id: 0x%x\n",
+				__func__, *((u8 *)ctrl->p_new.p + 2));
+			if (DEPTH_CALIBRATION_ID == *((u8 *)ctrl->p_new.p + 2)) {
+				calib_cmd = devm_kzalloc(&state->client->dev,
+					sizeof(struct hwm_cmd) + 256, GFP_KERNEL);
+				if (!calib_cmd) {
+					dev_err(&state->client->dev,
+						"%s(): Can't allocate memory for 0x%x\n",
+						__func__, ctrl->id);
+					ret = -ENOMEM;
+					break;
+				}
+				memcpy(calib_cmd, &set_calib_data, sizeof(set_calib_data));
+				calib_cmd->header = 276;
+				calib_cmd->param1 = DEPTH_CALIBRATION_ID;
+				memcpy(calib_cmd->Data, (u8 *)ctrl->p_new.p, 256);
+				ret = ds5_set_calibration_data(state, calib_cmd,
+					sizeof(struct hwm_cmd) + 256);
+				devm_kfree(&state->client->dev, calib_cmd);
+			}
+		}
+		break;
+	case DS5_CAMERA_COEFF_CALIBRATION_TABLE_SET:
+			dev_dbg(&state->client->dev,
+				"%s(): DS5_CAMERA_COEFF_CALIBRATION_TABLE_SET \n",
+				__func__);
+			if (ctrl->p_new.p) {
+				struct hwm_cmd *calib_cmd;
+				dev_dbg(&state->client->dev,
+					"%s(): table id %d\n",
+					__func__, *((u8 *)ctrl->p_new.p + 2));
+				if (COEF_CALIBRATION_ID == *((u8 *)ctrl->p_new.p + 2)) {
+					calib_cmd = devm_kzalloc(&state->client->dev,
+						sizeof(struct hwm_cmd) + 512, GFP_KERNEL);
+					if (!calib_cmd) {
+						dev_err(&state->client->dev,
+							"%s(): Can't allocate memory for 0x%x\n",
+							__func__, ctrl->id);
+						ret = -ENOMEM;
+						break;
+					}
+				memcpy(calib_cmd, &set_calib_data, sizeof (set_calib_data));
+				calib_cmd->header = 532;
+				calib_cmd->param1 = COEF_CALIBRATION_ID;
+				memcpy(calib_cmd->Data, (u8 *)ctrl->p_new.p, 512);
+				ret = ds5_set_calibration_data(state, calib_cmd,
+						sizeof(struct hwm_cmd) + 512);
+				devm_kfree(&state->client->dev, calib_cmd);
+			}
+		}
+		break;
+	case DS5_CAMERA_CID_AE_ROI_SET: 
+		if (ctrl->p_new.p_u16) {
+			struct hwm_cmd ae_roi_cmd;
+			memcpy(&ae_roi_cmd, &set_ae_roi, sizeof(ae_roi_cmd));
+			ae_roi_cmd.param1 = *((u16 *)ctrl->p_new.p_u16);
+			ae_roi_cmd.param2 = *((u16 *)ctrl->p_new.p_u16 + 1);
+			ae_roi_cmd.param3 = *((u16 *)ctrl->p_new.p_u16 + 2);
+			ae_roi_cmd.param4 = *((u16 *)ctrl->p_new.p_u16 + 3);
+			ret = ds5_hwmc_send(state, sizeof(struct hwm_cmd),
+				&ae_roi_cmd);
+			if (!ret)
+				ret = ds5_hwmc_wait(state);
+		}
+		break;
+	case DS5_CAMERA_CID_AE_SETPOINT_SET:
+		if (ctrl->p_new.p_s32) {
+			struct hwm_cmd *ae_setpoint_cmd;
+			dev_dbg(&state->client->dev, "%s():0x%x \n",
+				__func__, *(ctrl->p_new.p_s32));
+			ae_setpoint_cmd = devm_kzalloc(&state->client->dev,
+					sizeof(struct hwm_cmd) + 4, GFP_KERNEL);
+			if (!ae_setpoint_cmd) {
+				dev_err(&state->client->dev,
+					"%s(): Can't allocate memory for 0x%x\n",
+					__func__, ctrl->id);
+				ret = -ENOMEM;
+				break;
+			}
+			memcpy(ae_setpoint_cmd, &set_ae_setpoint, sizeof (set_ae_setpoint));
+			memcpy(ae_setpoint_cmd->Data, (u8 *)ctrl->p_new.p_s32, 4);
+			ret = ds5_hwmc_send(state, sizeof(struct hwm_cmd) + 4,
+					ae_setpoint_cmd);
+			if (!ret)
+				ret = ds5_hwmc_wait(state);
+			devm_kfree(&state->client->dev, ae_setpoint_cmd);
+		}
+		break;
+	case DS5_CAMERA_CID_ERB:
+		if (ctrl->p_new.p_u8) {
+			u16 offset = 0;
+			u16 size = 0;
+			u16 len = 0;
+			struct hwm_cmd *erb_cmd;
+
+			offset = *(ctrl->p_new.p_u8) << 8;
+			offset |= *(ctrl->p_new.p_u8 + 1);
+			size = *(ctrl->p_new.p_u8 + 2) << 8;
+			size |= *(ctrl->p_new.p_u8 + 3);
+
+			dev_dbg(&state->client->dev, "%s(): offset %x, size: %x\n",
+							__func__, offset, size);
+			len = sizeof(struct hwm_cmd) + size;
+			erb_cmd = devm_kzalloc(&state->client->dev,	len, GFP_KERNEL);
+			if (!erb_cmd) {
+				dev_err(&state->client->dev,
+					"%s(): Can't allocate memory for 0x%x\n",
+					__func__, ctrl->id);
+				ret = -ENOMEM;
+				break;
+			}
+			memcpy(erb_cmd, &erb, sizeof(struct hwm_cmd));
+			erb_cmd->param1 = offset;
+			erb_cmd->param2 = size;
+			ret = ds5_hwmc_send(state, sizeof(struct hwm_cmd), erb_cmd);
+			if (!ret)
+				ret = ds5_get_hwmc(state, erb_cmd->Data, len, &size);
+			if (ret) {
+				dev_err(&state->client->dev,
+					"%s(): ERB cmd failed, ret: %d,"
+					"requested size: %d, actual size: %d\n",
+					__func__, ret, erb_cmd->param2, size);
+				devm_kfree(&state->client->dev, erb_cmd);
+				return -EAGAIN;
+			}
+
+			// Actual size returned from FW
+			*(ctrl->p_new.p_u8 + 2) = (size & 0xFF00) >> 8;
+			*(ctrl->p_new.p_u8 + 3) = (size & 0x00FF);
+
+			memcpy(ctrl->p_new.p_u8 + 4, erb_cmd->Data + 4, size - 4);
+			dev_dbg(&state->client->dev, "%s(): 0x%x 0x%x 0x%x 0x%x \n",
+				__func__,
+				*(ctrl->p_new.p_u8),
+				*(ctrl->p_new.p_u8+1),
+				*(ctrl->p_new.p_u8+2),
+				*(ctrl->p_new.p_u8+3));
+			devm_kfree(&state->client->dev, erb_cmd);
+		}
+		break;
+	case DS5_CAMERA_CID_EWB:
+		if (ctrl->p_new.p_u8) {
+			u16 offset = 0;
+			u16 size = 0;
+			struct hwm_cmd *ewb_cmd;
+
+			offset = *((u8 *)ctrl->p_new.p_u8) << 8;
+			offset |= *((u8 *)ctrl->p_new.p_u8 + 1);
+			size = *((u8 *)ctrl->p_new.p_u8 + 2) << 8;
+			size |= *((u8 *)ctrl->p_new.p_u8 + 3);
+
+			dev_dbg(&state->client->dev, "%s():0x%x 0x%x 0x%x 0x%x\n",
+					__func__,
+					*((u8 *)ctrl->p_new.p_u8),
+					*((u8 *)ctrl->p_new.p_u8 + 1),
+					*((u8 *)ctrl->p_new.p_u8 + 2),
+					*((u8 *)ctrl->p_new.p_u8 + 3));
+
+			ewb_cmd = devm_kzalloc(&state->client->dev,
+					sizeof(struct hwm_cmd) + size,
+					GFP_KERNEL);
+			if (!ewb_cmd) {
+				dev_err(&state->client->dev,
+					"%s(): Can't allocate memory for 0x%x\n",
+					__func__, ctrl->id);
+				ret = -ENOMEM;
+				break;
+			}
+			memcpy(ewb_cmd, &ewb, sizeof(ewb));
+			ewb_cmd->header = 0x14 + size;
+			ewb_cmd->param1 = offset; // start index
+			ewb_cmd->param2 = size; // size
+			memcpy(ewb_cmd->Data, (u8 *)ctrl->p_new.p_u8 + 4, size);
+			ret = ds5_hwmc_send(state, sizeof(struct hwm_cmd) + size, ewb_cmd);
+			if (!ret)
+				ret = ds5_hwmc_wait(state);
+			if (ret) {
+				dev_err(&state->client->dev,
+					"%s(): EWB cmd failed, ret: %d,"
+					"requested size: %d, actual size: %d\n",
+					__func__, ret, ewb_cmd->param2, size);
+				devm_kfree(&state->client->dev, ewb_cmd);
+				return -EAGAIN;
+			}
+
+			devm_kfree(&state->client->dev, ewb_cmd);
+		}
+		break;
+	case DS5_CAMERA_CID_HWMC:
+		if (ctrl->p_new.p_u8) {
+			u16 size = 0;
+			struct hwm_cmd *cmd = (struct hwm_cmd *)ctrl->p_new.p_u8;
+			size = *((u8 *)ctrl->p_new.p_u8 + 1) << 8;
+			size |= *((u8 *)ctrl->p_new.p_u8 + 0);
+			ret = ds5_hwmc_send(state, size + 4, cmd);
+			ret = ds5_get_hwmc(state, cmd->Data, ctrl->dims[0], &size);
+			if (ctrl->dims[0] < DS5_HWMC_BUFFER_SIZE) {
+				ret = -ENODATA;
+				break;
+			}
+			/*This is needed for legacy hwmc */
+			size += 4; // SIZE_OF_HW_MONITOR_HEADER
+			cmd->Data[1000] = (unsigned char)((size) & 0x00FF);
+			cmd->Data[1001] = (unsigned char)(((size) & 0xFF00) >> 8);
+		}
+		break;
+	case DS5_CAMERA_CID_HWMC_RW:
+		if (ctrl->p_new.p_u8) {
+			struct hwm_cmd *cmd = (struct hwm_cmd *)ctrl->p_new.p_u8;
+			u16 size = *((u8 *)ctrl->p_new.p_u8 + 1) << 8;
+			size |= *((u8 *)ctrl->p_new.p_u8 + 0);
+
+			/* Check if this is a HW reset command (opcode 0x20) */
+			if (cmd->opcode == 0x20) {
+				dev_info(&state->client->dev,
+					"%s(): HW reset detected via HWMC_RW, using recovery path\n",
+					__func__);
+				ret = ds5_hw_reset_with_recovery(state);
+			} else {
+				ret = ds5_hwmc_send(state, size + 4, cmd);
+			}
+		}
+		break;
+	case DS5_CAMERA_CID_HW_RESET:
+		dev_info(&state->client->dev, "%s(): HW reset requested via V4L2 control\n",
+			__func__);
+		ret = ds5_hw_reset_with_recovery(state);
+		break;
+	case DS5_CAMERA_CID_SYNC_MODE:
+		dev_info(&state->client->dev, "%s(): XU SYNC_MODE control received, value: %d\n",
+			__func__, ctrl->val);
+		if (state->is_depth) {
+			ret = ds5_write(state, base | DS5_CAMERA_SYNC_MODE, ctrl->val);
+			dev_info(&state->client->dev, "%s(): SYNC_MODE command passed to FW, addr: 0x%x, value: %d, ret: %d\n",
+				__func__, base | DS5_CAMERA_SYNC_MODE, ctrl->val, ret);
+			if (!ret) {
+				bool need_esync = (ctrl->val == DS5_SYNC_MODE_SLAVE ||
+						   ctrl->val == DS5_SYNC_MODE_FULL_SLAVE);
+
+				dev_dbg(&state->client->dev,
+					"%s(): sync_mode=%d -> serializer ESYNC %s\n",
+					__func__, ctrl->val,
+					need_esync ? "enable" : "disable");
+				ret = ds5_set_ser_esync_tunneling(state, need_esync);
+			}
+		}
+		break;
+	case DS5_CAMERA_CID_PWM:
+		if (state->is_depth)
+			ret = ds5_write(state, base | DS5_PWM_FREQUENCY, ctrl->val);
+		break;
+	}
+
+	mutex_unlock(&state->lock);
+
+	return ret;
+}
+
+static int ds5_get_calibration_data(struct ds5 *state, enum table_id id,
+		unsigned char *table, unsigned int length)
+{
+	struct hwm_cmd *cmd;
+	int ret;
+	u16 table_length;
+
+	cmd = devm_kzalloc(&state->client->dev,
+			sizeof(struct hwm_cmd) + length + 4, GFP_KERNEL);
+	if (!cmd) {
+		dev_err(&state->client->dev, "%s(): Can't allocate memory\n", __func__);
+		return -ENOMEM;
+	}
+
+	memcpy(cmd, &get_calib_data, sizeof(get_calib_data));
+	cmd->param1 = id;
+	ret = ds5_hwmc_send(state, sizeof(struct hwm_cmd), cmd);
+	if (ret) {
+		devm_kfree(&state->client->dev, cmd);
+		return ret;
+	}
+
+	ret = ds5_hwmc_wait(state);
+
+	if (ret) {
+		dev_err(&state->client->dev,
+				"%s(): Failed to get calibration table %d, error: %d\n",
+				__func__, id, ret);
+		devm_kfree(&state->client->dev, cmd);
+		return ret;
+	}
+
+	// get table length from fw
+	ret = ds5_raw_read(state, DS5_HWMC_RESP_LEN,
+			&table_length, sizeof(table_length)); /* Read response length */
+
+	// read table
+	ds5_raw_read_with_check(state, DS5_HWMC_DATA, cmd->Data, table_length); /* Read table data */
+
+	// first 4 bytes are opcode HWM, not part of calibration table
+	memcpy(table, cmd->Data + 4, length);
+	devm_kfree(&state->client->dev, cmd);
+	return 0;
+}
+
+static int ds5_gvd(struct ds5 *state, unsigned char *data)
+{
+	struct hwm_cmd cmd;
+	int ret;
+	u16 length = 0;
+
+	memcpy(&cmd, &gvd, sizeof(gvd));
+	ret = ds5_hwmc_send(state, sizeof(cmd), &cmd);
+	if (ret)
+		return ret;
+
+	ret = ds5_hwmc_wait(state);
+	if (ret) {
+		dev_err(&state->client->dev,
+			"%s(): Failed to read GVD, error: %d\n",
+			__func__, ret);
+		return -EIO;
+	}
+
+	ret = ds5_raw_read(state, DS5_HWMC_RESP_LEN, &length, sizeof(length)); /* Read response length */
+	ds5_raw_read_with_check(state, DS5_HWMC_DATA, data, length); /* Read response data */
+
+	return ret;
+}
+
+static int ds5_g_volatile_ctrl(struct v4l2_ctrl *ctrl)
+{
+	struct ds5 *state = container_of(ctrl->handler, struct ds5,
+			ctrls.handler);
+			
+	u32 data;
+	int ret = 0;
+	struct ds5_sensor *sensor = (struct ds5_sensor *)ctrl->priv;
+	u16 base;
+	u16 reg;
+
+	if (sensor) {
+		switch (sensor->mux_pad) {
+		case DS5_MUX_PAD_DEPTH:
+			state = container_of(ctrl->handler, struct ds5, ctrls.handler_depth);
+			break;
+		case DS5_MUX_PAD_RGB:
+			state = container_of(ctrl->handler, struct ds5, ctrls.handler_rgb);
+			break;
+		case DS5_MUX_PAD_IR:
+			state = container_of(ctrl->handler, struct ds5, ctrls.handler_y8);
+			break;
+		case DS5_MUX_PAD_IMU:
+			state = container_of(ctrl->handler, struct ds5, ctrls.handler_imu);
+			break;
+		default:
+			break;
+		}
+	}
+	base = state->control_base;
+
+	dev_dbg(&state->client->dev, "%s(): %s - ctrl: %s \n",
+		__func__, ds5_get_sensor_name(state), ctrl->name);
+
+	switch (ctrl->id) {
+
+	case V4L2_CID_ANALOGUE_GAIN:
+		if (state->is_imu)
+			return -EINVAL;
+		ret = ds5_read(state, base | DS5_MANUAL_GAIN, ctrl->p_new.p_u16);
+		break;
+
+	case V4L2_CID_EXPOSURE_AUTO:
+		if (state->is_imu)
+			return -EINVAL;
+		ds5_read(state, base | DS5_AUTO_EXPOSURE_MODE, &reg);
+		*ctrl->p_new.p_u16 = reg;
+		/* see ds5_hw_set_auto_exposure */
+		if (!state->is_rgb) {
+			if (reg == 1)
+				*ctrl->p_new.p_u16 = V4L2_EXPOSURE_APERTURE_PRIORITY;
+			else if (reg == 0)
+				*ctrl->p_new.p_u16 = V4L2_EXPOSURE_MANUAL;
+		}
+
+		if (state->is_rgb && reg == 8)
+			*ctrl->p_new.p_u16 = V4L2_EXPOSURE_APERTURE_PRIORITY;
+
+		break;
+
+	case V4L2_CID_EXPOSURE_ABSOLUTE:
+		if (state->is_imu)
+			return -EINVAL;
+		/* see ds5_hw_set_exposure */
+		ds5_read(state, base | DS5_MANUAL_EXPOSURE_MSB, &reg);
+		data = ((u32)reg << 16) & 0xffff0000;
+		ds5_read(state, base | DS5_MANUAL_EXPOSURE_LSB, &reg);
+		data |= reg;
+		*ctrl->p_new.p_u32 = data;
+		break;
+
+	case DS5_CAMERA_CID_LASER_POWER:
+		if (!state->is_rgb)
+			ds5_read(state, base | DS5_LASER_POWER, ctrl->p_new.p_u16);
+		break;
+
+	case DS5_CAMERA_CID_MANUAL_LASER_POWER:
+		if (!state->is_rgb)
+			ds5_read(state, base | DS5_MANUAL_LASER_POWER, ctrl->p_new.p_u16);
+		break;
+
+	case DS5_CAMERA_CID_LOG:
+		ret = ds5_hwmc_send(state, sizeof(log_prepare), &log_prepare);
+		if (ret)
+			return ret;
+
+		ret = ds5_hwmc_wait(state);
+		if (ret)
+			return ret;
+
+		ret = ds5_raw_read(state, DS5_HWMC_RESP_LEN, &data, sizeof(data)); /* Read response length */
+		dev_dbg(&state->client->dev, "%s(): log size 0x%x\n", __func__, data);
+		if (ret < 0)
+			return ret;
+		if (!data)
+			return 0;
+		if (data > 1024)
+			return -ENOBUFS;
+		ret = ds5_raw_read(state, DS5_HWMC_DATA,
+				ctrl->p_new.p_u8, data);
+		break;
+	case DS5_CAMERA_DEPTH_CALIBRATION_TABLE_GET:
+		ret = ds5_get_calibration_data(state, DEPTH_CALIBRATION_ID,
+				ctrl->p_new.p_u8, 256);
+		break;
+	case DS5_CAMERA_COEFF_CALIBRATION_TABLE_GET:
+		ret = ds5_get_calibration_data(state, COEF_CALIBRATION_ID,
+				ctrl->p_new.p_u8, 512);
+		break;
+	case DS5_CAMERA_CID_FW_VERSION:
+		ret = ds5_read(state, DS5_FW_VERSION, &state->fw_version);
+		ret = ds5_read(state, DS5_FW_BUILD, &state->fw_build);
+		*ctrl->p_new.p_u32 = state->fw_version << 16;
+		*ctrl->p_new.p_u32 |= state->fw_build;
+		break;
+	case DS5_CAMERA_CID_GVD:
+		ret = ds5_gvd(state, ctrl->p_new.p_u8);
+		break;
+	case DS5_CAMERA_CID_AE_ROI_GET:
+		if (ctrl->p_new.p_u16) {
+			u16 len = sizeof(struct hwm_cmd) + 12;
+			u16 dataLen = 0;
+			struct hwm_cmd *ae_roi_cmd;
+			ae_roi_cmd = devm_kzalloc(&state->client->dev, len, GFP_KERNEL);
+			if (!ae_roi_cmd) {
+				dev_err(&state->client->dev,
+					"%s(): Can't allocate memory for 0x%x\n",
+					__func__, ctrl->id);
+				ret = -ENOMEM;
+				break;
+			}
+			memcpy(ae_roi_cmd, &get_ae_roi, sizeof(struct hwm_cmd));
+			ret = ds5_hwmc_send(state, sizeof(struct hwm_cmd), ae_roi_cmd);
+			if (ret) {
+				devm_kfree(&state->client->dev, ae_roi_cmd);
+				return ret;
+			}
+			ret = ds5_get_hwmc(state, ae_roi_cmd->Data, len, &dataLen);
+			if (!ret && dataLen <= ctrl->dims[0])
+				memcpy(ctrl->p_new.p_u16, ae_roi_cmd->Data + 4, 8);
+			devm_kfree(&state->client->dev, ae_roi_cmd);
+		}
+		break;
+	case DS5_CAMERA_CID_AE_SETPOINT_GET:
+	if (ctrl->p_new.p_s32) {
+		u16 len = sizeof(struct hwm_cmd) + 8;
+		u16 dataLen = 0;
+		struct hwm_cmd *ae_setpoint_cmd;
+		ae_setpoint_cmd = devm_kzalloc(&state->client->dev,	len, GFP_KERNEL);
+		if (!ae_setpoint_cmd) {
+			dev_err(&state->client->dev,
+					"%s(): Can't allocate memory for 0x%x\n",
+					__func__, ctrl->id);
+			ret = -ENOMEM;
+			break;
+		}
+		memcpy(ae_setpoint_cmd, &get_ae_setpoint, sizeof(struct hwm_cmd));
+		ret = ds5_hwmc_send(state, sizeof(struct hwm_cmd), ae_setpoint_cmd);
+		if (ret) {		
+			devm_kfree(&state->client->dev, ae_setpoint_cmd);
+			return ret;
+		}
+		ret = ds5_get_hwmc(state, ae_setpoint_cmd->Data, len, &dataLen);
+		memcpy(ctrl->p_new.p_s32, ae_setpoint_cmd->Data + 4, 4);
+		dev_dbg(&state->client->dev, "%s(): len: %d, 0x%x \n",
+			__func__, dataLen, *(ctrl->p_new.p_s32));
+		devm_kfree(&state->client->dev, ae_setpoint_cmd);
+		}
+		break;
+	case DS5_CAMERA_CID_HWMC_RW: 
+		if (ctrl->p_new.p_u8) {
+			unsigned char *data = (unsigned char *)ctrl->p_new.p_u8;
+			u16 dataLen = 0;
+			u16 bufLen = ctrl->dims[0];
+			ret = ds5_get_hwmc(state, data,	bufLen, &dataLen);
+			/* This is needed for librealsense, to align there code with UVC,
+		 	 * last word is length - 4 bytes header length */
+			dataLen -= 4;
+			data[bufLen - 4] = (unsigned char)(dataLen & 0x00FF);
+			data[bufLen - 3] = (unsigned char)((dataLen & 0xFF00) >> 8);
+			data[bufLen - 2] = 0;
+			data[bufLen - 1] = 0;
+		}
+		break;
+	case DS5_CAMERA_CID_SYNC_MODE:
+		if (state->is_depth)
+			ds5_read(state, base | DS5_CAMERA_SYNC_MODE, ctrl->p_new.p_u16);
+		break;
+	case DS5_CAMERA_CID_PWM:
+		if (state->is_depth)
+			ds5_read(state, base | DS5_PWM_FREQUENCY, ctrl->p_new.p_u16);
+		break;
+	}
+	return ret;
+}
+
+static const struct v4l2_ctrl_ops ds5_ctrl_ops = {
+	.s_ctrl	= ds5_s_ctrl,
+	.g_volatile_ctrl = ds5_g_volatile_ctrl,
+};
+
+static const struct v4l2_ctrl_config ds5_ctrl_log = {
+	.ops = &ds5_ctrl_ops,
+	.id = DS5_CAMERA_CID_LOG,
+	.name = "Logger",
+	.type = V4L2_CTRL_TYPE_U8,
+	.dims = {1024},
+	.elem_size = sizeof(u8),
+	.flags = V4L2_CTRL_FLAG_VOLATILE | V4L2_CTRL_FLAG_READ_ONLY,
+	.step = 1,
+};
+
+static const struct v4l2_ctrl_config ds5_ctrl_laser_power = {
+	.ops = &ds5_ctrl_ops,
+	.id = DS5_CAMERA_CID_LASER_POWER,
+	.name = "Laser power on/off",
+	.type = V4L2_CTRL_TYPE_BOOLEAN,
+	.min = 0,
+	.max = 1,
+	.step = 1,
+	.def = 1,
+	.flags = V4L2_CTRL_FLAG_VOLATILE | V4L2_CTRL_FLAG_EXECUTE_ON_WRITE,
+};
+
+static const struct v4l2_ctrl_config ds5_ctrl_manual_laser_power = {
+	.ops = &ds5_ctrl_ops,
+	.id = DS5_CAMERA_CID_MANUAL_LASER_POWER,
+	.name = "Manual laser power",
+	.type = V4L2_CTRL_TYPE_INTEGER,
+	.min = 0,
+	.max = 360,
+	.step = 30,
+	.def = 150,
+	.flags = V4L2_CTRL_FLAG_VOLATILE | V4L2_CTRL_FLAG_EXECUTE_ON_WRITE,
+};
+
+static const struct v4l2_ctrl_config ds5_ctrl_fw_version = {
+	.ops = &ds5_ctrl_ops,
+	.id = DS5_CAMERA_CID_FW_VERSION,
+	.name = "fw version",
+	.type = V4L2_CTRL_TYPE_U32,
+	.dims = {1},
+	.elem_size = sizeof(u32),
+	.flags = V4L2_CTRL_FLAG_VOLATILE | V4L2_CTRL_FLAG_READ_ONLY,
+	.step = 1,
+};
+
+static const struct v4l2_ctrl_config ds5_ctrl_gvd = {
+	.ops = &ds5_ctrl_ops,
+	.id = DS5_CAMERA_CID_GVD,
+	.name = "GVD",
+	.type = V4L2_CTRL_TYPE_U8,
+	.dims = {239},
+	.elem_size = sizeof(u8),
+	.flags = V4L2_CTRL_FLAG_VOLATILE | V4L2_CTRL_FLAG_READ_ONLY,
+	.step = 1,
+};
+
+static const struct v4l2_ctrl_config ds5_ctrl_get_depth_calib = {
+	.ops = &ds5_ctrl_ops,
+	.id = DS5_CAMERA_DEPTH_CALIBRATION_TABLE_GET,
+	.name = "get depth calib",
+	.type = V4L2_CTRL_TYPE_U8,
+	.dims = {256},
+	.elem_size = sizeof(u8),
+	.flags = V4L2_CTRL_FLAG_VOLATILE | V4L2_CTRL_FLAG_READ_ONLY,
+	.step = 1,
+};
+
+static const struct v4l2_ctrl_config ds5_ctrl_set_depth_calib = {
+	.ops = &ds5_ctrl_ops,
+	.id = DS5_CAMERA_DEPTH_CALIBRATION_TABLE_SET,
+	.name = "set depth calib",
+	.type = V4L2_CTRL_TYPE_U8,
+	.dims = {256},
+	.elem_size = sizeof(u8),
+	.min = 0,
+	.max = 0xFFFFFFFF,
+	.def = 240,
+	.step = 1,
+};
+
+static const struct v4l2_ctrl_config ds5_ctrl_get_coeff_calib = {
+	.ops = &ds5_ctrl_ops,
+	.id = DS5_CAMERA_COEFF_CALIBRATION_TABLE_GET,
+	.name = "get coeff calib",
+	.type = V4L2_CTRL_TYPE_U8,
+	.dims = {512},
+	.elem_size = sizeof(u8),
+	.flags = V4L2_CTRL_FLAG_VOLATILE | V4L2_CTRL_FLAG_READ_ONLY,
+	.step = 1,
+};
+
+static const struct v4l2_ctrl_config ds5_ctrl_set_coeff_calib = {
+	.ops = &ds5_ctrl_ops,
+	.id = DS5_CAMERA_COEFF_CALIBRATION_TABLE_SET,
+	.name = "set coeff calib",
+	.type = V4L2_CTRL_TYPE_U8,
+	.dims = {512},
+	.elem_size = sizeof(u8),
+	.min = 0,
+	.max = 0xFFFFFFFF,
+	.def = 240,
+	.step = 1,
+};
+
+static const struct v4l2_ctrl_config ds5_ctrl_ae_roi_get = {
+	.ops = &ds5_ctrl_ops,
+	.id = DS5_CAMERA_CID_AE_ROI_GET,
+	.name = "ae roi get",
+	.type = V4L2_CTRL_TYPE_U8,
+	.dims = {8},
+	.elem_size = sizeof(u16),
+	.flags = V4L2_CTRL_FLAG_VOLATILE | V4L2_CTRL_FLAG_READ_ONLY,
+	.step = 1,
+};
+
+static const struct v4l2_ctrl_config ds5_ctrl_ae_roi_set = {
+	.ops = &ds5_ctrl_ops,
+	.id = DS5_CAMERA_CID_AE_ROI_SET,
+	.name = "ae roi set",
+	.type = V4L2_CTRL_TYPE_U8,
+	.dims = {8},
+	.elem_size = sizeof(u16),
+	.min = 0,
+	.max = 0xFFFFFFFF,
+	.def = 240,
+	.step = 1,
+};
+
+static const struct v4l2_ctrl_config ds5_ctrl_ae_setpoint_get = {
+	.ops = &ds5_ctrl_ops,
+	.id = DS5_CAMERA_CID_AE_SETPOINT_GET,
+	.name = "ae setpoint get",
+	.type = V4L2_CTRL_TYPE_INTEGER,
+	.flags = V4L2_CTRL_FLAG_VOLATILE | V4L2_CTRL_FLAG_READ_ONLY,
+	.min = 0,
+	.max = 4095,
+	.step = 1,
+};
+
+static const struct v4l2_ctrl_config ds5_ctrl_ae_setpoint_set = {
+	.ops = &ds5_ctrl_ops,
+	.id = DS5_CAMERA_CID_AE_SETPOINT_SET,
+	.name = "ae setpoint set",
+	.type = V4L2_CTRL_TYPE_INTEGER,
+	.min = 0,
+	.max = 4095,
+	.step = 1,
+	.def = 0,
+};
+
+static const struct v4l2_ctrl_config ds5_ctrl_erb = {
+	.ops = &ds5_ctrl_ops,
+	.id = DS5_CAMERA_CID_ERB,
+	.name = "ERB eeprom read",
+	.type = V4L2_CTRL_TYPE_U8,
+	.dims = {1020},
+	.elem_size = sizeof(u8),
+	.min = 0,
+	.max = 0xFFFFFFFF,
+	.def = 240,
+	.step = 1,
+	.step = 1,
+};
+
+static const struct v4l2_ctrl_config ds5_ctrl_ewb = {
+	.ops = &ds5_ctrl_ops,
+	.id = DS5_CAMERA_CID_EWB,
+	.name = "EWB eeprom write",
+	.type = V4L2_CTRL_TYPE_U8,
+	.dims = {1020},
+	.elem_size = sizeof(u8),
+	.min = 0,
+	.max = 0xFFFFFFFF,
+	.def = 240,
+	.step = 1,
+	.step = 1,
+};
+
+static const struct v4l2_ctrl_config ds5_ctrl_hwmc = {
+	.ops = &ds5_ctrl_ops,
+	.id = DS5_CAMERA_CID_HWMC,
+	.name = "HWMC",
+	.type = V4L2_CTRL_TYPE_U8,
+	.dims = {DS5_HWMC_BUFFER_SIZE + 4},
+	.elem_size = sizeof(u8),
+	.min = 0,
+	.max = 0xFFFFFFFF,
+	.def = 240,
+	.step = 1,
+	.step = 1,
+};
+
+static const struct v4l2_ctrl_config ds5_ctrl_hwmc_rw = {
+	.ops = &ds5_ctrl_ops,
+	.id = DS5_CAMERA_CID_HWMC_RW,
+	.name = "HWMC_RW",
+	.type = V4L2_CTRL_TYPE_U8,
+	.dims = {DS5_HWMC_BUFFER_SIZE},
+	.elem_size = sizeof(u8),
+	.min = 0,
+	.max = 0xFFFFFFFF,
+	.def = 240,
+	.step = 1,
+	.flags = V4L2_CTRL_FLAG_VOLATILE | V4L2_CTRL_FLAG_EXECUTE_ON_WRITE,
+};
+
+static const struct v4l2_ctrl_config ds5_ctrl_hw_reset = {
+	.ops = &ds5_ctrl_ops,
+	.id = DS5_CAMERA_CID_HW_RESET,
+	.name = "HW Reset",
+	.type = V4L2_CTRL_TYPE_BUTTON,
+	.min = 0,
+	.max = 1,
+	.step = 1,
+	.def = 0,
+	.flags = V4L2_CTRL_FLAG_EXECUTE_ON_WRITE,
+};
+
+/* Sync mode menu arrays for different camera platforms */
+static const char * const sync_mode_menu_full[] = {
+	[DS5_SYNC_MODE_DEFAULT]       = "Default",
+	[DS5_SYNC_MODE_MASTER]        = "Master",
+	[DS5_SYNC_MODE_SLAVE]         = "Slave",
+	[DS5_SYNC_MODE_FULL_SLAVE]    = "Full Slave",
+	[DS5_SYNC_MODE_SUB_PREMASTER] = "Sub Pre-Master",
+	[DS5_SYNC_MODE_FULL_MASTER]   = "Full Master",
+};
+
+static struct v4l2_ctrl_config ds5_ctrl_sync_mode = {
+	.ops = &ds5_ctrl_ops,
+	.id = DS5_CAMERA_CID_SYNC_MODE,
+	.name = "Camera Sync Mode",
+	.type = V4L2_CTRL_TYPE_MENU,
+	.min = 0,
+	.max = 5,
+	.def = 0,
+	.qmenu = sync_mode_menu_full,
+	.flags = V4L2_CTRL_FLAG_VOLATILE | V4L2_CTRL_FLAG_EXECUTE_ON_WRITE,
+};
+
+static const struct v4l2_ctrl_config ds5_ctrl_pwm = {
+	.ops = &ds5_ctrl_ops,
+	.id = DS5_CAMERA_CID_PWM,
+	.name = "PWM Frequency Selector",
+	.type = V4L2_CTRL_TYPE_INTEGER,
+	.min = 0,
+	.max = 1,
+	.step = 1,
+	.def = 1,
+	.flags = V4L2_CTRL_FLAG_VOLATILE | V4L2_CTRL_FLAG_EXECUTE_ON_WRITE,
+};
+static int ds5_mux_open(struct v4l2_subdev *sd, struct v4l2_subdev_fh *fh)
+{
+	struct ds5 *state = v4l2_get_subdevdata(sd);
+
+	dev_dbg(sd->dev, "%s(): %s (%p)\n", __func__, sd->name, fh);
+
+	mutex_lock(&state->lock);
+	if (state->dfu_dev.dfu_state_flag)
+	{
+		mutex_unlock(&state->lock);
+		return -EBUSY;
+	}
+
+	state->dfu_dev.device_open_count++;
+	mutex_unlock(&state->lock);
+
+	return 0;
+};
+
+static int ds5_mux_close(struct v4l2_subdev *sd, struct v4l2_subdev_fh *fh)
+{
+	struct ds5 *state = v4l2_get_subdevdata(sd);
+
+	dev_dbg(sd->dev, "%s(): %s (%p)\n", __func__, sd->name, fh);
+	mutex_lock(&state->lock);
+	state->dfu_dev.device_open_count--;
+	mutex_unlock(&state->lock);
+	return 0;
+};
+
+static const struct v4l2_subdev_internal_ops ds5_sensor_internal_ops = {
+	.open = ds5_mux_open,
+	.close = ds5_mux_close,
+};
+
+static void ds5_init_ds5_dev(struct ds5 *state, struct ds5_dev *ds5_dev)
+{
+	state->ds5_dev = ds5_dev;
+	mutex_lock(&ds5_dev->lock);
+	ds5_dev->ds5_primary = state;
+	ds5_dev->cached_device_type = DS5_DEVICE_TYPE_UNKNOWN;
+	mutex_unlock(&ds5_dev->lock);
+	ds5_reset_streaming_flags(ds5_dev);
+}
+
+#ifdef CONFIG_VIDEO_D5XX_SERDES
+static int ds5_setup_and_link(struct ds5 *state)
+{
+	int i;
+	int err = 0;
+	struct device *dev = &state->client->dev;
+
+	mutex_lock(&serdes_lock__);
+	ds5_init_global_slots_once();
+	state->ds5_dev = NULL;
+	/* Look for existing DS5 instances */
+	for (i = 0; i < MAX_DS5_NUM; i++) {
+		bool match;
+
+		mutex_lock(&ds5_inited[i].lock);
+		match = ds5_inited[i].ds5_primary &&
+			ds5_inited[i].ds5_primary->ser_dev == state->ser_dev;
+		mutex_unlock(&ds5_inited[i].lock);
+		if (match) { /* Same camera, different stream instance. */
+			state->serdes_primary = false;
+			state->ds5_dev = &ds5_inited[i];
+			break;
+		}
+	}
+	if (NULL == state->ds5_dev) {
+	/* First stream instance for this camera, setup and link new DS5. */
+		for (i = 0; i < MAX_DS5_NUM; i++) {
+			bool free_slot;
+
+			mutex_lock(&ds5_inited[i].lock);
+			free_slot = (NULL == ds5_inited[i].ds5_primary);
+			mutex_unlock(&ds5_inited[i].lock);
+			if (free_slot) {
+				int j;
+				ds5_init_ds5_dev(state, &ds5_inited[i]);
+				state->serdes_primary = true;
+				/* Look for matching deserializer */
+				state->ds5_dev->dser_control = NULL;
+				for (j = 0; j < MAX_DSER_NUM; j++) {
+					mutex_lock(&dser_inited[j].lock);
+					if (dser_inited[j].dser_dev == state->dser_dev)
+						state->ds5_dev->dser_control = &dser_inited[j];
+					mutex_unlock(&dser_inited[j].lock);
+					if (state->ds5_dev->dser_control)
+						break;
+				}
+				if (NULL == state->ds5_dev->dser_control) {
+				/* Setup and link new deserializer */
+					for (j = 0; j < MAX_DSER_NUM; j++) {
+						mutex_lock(&dser_inited[j].lock);
+						if (NULL == dser_inited[j].dser_dev) {
+							dser_inited[j].dser_dev = state->dser_dev;
+							state->ds5_dev->dser_control = &dser_inited[j];
+						}
+						mutex_unlock(&dser_inited[j].lock);
+						if (state->ds5_dev->dser_control)
+							break;
+					}
+				}
+				if (NULL == state->ds5_dev->dser_control) {
+					dev_err(dev, "cannot handle more than %d deserializers\n", MAX_DSER_NUM);
+					err = -ENOSPC;
+					goto out_unlock;
+				} else {
+					dev_info(dev, "Deserializer %s linked\n", dev_name(state->dser_dev));
+				}
+				break;
+			}
+		}
+	}
+	if (NULL == state->ds5_dev) {
+		err = -ENOSPC;
+		dev_err(dev, "cannot handle more than %d DS5 cameras\n", MAX_DS5_NUM);
+	}
+
+out_unlock:
+	mutex_unlock(&serdes_lock__);
+	return err;
+}
+
+/*
+ * FIXME
+ * temporary solution before changing GMSL data structure or merging all 4 D457
+ * sensors into one i2c device. Only first sensor node per max96717 sets up the
+ * link.
+ */
+#ifdef CONFIG_OF
+static int ds5_board_setup(struct ds5 *state)
+{
+	struct device *dev = &state->client->dev;
+	struct device_node *node = dev->of_node;
+	struct device_node *ser_node;
+	struct i2c_client *ser_i2c = NULL;
+	struct device_node *dser_node;
+	struct i2c_client *dser_i2c = NULL;
+	struct device_node *gmsl;
+	int value = 0xFFFF;
+	const char *str_value;
+	int err;
+
+	state->g_ctx.sdev_reg = state->client->addr;
+
+	err = of_property_read_u32(node, "def-addr",
+					&state->g_ctx.sdev_def);
+	if (err < 0) {
+		dev_err(dev, "def-addr not found\n");
+		goto error;
+	}
+
+	ser_node = of_parse_phandle(node, "maxim,gmsl-ser-device", 0);
+	if (ser_node == NULL) {
+		/* check compatibility with jetpack */
+		ser_node = of_parse_phandle(node, "nvidia,gmsl-ser-device", 0);
+		if (ser_node == NULL) {
+			dev_err(dev, "missing %s handle\n", "[maxim|nvidia],gmsl-ser-device");
+			goto error;
+		}
+	}
+	err = of_property_read_u32(ser_node, "reg", &state->g_ctx.ser_reg);
+	dev_dbg(dev,  "serializer reg: 0x%x\n", state->g_ctx.ser_reg);
+	if (err < 0) {
+		dev_err(dev, "serializer reg not found\n");
+		goto error;
+	}
+
+	ser_i2c = of_find_i2c_device_by_node(ser_node);
+	of_node_put(ser_node);
+
+	if (ser_i2c == NULL) {
+		err = -EPROBE_DEFER;
+		goto error;
+	}
+	if (ser_i2c->dev.driver == NULL) {
+		dev_err(dev, "missing serializer driver\n");
+		goto error;
+	}
+
+	state->ser_dev = &ser_i2c->dev;
+
+	dser_node = of_parse_phandle(node, "maxim,gmsl-dser-device", 0);
+	if (dser_node == NULL) {
+		dser_node = of_parse_phandle(node, "nvidia,gmsl-dser-device", 0);
+		if (dser_node == NULL) {
+			dev_err(dev, "missing %s handle\n", "[maxim|nvidia],gmsl-dser-device");
+			goto error;
+		}
+	}
+
+	dser_i2c = of_find_i2c_device_by_node(dser_node);
+
+	if (dser_i2c == NULL) {
+		err = -EPROBE_DEFER;
+		goto error;
+	}
+	if (dser_i2c->dev.driver == NULL) {
+		dev_err(dev, "missing deserializer driver\n");
+		goto error;
+	}
+
+	state->dser_dev = &dser_i2c->dev;
+	/* Initialize deserializer interface */
+	if (!strcmp(dser_node->name, "max96724")) {
+		state->dser_ops = &max96724_interface;
+	} else {
+		dev_err(dev, "%s: Unsupported deserializer = %s\n", __func__, dser_node->name);
+		state->dser_ops = &max96724_interface;
+		goto error;
+	}
+	dev_info(dev, "Using deserializer %s\n", state->dser_ops->name);
+	of_node_put(dser_node);
+
+	/* populate g_ctx from DT */
+	gmsl = of_get_child_by_name(node, "gmsl-link");
+	if (gmsl == NULL) {
+		dev_err(dev, "missing gmsl-link device node\n");
+		err = -EINVAL;
+		goto error;
+	}
+
+	err = of_property_read_string(gmsl, "dst-csi-port", &str_value);
+	if (err < 0) {
+		dev_err(dev, "No dst-csi-port found\n");
+		goto error;
+	}
+	state->g_ctx.dst_csi_port =
+		(!strcmp(str_value, "a")) ? GMSL_CSI_PORT_A : GMSL_CSI_PORT_B;
+
+	err = of_property_read_string(gmsl, "src-csi-port", &str_value);
+	if (err < 0) {
+		dev_err(dev, "No src-csi-port found\n");
+		goto error;
+	}
+	state->g_ctx.src_csi_port =
+		(!strcmp(str_value, "a")) ? GMSL_CSI_PORT_A : GMSL_CSI_PORT_B;
+
+	err = of_property_read_string(gmsl, "csi-mode", &str_value);
+	if (err < 0) {
+		dev_err(dev, "No csi-mode found\n");
+		goto error;
+	}
+
+	if (!strcmp(str_value, "1x4")) {
+		state->g_ctx.csi_mode = GMSL_CSI_1X4_MODE;
+	} else if (!strcmp(str_value, "2x4")) {
+		state->g_ctx.csi_mode = GMSL_CSI_2X4_MODE;
+	} else if (!strcmp(str_value, "4x2")) {
+		state->g_ctx.csi_mode = GMSL_CSI_4X2_MODE;
+	} else if (!strcmp(str_value, "2x2")) {
+		state->g_ctx.csi_mode = GMSL_CSI_2X2_MODE;
+	} else {
+		dev_err(dev, "invalid csi mode\n");
+		goto error;
+	}
+
+	err = of_property_read_string(gmsl, "serdes-csi-link", &str_value);
+	if (err < 0) {
+		dev_err(dev, "No serdes-csi-link found\n");
+		goto error;
+	}
+	state->g_ctx.serdes_csi_link =
+		(!strcmp(str_value, "a")) ?
+			GMSL_SERDES_CSI_LINK_A : GMSL_SERDES_CSI_LINK_B;
+
+	err = of_property_read_u32(gmsl, "st-vc", &value);
+	if (err < 0) {
+		dev_err(dev, "No st-vc info\n");
+		goto error;
+	}
+	state->g_ctx.st_vc = value;
+
+	err = of_property_read_u32(gmsl, "vc-id", &value);
+	if (err < 0) {
+		dev_err(dev, "No vc-id info\n");
+		goto error;
+	}
+	state->g_ctx.dst_vc = value;
+
+	err = of_property_read_u32(gmsl, "num-lanes", &value);
+	if (err < 0) {
+		dev_err(dev, "No num-lanes info\n");
+		goto error;
+	}
+	state->g_ctx.num_csi_lanes = value;
+	state->g_ctx.s_dev = dev;
+
+	err = ds5_setup_and_link(state);
+error:
+	return err;
+}
+#else /* CONFIG_OF */
+// ds5mux i2c ser des
+// mux a - 2 0x42 0x48
+// mux b - 2 0x44 0x4a
+// mux c - 4 0x42 0x48
+// mux d - 4 0x44 0x4a
+// axiomtek
+// mux a - 2 0x42 0x48
+// mux b - 2 0x44 0x4a
+// mux c - 4 0x62 0x68
+// mux d - 4 0x64 0x6a
+
+static int ds5_board_setup(struct ds5 *state)
+{
+	struct device *dev = &state->client->dev;
+	struct d4xx_pdata *pdata = dev->platform_data;
+	struct i2c_adapter *adapter = state->client->adapter;
+	int bus = adapter->nr;
+	int err = 0;
+	int i;
+	char suffix = pdata->suffix;
+	static struct max96717_pdata max96717_pdata = {
+		.is_prim_ser = 1, // todo: configurable
+		.def_addr = 0x40, // todo: configurable
+	};
+
+	static struct max96724_pdata max96724_pdata = {
+		.max_src = 2,
+		.csi_mode = GMSL_CSI_2X4_MODE,
+	};
+	static struct i2c_board_info i2c_info_des = {
+		I2C_BOARD_INFO("max96724", 0x27),
+		.platform_data = &max96724_pdata,
+	};
+	static struct i2c_board_info i2c_info_ser = {
+		I2C_BOARD_INFO("max96717", 0x60),
+		.platform_data = &max96717_pdata,
+	};
+
+	i2c_info_ser.addr = pdata->subdev_info[0].ser_alias; //0x42, 0x44, 0x62, 0x64
+	state->ser_i2c = i2c_new_client_device(adapter, &i2c_info_ser);
+
+	i2c_info_des.addr = pdata->subdev_info[0].board_info.addr; //0x48, 0x4a, 0x68, 0x6a
+
+	/* look for already registered max96724, use same context if found */
+	mutex_lock(&serdes_lock__);
+	ds5_init_global_slots_once();
+	for (i = 0; i < MAX_DS5_NUM; i++) {
+		struct ds5 *primary;
+
+		mutex_lock(&ds5_inited[i].lock);
+		primary = ds5_inited[i].ds5_primary;
+		if (primary && primary->dser_i2c) {
+			dev_info(dev, "MAX96724 found device on %d@0x%x\n",
+				primary->dser_i2c->adapter->nr, primary->dser_i2c->addr);
+			if (bus == primary->dser_i2c->adapter->nr
+				&& primary->dser_i2c->addr == i2c_info_des.addr) {
+				dev_info(dev, "MAX96724 AGGREGATION found device on 0x%x\n", i2c_info_des.addr);
+				state->dser_i2c = primary->dser_i2c;
+				state->aggregated = 1;
+			}
+		}
+		mutex_unlock(&ds5_inited[i].lock);
+	}
+	mutex_unlock(&serdes_lock__);
+	if (state->aggregated)
+		suffix += 4;
+	dev_info(dev, "Init SerDes %c on %d@0x%x<->%d@0x%x\n",
+		suffix,
+		bus, pdata->subdev_info[0].board_info.addr, //48
+		bus, pdata->subdev_info[0].ser_alias); //42
+
+	if (!state->dser_i2c)
+		state->dser_i2c = i2c_new_client_device(adapter, &i2c_info_des);
+
+	if (state->ser_i2c == NULL) {
+		err = -EPROBE_DEFER;
+		dev_err(dev, "missing serializer client\n");
+		goto error;
+	}
+	if (state->ser_i2c->dev.driver == NULL) {
+		err = -EPROBE_DEFER;
+		dev_err(dev, "missing serializer driver\n");
+		goto error;
+	}
+	if (state->dser_i2c == NULL) {
+		err = -EPROBE_DEFER;
+		dev_err(dev, "missing deserializer client\n");
+		goto error;
+	}
+	if (state->dser_i2c->dev.driver == NULL) {
+		err = -EPROBE_DEFER;
+		dev_err(dev, "missing deserializer driver\n");
+		goto error;
+	}
+
+	// reg
+
+	state->g_ctx.sdev_reg = state->client->addr;
+	state->g_ctx.sdev_def = 0x10;// def-addr TODO: configurable
+	// Address reassignment for d5xx-a 0x10->0x12
+	dev_info(dev, "Address reassignment for %s-%c 0x%x->0x%x\n",
+		pdata->subdev_info[0].board_info.type, suffix,
+		state->g_ctx.sdev_def, state->g_ctx.sdev_reg);
+	//0x42, 0x44, 0x62, 0x64
+	state->g_ctx.ser_reg = pdata->subdev_info[0].ser_alias;
+	dev_info(dev,  "serializer: i2c-%d@0x%x\n",
+		state->ser_i2c->adapter->nr, state->g_ctx.ser_reg);
+
+	if (err < 0) {
+		dev_err(dev, "serializer reg not found\n");
+		goto error;
+	}
+
+	state->ser_dev = &state->ser_i2c->dev;
+
+	dev_info(dev,  "deserializer: i2c-%d@0x%x\n",
+		state->dser_i2c->adapter->nr, state->dser_i2c->addr);
+
+
+	state->dser_dev = &state->dser_i2c->dev;
+	/* Initialize deserializer interface */
+	state->dser_ops = &max96724_interface;
+
+
+	/* populate g_ctx from pdata */
+	state->g_ctx.dst_csi_port = GMSL_CSI_PORT_A;
+	state->g_ctx.src_csi_port = GMSL_CSI_PORT_B;
+	state->g_ctx.csi_mode = GMSL_CSI_1X4_MODE;
+	if (state->aggregated) { // aggregation
+		dev_info(dev,  "configure GMSL port B\n");
+		state->g_ctx.serdes_csi_link = GMSL_SERDES_CSI_LINK_B;
+	} else {
+		dev_info(dev,  "configure GMSL port A\n");
+		state->g_ctx.serdes_csi_link = GMSL_SERDES_CSI_LINK_A;
+	}
+	state->g_ctx.st_vc = 0;
+	state->g_ctx.dst_vc = 0;
+
+	state->g_ctx.num_csi_lanes = 2;
+	state->g_ctx.s_dev = dev;
+
+	err = ds5_setup_and_link(state);
+error:
+	return err;
+}
+#endif /* CONFIG_OF */
+
+static int ds5_gmsl_serdes_setup(struct ds5 *state)
+{
+	int err = 0;
+	int des_err = 0;
+	struct device *dev;
+
+	if (!state || !state->ser_dev || !state->dser_dev || !state->client)
+		return -EINVAL;
+
+	dev = &state->client->dev;
+
+	mutex_lock(&serdes_lock__);
+
+	/*
+	 * Skip power cycle: On Orin AGX the CAM0_RST_L GPIO is shared
+	 * with the I2C bus pull-up domain. Asserting reset hangs the
+	 * entire I2C-2 bus (TCA9548 + MAX96724 become unreachable).
+	 * The MAX96724 is already responsive from probe; just proceed
+	 * with link setup directly.
+	 */
+	msleep(100);
+
+	dev_dbg(dev, "Setup SERDES addressing and control pipeline\n");
+	/* setup serdes addressing and control pipeline */
+	err = state->dser_ops->setup_link(state->dser_dev, &state->client->dev);
+	if (err) {
+		dev_err(dev, "gmsl deserializer link config failed\n");
+		goto error;
+	}
+	/*
+	 * [HW requirement] After GMSL link locks, I2C pass-through to the
+	 * remote serializer requires settling time before the first I2C
+	 * write is ACKed.  Shorter delays result in -121 (EREMOTEIO).
+	 */
+	msleep(1000);
+	err = max96717_setup_control(state->ser_dev);
+	if (err) {
+		dev_err(dev, "gmsl serializer setup failed\n");
+		goto error;
+	}
+
+	/*
+	 * [Ordering critical] Configure serializer registers (PIPE_EN,
+	 * EXT11 tunnel mode, FRONTTOP) BEFORE the deserializer one-shot
+	 * reset.  The one-shot in setup_control(dser) briefly disrupts
+	 * the GMSL link; if init_settings runs after it, the first
+	 * I2C write to the serializer NACKs with -121.
+	 */
+	msleep(200);
+	err = max96717_init_settings(state->ser_dev);
+	if (err) {
+		dev_warn(dev, "max96717 init settings failed\n");
+		/* non-fatal: tunnel mode + pipes will be set in setup_streaming */
+		err = 0;
+	}
+
+	des_err = state->dser_ops->setup_control(state->dser_dev, &state->client->dev);
+	if (des_err) {
+		dev_err(dev, "gmsl deserializer setup failed\n");
+		err = des_err;
+	}
+
+error:
+	mutex_unlock(&serdes_lock__);
+	return err;
+}
+
+static int ds5_serdes_setup(struct ds5 *state)
+{
+	int ret = 0;
+	struct i2c_client *c = state->client;
+
+	ret = ds5_board_setup(state);
+	if (ret) {
+		dev_err(&c->dev, "board setup failed\n");
+		return ret;
+	}
+
+	/* Peer instance of an already-initialized camera.
+	 * ds5_setup_and_link() found that another instance already set up
+	 * this serializer and marked us non-primary.  Skip SERDES setup
+	 * (pair, register, gmsl init) — the primary already did it.
+	 */
+	if (!state->serdes_primary) {
+		dev_info(&c->dev, "peer instance, skipping SERDES setup\n");
+		return 0;
+	}
+
+	/* Pair sensor to serializer dev */
+	ret = max96717_sdev_pair(state->ser_dev, &state->g_ctx);
+	if (ret) {
+		dev_err(&c->dev, "gmsl ser pairing failed\n");
+		goto serdes_setup_end;
+	}
+
+	/* Register sensor to deserializer dev */
+	ret = state->dser_ops->sdev_register(state->dser_dev, &state->g_ctx);
+	if (ret) {
+		dev_err(&c->dev, "gmsl deserializer register failed\n");
+		goto serdes_setup_end;
+	}
+
+	ret = ds5_gmsl_serdes_setup(state);
+	if (ret) {
+		dev_err(&c->dev, "%s gmsl serdes setup failed\n", __func__);
+		goto serdes_setup_end;
+	}
+
+	/*
+	 * max96717_init_settings is now called inside ds5_gmsl_serdes_setup,
+	 * after setup_control(ser) but before setup_control(dser) to avoid
+	 * the deserializer one-shot reset disrupting I2C to the serializer.
+	 */
+
+	ret = state->dser_ops->init_settings(state->dser_dev);
+	if (ret) {
+		dev_warn(&c->dev, "%s, failed to init %s settings\n",
+			__func__, state->dser_ops->name);
+		goto serdes_setup_end;
+	}
+
+	/*
+	 * [Aardvark-verified] Setup CSI output pipeline on deserializer
+	 * and enable tunnel mode + CSI input on serializer.
+	 * These calls configure PHY, DPLL, lane mapping, CSI output enable,
+	 * and serializer tunnel mode — without them, no CSI output occurs.
+	 */
+	ret = max96724_setup_streaming(state->dser_dev, state->g_ctx.s_dev);
+	if (ret) {
+		dev_warn(&c->dev, "%s, failed to setup max96724 streaming\n",
+			__func__);
+		goto serdes_setup_end;
+	}
+	
+	/*
+	 * [HW requirement] max96724_setup_streaming issues a one-shot reset
+	 * (reg 0x0018=0x0F) which briefly disrupts the GMSL link.
+	 * I2C pass-through to the remote serializer requires the link to
+	 * re-lock first.  Without this delay, writes to MAX96717 fail
+	 * with -121 (EREMOTEIO).
+	 */
+	msleep(1000);
+
+	ret = max96717_setup_streaming(state->ser_dev);
+	if (ret) {
+		dev_warn(&c->dev, "%s, failed to setup max96717 streaming\n",
+			__func__);
+		goto serdes_setup_end;
+	}
+
+	/*
+	 * [Timing fix] SER setup includes a soft reset (0x0002=0x03) which
+	 * disrupts the GMSL link. After SER final enable (0x0002=0x43),
+	 * the link re-trains. DES needs ONESHOT to resync CSI TX controller
+	 * to the now-active tunnel data stream.
+	 * XML sequence: SER config → DES ONESHOT → SER enable (no link drop).
+	 * Driver sequence: DES ONESHOT → SER reset+config+enable (link drop!).
+	 * Fix: add delay for link re-lock, then fire ONESHOT.
+	 */
+	msleep(500);
+	state->dser_ops->reset_oneshot(state->dser_dev);
+
+serdes_setup_end:
+	if (ret) {
+		max96717_sdev_unpair(state->ser_dev, state->g_ctx.s_dev);
+		state->dser_ops->sdev_unregister(state->dser_dev, state->g_ctx.s_dev);
+	}
+
+	return ret;
+}
+#endif
+enum state_sid {
+	DEPTH_SID = 0,
+	RGB_SID,
+	IR_SID,
+	IMU_SID,
+	MUX_SID = -1
+};
+
+static int ds5_ctrl_init(struct ds5 *state, int sid)
+{
+	const struct v4l2_ctrl_ops *ops = &ds5_ctrl_ops;
+	struct ds5_ctrls *ctrls = &state->ctrls;
+	struct v4l2_ctrl_handler *hdl = &ctrls->handler;
+	struct v4l2_subdev *sd = &state->mux.sd.subdev;
+	int ret = -1;
+	struct ds5_sensor *sensor = NULL;
+
+	switch (sid) {
+	case DEPTH_SID:
+		hdl = &ctrls->handler_depth;
+		sensor = &state->depth.sensor;
+		break;
+	case RGB_SID:
+		hdl = &ctrls->handler_rgb;
+		sensor = &state->rgb.sensor;
+		break;
+	case IR_SID:
+		hdl = &ctrls->handler_y8;
+		sensor = &state->ir.sensor;
+		break;
+	case IMU_SID:
+		hdl = &ctrls->handler_imu;
+		sensor = &state->imu.sensor;
+		break;
+	default:
+		/* control for MUX */
+		hdl = &ctrls->handler;
+		sensor = NULL;
+		break;
+	}
+
+	dev_dbg(NULL, "%s():%d sid: %d\n", __func__, __LINE__, sid);
+	ret = v4l2_ctrl_handler_init(hdl, DS5_N_CONTROLS);
+	if (ret < 0) {
+		v4l2_err(sd, "cannot init ctrl handler (%d)\n", ret);
+		return ret;
+	}
+
+	if (sid == DEPTH_SID || sid == IR_SID) {
+		ctrls->laser_power = v4l2_ctrl_new_custom(hdl,
+						&ds5_ctrl_laser_power,
+						sensor);
+		ctrls->manual_laser_power = v4l2_ctrl_new_custom(hdl,
+						&ds5_ctrl_manual_laser_power,
+						sensor);
+	}
+
+	/* Total gain */
+	if (sid == DEPTH_SID || sid == IR_SID) {
+		ctrls->gain = v4l2_ctrl_new_std(hdl, ops,
+						V4L2_CID_ANALOGUE_GAIN,
+						16, 248, 1, 16);
+	} else if (sid == RGB_SID) {
+		ctrls->gain = v4l2_ctrl_new_std(hdl, ops,
+						V4L2_CID_ANALOGUE_GAIN,
+						0, 128, 1, 64);
+	}
+
+	if ((ctrls->gain) && (sid >= DEPTH_SID && sid < IMU_SID)) {
+		ctrls->gain->priv = sensor;
+		ctrls->gain->flags =
+				V4L2_CTRL_FLAG_VOLATILE | V4L2_CTRL_FLAG_EXECUTE_ON_WRITE;
+	}
+	if (sid >= DEPTH_SID && sid < IMU_SID) {
+
+		ctrls->auto_exp = v4l2_ctrl_new_std_menu(hdl, ops,
+				V4L2_CID_EXPOSURE_AUTO,
+				V4L2_EXPOSURE_APERTURE_PRIORITY,
+				~((1 << V4L2_EXPOSURE_MANUAL) |
+						(1 << V4L2_EXPOSURE_APERTURE_PRIORITY)),
+						V4L2_EXPOSURE_APERTURE_PRIORITY);
+
+		if (ctrls->auto_exp) {
+			ctrls->auto_exp->flags |=
+					V4L2_CTRL_FLAG_VOLATILE | V4L2_CTRL_FLAG_EXECUTE_ON_WRITE;
+			ctrls->auto_exp->priv = sensor;
+		}
+	}
+
+	/* Exposure time: V4L2_CID_EXPOSURE_ABSOLUTE default unit: 100 us. */
+	if (sid == DEPTH_SID || sid == IR_SID) {
+		ctrls->exposure = v4l2_ctrl_new_std(hdl, ops,
+					V4L2_CID_EXPOSURE_ABSOLUTE,
+					1, MAX_DEPTH_EXP, 1, DEF_DEPTH_EXP);
+	} else if (sid == RGB_SID) {
+		ctrls->exposure = v4l2_ctrl_new_std(hdl, ops,
+					V4L2_CID_EXPOSURE_ABSOLUTE,
+					1, MAX_RGB_EXP, 1, DEF_RGB_EXP);
+	}
+
+	if ((ctrls->exposure) && (sid >= DEPTH_SID && sid < IMU_SID)) {
+		ctrls->exposure->priv = sensor;
+		ctrls->exposure->flags |=
+				V4L2_CTRL_FLAG_VOLATILE | V4L2_CTRL_FLAG_EXECUTE_ON_WRITE;
+		/* override default int type to u32 to match SKU & UVC */
+		ctrls->exposure->type = V4L2_CTRL_TYPE_U32;
+	}
+	if (hdl->error) {
+		v4l2_err(sd, "error creating controls (%d)\n", hdl->error);
+		ret = hdl->error;
+		v4l2_ctrl_handler_free(hdl);
+		return ret;
+	}
+
+	// Add these after v4l2_ctrl_handler_setup so they won't be set up
+	if (sid >= DEPTH_SID && sid < IMU_SID) {
+		ctrls->log = v4l2_ctrl_new_custom(hdl, &ds5_ctrl_log, sensor);
+		ctrls->fw_version = v4l2_ctrl_new_custom(hdl, &ds5_ctrl_fw_version, sensor);
+		ctrls->gvd = v4l2_ctrl_new_custom(hdl, &ds5_ctrl_gvd, sensor);
+		ctrls->get_depth_calib =
+				v4l2_ctrl_new_custom(hdl, &ds5_ctrl_get_depth_calib, sensor);
+		ctrls->set_depth_calib =
+				v4l2_ctrl_new_custom(hdl, &ds5_ctrl_set_depth_calib, sensor);
+		ctrls->get_coeff_calib =
+				v4l2_ctrl_new_custom(hdl, &ds5_ctrl_get_coeff_calib, sensor);
+		ctrls->set_coeff_calib =
+				v4l2_ctrl_new_custom(hdl, &ds5_ctrl_set_coeff_calib, sensor);
+		ctrls->ae_roi_get = v4l2_ctrl_new_custom(hdl, &ds5_ctrl_ae_roi_get, sensor);
+		ctrls->ae_roi_set = v4l2_ctrl_new_custom(hdl, &ds5_ctrl_ae_roi_set, sensor);
+		ctrls->ae_setpoint_get =
+				v4l2_ctrl_new_custom(hdl, &ds5_ctrl_ae_setpoint_get, sensor);
+		ctrls->ae_setpoint_set =
+				v4l2_ctrl_new_custom(hdl, &ds5_ctrl_ae_setpoint_set, sensor);
+		ctrls->erb = v4l2_ctrl_new_custom(hdl, &ds5_ctrl_erb, sensor);
+		ctrls->ewb = v4l2_ctrl_new_custom(hdl, &ds5_ctrl_ewb, sensor);
+		ctrls->hwmc = v4l2_ctrl_new_custom(hdl, &ds5_ctrl_hwmc, sensor);
+		v4l2_ctrl_new_custom(hdl, &ds5_ctrl_hwmc_rw, sensor);
+		v4l2_ctrl_new_custom(hdl, &ds5_ctrl_hw_reset, sensor);
+	}
+	// DEPTH custom
+	if (sid == DEPTH_SID) {
+		ctrls->sync_mode = v4l2_ctrl_new_custom(hdl, &ds5_ctrl_sync_mode, sensor);
+		v4l2_ctrl_new_custom(hdl, &ds5_ctrl_pwm, sensor);
+	}
+	// IMU custom
+	if (sid == IMU_SID)
+		ctrls->fw_version = v4l2_ctrl_new_custom(hdl, &ds5_ctrl_fw_version, sensor);
+
+	switch (sid) {
+	case DEPTH_SID:
+		state->depth.sensor.sd.ctrl_handler = hdl;
+		dev_dbg(state->depth.sensor.sd.dev,
+			"%s():%d set ctrl_handler pad:%d\n",
+			__func__, __LINE__, state->depth.sensor.mux_pad);
+		break;
+	case RGB_SID:
+		state->rgb.sensor.sd.ctrl_handler = hdl;
+		dev_dbg(state->rgb.sensor.sd.dev,
+			"%s():%d set ctrl_handler pad:%d\n",
+			__func__, __LINE__, state->rgb.sensor.mux_pad);
+		break;
+	case IR_SID:
+		state->ir.sensor.sd.ctrl_handler = hdl;
+		dev_dbg(state->ir.sensor.sd.dev,
+			"%s():%d set ctrl_handler pad:%d\n",
+			__func__, __LINE__, state->ir.sensor.mux_pad);
+		break;
+	case IMU_SID:
+		state->imu.sensor.sd.ctrl_handler = hdl;
+		dev_dbg(state->imu.sensor.sd.dev,
+			"%s():%d set ctrl_handler pad:%d\n",
+			__func__, __LINE__, state->imu.sensor.mux_pad);
+		break;
+	default:
+		state->mux.sd.subdev.ctrl_handler = hdl;
+		dev_dbg(state->mux.sd.subdev.dev,
+			"%s():%d set ctrl_handler for MUX\n", __func__, __LINE__);
+		break;
+	}
+
+	return 0;
+}
+
+static int ds5_sensor_init(struct i2c_client *c, struct ds5 *state,
+		struct ds5_sensor *sensor, const struct v4l2_subdev_ops *ops,
+		const char *name)
+{
+	struct v4l2_subdev *sd = &sensor->sd;
+	struct media_entity *entity = &sensor->sd.entity;
+	struct media_pad *pad = &sensor->pad;
+	dev_t *dev_num = &state->client->dev.devt;
+#ifndef CONFIG_OF
+	struct d4xx_pdata *dpdata = c->dev.platform_data;
+	char suffix = dpdata->suffix;
+#endif
+	sensor->pipe_id = PIPE_NOT_CONFIGURED;
+	v4l2_i2c_subdev_init(sd, c, ops);
+	// See tegracam_v4l2.c tegracam_v4l2subdev_register()
+	// Set owner to NULL so we can unload the driver module
+	sd->owner = NULL;
+	sd->internal_ops = &ds5_sensor_internal_ops;
+	sd->grp_id = *dev_num;
+	v4l2_set_subdevdata(sd, state);
+#ifndef CONFIG_OF
+	/*
+	 * TODO: suffix for 2 D457 connected to 1 Deser
+	 */
+	if (state->aggregated & 1)
+		suffix += 4;
+	snprintf(sd->name, sizeof(sd->name), "D5XX %s %c", name, suffix);
+#else
+	snprintf(sd->name, sizeof(sd->name), "D5XX %s %d-%04x",
+		 name, i2c_adapter_id(c->adapter), c->addr);
+#endif
+
+	sd->flags |= V4L2_SUBDEV_FL_HAS_DEVNODE;
+
+	pad->flags = MEDIA_PAD_FL_SOURCE;
+	entity->obj_type = MEDIA_ENTITY_TYPE_V4L2_SUBDEV;
+	entity->function = MEDIA_ENT_F_CAM_SENSOR;
+	return media_entity_pads_init(entity, 1, pad);
+}
+
+static int ds5_sensor_register(struct ds5 *state, struct ds5_sensor *sensor)
+{
+	struct v4l2_subdev *sd = &sensor->sd;
+	struct media_entity *entity = &sensor->sd.entity;
+	int ret = -1;
+
+	// FIXME: is async needed?
+	ret = v4l2_device_register_subdev(state->mux.sd.subdev.v4l2_dev, sd);
+	if (ret < 0) {
+		dev_err(sd->dev, "%s(): %d: %d\n", __func__, __LINE__, ret);
+		return ret;
+	}
+
+	ret = media_create_pad_link(entity, 0,
+			&state->mux.sd.subdev.entity, sensor->mux_pad,
+			MEDIA_LNK_FL_IMMUTABLE | MEDIA_LNK_FL_ENABLED);
+	if (ret < 0) {
+		dev_err(sd->dev, "%s(): %d: %d\n", __func__, __LINE__, ret);
+		goto e_sd;
+	}
+
+	dev_dbg(sd->dev, "%s(): 0 -> %d\n", __func__, sensor->mux_pad);
+
+	return 0;
+
+e_sd:
+	v4l2_device_unregister_subdev(sd);
+
+	return ret;
+}
+
+static void ds5_sensor_remove(struct ds5_sensor *sensor)
+{
+	v4l2_device_unregister_subdev(&sensor->sd);
+
+	media_entity_cleanup(&sensor->sd.entity);
+}
+
+static int ds5_depth_init(struct i2c_client *c, struct ds5 *state)
+{
+	/* Which mux pad we're connecting to */
+	state->depth.sensor.mux_pad = DS5_MUX_PAD_DEPTH;
+	return ds5_sensor_init(c, state, &state->depth.sensor,
+		       &ds5_subdev_ops, "depth");
+}
+
+static int ds5_ir_init(struct i2c_client *c, struct ds5 *state)
+{
+	state->ir.sensor.mux_pad = DS5_MUX_PAD_IR;
+	return ds5_sensor_init(c, state, &state->ir.sensor,
+		       &ds5_subdev_ops, "ir");
+}
+
+static int ds5_rgb_init(struct i2c_client *c, struct ds5 *state)
+{
+	state->rgb.sensor.mux_pad = DS5_MUX_PAD_RGB;
+	return ds5_sensor_init(c, state, &state->rgb.sensor,
+		       &ds5_subdev_ops, "rgb");
+}
+
+static int ds5_imu_init(struct i2c_client *c, struct ds5 *state)
+{
+	state->imu.sensor.mux_pad = DS5_MUX_PAD_IMU;
+	return ds5_sensor_init(c, state, &state->imu.sensor,
+		       &ds5_subdev_ops, "imu");
+}
+
+/* No locking needed */
+static int ds5_mux_enum_mbus_code(struct v4l2_subdev *sd,
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 15, 10)
+				     struct v4l2_subdev_pad_config *cfg,
+#else
+				     struct v4l2_subdev_state *v4l2_state,
+#endif
+				  struct v4l2_subdev_mbus_code_enum *mce)
+{
+	struct ds5 *state = container_of(sd, struct ds5, mux.sd.subdev);
+	struct v4l2_subdev_mbus_code_enum tmp = *mce;
+	struct v4l2_subdev *remote_sd;
+	int ret = -1;
+
+	dev_dbg(&state->client->dev, "%s(): %s \n", __func__, sd->name);
+	switch (mce->pad) {
+	case DS5_MUX_PAD_IR:
+		remote_sd = &state->ir.sensor.sd;
+		break;
+	case DS5_MUX_PAD_DEPTH:
+		remote_sd = &state->depth.sensor.sd;
+		break;
+	case DS5_MUX_PAD_RGB:
+		remote_sd = &state->rgb.sensor.sd;
+		break;
+	case DS5_MUX_PAD_IMU:
+		remote_sd = &state->imu.sensor.sd;
+		break;
+	case DS5_MUX_PAD_EXTERNAL:
+		if (mce->index >= state->ir.sensor.n_formats +
+				state->depth.sensor.n_formats)
+			return -EINVAL;
+
+		/*
+		 * First list Left node / Motion Tracker formats, then depth.
+		 * This should also help because D16 doesn't have a direct
+		 * analog in MIPI CSI-2.
+		 */
+		if (mce->index < state->ir.sensor.n_formats) {
+			remote_sd = &state->ir.sensor.sd;
+		} else {
+			tmp.index = mce->index - state->ir.sensor.n_formats;
+			remote_sd = &state->depth.sensor.sd;
+		}
+
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	tmp.pad = 0;
+	if (state->is_rgb)
+		remote_sd = &state->rgb.sensor.sd;
+	if (state->is_depth)
+		remote_sd = &state->depth.sensor.sd;
+	if (state->is_y8)
+		remote_sd = &state->ir.sensor.sd;
+	if (state->is_imu)
+		remote_sd = &state->imu.sensor.sd;
+	/* Locks internally */
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 15, 10)
+	ret = ds5_sensor_enum_mbus_code(remote_sd, cfg, &tmp);
+#else
+	ret = ds5_sensor_enum_mbus_code(remote_sd, v4l2_state, &tmp);
+#endif
+	if (!ret)
+		mce->code = tmp.code;
+
+	return ret;
+}
+static int ds5_state_to_pad(struct ds5 *state) {
+	int pad = -1;
+	if (state->is_depth)
+		pad = DS5_MUX_PAD_DEPTH;
+	if (state->is_y8)
+		pad = DS5_MUX_PAD_IR;
+	if (state->is_rgb)
+		pad = DS5_MUX_PAD_RGB;
+	if (state->is_imu)
+		pad = DS5_MUX_PAD_IMU;
+	return pad;
+}
+
+/* No locking needed */
+static int ds5_mux_enum_frame_size(struct v4l2_subdev *sd,
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 15, 10)
+				     struct v4l2_subdev_pad_config *cfg,
+#else
+				     struct v4l2_subdev_state *v4l2_state,
+#endif
+				   struct v4l2_subdev_frame_size_enum *fse)
+{
+	struct ds5 *state = container_of(sd, struct ds5, mux.sd.subdev);
+	struct v4l2_subdev_frame_size_enum tmp = *fse;
+	struct v4l2_subdev *remote_sd;
+	u32 pad = fse->pad;
+	int ret = -1;
+
+	tmp.pad = 0;
+	pad = ds5_state_to_pad(state);
+
+	switch (pad) {
+	case DS5_MUX_PAD_IR:
+		remote_sd = &state->ir.sensor.sd;
+		break;
+	case DS5_MUX_PAD_DEPTH:
+		remote_sd = &state->depth.sensor.sd;
+		break;
+	case DS5_MUX_PAD_RGB:
+		remote_sd = &state->rgb.sensor.sd;
+		break;
+	case DS5_MUX_PAD_IMU:
+		remote_sd = &state->imu.sensor.sd;
+		break;
+	case DS5_MUX_PAD_EXTERNAL:
+		/*
+		 * Assume, that different sensors don't support the same formats
+		 * Try the Depth sensor first, then the Motion Tracker
+		 */
+		remote_sd = &state->depth.sensor.sd;
+		ret = ds5_sensor_enum_frame_size(remote_sd, NULL, &tmp);
+		if (!ret) {
+			*fse = tmp;
+			fse->pad = pad;
+			return 0;
+		}
+
+		remote_sd = &state->ir.sensor.sd;
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	/* Locks internally */
+	ret = ds5_sensor_enum_frame_size(remote_sd, NULL, &tmp);
+	if (!ret) {
+		*fse = tmp;
+		fse->pad = pad;
+	}
+
+	return ret;
+}
+
+/* No locking needed */
+static int ds5_mux_enum_frame_interval(struct v4l2_subdev *sd,
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 15, 10)
+				     struct v4l2_subdev_pad_config *cfg,
+#else
+				     struct v4l2_subdev_state *v4l2_state,
+#endif
+				     struct v4l2_subdev_frame_interval_enum *fie)
+{
+	struct ds5 *state = container_of(sd, struct ds5, mux.sd.subdev);
+	struct v4l2_subdev_frame_interval_enum tmp = *fie;
+	struct v4l2_subdev *remote_sd;
+	u32 pad = fie->pad;
+	int ret = -1;
+
+	tmp.pad = 0;
+
+	dev_dbg(state->depth.sensor.sd.dev,
+			"%s(): pad %d code %x width %d height %d\n",
+			__func__, pad, tmp.code, tmp.width, tmp.height);
+
+	pad = ds5_state_to_pad(state);
+
+	switch (pad) {
+	case DS5_MUX_PAD_IR:
+		remote_sd = &state->ir.sensor.sd;
+		break;
+	case DS5_MUX_PAD_DEPTH:
+		remote_sd = &state->depth.sensor.sd;
+		break;
+	case DS5_MUX_PAD_RGB:
+		remote_sd = &state->rgb.sensor.sd;
+		break;
+	case DS5_MUX_PAD_IMU:
+		remote_sd = &state->imu.sensor.sd;
+		break;
+	case DS5_MUX_PAD_EXTERNAL:
+		/* Similar to ds5_mux_enum_frame_size() above */
+		if (state->is_rgb)
+			remote_sd = &state->rgb.sensor.sd;
+		else
+			remote_sd = &state->ir.sensor.sd;
+		ret = ds5_sensor_enum_frame_interval(remote_sd, NULL, &tmp);
+		if (!ret) {
+			*fie = tmp;
+			fie->pad = pad;
+			return 0;
+		}
+
+		remote_sd = &state->ir.sensor.sd;
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	/* Locks internally */
+	ret = ds5_sensor_enum_frame_interval(remote_sd, NULL, &tmp);
+	if (!ret) {
+		*fie = tmp;
+		fie->pad = pad;
+	}
+
+	return ret;
+}
+
+/* No locking needed */
+static int ds5_mux_set_fmt(struct v4l2_subdev *sd,
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 15, 10)
+		struct v4l2_subdev_pad_config *cfg,
+#else
+		struct v4l2_subdev_state *v4l2_state,
+#endif
+		struct v4l2_subdev_format *fmt)
+{
+	struct ds5 *state = container_of(sd, struct ds5, mux.sd.subdev);
+	struct v4l2_subdev_format tmp;
+	struct v4l2_subdev *remote_sd;
+	u32 pad;
+	int ret = 0;
+
+	if (!state) return -EINVAL;
+	if (!fmt) return -EINVAL;
+
+	pad = ds5_state_to_pad(state);
+	tmp = *fmt;
+
+	dev_dbg(sd->dev, "%s(): pad: %x %x: %ux%u\n",
+			__func__, pad, fmt->format.code,
+			fmt->format.width, fmt->format.height);
+
+	switch (pad) {
+	case DS5_MUX_PAD_IR:
+		remote_sd = &state->ir.sensor.sd;
+		break;
+	case DS5_MUX_PAD_DEPTH:
+		remote_sd = &state->depth.sensor.sd;
+		break;
+	case DS5_MUX_PAD_RGB:
+		remote_sd = &state->rgb.sensor.sd;
+		break;
+	case DS5_MUX_PAD_IMU:
+		remote_sd = &state->imu.sensor.sd;
+		break;
+	case DS5_MUX_PAD_EXTERNAL:
+		if (state->is_rgb)
+			remote_sd = &state->rgb.sensor.sd;
+		else
+			remote_sd = &state->mux.last_set->sd;
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	tmp.pad = 0;
+
+	/* Locks internally */
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 15, 10)
+	ret = ds5_sensor_set_fmt(remote_sd, cfg, &tmp);
+#else
+	ret = ds5_sensor_set_fmt(remote_sd, v4l2_state, &tmp);
+#endif
+	if (!ret) {
+		*fmt = tmp;
+		fmt->pad = pad;
+	}
+	return ret;
+}
+
+/* No locking needed */
+static int ds5_mux_get_fmt(struct v4l2_subdev *sd,
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 15, 10)
+		struct v4l2_subdev_pad_config *cfg,
+#else
+		struct v4l2_subdev_state *v4l2_state,
+#endif
+		struct v4l2_subdev_format *fmt)
+{
+	struct ds5 *state = container_of(sd, struct ds5, mux.sd.subdev);
+	struct v4l2_subdev_format tmp;
+	struct v4l2_subdev *remote_sd;
+	u32 pad;
+	int ret = 0;
+	struct ds5_sensor *sensor;
+
+	if (!state) return -EINVAL;
+	if (!fmt) return -EINVAL;
+
+	sensor = state->mux.last_set;
+	tmp = *fmt;
+	pad = ds5_state_to_pad(state);
+
+	dev_dbg(sd->dev, "%s(): %u %s %p\n", __func__, pad, ds5_get_sensor_name(state), state->mux.last_set);
+
+	switch (pad) {
+	case DS5_MUX_PAD_IR:
+		remote_sd = &state->ir.sensor.sd;
+		break;
+	case DS5_MUX_PAD_DEPTH:
+		remote_sd = &state->depth.sensor.sd;
+		break;
+	case DS5_MUX_PAD_EXTERNAL:
+		remote_sd = &state->mux.last_set->sd;
+		break;
+	case DS5_MUX_PAD_RGB:
+		remote_sd = &state->rgb.sensor.sd;
+		break;
+	case DS5_MUX_PAD_IMU:
+		remote_sd = &state->imu.sensor.sd;
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	dev_dbg(sd->dev, "%s(): fmt->pad:%d, sensor->mux_pad:%u size:%d-%d, code:0x%x field:%d, color:%d\n",
+		__func__, fmt->pad, pad,
+		fmt->format.width, fmt->format.height, fmt->format.code,
+		fmt->format.field, fmt->format.colorspace);
+	/* Locks internally */
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 15, 10)
+	ret = ds5_sensor_get_fmt(remote_sd, cfg, &tmp);
+#else
+	ret = ds5_sensor_get_fmt(remote_sd, v4l2_state, &tmp);
+#endif
+	if (!ret) {
+		*fmt = tmp;
+		fmt->pad = pad;
+	}
+
+	return ret;
+}
+
+/* Video ops */
+static int ds5_mux_g_frame_interval(struct v4l2_subdev *sd,
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 8, 0)
+		struct v4l2_subdev_state *state,
+#endif
+		struct v4l2_subdev_frame_interval *fi)
+{
+	struct ds5 *ds5_state = container_of(sd, struct ds5, mux.sd.subdev);
+	struct ds5_sensor *sensor = NULL;
+
+	if (NULL == sd || NULL == fi)
+		return -EINVAL;
+
+	sensor = ds5_state->mux.last_set;
+
+	fi->interval.numerator = 1;
+	fi->interval.denominator = sensor->config.framerate;
+
+	dev_dbg(sd->dev, "%s(): %s %u\n", __func__, sd->name,
+			fi->interval.denominator);
+
+	return 0;
+}
+
+static u16 __ds5_probe_framerate(const struct ds5_resolution *res, u16 target)
+{
+	int i;
+	u16 framerate;
+
+	for (i = 0; i < res->n_framerates; i++) {
+		framerate = res->framerates[i];
+		if (target <= framerate)
+			return framerate;
+	}
+
+	return res->framerates[res->n_framerates - 1];
+}
+
+static int ds5_mux_s_frame_interval(struct v4l2_subdev *sd,
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 10, 0) || LINUX_VERSION_CODE >= KERNEL_VERSION(6, 8, 0)
+		struct v4l2_subdev_state *state,
+#endif
+		struct v4l2_subdev_frame_interval *fi)
+{
+	struct ds5 *ds5_state = container_of(sd, struct ds5, mux.sd.subdev);
+	struct ds5_sensor *sensor = NULL;
+	u16 framerate = 1;
+
+	if (NULL == sd || NULL == fi || fi->interval.numerator == 0)
+		return -EINVAL;
+
+	sensor = ds5_state->mux.last_set;
+
+	framerate = fi->interval.denominator / fi->interval.numerator;
+	framerate = __ds5_probe_framerate(sensor->config.resolution, framerate);
+	sensor->config.framerate = framerate;
+	fi->interval.numerator = 1;
+	fi->interval.denominator = framerate;
+
+	dev_dbg(sd->dev, "%s(): %s %u\n", __func__, sd->name, framerate);
+
+	return 0;
+}
+
+static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on)
+{
+	struct ds5 *state = container_of(sd, struct ds5, mux.sd.subdev);
+#ifdef DS5_BYPASS_CAMERA_I2C
+	struct ds5_sensor *sensor = state->mux.last_set;
+	bool *streaming_flag = NULL;
+	int ret;
+
+	dev_info(&state->client->dev,
+		"ds5_mux_s_stream(): BYPASS mode - SERDES pipe setup only, on=%d\n", on);
+
+	if (state->is_depth)
+		streaming_flag = &state->ds5_dev->depth_streaming;
+	else if (state->is_rgb)
+		streaming_flag = &state->ds5_dev->rgb_streaming;
+	else if (state->is_y8)
+		streaming_flag = &state->ds5_dev->ir_streaming;
+	else if (state->is_imu)
+		streaming_flag = &state->ds5_dev->imu_streaming;
+	else
+		return -EINVAL;
+
+	if (sensor->streaming == on)
+		return 0;
+
+	mutex_lock(&state->ds5_dev->lock);
+	*streaming_flag = on;
+	mutex_unlock(&state->ds5_dev->lock);
+	sensor->streaming = on;
+
+	if (on) {
+		/* Configure SERDES pipes - this is essential for MIPI data flow */
+		ret = ds5_configure(state);
+		if (ret < 0) {
+			dev_err(&state->client->dev,
+				"BYPASS: ds5_configure (SERDES pipe setup) failed: %d\n", ret);
+			sensor->streaming = false;
+			mutex_lock(&state->ds5_dev->lock);
+			*streaming_flag = false;
+			mutex_unlock(&state->ds5_dev->lock);
+			return ret;
+		}
+	} else {
+		/* On stream off, release SERDES pipe */
+#ifdef CONFIG_VIDEO_D5XX_SERDES
+		if (sensor->pipe_id >= 0) {
+			mutex_lock(&serdes_lock__);
+			if (state->dser_ops->release_pipe(state->dser_dev, sensor->pipe_id) < 0)
+				dev_warn(&state->client->dev, "release pipe failed\n");
+			else
+				sensor->pipe_id = PIPE_NOT_CONFIGURED;
+			mutex_unlock(&serdes_lock__);
+		}
+#endif
+	}
+	return 0;
+#else
+	u16 streaming, status;
+	int ret = 0;
+	unsigned int i = 0, ds5_config_retries = MAX_DS5_CONFIG_RETRIES;
+	unsigned long timeout, ts;
+	int restore_val = 0;
+	u16 stream_cmd;
+	u16 config_status_base, stream_status_base, stream_id, vc_id;
+	struct ds5_sensor *sensor = state->mux.last_set;
+	u16 expected_streaming_state;
+	bool ds5_config_done = !on; /* for stop, skip config */
+	bool reset_invalidated = false;
+	bool *streaming_flag = NULL;
+#ifdef CONFIG_VIDEO_D5XX_SERDES
+	int cur_dser = atomic_read(dser_get_reset_gen(state));
+#else
+	int cur_dser = 0;
+#endif
+	int cur_ds5 = atomic_read(ds5_get_reset_gen(state));
+
+	/* Lazy invalidation after HW or deserializer reset.
+	 * Detect gen-counter bumps, clear stale streaming/config/pipe
+	 * state, then update refs.  Must run before the duplicate-call
+	 * guard so a reset-killed stream is not mistaken for "already off".
+	 */
+	if (state->reset_ref_ds5 != cur_ds5
+			|| state->reset_ref_dser != cur_dser) {
+		ds5_invalidate_sensor(state, sensor);
+		sensor->streaming = false;
+		reset_invalidated = true;
+		state->reset_ref_ds5 = cur_ds5;
+		state->reset_ref_dser = cur_dser;
+	}
+
+	// spare duplicate calls
+	if (sensor->streaming == on)
+		return 0;
+	if (state->is_depth) {
+		config_status_base = DS5_DEPTH_CONFIG_STATUS;
+		stream_status_base = DS5_DEPTH_STREAM_STATUS;
+		stream_id = DS5_STREAM_DEPTH;
+		vc_id = 0;
+		streaming_flag = &state->ds5_dev->depth_streaming;
+	} else if (state->is_rgb) {
+		config_status_base = DS5_RGB_CONFIG_STATUS;
+		stream_status_base = DS5_RGB_STREAM_STATUS;
+		stream_id = DS5_STREAM_RGB;
+		vc_id = 1;
+		streaming_flag = &state->ds5_dev->rgb_streaming;
+	} else if (state->is_y8) {
+		config_status_base = DS5_IR_CONFIG_STATUS;
+		stream_status_base = DS5_IR_STREAM_STATUS;
+		stream_id = DS5_STREAM_IR;
+		vc_id = 2;
+		streaming_flag = &state->ds5_dev->ir_streaming;
+	} else if (state->is_imu) {
+		config_status_base = DS5_IMU_CONFIG_STATUS;
+		stream_status_base = DS5_IMU_STREAM_STATUS;
+		stream_id = DS5_STREAM_IMU;
+		vc_id = 3;
+		streaming_flag = &state->ds5_dev->imu_streaming;
+	} else {
+		return -EINVAL;
+	}
+#ifdef CONFIG_TEGRA_CAMERA_PLATFORM
+#ifdef CONFIG_VIDEO_D5XX_SERDES
+	vc_id = state->g_ctx.dst_vc;
+#endif
+#endif
+	dev_dbg(&state->client->dev, "s_stream for stream %s, vc:%d, SENSOR=%s on = %d\n",
+			sensor->sd.name, vc_id, ds5_get_sensor_name(state), on);
+
+	if (on) {
+		stream_cmd = (DS5_STREAM_START | stream_id);
+		expected_streaming_state = DS5_STREAM_STREAMING;
+		status = 0;
+	} else {
+		stream_cmd = (DS5_STREAM_STOP | stream_id);
+		expected_streaming_state = DS5_STREAM_IDLE;
+		status = DS5_STATUS_STREAMING;
+	}
+
+	/* Verify stream is in the expected state before issuing command */
+	ts = jiffies;
+	for (timeout = ts + msecs_to_jiffies(DS5_START_MAX_TIME), i = 0;
+			time_before(jiffies, timeout); i++, msleep_range(i*DS5_START_POLL_TIME))
+	{
+		ret = ds5_read(state, config_status_base, &status);
+		if ((ret >= 0) && (on == !(status & DS5_STATUS_STREAMING))) {
+			break;
+		}
+	}
+	if (on == !(status & DS5_STATUS_STREAMING))
+	{
+		dev_dbg(&state->client->dev,
+			"stream %d in expected state, toggling to %d (status: 0x%04x) %dms\n",
+			stream_id, on, status, jiffies_to_msecs(jiffies - ts));
+	} else {
+		/* If state was invalidated by reset-generation bump and FW still
+		 * reports this stream as active, force a stop to guarantee next
+		 * start goes through full reconfiguration.
+		 */
+		if (on && reset_invalidated && (status & DS5_STATUS_STREAMING)) {
+			dev_warn(&state->client->dev,
+				"stream %d reports streaming after reset invalidation (status: 0x%04x), forcing stop and reconfigure\n",
+				stream_id, status);
+
+			ret = ds5_write(state, DS5_START_STOP_STREAM,
+					DS5_STREAM_STOP | stream_id);
+			if (ret < 0)
+				dev_warn(&state->client->dev,
+					"stream %d forced stop write failed (%d), continuing with reconfigure\n",
+					stream_id, ret);
+
+			mutex_lock(&state->ds5_dev->lock);
+			*streaming_flag = false;
+			mutex_unlock(&state->ds5_dev->lock);
+			sensor->streaming = false;
+		} else {
+			/* After HW reset the FW reboots and all streams return to
+			 * idle.  If VI error recovery tries to stop a stream that
+			 * is already stopped (or start one already started), treat
+			 * it as a no-op so the upper layer can proceed with
+			 * restart instead of getting stuck in an EBUSY loop.
+			 */
+			dev_warn(&state->client->dev,
+				"stream %d in %d state already (status: 0x%04x) %dms, treating as no-op\n",
+				stream_id, on, status, jiffies_to_msecs(jiffies - ts));
+			mutex_lock(&state->ds5_dev->lock);
+			*streaming_flag = on;
+			mutex_unlock(&state->ds5_dev->lock);
+			sensor->streaming = on;
+			return 0;
+		}
+	}
+
+	restore_val = sensor->streaming;
+	mutex_lock(&state->ds5_dev->lock);
+	*streaming_flag = on;
+	mutex_unlock(&state->ds5_dev->lock);
+	sensor->streaming = on;
+
+	/*
+	 * Execute command, poll state (retry if necessary) and poll completion.
+	 * For start, also confirm config status is valid and not rejected by FW, otherwise retry.
+	 */
+	ts = jiffies;
+	streaming = ~expected_streaming_state; /* force initial toggle */
+	for (timeout = ts + msecs_to_jiffies(DS5_START_MAX_TIME), i = 0;
+			time_before(jiffies, timeout); i++, msleep_range(i*DS5_START_POLL_TIME))
+	{
+		if (!ds5_config_done) {
+			ret = ds5_configure(state);
+			if (ret < 0) {
+				if (ret == -ENOSR) {
+					/* No recovery can help if no resources are available */
+					return ret;
+				}
+				dev_warn(&state->client->dev, "stream %d config failed, retry %d, %dms\n",
+					stream_id, i, jiffies_to_msecs(jiffies - ts));
+				continue;
+			}
+			ds5_config_done = true;
+		}
+
+		if (streaming != expected_streaming_state) {
+			ret = ds5_write(state, DS5_START_STOP_STREAM, stream_cmd);
+			if (ret < 0) {
+				dev_warn(&state->client->dev, "stream %d cmd 0x%x write failed, retry %d, %dms\n",
+					stream_id, stream_cmd, i, jiffies_to_msecs(jiffies - ts));
+			}
+		}
+
+		ret = ds5_read(state, stream_status_base, &streaming);
+		if (ret < 0) {
+			dev_warn(&state->client->dev,
+				"stream %d status i2c read failed (%d), retry %u, %dms\n",
+				stream_id, ret, i, jiffies_to_msecs(jiffies - ts));
+		}
+
+		if (streaming != expected_streaming_state) {
+			dev_warn(&state->client->dev, "stream %d status not as expected (%d != %d), retry %d, %dms\n",
+				stream_id, streaming, expected_streaming_state, i, jiffies_to_msecs(jiffies - ts));
+			continue;
+		}
+
+		ret = ds5_read(state, config_status_base, &status);
+		if (ret < 0) {
+			dev_warn(&state->client->dev,
+				"stream %d config status i2c read failed (%d), retry %u, %dms\n",
+				stream_id, ret, i, jiffies_to_msecs(jiffies - ts));
+			continue;
+		}
+
+		if (on && (status & (DS5_STATUS_INVALID_DT |
+								DS5_STATUS_INVALID_RES |
+								DS5_STATUS_INVALID_FPS)))
+		{
+			dev_warn(&state->client->dev,
+				"stream %d config rejected, status 0x%04x, retry %u, %dms\n",
+				stream_id, status, i, jiffies_to_msecs(jiffies - ts));
+			if (ds5_config_retries > 0) {
+				ds5_config_retries--;
+				ds5_config_done = false;
+				ds5_config_cache_clear(sensor);
+			} else {
+				dev_warn(&state->client->dev,
+					"stream %d config failed after %d retries, aborting, %dms\n",
+					stream_id, i, jiffies_to_msecs(jiffies - ts));
+				break;
+			}
+			continue;
+		}
+
+		if (!on == !(status & DS5_STATUS_STREAMING))
+		{
+			dev_info(&state->client->dev,
+				"stream %d toggle ok to %d in %dms, retries %d\n",
+				stream_id, on, jiffies_to_msecs(jiffies - ts), i);
+			break;
+		}
+	}
+
+	if (on == !(status & DS5_STATUS_STREAMING))
+	{
+		dev_warn(&state->client->dev,
+			"stream %d toggle to %d timeout in %dms, retries %d\n",
+			stream_id, on, jiffies_to_msecs(jiffies - ts), i);
+
+		if (streaming == expected_streaming_state) { /* try to toggle stream back on timeout  */
+			ds5_write(state, DS5_START_STOP_STREAM,
+				(on ? DS5_STREAM_STOP : DS5_STREAM_START) | stream_id);
+		}
+#ifdef CONFIG_VIDEO_D5XX_SERDES
+		if (on && sensor->pipe_id >= 0) {
+			mutex_lock(&serdes_lock__);
+			ret = state->dser_ops->release_pipe(state->dser_dev, sensor->pipe_id);
+			mutex_unlock(&serdes_lock__);
+			if (ret < 0) {
+				dev_warn(&state->client->dev, "release pipe failed\n");
+			} else {
+				sensor->pipe_id = PIPE_NOT_CONFIGURED;
+			}
+		}
+#endif
+		mutex_lock(&state->ds5_dev->lock);
+		*streaming_flag = restore_val;
+		mutex_unlock(&state->ds5_dev->lock);
+		sensor->streaming = restore_val;
+		ret = -EAGAIN;
+	}
+	else if (!on)
+	{
+#ifdef CONFIG_VIDEO_D5XX_SERDES
+		mutex_lock(&serdes_lock__);
+		if (state->dser_ops->release_pipe(state->dser_dev, sensor->pipe_id) < 0)
+			dev_warn(&state->client->dev, "release pipe failed\n");
+		else
+			sensor->pipe_id = PIPE_NOT_CONFIGURED;
+		if (state->is_y8
+			&& (state->ir.sensor.config.format->data_type == GMSL_CSI_DT_RGB_888))
+		{
+			state->dser_ops->reset_oneshot(state->dser_dev);
+		}
+		mutex_unlock(&serdes_lock__);
+		msleep_range(100);
+#endif
+	}
+	return ret;
+#endif /* !DS5_BYPASS_CAMERA_I2C */
+}
+
+static int ds5_mux_get_frame_desc(struct v4l2_subdev *sd,
+	unsigned int pad, struct v4l2_mbus_frame_desc *desc)
+{
+	unsigned int i;
+
+	desc->num_entries = V4L2_FRAME_DESC_ENTRY_MAX;
+
+	for (i = 0; i < desc->num_entries; i++) {
+		desc->entry[i].flags = 0;
+		desc->entry[i].pixelcode = MEDIA_BUS_FMT_FIXED;
+		desc->entry[i].length = 0;
+		if (i == desc->num_entries - 1) {
+			desc->entry[i].pixelcode = 0x12;
+			desc->entry[i].length = 68;
+		}
+	}
+	return 0;
+}
+
+static const struct v4l2_subdev_pad_ops ds5_mux_pad_ops = {
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 8, 0)
+	.get_frame_interval	= ds5_mux_g_frame_interval,
+	.set_frame_interval	= ds5_mux_s_frame_interval,
+#endif
+	.enum_mbus_code		= ds5_mux_enum_mbus_code,
+	.enum_frame_size	= ds5_mux_enum_frame_size,
+	.enum_frame_interval	= ds5_mux_enum_frame_interval,
+	.get_fmt		= ds5_mux_get_fmt,
+	.set_fmt		= ds5_mux_set_fmt,
+	.get_frame_desc		= ds5_mux_get_frame_desc,
+};
+
+static const struct v4l2_subdev_core_ops ds5_mux_core_ops = {
+	//.s_power = ds5_mux_set_power,
+	.log_status = v4l2_ctrl_subdev_log_status,
+};
+
+static const struct v4l2_subdev_video_ops ds5_mux_video_ops = {
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 8, 0)
+	.g_frame_interval	= ds5_mux_g_frame_interval,
+	.s_frame_interval	= ds5_mux_s_frame_interval,
+#endif
+	.s_stream		= ds5_mux_s_stream,
+};
+
+static const struct v4l2_subdev_ops ds5_mux_subdev_ops = {
+	.core = &ds5_mux_core_ops,
+	.pad = &ds5_mux_pad_ops,
+	.video = &ds5_mux_video_ops,
+};
+
+static int ds5_mux_registered(struct v4l2_subdev *sd)
+{
+	struct ds5 *state = v4l2_get_subdevdata(sd);
+	int ret = ds5_sensor_register(state, &state->depth.sensor);
+	if (ret < 0)
+		return ret;
+
+	ret = ds5_sensor_register(state, &state->ir.sensor);
+	if (ret < 0)
+		goto e_depth;
+
+	ret = ds5_sensor_register(state, &state->rgb.sensor);
+	if (ret < 0)
+		goto e_rgb;
+
+	ret = ds5_sensor_register(state, &state->imu.sensor);
+	if (ret < 0)
+		goto e_imu;
+
+	return 0;
+
+e_imu:
+	v4l2_device_unregister_subdev(&state->rgb.sensor.sd);
+
+e_rgb:
+	v4l2_device_unregister_subdev(&state->ir.sensor.sd);
+
+e_depth:
+	v4l2_device_unregister_subdev(&state->depth.sensor.sd);
+
+	return ret;
+}
+
+static void ds5_mux_unregistered(struct v4l2_subdev *sd)
+{
+	struct ds5 *state = v4l2_get_subdevdata(sd);
+	ds5_sensor_remove(&state->imu.sensor);
+	ds5_sensor_remove(&state->rgb.sensor);
+	ds5_sensor_remove(&state->ir.sensor);
+	ds5_sensor_remove(&state->depth.sensor);
+}
+
+static const struct v4l2_subdev_internal_ops ds5_mux_internal_ops = {
+	.open = ds5_mux_open,
+	.close = ds5_mux_close,
+	.registered = ds5_mux_registered,
+	.unregistered = ds5_mux_unregistered,
+};
+
+static int ds5_mux_register(struct i2c_client *c, struct ds5 *state)
+{
+	return v4l2_async_register_subdev(&state->mux.sd.subdev);
+}
+
+static int ds5_hw_init(struct i2c_client *c, struct ds5 *state)
+{
+	struct v4l2_subdev *sd = &state->mux.sd.subdev;
+#ifdef DS5_BYPASS_CAMERA_I2C
+	dev_info(sd->dev, "%s(): BYPASS - skip camera MIPI config I2C\n", __func__);
+	return 0;
+#else
+	u16 mipi_status, n_lanes, phy, drate_min, drate_max;
+	int ret = ds5_read(state, DS5_MIPI_SUPPORT_LINES, &n_lanes);
+	if (!ret)
+		ret = ds5_read(state, DS5_MIPI_SUPPORT_PHY, &phy);
+
+	if (!ret)
+		ret = ds5_read(state, DS5_MIPI_DATARATE_MIN, &drate_min);
+
+	if (!ret)
+		ret = ds5_read(state, DS5_MIPI_DATARATE_MAX, &drate_max);
+
+	if (!ret)
+		dev_dbg(sd->dev, "%s(): %d: %u lanes, phy %x, data rate %u-%u\n",
+			 __func__, __LINE__, n_lanes, phy, drate_min, drate_max);
+
+#ifdef CONFIG_TEGRA_CAMERA_PLATFORM
+	n_lanes = state->mux.sd.numlanes;
+#else
+	n_lanes = 2;
+#endif
+
+	ret = ds5_write(state, DS5_MIPI_LANE_NUMS, n_lanes - 1);
+	if (!ret)
+		ret = ds5_write(state, DS5_MIPI_LANE_DATARATE, MIPI_LANE_RATE);
+
+	if (!ret)
+		ret = ds5_read(state, DS5_MIPI_CONF_STATUS, &mipi_status);
+
+#ifdef CONFIG_TEGRA_CAMERA_PLATFORM
+	dev_dbg(sd->dev, "%s(): %d phandle %x node %s status %x\n", __func__, __LINE__,
+		 c->dev.of_node->phandle, c->dev.of_node->full_name, mipi_status);
+#endif
+
+	return ret;
+#endif /* !DS5_BYPASS_CAMERA_I2C */
+}
+
+static int ds5_mux_init(struct i2c_client *c, struct ds5 *state)
+{
+	struct v4l2_subdev *sd = &state->mux.sd.subdev;
+	struct media_entity *entity = &state->mux.sd.subdev.entity;
+	struct media_pad *pads = state->mux.pads, *pad;
+	unsigned int i;
+	int ret;
+#ifndef CONFIG_OF
+	struct d4xx_pdata *dpdata = c->dev.platform_data;
+	char suffix = dpdata->suffix;
+#endif
+	v4l2_i2c_subdev_init(sd, c, &ds5_mux_subdev_ops);
+	// See tegracam_v4l2.c tegracam_v4l2subdev_register()
+	// Set owner to NULL so we can unload the driver module
+	sd->owner = NULL;
+	sd->internal_ops = &ds5_mux_internal_ops;
+	v4l2_set_subdevdata(sd, state);
+#ifdef CONFIG_OF
+	snprintf(sd->name, sizeof(sd->name), "D5XX mux %d-%04x",
+		 i2c_adapter_id(c->adapter), c->addr);
+#else
+	if (state->aggregated)
+		suffix += 4;
+	snprintf(sd->name, sizeof(sd->name), "D5XX mux %c", suffix);
+#endif
+	sd->flags |= V4L2_SUBDEV_FL_HAS_DEVNODE;
+	entity->obj_type = MEDIA_ENTITY_TYPE_V4L2_SUBDEV;
+	entity->function = MEDIA_ENT_F_CAM_SENSOR;
+
+	pads[0].flags = MEDIA_PAD_FL_SOURCE;
+	for (i = 1, pad = pads + 1; i < ARRAY_SIZE(state->mux.pads); i++, pad++)
+		pad->flags = MEDIA_PAD_FL_SINK;
+
+	ret = media_entity_pads_init(entity, ARRAY_SIZE(state->mux.pads), pads);
+	if (ret < 0)
+		return ret;
+
+	/*set for mux*/
+	ret = ds5_ctrl_init(state, MUX_SID);
+	if (ret < 0)
+		goto e_entity;
+
+	/*set for depth*/
+	ret = ds5_ctrl_init(state, DEPTH_SID);
+	if (ret < 0)
+		return ret;
+	/*set for rgb*/
+	ret = ds5_ctrl_init(state, RGB_SID);
+	if (ret < 0)
+		return ret;
+	/*set for y8*/
+	ret = ds5_ctrl_init(state, IR_SID);
+	if (ret < 0)
+		return ret;
+	/*set for imu*/
+	ret = ds5_ctrl_init(state, IMU_SID);
+	if (ret < 0)
+		return ret;
+
+	ds5_set_state_last_set(state);
+
+#ifdef CONFIG_TEGRA_CAMERA_PLATFORM
+	if (state->is_depth) {
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 20, 0)
+		v4l2_ctrl_add_handler(&state->ctrls.handler,
+					&state->ctrls.handler_depth, NULL);
+#else
+		v4l2_ctrl_add_handler(&state->ctrls.handler,
+					&state->ctrls.handler_depth, NULL, true);
+#endif
+		state->mux.last_set = &state->depth.sensor;
+	}
+	else if (state->is_rgb) {
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 20, 0)
+		v4l2_ctrl_add_handler(&state->ctrls.handler,
+					&state->ctrls.handler_rgb, NULL);
+#else
+		v4l2_ctrl_add_handler(&state->ctrls.handler,
+					&state->ctrls.handler_rgb, NULL, true);
+#endif
+		state->mux.last_set = &state->rgb.sensor;
+	}
+	else if (state->is_y8) {
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 20, 0)
+		v4l2_ctrl_add_handler(&state->ctrls.handler,
+					&state->ctrls.handler_y8, NULL);
+#else
+		v4l2_ctrl_add_handler(&state->ctrls.handler,
+					&state->ctrls.handler_y8, NULL, true);
+#endif
+		state->mux.last_set = &state->ir.sensor;
+	}
+	else
+		state->mux.last_set = &state->imu.sensor;
+
+	state->mux.sd.dev = &c->dev;
+	ret = camera_common_initialize(&state->mux.sd, "d5xx");
+	if (ret) {
+		dev_err(&c->dev, "Failed to initialize d5xx.\n");
+		goto e_ctrl;
+	}
+#endif
+
+	return 0;
+
+#ifdef CONFIG_TEGRA_CAMERA_PLATFORM
+e_ctrl:
+	v4l2_ctrl_handler_free(sd->ctrl_handler);
+#endif
+e_entity:
+	media_entity_cleanup(entity);
+
+	return ret;
+}
+
+#define USE_Y
+
+static int ds5_fixed_configuration(struct i2c_client *client, struct ds5 *state)
+{
+	struct ds5_sensor *sensor;
+	u16 cfg0 = 0, cfg0_md = 0, cfg1 = 0, cfg1_md = 0;
+	u16 dw = 0, dh = 0, yw = 0, yh = 0, dev_type = 0;
+	int ret;
+
+#ifdef DS5_BYPASS_CAMERA_I2C
+	/* Hardcode D58X configuration - no camera I2C available */
+	dev_info(&client->dev, "%s(): BYPASS - using hardcoded D58X config\n", __func__);
+	cfg0 = 0x1e;   /* depth DT: GMSL_CSI_DT_YUV422_8 */
+	dw = 1280;
+	dh = 720;
+	cfg1 = 0x2a;   /* IR DT: RAW8 */
+	yw = 1280;
+	yh = 720;
+	dev_type = DS5_DEVICE_TYPE_D58X;
+	ret = 0;
+#else
+	ret = ds5_read(state, DS5_DEPTH_STREAM_DT, &cfg0);
+	if (!ret)
+		ret = ds5_read(state, DS5_DEPTH_STREAM_MD, &cfg0_md);
+	if (!ret)
+		ret = ds5_read(state, DS5_DEPTH_RES_WIDTH, &dw);
+	if (!ret)
+		ret = ds5_read(state, DS5_DEPTH_RES_HEIGHT, &dh);
+	if (!ret)
+		ret = ds5_read(state, DS5_IR_STREAM_DT, &cfg1);
+	if (!ret)
+		ret = ds5_read(state, DS5_IR_STREAM_MD, &cfg1_md);
+	if (!ret)
+		ret = ds5_read(state, DS5_IR_RES_WIDTH, &yw);
+	if (!ret)
+		ret = ds5_read(state, DS5_IR_RES_HEIGHT, &yh);
+	if (!ret)
+		ret = ds5_read(state, DS5_DEVICE_TYPE, &dev_type);
+	if (ret < 0)
+		return ret;
+#endif
+
+	dev_dbg(&client->dev, "%s(): cfg0 %x %ux%u cfg0_md %x %ux%u\n", __func__,
+		 cfg0, dw, dh, cfg0_md, yw, yh);
+
+	dev_dbg(&client->dev, "%s(): cfg1 %x %ux%u cfg1_md %x %ux%u\n", __func__,
+		 cfg1, dw, dh, cfg1_md, yw, yh);
+
+	sensor = &state->depth.sensor;
+	dev_type = ds5_dev_type(state, dev_type);
+	switch (dev_type) {
+	case DS5_DEVICE_TYPE_D58X:
+	default:
+		if (dev_type != DS5_DEVICE_TYPE_D58X)
+			dev_warn(&client->dev,
+				"%s(): unknown device type 0x%x, using D58X format tables\n",
+				__func__, dev_type);
+		sensor->formats = ds5_depth_formats_d58x;
+	}
+	sensor->n_formats = 1;
+	sensor->mux_pad = DS5_MUX_PAD_DEPTH;
+
+	sensor = &state->ir.sensor;
+	switch (dev_type) {
+	case DS5_DEVICE_TYPE_D58X:
+		sensor->formats = ds5_y_formats_d58x;
+		sensor->n_formats = ARRAY_SIZE(ds5_y_formats_d58x);
+		break;
+	default:
+		sensor->formats = state->variant->formats;
+		sensor->n_formats = state->variant->n_formats;
+	}
+	sensor->mux_pad = DS5_MUX_PAD_IR;
+
+	sensor = &state->rgb.sensor;
+	switch (dev_type) {
+	case DS5_DEVICE_TYPE_D58X:
+	default:
+		sensor->formats = &ds5_d58x_rgb_format;
+		sensor->n_formats = DS5_D58X_RGB_N_FORMATS;
+	}
+	sensor->mux_pad = DS5_MUX_PAD_RGB;
+
+	sensor = &state->imu.sensor;
+
+	/* For fimware version starting from: 5.16,
+	   IMU will have 32bit axis values.
+ 	   5.16.x.y = firmware version: 0x0510 */
+	if (state->fw_version >= 0x510)
+		sensor->formats = ds5_imu_formats_extended;
+	else
+		sensor->formats = ds5_imu_formats;
+	
+	sensor->n_formats = 1;
+	sensor->mux_pad = DS5_MUX_PAD_IMU;
+
+	/* Development: set a configuration during probing */
+	if ((cfg0 & 0xff00) == 0x1800) {
+		/* MIPI CSI-2 YUV420 isn't supported by V4L, reconfigure to Y8 */
+		struct v4l2_subdev_format fmt = {
+			.which = V4L2_SUBDEV_FORMAT_ACTIVE,
+			.pad = 0,
+			/* Use template to fill in .field, .colorspace etc. */
+			.format = ds5_mbus_framefmt_template,
+		};
+
+//#undef USE_Y
+#ifdef USE_Y
+		/* Override .width, .height, .code */
+		fmt.format.width = yw;
+		fmt.format.height = yh;
+		fmt.format.code = MEDIA_BUS_FMT_UYVY8_2X8;
+#ifdef CONFIG_TEGRA_CAMERA_PLATFORM
+		state->mux.sd.mode_prop_idx = 0;
+#endif
+		state->ir.sensor.streaming = true;
+		state->depth.sensor.streaming = true;
+		ret = __ds5_sensor_set_fmt(state, &state->ir.sensor, NULL, &fmt);
+#else
+		fmt.format.width = dw;
+		fmt.format.height = dh;
+		fmt.format.code = MEDIA_BUS_FMT_UYVY8_1X16;
+#ifdef CONFIG_TEGRA_CAMERA_PLATFORM
+		state->mux.sd.mode_prop_idx = 1;
+#endif
+		state->ir.sensor.streaming = false;
+		state->depth.sensor.streaming = true;
+		ret = __ds5_sensor_set_fmt(state, &state->depth.sensor, NULL, &fmt);
+#endif
+		if (ret < 0)
+			return ret;
+	}
+
+	return 0;
+}
+
+static int ds5_parse_cam(struct i2c_client *client, struct ds5 *state)
+{
+	int ret;
+
+	ret = ds5_fixed_configuration(client, state);
+	if (ret < 0)
+		return ret;
+
+	ds5_sensor_format_init(&state->depth.sensor);
+	ds5_sensor_format_init(&state->ir.sensor);
+	ds5_sensor_format_init(&state->rgb.sensor);
+	ds5_sensor_format_init(&state->imu.sensor);
+
+	return 0;
+}
+
+static void ds5_mux_remove(struct ds5 *state)
+{
+#ifdef CONFIG_TEGRA_CAMERA_PLATFORM
+	camera_common_cleanup(&state->mux.sd);
+#endif
+	v4l2_async_unregister_subdev(&state->mux.sd.subdev);
+	v4l2_ctrl_handler_free(state->mux.sd.subdev.ctrl_handler);
+	media_entity_cleanup(&state->mux.sd.subdev.entity);
+}
+
+static const struct regmap_config ds5_regmap_config = {
+	.reg_bits = 16,
+	.val_bits = 8,
+	.reg_format_endian = REGMAP_ENDIAN_NATIVE,
+	.val_format_endian = REGMAP_ENDIAN_NATIVE,
+};
+
+static int ds5_dfu_wait_for_status(struct ds5 *state)
+{
+	int i, ret = 0;
+	u16 status;
+
+	for (i = 0; i < DS5_START_MAX_COUNT; i++) {
+		ds5_read(state, 0x5000, &status);
+		if (status == 0x0001 || status == 0x0002) {
+			dev_err(&state->client->dev,
+					"%s(): dfu failed status(0x%4x)\n",
+					__func__, status);
+			ret = -EREMOTEIO;
+			break;
+		}
+		if (!status)
+			break;
+		msleep_range(DS5_START_POLL_TIME);
+	}
+
+	return ret;
+};
+
+static int ds5_dfu_switch_to_dfu(struct ds5 *state)
+{
+	int ret;
+	int i = DS5_START_MAX_COUNT;
+	u16 status;
+
+	ret = ds5_hwmc_send(state, sizeof(cmd_switch_to_dfu),
+			    (struct hwm_cmd *)&cmd_switch_to_dfu);
+	if (ret)
+		return ret;
+	/*Wait for DFU fw to boot*/
+	do {
+		msleep_range(DS5_START_POLL_TIME*10);
+		ret = ds5_read(state, 0x5000, &status);
+	} while (ret && i--);
+	return ret;
+};
+
+static int ds5_dfu_wait_for_get_dfu_status(struct ds5 *state,
+		enum dfu_fw_state exp_state)
+{
+	int ret = 0;
+	u16 status, dfu_state_len = 0x0000;
+	unsigned char dfu_asw_buf[DFU_WAIT_RET_LEN];
+	unsigned int dfu_wr_wait_msec = 0;
+
+	do {
+		ds5_write_with_check(state, 0x5008, 0x0003); // Get Write state
+		do {
+			ds5_read_with_check(state, 0x5000, &status);
+			if (status == 0x0001) {
+				dev_err(&state->client->dev,
+						"%s(): Write status error I2C_STATUS_ERROR(1)\n",
+						__func__);
+				return -EINVAL;
+			} else
+				if (status == 0x0002 && dfu_wr_wait_msec)
+					msleep_range(dfu_wr_wait_msec);
+
+		} while (status);
+
+		ds5_read_with_check(state, 0x5004, &dfu_state_len);
+		if (dfu_state_len != DFU_WAIT_RET_LEN) {
+			dev_err(&state->client->dev,
+					"%s(): Wrong answer len (%d)\n", __func__, dfu_state_len);
+			return -EINVAL;
+		}
+		ds5_raw_read_with_check(state, 0x4e00, &dfu_asw_buf, DFU_WAIT_RET_LEN);
+		if (dfu_asw_buf[0]) {
+			dev_err(&state->client->dev,
+					"%s(): Wrong dfu_status (%d)\n", __func__, dfu_asw_buf[0]);
+			return -EINVAL;
+		}
+		dfu_wr_wait_msec = (((unsigned int)dfu_asw_buf[3]) << 16)
+						| (((unsigned int)dfu_asw_buf[2]) << 8)
+						| dfu_asw_buf[1];
+	} while (dfu_asw_buf[4] == dfuDNBUSY && exp_state == dfuDNLOAD_IDLE);
+
+	if (dfu_asw_buf[4] != exp_state) {
+		dev_notice(&state->client->dev,
+				"%s(): Wrong dfu_state (%d) while expected(%d)\n",
+				__func__, dfu_asw_buf[4], exp_state);
+		ret = -EINVAL;
+	}
+	return ret;
+};
+
+static int ds5_dfu_get_dev_info(struct ds5 *state, struct __fw_status *buf)
+{
+	int ret = 0;
+	u16 len = 0;
+
+	ret = ds5_write(state, 0x5008, 0x0002); //Upload DFU cmd
+	if (!ret)
+		ret = ds5_dfu_wait_for_status(state);
+	if (!ret)
+		ds5_read_with_check(state, 0x5004, &len);
+	/*Sanity check*/
+	if (len == sizeof(struct __fw_status)) {
+		ds5_raw_read_with_check(state, 0x4e00, buf, len);
+	} else {
+		dev_err(&state->client->dev,
+				"%s(): Wrong state size (%d)\n",
+				__func__, len);
+		ret = -EINVAL;
+	}
+	return ret;
+};
+
+static int ds5_dfu_detach(struct ds5 *state)
+{
+	int ret;
+	struct __fw_status buf = {0};
+
+	ds5_write_with_check(state, 0x500c, 0x00);
+	ret = ds5_dfu_wait_for_get_dfu_status(state, dfuIDLE);
+	if (!ret)
+		ret = ds5_dfu_get_dev_info(state, &buf);
+	dev_notice(&state->client->dev, "%s():DFU ver (0x%x) received\n",
+			__func__, buf.DFU_version);
+	dev_notice(&state->client->dev, "%s():FW last version (0x%x) received\n",
+			__func__, buf.FW_lastVersion);
+	dev_notice(&state->client->dev, "%s():FW status (%s)\n",
+			__func__, buf.DFU_isLocked ? "locked" : "unlocked");
+	return ret;
+};
+
+/* When a process reads from our device, this gets called. */
+static ssize_t ds5_dfu_device_read(struct file *flip,
+		char __user *buffer, size_t len, loff_t *offset)
+{
+	struct ds5 *state = flip->private_data;
+	u16 fw_ver, fw_build;
+	char msg[64];
+	int ret = 0;
+	struct __fw_status f = {0};
+
+	if (mutex_lock_interruptible(&state->lock))
+		return -ERESTARTSYS;
+	if (state->dfu_dev.dfu_state_flag == DS5_DFU_RECOVERY) {
+		/* Read device info in recovery mode */
+		ret = ds5_dfu_detach(state);
+		if (ret < 0)
+			goto e_dfu_read_failed;
+		ret = ds5_dfu_get_dev_info(state, &f);
+		if (ret < 0)
+			goto e_dfu_read_failed;
+		snprintf(msg, sizeof(msg) ,
+			 "DFU info: \trecovery:  %02x%02x%02x%02x%02x%02x\n",
+			 f.ivcamSerialNum[0], f.ivcamSerialNum[1], f.ivcamSerialNum[2],
+			 f.ivcamSerialNum[3], f.ivcamSerialNum[4], f.ivcamSerialNum[5] );
+	} else {
+		ret |= ds5_read(state, DS5_FW_VERSION, &fw_ver);
+		ret |= ds5_read(state, DS5_FW_BUILD, &fw_build);
+		if (ret < 0)
+			goto e_dfu_read_failed;
+		snprintf(msg, sizeof(msg) ,"DFU info: \tver:  %d.%d.%d.%d\n",
+			(fw_ver >> 8) & 0xff, fw_ver & 0xff,
+			(fw_build >> 8) & 0xff, fw_build & 0xff);
+	}
+
+	if (copy_to_user(buffer, msg, strlen(msg)))
+		ret = -EFAULT;
+	else {
+		state->dfu_dev.msg_write_once = ~state->dfu_dev.msg_write_once;
+		ret = strlen(msg) & state->dfu_dev.msg_write_once;
+	}
+
+e_dfu_read_failed:
+	mutex_unlock(&state->lock);
+	return ret;
+};
+
+static ssize_t ds5_dfu_device_write(struct file *flip,
+		const char __user *buffer, size_t len, loff_t *offset)
+{
+	struct ds5 *state = flip->private_data;
+	int ret = 0;
+	(void)offset;
+
+	if (mutex_lock_interruptible(&state->lock))
+		return -ERESTARTSYS;
+	switch (state->dfu_dev.dfu_state_flag) {
+
+	case DS5_DFU_OPEN:
+		ret = ds5_dfu_switch_to_dfu(state);
+		if (ret < 0) {
+			dev_err(&state->client->dev, "%s(): Switch to dfu failed (%d)\n",
+					__func__, ret);
+			goto dfu_write_error;
+		}
+	/* fallthrough - procceed to recovery */
+	__attribute__((__fallthrough__));
+	case DS5_DFU_RECOVERY:
+		ret = ds5_dfu_detach(state);
+		if (ret < 0) {
+			dev_err(&state->client->dev, "%s(): Detach failed (%d)\n",
+					__func__, ret);
+			goto dfu_write_error;
+		}
+		state->dfu_dev.dfu_state_flag = DS5_DFU_IN_PROGRESS;
+	/* find a better way to reinitialize driver from recovery to operational */
+		// state->dfu_dev.init_v4l_f = 1;
+	/* fallthrough - procceed to download */
+	__attribute__((__fallthrough__));
+	case DS5_DFU_IN_PROGRESS: {
+		unsigned int dfu_full_blocks = len / DFU_BLOCK_SIZE;
+		unsigned int dfu_part_blocks = len % DFU_BLOCK_SIZE;
+
+		while (dfu_full_blocks--) {
+			if (copy_from_user(state->dfu_dev.dfu_msg, buffer, DFU_BLOCK_SIZE)) {
+				ret = -EFAULT;
+				goto dfu_write_error;
+			}
+			ret = ds5_raw_write(state, 0x4a00,
+					state->dfu_dev.dfu_msg, DFU_BLOCK_SIZE);
+			if (ret < 0)
+				goto dfu_write_error;
+			ret = ds5_dfu_wait_for_get_dfu_status(state, dfuDNLOAD_IDLE);
+			if (ret < 0)
+				goto dfu_write_error;
+			buffer += DFU_BLOCK_SIZE;
+		}
+		if (copy_from_user(state->dfu_dev.dfu_msg, buffer, dfu_part_blocks)) {
+				ret = -EFAULT;
+				goto dfu_write_error;
+		}
+		if (dfu_part_blocks) {
+			ret = ds5_raw_write(state, 0x4a00,
+					state->dfu_dev.dfu_msg, dfu_part_blocks);
+			if (!ret)
+				ret = ds5_dfu_wait_for_get_dfu_status(state, dfuDNLOAD_IDLE);
+			if (!ret)
+				ret = ds5_write(state, 0x4a04, 0x00); /*Download complete */
+			if (!ret)
+				ret = ds5_dfu_wait_for_get_dfu_status(state, dfuMANIFEST);
+			if (ret < 0)
+				goto dfu_write_error;
+			state->dfu_dev.dfu_state_flag = DS5_DFU_DONE;
+		}
+		if (len)
+			dev_notice(&state->client->dev, "%s(): DFU block (%d) bytes written\n",
+				__func__, (int)len);
+		break;
+	}
+	default:
+		dev_err(&state->client->dev, "%s(): Wrong state (%d)\n",
+				__func__, state->dfu_dev.dfu_state_flag);
+		ret = -EINVAL;
+		goto dfu_write_error;
+
+	};
+	mutex_unlock(&state->lock);
+	return len;
+
+dfu_write_error:
+	state->dfu_dev.dfu_state_flag = DS5_DFU_ERROR;
+	// Reset DFU device to IDLE states
+	if (!ds5_write(state, 0x5010, 0x0))
+		state->dfu_dev.dfu_state_flag = DS5_DFU_IDLE;
+	mutex_unlock(&state->lock);
+	return ret;
+};
+
+static int ds5_dfu_device_open(struct inode *inode, struct file *file)
+{
+	struct ds5 *state = container_of(inode->i_cdev, struct ds5,
+			dfu_dev.ds5_cdev);
+#ifdef CONFIG_TEGRA_CAMERA_PLATFORM
+	struct i2c_adapter *parent = i2c_parent_is_i2c_adapter(
+			state->client->adapter);
+#endif
+	mutex_lock(&state->lock);
+	if (state->dfu_dev.device_open_count) {
+		mutex_unlock(&state->lock);
+		return -EBUSY;
+	}
+	state->dfu_dev.device_open_count++;
+	if (state->dfu_dev.dfu_state_flag != DS5_DFU_RECOVERY)
+		state->dfu_dev.dfu_state_flag = DS5_DFU_OPEN;
+	state->dfu_dev.dfu_msg = devm_kzalloc(&state->client->dev,
+			DFU_BLOCK_SIZE, GFP_KERNEL);
+	if (!state->dfu_dev.dfu_msg) {
+		mutex_unlock(&state->lock);
+		return -ENOMEM;
+	}
+	file->private_data = state;
+#ifdef CONFIG_TEGRA_CAMERA_PLATFORM
+	/* get i2c controller and set dfu bus clock rate */
+	while (parent && i2c_parent_is_i2c_adapter(parent))
+		parent = i2c_parent_is_i2c_adapter(state->client->adapter);
+
+	if (!parent) {
+		mutex_unlock(&state->lock);
+		return 0;
+	}
+	dev_dbg(&state->client->dev, "%s(): i2c-%d bus_clk = %d, set %d\n",
+			__func__,
+			i2c_adapter_id(parent),
+			i2c_get_adapter_bus_clk_rate(parent),
+			DFU_I2C_BUS_CLK_RATE);
+
+	state->dfu_dev.bus_clk_rate = i2c_get_adapter_bus_clk_rate(parent);
+	i2c_set_adapter_bus_clk_rate(parent, DFU_I2C_BUS_CLK_RATE);
+#endif
+	mutex_unlock(&state->lock);
+	return 0;
+};
+
+/* Adjust sync_mode control range based on device type.
+ * Must be called after ds5_mux_init() which creates the control.
+ */
+static void ds5_adjust_sync_mode_control(struct i2c_client *client, struct ds5 *state)
+{
+	u16 dev_type = 0;
+#ifndef DS5_BYPASS_CAMERA_I2C
+	int ret;
+#endif
+
+	if (!state->ctrls.sync_mode)
+		return;
+
+#ifdef DS5_BYPASS_CAMERA_I2C
+	dev_type = DS5_DEVICE_TYPE_D58X;
+#else
+	ret = ds5_read(state, DS5_DEVICE_TYPE, &dev_type);
+	if (ret < 0) {
+		dev_warn(&client->dev, "%s(): Failed to read device type\n", __func__);
+		return;
+	}
+	dev_type = ds5_dev_type(state, dev_type);
+#endif
+	switch (dev_type) {
+	case DS5_DEVICE_TYPE_D58X:
+		/* D58X supports all 6 sync modes (0-5) */
+		__v4l2_ctrl_modify_range(state->ctrls.sync_mode, 0, 5, 0, 0);
+		state->ctrls.sync_mode->qmenu = sync_mode_menu_full;
+		dev_dbg(&client->dev, "%s(): D58X sync mode: all modes 0-5 supported\n", __func__);
+		break;
+	default:
+		/* Unknown device - disable sync mode */
+		dev_warn(&client->dev, "%s(): Unknown device type %d, disabling sync mode\n",
+			__func__, dev_type);
+		__v4l2_ctrl_modify_range(state->ctrls.sync_mode, 0, 0, 0, 0);
+		break;
+	}
+}
+
+static int ds5_v4l_init(struct i2c_client *c, struct ds5 *state)
+{
+	int ret;
+
+	ret = ds5_parse_cam(c, state);
+	if (ret < 0)
+		return ret;
+
+	ret = ds5_depth_init(c, state);
+	if (ret < 0)
+		return ret;
+
+	ret = ds5_ir_init(c, state);
+	if (ret < 0)
+		goto e_depth;
+
+	ret = ds5_rgb_init(c, state);
+	if (ret < 0)
+		goto e_ir;
+
+	ret = ds5_imu_init(c, state);
+	if (ret < 0)
+		goto e_rgb;
+
+	ret = ds5_mux_init(c, state);
+	if (ret < 0)
+		goto e_imu;
+
+	/* Adjust sync_mode control range based on device type - must be done
+	 * after ds5_mux_init() creates the control */
+	ds5_adjust_sync_mode_control(c, state);
+
+	ret = ds5_hw_init(c, state);
+	if (ret < 0)
+		goto e_mux;
+
+	ret = ds5_mux_register(c, state);
+	if (ret < 0)
+		goto e_mux;
+
+	return 0;
+e_mux:
+	ds5_mux_remove(state);
+e_imu:
+	media_entity_cleanup(&state->imu.sensor.sd.entity);
+e_rgb:
+	media_entity_cleanup(&state->rgb.sensor.sd.entity);
+e_ir:
+	media_entity_cleanup(&state->ir.sensor.sd.entity);
+e_depth:
+	media_entity_cleanup(&state->depth.sensor.sd.entity);
+	return ret;
+}
+
+static int ds5_dfu_device_release(struct inode *inode, struct file *file)
+{
+	struct ds5 *state = container_of(inode->i_cdev, struct ds5, dfu_dev.ds5_cdev);
+#ifdef CONFIG_TEGRA_CAMERA_PLATFORM
+	struct i2c_adapter *parent = i2c_parent_is_i2c_adapter(
+			state->client->adapter);
+#endif
+	int ret = 0, retry = 10;
+	mutex_lock(&state->lock);
+	state->dfu_dev.device_open_count--;
+	if (state->dfu_dev.dfu_state_flag != DS5_DFU_RECOVERY)
+		state->dfu_dev.dfu_state_flag = DS5_DFU_IDLE;
+	/* We disable this section as it has no effect when device in operational
+	   mode and has not enough effect when device in recovery mode */
+	// if (state->dfu_dev.dfu_state_flag == DS5_DFU_DONE
+	// 		&& state->dfu_dev.init_v4l_f)
+	// 	ds5_v4l_init(state->client, state);
+	// state->dfu_dev.init_v4l_f = 0;
+	if (state->dfu_dev.dfu_msg)
+		devm_kfree(&state->client->dev, state->dfu_dev.dfu_msg);
+	state->dfu_dev.dfu_msg = NULL;
+#ifdef CONFIG_TEGRA_CAMERA_PLATFORM
+	/* get i2c controller and restore bus clock rate */
+	while (parent && i2c_parent_is_i2c_adapter(parent))
+		parent = i2c_parent_is_i2c_adapter(state->client->adapter);
+	if (!parent) {
+		mutex_unlock(&state->lock);
+		return 0;
+	}
+	dev_dbg(&state->client->dev, "%s(): i2c-%d bus_clk %d, restore to %d\n",
+			__func__, i2c_adapter_id(parent),
+			i2c_get_adapter_bus_clk_rate(parent),
+			state->dfu_dev.bus_clk_rate);
+
+	i2c_set_adapter_bus_clk_rate(parent, state->dfu_dev.bus_clk_rate);
+#endif
+	/* Verify communication */
+	do {
+		ret = ds5_read(state, DS5_FW_VERSION, &state->fw_version);
+		if (ret)
+			msleep_range(10);
+	} while (retry-- && ret != 0 );
+	if (ret) {
+		dev_warn(&state->client->dev,
+			"%s(): no communication with d4xx\n", __func__);
+		mutex_unlock(&state->lock);
+		return ret;
+	}
+	ret = ds5_read(state, DS5_FW_BUILD, &state->fw_build);
+	mutex_unlock(&state->lock);
+	return ret;
+};
+
+static const struct file_operations ds5_device_file_ops = {
+	.owner = THIS_MODULE,
+	.read = &ds5_dfu_device_read,
+	.write = &ds5_dfu_device_write,
+	.open = &ds5_dfu_device_open,
+	.release = &ds5_dfu_device_release
+};
+
+struct class *g_ds5_class;
+atomic_t primary_chardev = ATOMIC_INIT(0);
+
+static int ds5_chrdev_init(struct i2c_client *c, struct ds5 *state)
+{
+	struct cdev *ds5_cdev = &state->dfu_dev.ds5_cdev;
+	struct class **ds5_class = &state->dfu_dev.ds5_class;
+#ifndef CONFIG_OF
+	struct d4xx_pdata *pdata = c->dev.platform_data;
+	char suffix = pdata->suffix;
+#endif
+	struct device *chr_dev;
+	char dev_name[sizeof(DS5_DRIVER_NAME_DFU) + 8];
+	dev_t *dev_num = &c->dev.devt;
+	int ret;
+
+	dev_dbg(&c->dev, "%s()\n", __func__);
+	/* Request the kernel for N_MINOR devices */
+	ret = alloc_chrdev_region(dev_num, 0, 1, DS5_DRIVER_NAME_DFU);
+	if (ret < 0)
+		return ret;
+
+	if (!atomic_read(&primary_chardev)) {
+		dev_dbg(&c->dev, "%s(): <Major, Minor>: <%d, %d>\n",
+				__func__, MAJOR(*dev_num), MINOR(*dev_num));
+		/* Create a class : appears at /sys/class */
+#if defined(NV_CLASS_CREATE_HAS_NO_OWNER_ARG) || LINUX_VERSION_CODE < KERNEL_VERSION(6, 8, 0)
+		*ds5_class = class_create(THIS_MODULE, DS5_DRIVER_NAME_CLASS);
+#else
+		*ds5_class = class_create(DS5_DRIVER_NAME_CLASS);
+#endif
+		dev_warn(&state->client->dev, "%s() class_create\n", __func__);
+		if (IS_ERR(*ds5_class)) {
+			dev_err(&c->dev, "Could not create class device\n");
+			unregister_chrdev_region(0, 1);
+			ret = PTR_ERR(*ds5_class);
+			return ret;
+		}
+		g_ds5_class = *ds5_class;
+	} else
+		*ds5_class = g_ds5_class;
+	/* Associate the cdev with a set of file_operations */
+	cdev_init(ds5_cdev, &ds5_device_file_ops);
+	/* Build up the current device number. To be used further */
+	*dev_num = MKDEV(MAJOR(*dev_num), MINOR(*dev_num));
+	/* Create a device node for this device. */
+#ifndef CONFIG_OF
+	if (state->aggregated)
+		suffix += 4;
+	snprintf(dev_name, sizeof(dev_name), "%s-%c",
+		DS5_DRIVER_NAME_DFU, suffix);
+#else
+	snprintf (dev_name, sizeof(dev_name), "%s-%d-%04x",
+			DS5_DRIVER_NAME_DFU, i2c_adapter_id(c->adapter), c->addr);
+#endif
+	chr_dev = device_create(*ds5_class, NULL, *dev_num, NULL, dev_name);
+	if (IS_ERR(chr_dev)) {
+		ret = PTR_ERR(chr_dev);
+		dev_err(&c->dev, "Could not create device\n");
+		class_destroy(*ds5_class);
+		unregister_chrdev_region(0, 1);
+		return ret;
+	}
+	cdev_add(ds5_cdev, *dev_num, 1);
+	atomic_inc(&primary_chardev);
+	return 0;
+};
+
+static int ds5_chrdev_remove(struct ds5 *state)
+{
+	struct class **ds5_class = &state->dfu_dev.ds5_class;
+	dev_t *dev_num = &state->client->dev.devt;
+	if (!ds5_class) {
+		return 0;
+	}
+	dev_dbg(&state->client->dev, "%s()\n", __func__);
+	unregister_chrdev_region(*dev_num, 1);
+	device_destroy(*ds5_class, *dev_num);
+	if (atomic_dec_and_test(&primary_chardev)) {
+		dev_warn(&state->client->dev, "%s() class_destroy\n", __func__);
+		class_destroy(*ds5_class);
+	}
+	return 0;
+}
+
+/* SYSFS attributes */
+#ifdef CONFIG_SYSFS
+static ssize_t ds5_fw_ver_show(struct device *dev,
+		struct device_attribute *attr, char *buf)
+{
+	struct i2c_client *c = to_i2c_client(dev);
+	struct ds5 *state = container_of(i2c_get_clientdata(c),
+			struct ds5, mux.sd.subdev);
+
+	ds5_read(state, DS5_FW_VERSION, &state->fw_version);
+	ds5_read(state, DS5_FW_BUILD, &state->fw_build);
+
+	return snprintf(buf, PAGE_SIZE, "D4XX Sensor: %s, Version: %d.%d.%d.%d\n",
+			ds5_get_sensor_name(state),
+			(state->fw_version >> 8) & 0xff, state->fw_version & 0xff,
+			(state->fw_build >> 8) & 0xff, state->fw_build & 0xff);
+}
+
+static DEVICE_ATTR_RO(ds5_fw_ver);
+
+/* Derive 'device_attribute' structure for a read register's attribute */
+struct dev_ds5_reg_attribute {
+	struct device_attribute attr;
+	u16 reg;	// register
+	u8 valid;	// validity of above data
+};
+
+/** Read DS5 register.
+ * ds5_read_reg_show will actually read register from ds5 while
+ * ds5_read_reg_store will store register to read
+ * Example:
+ * echo -n "0xc03c" >ds5_read_reg
+ * Read register result:
+ * cat ds5_read_reg
+ * Expected:
+ * reg:0xc93c, result:0x11
+ */
+static ssize_t ds5_read_reg_show(struct device *dev,
+		struct device_attribute *attr, char *buf)
+{
+	u16 rbuf;
+	int n;
+	struct i2c_client *c = to_i2c_client(dev);
+	struct ds5 *state = container_of(i2c_get_clientdata(c),
+			struct ds5, mux.sd.subdev);
+	struct dev_ds5_reg_attribute *ds5_rw_attr = container_of(attr,
+			struct dev_ds5_reg_attribute, attr);
+	if (ds5_rw_attr->valid != 1)
+		return -EINVAL;
+	ds5_read(state, ds5_rw_attr->reg, &rbuf);
+
+	n = snprintf(buf, PAGE_SIZE, "register:0x%4x, value:0x%02x\n",
+			ds5_rw_attr->reg, rbuf);
+
+	return n;
+}
+
+/** Read DS5 register - Store reg to attr struct pointer
+ * ds5_read_reg_show will actually read register from ds5 while
+ * ds5_read_reg_store will store module, offset and length
+ */
+static ssize_t ds5_read_reg_store(struct device *dev,
+		struct device_attribute *attr, const char *buf, size_t count)
+{
+	struct dev_ds5_reg_attribute *ds5_rw_attr = container_of(attr,
+			struct dev_ds5_reg_attribute, attr);
+	int rc = -1;
+	u32 reg;
+	ds5_rw_attr->valid = 0;
+	/* Decode input */
+	rc = sscanf(buf, "0x%04x", &reg);
+	if (rc != 1)
+		return -EINVAL;
+	ds5_rw_attr->reg = reg;
+	ds5_rw_attr->valid = 1;
+	return count;
+}
+
+#define DS5_RW_REG_ATTR(_name) \
+		struct dev_ds5_reg_attribute dev_attr_##_name = { \
+			__ATTR(_name, S_IRUGO | S_IWUSR, \
+			ds5_read_reg_show, ds5_read_reg_store), \
+			0, 0 }
+
+static DS5_RW_REG_ATTR(ds5_read_reg);
+
+static ssize_t ds5_write_reg_store(struct device *dev,
+		struct device_attribute *attr, const char *buf, size_t count)
+{
+	struct i2c_client *c = to_i2c_client(dev);
+	struct ds5 *state = container_of(i2c_get_clientdata(c),
+			struct ds5, mux.sd.subdev);
+
+	int rc = -1;
+	u32 reg, w_val = 0;
+	u16 val = -1;
+	/* Decode input */
+	rc = sscanf(buf, "0x%04x 0x%04x", &reg, &w_val);
+	if (rc != 2)
+		return -EINVAL;
+	val = w_val & 0xffff;
+	mutex_lock(&state->lock);
+	ds5_write(state, reg, val);
+	mutex_unlock(&state->lock);
+	return count;
+}
+
+static DEVICE_ATTR_WO(ds5_write_reg);
+
+static struct attribute *ds5_attributes[] = {
+		&dev_attr_ds5_fw_ver.attr,
+		&dev_attr_ds5_read_reg.attr.attr,
+		&dev_attr_ds5_write_reg.attr,
+		NULL
+};
+
+static const struct attribute_group ds5_attr_group = {
+	.attrs = ds5_attributes,
+};
+#endif
+
+static int ds5_probe(struct i2c_client *c
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 3, 0)
+		, const struct i2c_device_id *id
+#endif
+		)
+{
+	struct ds5 *state = devm_kzalloc(&c->dev, sizeof(*state), GFP_KERNEL);
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 3, 0)
+	const struct i2c_device_id *id = i2c_client_get_device_id(c);
+#endif
+	u16 rec_state;
+	int ret, err = 0;
+#ifdef CONFIG_OF
+	const char *str;
+	uint32_t override_addr = 0;
+	struct device_node *mode0_node;
+#endif
+	if (!state)
+		return -ENOMEM;
+
+	mutex_init(&state->lock);
+
+	state->client = c;
+
+	dev_warn(&c->dev, "Probing driver for D5xx\n");
+#ifdef CONFIG_OF
+	ret = of_property_read_u32(c->dev.of_node, "override_reg", &override_addr);
+	if (!ret) {
+		// Override probed address
+		dev_dbg(&c->dev, "Using override addr 0x%x\n", override_addr);
+		c->addr = override_addr;
+	}
+#endif
+	state->variant = ds5_variants + id->driver_data;
+#ifdef CONFIG_OF
+	state->vcc = devm_regulator_get(&c->dev, "vcc");
+	if (IS_ERR(state->vcc)) {
+		ret = PTR_ERR(state->vcc);
+		dev_warn(&c->dev, "failed %d to get vcc regulator\n", ret);
+		return ret;
+	}
+
+	if (state->vcc) {
+		ret = regulator_enable(state->vcc);
+		if (ret < 0) {
+			dev_warn(&c->dev, "failed %d to enable the vcc regulator\n", ret);
+			return ret;
+		}
+	}
+#endif
+	state->regmap = devm_regmap_init_i2c(c, &ds5_regmap_config);
+	if (IS_ERR(state->regmap)) {
+		ret = PTR_ERR(state->regmap);
+		dev_err(&c->dev, "regmap init failed: %d\n", ret);
+		goto e_regulator;
+	}
+
+#ifdef CONFIG_VIDEO_D5XX_SERDES
+	ret = ds5_serdes_setup(state);
+	if (ret < 0)
+		goto e_regulator;
+	state->reset_ref_dser = atomic_read(dser_get_reset_gen(state));
+#else
+	ds5_init_global_slots_once();
+	mutex_lock(&ds5_inited[0].lock);
+	if (NULL == ds5_inited[0].ds5_primary) {
+		ds5_init_ds5_dev(state, &ds5_inited[0]);
+		dev_dbg(&c->dev, "%s(): set primary ds5 instance\n", __func__);
+	}
+	state->ds5_dev = &ds5_inited[0];
+	mutex_unlock(&ds5_inited[0].lock);
+#endif
+	state->reset_ref_ds5 = atomic_read(ds5_get_reset_gen(state));
+
+#ifdef DS5_BYPASS_CAMERA_I2C
+	/* Skip camera I2C verification - use hardcoded FW version */
+	state->fw_version = 0x0516;
+	dev_info(&c->dev, "%s(): BYPASS - skip camera I2C verify, fake FW 5.22\n", __func__);
+#else
+	// Verify communication
+	ret = ds5_read(state, DS5_FW_VERSION, &state->fw_version);
+	if (ret < 0) {
+		dev_err(&c->dev,
+			"%s(): cannot communicate with D4XX: %d on addr: 0x%x\n",
+			__func__, ret, c->addr);
+		goto e_regulator;
+	}
+#endif
+
+	state->is_depth = 0;
+	state->is_y8 = 0;
+	state->is_rgb = 0;
+	state->is_imu = 0;
+#ifdef CONFIG_OF
+	ret = of_property_read_string(c->dev.of_node, "cam-type", &str);
+	if (!ret && !strncmp(str, "Depth", strlen("Depth"))) {
+		state->is_depth = 1;
+		state->control_base = DS5_DEPTH_CONTROL_BASE;
+		state->control_status_reg = DS5_DEPTH_CONTROL_STATUS;
+	}
+	if (!ret && !strncmp(str, "Y8", strlen("Y8"))) {
+		state->is_y8 = 1;
+		state->control_base = DS5_DEPTH_CONTROL_BASE;
+		state->control_status_reg = DS5_DEPTH_CONTROL_STATUS;
+	}
+	if (!ret && !strncmp(str, "RGB", strlen("RGB"))) {
+		state->is_rgb = 1;
+		state->control_base = DS5_RGB_CONTROL_BASE;
+		state->control_status_reg = DS5_RGB_CONTROL_STATUS;
+	}
+	if (!ret && !strncmp(str, "IMU", strlen("IMU"))) {
+		state->is_imu = 1;
+		state->control_base = DS5_DEPTH_CONTROL_BASE;
+		state->control_status_reg = DS5_DEPTH_CONTROL_STATUS;
+	}
+
+	mode0_node = of_get_child_by_name(state->client->dev.of_node, "mode0");
+	if (mode0_node) {
+		ret = of_property_read_string(mode0_node, "embedded_metadata_height", &str);
+		if (!ret && !strncmp(str, "1", 1)) {
+				state->metadata_enabled = 1;
+		} else {
+				state->metadata_enabled = 0;
+		}
+		of_node_put(mode0_node);
+	} else {
+		dev_err(&state->client->dev, "No mode0 provided\n");
+		goto e_regulator;
+	}
+
+	if (ret < 0) {
+		dev_err(&state->client->dev, "No embedded_metadata_height provided\n");
+		goto e_regulator;
+	}
+	dev_dbg(&state->client->dev, "metadata_enabled = %d\n", state->metadata_enabled);
+#else
+	state->is_depth = 1;
+	state->control_base = DS5_DEPTH_CONTROL_BASE;
+	state->control_status_reg = DS5_DEPTH_CONTROL_STATUS;
+#endif
+
+	if (!state->control_base) {
+		state->control_base = DS5_DEPTH_CONTROL_BASE;
+		state->control_status_reg = DS5_DEPTH_CONTROL_STATUS;
+	}
+	/* create DFU chardev once */
+	if (state->is_depth) {
+		ret = ds5_chrdev_init(c, state);
+		if (ret < 0)
+			goto e_regulator;
+	}
+
+	/* Verify format-discovery readiness.
+	 * FW_VERSION becomes readable earlier than DS5_DEVICE_TYPE, while later
+	 * probe code depends on DEVICE_TYPE to pick the correct format tables.
+	 */
+#ifdef DS5_BYPASS_CAMERA_I2C
+	rec_state = DS5_DEVICE_TYPE_D58X;
+	WRITE_ONCE(state->ds5_dev->cached_device_type, rec_state);
+	dev_info(&c->dev, "%s(): BYPASS - hardcode device type D58X\n", __func__);
+#else
+	ret = ds5_wait_device_type(state, &rec_state);
+	if (ret < 0) {
+		dev_err(&c->dev,
+			"%s(): device type is not valid: %d (last val 0x%x)\n",
+			__func__, ret, rec_state);
+		goto e_chardev;
+	}
+
+	ret = ds5_read(state, DS5_DFU_MAGIC_REG, &rec_state);
+	if (ret < 0)
+		rec_state = 0;
+
+	if (rec_state == DS5_DFU_MAGIC_LSW) {
+		dev_info(&c->dev, "%s(): D4XX recovery state\n", __func__);
+		state->dfu_dev.dfu_state_flag = DS5_DFU_RECOVERY;
+		/* Override I2C drvdata with state for use in remove function */
+		i2c_set_clientdata(c, state);
+		return 0;
+	}
+#endif
+
+#ifdef DS5_BYPASS_CAMERA_I2C
+	state->fw_build = 0x0100;
+#else
+	ds5_read_with_check(state, DS5_FW_VERSION, &state->fw_version);
+	ds5_read_with_check(state, DS5_FW_BUILD, &state->fw_build);
+#endif
+
+	dev_info(&c->dev, "D4XX Sensor: %s, firmware build: %d.%d.%d.%d\n",
+			ds5_get_sensor_name(state),
+			(state->fw_version >> 8) & 0xff, state->fw_version & 0xff,
+			(state->fw_build >> 8) & 0xff, state->fw_build & 0xff);
+
+	ret = ds5_v4l_init(c, state);
+	if (ret < 0)
+		goto e_chardev;
+
+	dev_info(&c->dev, "%s: driver version: %s\n", __func__,
+		THIS_MODULE->version ? THIS_MODULE->version : "N/A");
+
+#ifdef CONFIG_SYSFS
+	/* Custom sysfs attributes */
+	/* create the sysfs file group */
+	err = sysfs_create_group(&state->client->dev.kobj, &ds5_attr_group);
+#endif
+	return 0;
+
+e_chardev:
+	if (state->dfu_dev.ds5_class)
+		ds5_chrdev_remove(state);
+e_regulator:
+	if (state->vcc)
+		regulator_disable(state->vcc);
+#ifdef CONFIG_VIDEO_D5XX_SERDES
+#ifndef CONFIG_OF
+	if (state->ser_i2c)
+		i2c_unregister_device(state->ser_i2c);
+	if (state->dser_i2c && !state->aggregated)
+		i2c_unregister_device(state->dser_i2c);
+#endif
+#endif
+	return ret;
+}
+
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 8, 12)
+static int ds5_remove(struct i2c_client *c)
+#else
+static void ds5_remove(struct i2c_client *c)
+#endif
+{
+	struct ds5 *state = container_of(i2c_get_clientdata(c), struct ds5, mux.sd.subdev);
+	if (state && !state->mux.sd.subdev.v4l2_dev) {
+		state = i2c_get_clientdata(c);
+	}
+
+#ifdef CONFIG_VIDEO_D5XX_SERDES
+	if (state->serdes_primary) {
+		int ret;
+		bool do_cleanup = false;
+
+		mutex_lock(&serdes_lock__);
+		mutex_lock(&state->ds5_dev->lock);
+
+		if (state->ds5_dev->ds5_primary) {
+			state->ds5_dev->ds5_primary = NULL;
+			do_cleanup = true;
+		}
+
+		mutex_unlock(&state->ds5_dev->lock);
+
+		if (do_cleanup) {
+			ret = max96717_reset_control(state->ser_dev);
+			if (ret)
+				dev_warn(&c->dev,
+					"failed in 96717 reset control\n");
+			ret = state->dser_ops->reset_control(state->dser_dev,
+				state->g_ctx.s_dev);
+			if (ret)
+				dev_warn(&c->dev,
+					"failed in %s reset control\n", state->dser_ops->name);
+			ret = max96717_sdev_unpair(state->ser_dev,
+				state->g_ctx.s_dev);
+			if (ret)
+				dev_warn(&c->dev, "failed to unpair sdev\n");
+			ret = state->dser_ops->sdev_unregister(state->dser_dev,
+				state->g_ctx.s_dev);
+			if (ret)
+				dev_warn(&c->dev,
+					"failed to %s unregister sdev\n", state->dser_ops->name);
+			state->dser_ops->power_off(state->dser_dev);
+		}
+
+		mutex_unlock(&serdes_lock__);
+
+	}
+#ifndef CONFIG_OF
+	if (state->ser_i2c)
+		i2c_unregister_device(state->ser_i2c);
+	if (state->dser_i2c && !state->aggregated)
+		i2c_unregister_device(state->dser_i2c);
+#endif
+#endif /* CONFIG_VIDEO_D5XX_SERDES */
+#ifndef CONFIG_TEGRA_CAMERA_PLATFORM
+	state->is_depth = 1;
+#endif
+	dev_info(&c->dev, "D4XX remove %s\n",
+			ds5_get_sensor_name(state));
+	if (state->vcc)
+		regulator_disable(state->vcc);
+
+	if (state->dfu_dev.dfu_state_flag != DS5_DFU_RECOVERY && \
+		 state->mux.sd.subdev.v4l2_dev) {
+#ifdef CONFIG_SYSFS
+		sysfs_remove_group(&c->dev.kobj, &ds5_attr_group);
+#endif
+		ds5_mux_remove(state);
+	}
+
+	if (state->is_depth && state->dfu_dev.ds5_class) {
+		ds5_chrdev_remove(state);
+	}
+
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 8, 12)
+	return 0;
+#endif
+}
+
+static const struct i2c_device_id ds5_id[] = {
+	{ DS5_DRIVER_NAME, DS5_DS5U },
+	{ DS5_DRIVER_NAME_ASR, DS5_ASR },
+	{ DS5_DRIVER_NAME_AWG, DS5_AWG },
+	{ },
+};
+MODULE_DEVICE_TABLE(i2c, ds5_id);
+
+static const struct of_device_id d5xx_of_match[] = {
+	{ .compatible = "realsense,d5xx", },
+	{ },
+};
+MODULE_DEVICE_TABLE(of, d5xx_of_match);
+
+static struct i2c_driver ds5_i2c_driver = {
+	.driver = {
+		.owner = THIS_MODULE,
+		.of_match_table = of_match_ptr(d5xx_of_match),
+		.name = DS5_DRIVER_NAME
+	},
+	.probe		= ds5_probe,
+	.remove		= ds5_remove,
+	.id_table	= ds5_id,
+};
+
+module_i2c_driver(ds5_i2c_driver);
+
+MODULE_DESCRIPTION("RealSense D5XX Camera Driver");
+MODULE_AUTHOR("Pinquan Wang <pinquan.wang@realsenseai.com>,\n\
+				Gang Hu <gang.a.hu@realsenseai.com>,\n\
+				Shengyong Zhou <shengyong.zhou@realsenseai.com>,\n\
+				Shuai Liu <shuai2.liu@realsenseai.com>");
+MODULE_LICENSE("GPL v2");
+MODULE_VERSION("1.0.3.9");

--- a/nvidia-oot/6.0/0011-Add-MAX96717-serializer-and-MAX96724-deserializer-dr.patch
+++ b/nvidia-oot/6.0/0011-Add-MAX96717-serializer-and-MAX96724-deserializer-dr.patch
@@ -1,0 +1,2896 @@
+From 40fac9b67ddea60055961d32fa89fe8f608396ff Mon Sep 17 00:00:00 2001
+From: RealSense AI <realsense@realsenseai.com>
+Date: Tue, 12 May 2026 17:06:23 +0800
+Subject: [PATCH] Add MAX96717 serializer and MAX96724 deserializer drivers for
+ tunnel mode
+
+Add MAX96717 GMSL2 serializer and MAX96724 GMSL2 quad deserializer
+drivers for Tunnel Mode operation with D5xx cameras.
+
+MAX96717 serializer features:
+- CSI-2 input with 2/4 lane support
+- Tunnel Mode encapsulation of full CSI-2 byte stream
+- I2C address translation for sensor passthrough
+- GPIO-over-GMSL tunneling hook for FSIN/FOUT signals
+
+MAX96724 quad deserializer features:
+- Up to 4 GMSL2 links (quad camera support)
+- Configurable link speed (3 Gbps / 6 Gbps via DT)
+- Tunnel Mode pipe routing and CSI-2 output
+- 2x4 and 4x2 CSI output mode support
+- Power management with GPIO reset and regulator control
+
+Signed-off-by: RealSense AI <realsense@realsenseai.com>
+---
+ drivers/media/i2c/Makefile   |    2 +
+ drivers/media/i2c/max96717.c |  797 ++++++++++++++++
+ drivers/media/i2c/max96724.c | 1690 ++++++++++++++++++++++++++++++++++
+ include/media/max96717.h     |  151 +++
+ include/media/max96724.h     |  183 +++
+ 5 files changed, 2823 insertions(+)
+ create mode 100644 drivers/media/i2c/max96717.c
+ create mode 100644 drivers/media/i2c/max96724.c
+ create mode 100644 include/media/max96717.h
+ create mode 100644 include/media/max96724.h
+
+diff --git a/drivers/media/i2c/Makefile b/drivers/media/i2c/Makefile
+index b284938..947e6e9 100644
+--- a/drivers/media/i2c/Makefile
++++ b/drivers/media/i2c/Makefile
+@@ -8,6 +8,8 @@ obj-m += max9296.o
+ subdir-ccflags-y += -DCONFIG_VIDEO_D4XX_SERDES
+ subdir-ccflags-y += -DCONFIG_TEGRA_CAMERA_PLATFORM
+ obj-m += d4xx.o
++obj-m += max96717.o
++obj-m += max96724.o
+ ifeq ($(findstring ack_src,$(NV_BUILD_KERNEL_OPTIONS)),)
+ obj-m += max96712.o
+ 
+diff --git a/drivers/media/i2c/max96717.c b/drivers/media/i2c/max96717.c
+new file mode 100644
+index 0000000..78d8a01
+--- /dev/null
++++ b/drivers/media/i2c/max96717.c
+@@ -0,0 +1,797 @@
++/*
++ * max96717.c - MAX96717 GMSL2 Serializer driver (Tunnel Mode)
++ *
++ * Copyright (c) 2026, RealSense, Inc.  All rights reserved.
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms and conditions of the GNU General Public License,
++ * version 2, as published by the Free Software Foundation.
++ *
++ * This program is distributed in the hope it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
++ * more details.
++ *
++ * You should have received a copy of the GNU General Public License
++ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
++ */
++
++/*
++ * Register Reference Sources:
++ * [PPTX]  = GMSL_MAX96717_MAX96724_TechOverview - V1.pptx
++ * [XML]   = MAX96717_MAX96724_HKR_EVB_700mbps_tunnel_mode_basedonexcelsheet_D585.xml
++ *
++ * Every register address and value below is traceable to one of these sources.
++ */
++
++#include <media/camera_common.h>
++#include <linux/module.h>
++#include <media/max96717.h>
++
++/* ===== Register Addresses ===== */
++
++/* [PPTX slide 7] REG0: Device ID (read-only, returns 0x40) */
++#define MAX96717_DEV_ADDR		0x00
++
++/* [PPTX slide 7] REG1: Link Speed
++ *   bit[3]=1: 3 Gbps, bit[4]=1: 6 Gbps
++ */
++#define MAX96717_REG1_ADDR		0x01
++
++/* [PPTX slide 7 / XML 0x0002] PIPE_EN: Pipe enable / soft reset
++ *   [XML] 0x03 = soft reset, 0x43 = pipes enabled + video init
++ *   [PPTX slide 7] Matches MAX9295 PIPE_EN at 0x02
++ */
++#define MAX96717_PIPE_EN_ADDR		0x02
++
++/* [PPTX slide 7] CTRL0: GMSL2 TX Control
++ *   bit[5]=1: GMSL2 mode, bit[0]=1: enable transmitter
++ *   0x21 = GMSL2 mode + TX enable on Link A
++ */
++#define MAX96717_CTRL0_ADDR		0x10
++
++/* [PPTX slide 7] CTRL3: Start Video - final enable bit
++ *   bit[0]=1: activate video stream
++ */
++#define MAX96717_CTRL3_ADDR		0x13
++
++/* [PPTX slide 7] TX1: FEC Enable
++ *   bit[6]=1: Reed-Solomon FEC enabled
++ */
++#define MAX96717_TX1_ADDR		0x29
++
++/* [MAX96724 Users Guide, I2C Broadcasting section, p44-46]
++ * MAX96717 I2C address translation registers (GMSL2 standard):
++ *   SRC_A / DST_A (0x42/0x43): Translation pair A (SER broadcast addr)
++ *   SRC_B / DST_B (0x44/0x45): Translation pair B (sensor passthrough)
++ *
++ * When host writes to SRC_B address, the MAX96717 translates it to
++ * DST_B and forwards via GMSL back-channel to the remote sensor.
++ *
++ */
++#define MAX96717_SRC_A_ADDR		0x42
++#define MAX96717_DST_A_ADDR		0x43
++#define MAX96717_I2C4_ADDR		0x44	/* SRC_B: sensor proxy addr */
++#define MAX96717_I2C5_ADDR		0x45	/* DST_B: sensor default addr */
++
++/* [PPTX slide 14] TX_STR_SEL: Stream ID select
++ *   bits[1:0]: stream ID for DES pipe routing
++ */
++#define MAX96717_TX_STR_SEL_ADDR	0x5B
++
++/* [PPTX slide 7 / XML 0x0110-0x0111] VIDEO_TX0/TX1: Video TX path config
++ *   [XML] 0x0110=0xE9, 0x0111=0x10 for tunnel mode data path
++ */
++#define MAX96717_VIDEO_TX0_ADDR		0x110
++#define MAX96717_VIDEO_TX1_ADDR		0x111
++
++/* [PPTX slide 7] FRONTTOP_0: Front-end topology
++ *   0x12 = single CSI-2 port A, all VCs pass through
++ */
++#define MAX96717_FRONTTOP0_ADDR		0x308
++
++/* [XML / PPTX slide 7] MIPI_RX0-RX3: CSI-2 receiver configuration
++ *   RX0 (0x330): CSI mode (0x00 = D-PHY controller A)
++ *   RX1 (0x331): Lane count - [PPTX slide 14] ctrl1_num_lanes bits[5:4]
++ *                 [XML] 0x30 = bits[5:4]=11 (4 lanes)
++ *   RX2 (0x332): Lane mapping - [XML] 0xE0 = default 1x4 map
++ *   RX3 (0x333): Lane mapping - [XML] 0x04 = default 1x4 map
++ */
++#define MAX96717_MIPI_RX0_ADDR		0x330
++#define MAX96717_MIPI_RX1_ADDR		0x331
++#define MAX96717_MIPI_RX2_ADDR		0x332
++#define MAX96717_MIPI_RX3_ADDR		0x333
++
++/* [PPTX slide 7 / slide 14] EXT11: TUNNEL MODE ENABLE
++ *   bit[7]=1: Tun_Mode = ON  *** CRITICAL REGISTER ***
++ *   [PPTX slide 7] 0x383 = 0x80
++ */
++#define MAX96717_EXT11_ADDR		0x383
++
++/* ===== Register Values ===== */
++
++/* [XML] Soft reset value for PIPE_EN register */
++#define MAX96717_SOFT_RESET		0x03
++
++/* [XML] Final enable: pipes enabled + video init */
++#define MAX96717_PIPE_EN_ALL		0x43
++
++/* [PPTX slide 7] CTRL0: GMSL2 mode + TX enable (Link A) */
++#define MAX96717_CTRL0_LINK_A		0x21
++/* CTRL0: GMSL2 mode + TX enable (Link B) */
++#define MAX96717_CTRL0_LINK_B		0x22
++
++/* [PPTX slide 7] CTRL0 reset all */
++#define MAX96717_RESET_ALL		0x80
++
++/* [PPTX slide 7] EXT11 tunnel mode enable value */
++#define MAX96717_TUN_MODE_EN		0x80
++
++/* [XML] VIDEO_TX0 tunnel mode data path enable */
++#define MAX96717_VIDEO_TX0_TUN		0xE9
++/* [XML] VIDEO_TX1 tunnel mode config */
++#define MAX96717_VIDEO_TX1_TUN		0x10
++
++/* [XML / PPTX slide 14] MIPI RX1: 4-lane CSI-2, bits[5:4]=11 */
++#define MAX96717_CSI_4_LANES		0x30
++/* 2-lane CSI-2, bits[5:4]=01 */
++#define MAX96717_CSI_2_LANES		0x10
++
++/* [XML] Lane mapping for 1x4 mode (matches MAX9295 1x4 values) */
++#define MAX96717_CSI_1X4_LANE_MAP1	0xE0
++#define MAX96717_CSI_1X4_LANE_MAP2	0x04
++
++/* [PPTX slide 7] FRONTTOP_0: single port A, all VCs */
++#define MAX96717_FRONTTOP0_PORT_A	0x12
++
++/* [XML] MIPI_RX0: CSI reset on + non-continuous clock */
++#define MAX96717_MIPI_RX0_RESET		0x08
++/* [PPTX slide 7] MIPI_RX0: Normal operation */
++#define MAX96717_MIPI_RX0_NORMAL	0x00
++
++/* [PPTX slide 9] REG1: 3 Gbps link speed, bit[3]=1 */
++#define MAX96717_LINK_SPEED_3GBPS	0x08
++/* [PPTX slide 9] REG1: 6 Gbps link speed, bit[4]=1 */
++#define MAX96717_LINK_SPEED_6GBPS	0x10
++
++/* [XML] EXT11 tunnel mode pre-config (0x0383=0x80) */
++#define MAX96717_EXT11_TUN_PRE		0x80
++
++#define MAX96717_MAX_PIPES		4
++
++/* ===== Data Structures ===== */
++
++struct max96717_client_ctx {
++	struct gmsl_link_ctx *g_ctx;
++	bool st_done;
++};
++
++struct max96717 {
++	struct i2c_client *i2c_client;
++	struct regmap *regmap;
++	struct max96717_client_ctx g_client;
++	struct mutex lock;
++	/* primary serializer properties */
++	__u32 def_addr;
++	__u32 pst2_ref;
++};
++
++static struct max96717 *prim_priv__;
++
++struct reg_pair {
++	u16 addr;
++	u8 val;
++};
++
++/* ===== Low-level I2C ===== */
++
++static int max96717_write_reg(struct device *dev, u16 addr, u8 val)
++{
++	struct max96717 *priv = dev_get_drvdata(dev);
++	int err;
++
++	err = regmap_write(priv->regmap, addr, val);
++	if (err)
++		dev_err(dev, "%s:i2c write failed, 0x%x = %x\n",
++			__func__, addr, val);
++
++	/* delay before next i2c command as required for SERDES link */
++	usleep_range(100, 110);
++
++	return err;
++}
++
++static int max96717_set_registers(struct device *dev, struct reg_pair *map,
++				  u32 count)
++{
++	int err = 0;
++	u32 j;
++
++	for (j = 0; j < count; j++) {
++		err = max96717_write_reg(dev, map[j].addr, map[j].val);
++		if (err)
++			break;
++	}
++
++	return err;
++}
++
++/* ===== Streaming Setup ===== */
++
++/*
++ * max96717_setup_streaming - Configure CSI-2 input and enable Tunnel Mode
++ *
++ * In Tunnel Mode (unlike MAX9295 Pixel Mode), the serializer encapsulates
++ * the entire CSI-2 byte stream verbatim into a single GMSL2 tunnel.
++ * All VCs (VC0-VC3) are preserved end-to-end.
++ */
++int max96717_setup_streaming(struct device *dev)
++{
++	struct max96717 *priv = dev_get_drvdata(dev);
++	int err = 0;
++	struct gmsl_link_ctx *g_ctx;
++	u32 lane_count;
++
++	/*
++	 * [XML] Full initialization sequence:
++	 *   0x0002 = 0x03  (soft reset)
++	 *   0x0383 = 0x80  (tunnel mode enable)
++	 *   0x0331 = 0x30  (4-lane CSI)
++	 *   0x0332 = 0xE0  (lane map1)
++	 *   0x0333 = 0x04  (lane map2)
++	 *   0x0110 = 0xE9  (video TX0 tunnel path)
++	 *   0x0111 = 0x10  (video TX1 tunnel config)
++	 *   0x0330 = 0x08  (CSI reset on)
++	 *   0x0330 = 0x00  (CSI reset off)
++	 *   0x0002 = 0x43  (final enable)
++	 */
++	struct reg_pair tunnel_init[] = {
++		/* [PPTX slide 7] EXT11: Tunnel Mode Enable */
++		{MAX96717_EXT11_ADDR, MAX96717_TUN_MODE_EN},
++		/* [XML] VIDEO_TX0/TX1: tunnel data path */
++		{MAX96717_VIDEO_TX0_ADDR, MAX96717_VIDEO_TX0_TUN},
++		{MAX96717_VIDEO_TX1_ADDR, MAX96717_VIDEO_TX1_TUN},
++	};
++
++	mutex_lock(&priv->lock);
++
++	if (!priv->g_client.g_ctx) {
++		dev_err(dev, "%s: no sdev client found\n", __func__);
++		err = -EINVAL;
++		goto error;
++	}
++
++	if (priv->g_client.st_done) {
++		dev_dbg(dev, "%s: stream setup is already done\n", __func__);
++		goto error;
++	}
++
++	g_ctx = priv->g_client.g_ctx;
++
++	/*
++	 * [Aardvark-verified] Soft reset before tunnel mode configuration
++	 * Clears stale pipe/CSI state for clean initialization.
++	 * Aardvark: 0x0002=0x03, sleep 30ms, then proceed with config.
++	 */
++	max96717_write_reg(dev, MAX96717_PIPE_EN_ADDR, MAX96717_SOFT_RESET);
++	msleep(30);
++
++	/*
++	 * [PPTX slide 14] ctrl1_num_lanes at 0x0331 bits[5:4]
++	 * [XML] 0x0331 = 0x30 for 4-lane
++	 * MAX96717 supports 1x4 mode only (single 4-lane D-PHY input)
++	 */
++	lane_count = (g_ctx->num_csi_lanes == 4) ?
++		MAX96717_CSI_4_LANES : MAX96717_CSI_2_LANES;
++
++	max96717_write_reg(dev, MAX96717_MIPI_RX1_ADDR, lane_count);
++
++	/* [XML] Lane mapping: 1x4 mode default */
++	max96717_write_reg(dev, MAX96717_MIPI_RX2_ADDR,
++			   MAX96717_CSI_1X4_LANE_MAP1);
++	max96717_write_reg(dev, MAX96717_MIPI_RX3_ADDR,
++			   MAX96717_CSI_1X4_LANE_MAP2);
++
++	/* Enable tunnel mode and configure video TX path */
++	err = max96717_set_registers(dev, tunnel_init,
++				     ARRAY_SIZE(tunnel_init));
++	if (err)
++		goto error;
++
++	/* [Aardvark-verified] CSI reset cycle with 2ms delay */
++	max96717_write_reg(dev, MAX96717_MIPI_RX0_ADDR,
++			   MAX96717_MIPI_RX0_RESET);
++	usleep_range(2000, 2100);
++	max96717_write_reg(dev, MAX96717_MIPI_RX0_ADDR,
++			   MAX96717_MIPI_RX0_NORMAL);
++
++	/* [XML] Final enable: pipes on + video init */
++	max96717_write_reg(dev, MAX96717_PIPE_EN_ADDR,
++			   MAX96717_PIPE_EN_ALL);
++
++	priv->g_client.st_done = true;
++
++error:
++	mutex_unlock(&priv->lock);
++	return err;
++}
++EXPORT_SYMBOL(max96717_setup_streaming);
++
++/* ===== Control Setup ===== */
++
++/*
++ * max96717_setup_control - Set up I2C address translation and link control
++ *
++ * Steps:
++ *   1. Reassign serializer I2C address via DEV_ADDR (reg 0x00)
++ *   2. Configure GMSL2 link mode via CTRL0 (reg 0x10)
++ *   3. Set I2C address translation for sensor passthrough:
++ *      I2C4/SRC_B (0x44) <- (sdev_reg << 1): proxy addr visible to host
++ *      I2C5/DST_B (0x45) <- (sdev_def << 1): real addr on back-channel
++ *
++ * This lets the Orin host access the D5xx sensor (def-addr 0x42) via
++ * the aliased proxy address (e.g. 0x1a) through the GMSL link.
++ *
++ */
++int max96717_setup_control(struct device *dev)
++{
++	struct max96717 *priv = dev_get_drvdata(dev);
++	int err = 0;
++	struct gmsl_link_ctx *g_ctx;
++
++	mutex_lock(&priv->lock);
++
++	if (!priv->g_client.g_ctx) {
++		dev_err(dev, "%s: no sensor dev client found\n", __func__);
++		err = -EINVAL;
++		goto error;
++	}
++
++	g_ctx = priv->g_client.g_ctx;
++
++	if (prim_priv__) {
++		/*
++		 * [HW note] The MAX96717 retains its I2C address across
++		 * reboots (PoC stays on).  If already at the aliased address,
++		 * the DEV_ADDR write to 0x40 NACKs.  Skip reassignment when
++		 * the primary and alias are the same physical device and the
++		 * serializer is already responsive at a non-default address.
++		 *
++		 * For cold-start (first power-on), this write is required.
++		 * We detect "already reassigned" by trying a read first:
++		 * if the primary address (0x40) NACKs, skip the reassign.
++		 */
++		unsigned int dev_id;
++		int probe_ret;
++
++		probe_ret = regmap_read(prim_priv__->regmap,
++					MAX96717_DEV_ADDR, &dev_id);
++		if (probe_ret == 0) {
++			/* Primary address (0x40) still responsive — do reassign */
++			max96717_write_reg(&prim_priv__->i2c_client->dev,
++					   MAX96717_DEV_ADDR,
++					   (g_ctx->ser_reg << 1));
++		} else {
++			dev_info(&prim_priv__->i2c_client->dev,
++				 "%s: SER already reassigned (addr 0x40 NACK), skipping DEV_ADDR write\n",
++				 __func__);
++		}
++	}
++
++	/* [PPTX slide 7] CTRL0: GMSL2 mode + TX enable */
++	if (g_ctx->serdes_csi_link == GMSL_SERDES_CSI_LINK_A)
++		err = max96717_write_reg(dev, MAX96717_CTRL0_ADDR,
++					 MAX96717_CTRL0_LINK_A);
++	else
++		err = max96717_write_reg(dev, MAX96717_CTRL0_ADDR,
++					 MAX96717_CTRL0_LINK_B);
++
++	if (err) {
++		dev_err(dev, "%s: ERROR: ser device not found\n", __func__);
++		goto error;
++	}
++
++	/* delay to settle link */
++	msleep(100);
++
++	/*
++	 * I2C address translation for sensor passthrough.
++	 * [MAX96724 Users Guide, I2C Broadcasting, p44-46]
++	 *
++	 * I2C4 / SRC_B (0x44): sensor proxy addr visible to Orin host
++	 * I2C5 / DST_B (0x45): sensor real addr on GMSL back-channel
++	 *
++	 * When host sends I2C to sdev_reg (e.g., 0x1a), the MAX96717
++	 * translates it to sdev_def (e.g., 0x42) and forwards via GMSL
++	 * back-channel to the HKR sensor.
++	 */
++	max96717_write_reg(dev, MAX96717_I2C4_ADDR,
++			   (g_ctx->sdev_reg << 1));
++	max96717_write_reg(dev, MAX96717_I2C5_ADDR,
++			   (g_ctx->sdev_def << 1));
++
++	/* dev addr pass-through ref */
++	if (prim_priv__)
++		prim_priv__->pst2_ref++;
++
++	g_ctx->serdev_found = true;
++
++error:
++	mutex_unlock(&priv->lock);
++	return err;
++}
++EXPORT_SYMBOL(max96717_setup_control);
++
++/* ===== GPIO Tunneling ===== */
++
++/*
++ * max96717_setup_gpio_tunneling - GPIO-over-GMSL no-op hook
++ *
++ * [PPTX slide 10] GPIO Signal Mapping:
++ *   MFP0 → GPIO0: FSIN (DES→SER, frame sync in)
++ *   MFP1 → GPIO1: FOUT/STROBE (SER→DES, frame sync out)
++ *   MFP4 → GPIO4: RESET_N (DES→SER, hard reset)
++ *   MFP5 → GPIO5: IRQ (SER→DES, interrupt request)
++ *   MFP6 → GPIO6: ZV_SYNC (DES→SER, IR stereo sync)
++ *
++ * The PPTX defines the signal mapping and MFP_CFG register range,
++ * but not the confirmed direction/function values. Keep this as
++ * an explicit no-op hook until the MAX96717 GPIO register values
++ * are available from ADI.
++ */
++int max96717_setup_gpio_tunneling(struct device *dev)
++{
++	struct max96717 *priv = dev_get_drvdata(dev);
++	int err = 0;
++
++	mutex_lock(&priv->lock);
++
++	dev_info(dev, "%s: GPIO tunneling hook is a no-op; MFP_CFG values are not defined yet\n",
++		 __func__);
++
++	mutex_unlock(&priv->lock);
++
++	return err;
++}
++EXPORT_SYMBOL(max96717_setup_gpio_tunneling);
++
++/* ===== Reset Control ===== */
++
++int max96717_reset_control(struct device *dev)
++{
++	struct max96717 *priv = dev_get_drvdata(dev);
++	int err = 0;
++
++	mutex_lock(&priv->lock);
++	if (!priv->g_client.g_ctx) {
++		dev_err(dev, "%s: no sdev client found\n", __func__);
++		err = -EINVAL;
++		goto error;
++	}
++
++	priv->g_client.st_done = false;
++
++	if (prim_priv__) {
++		prim_priv__->pst2_ref--;
++
++		max96717_write_reg(dev, MAX96717_DEV_ADDR,
++				   (prim_priv__->def_addr << 1));
++		if (prim_priv__->pst2_ref == 0)
++			max96717_write_reg(&prim_priv__->i2c_client->dev,
++					   MAX96717_CTRL0_ADDR,
++					   MAX96717_RESET_ALL);
++	}
++
++error:
++	mutex_unlock(&priv->lock);
++	return err;
++}
++EXPORT_SYMBOL(max96717_reset_control);
++
++/* ===== Device Pairing ===== */
++
++int max96717_sdev_pair(struct device *dev, struct gmsl_link_ctx *g_ctx)
++{
++	struct max96717 *priv;
++	int err = 0;
++
++	if (!dev || !g_ctx || !g_ctx->s_dev) {
++		dev_err(dev, "%s: invalid input params\n", __func__);
++		return -EINVAL;
++	}
++
++	priv = dev_get_drvdata(dev);
++	mutex_lock(&priv->lock);
++	if (priv->g_client.g_ctx) {
++		/* Already paired — tolerate if this is a re-probe of
++		 * the same camera after a failed first attempt.
++		 * Simply overwrite with the new g_ctx.
++		 */
++		dev_warn(dev, "%s: re-pairing (previous probe may have failed)\n",
++			 __func__);
++	}
++
++	priv->g_client.st_done = false;
++	priv->g_client.g_ctx = g_ctx;
++
++	/* mutex_unlock in error path, but we have none — inline the unlock */
++	mutex_unlock(&priv->lock);
++	return err;
++}
++EXPORT_SYMBOL(max96717_sdev_pair);
++
++int max96717_sdev_unpair(struct device *dev, struct device *s_dev)
++{
++	struct max96717 *priv = NULL;
++	int err = 0;
++
++	if (!dev || !s_dev) {
++		dev_err(dev, "%s: invalid input params\n", __func__);
++		return -EINVAL;
++	}
++
++	priv = dev_get_drvdata(dev);
++
++	mutex_lock(&priv->lock);
++
++	if (!priv->g_client.g_ctx) {
++		dev_dbg(dev, "%s: device is not paired\n", __func__);
++		err = 0; /* Not an error — already unpaired */
++		goto error;
++	}
++
++	if (priv->g_client.g_ctx->s_dev != s_dev) {
++		dev_warn(dev, "%s: s_dev mismatch, clearing anyway\n", __func__);
++	}
++
++	priv->g_client.g_ctx = NULL;
++	priv->g_client.st_done = false;
++
++error:
++	mutex_unlock(&priv->lock);
++	return err;
++}
++EXPORT_SYMBOL(max96717_sdev_unpair);
++
++/* ===== Pipe Configuration ===== */
++
++/*
++ * __max96717_set_pipe - Configure a single pipe's DT/VC mapping
++ *
++ * In Tunnel Mode, per-pipe DT/VC filtering is bypassed on the serializer。
++ * However, we still write the registers for d4xx framework compatibility.
++ *
++ */
++static int __max96717_set_pipe(struct device *dev, int pipe_id, u8 data_type1,
++			       u8 data_type2, u32 vc_id)
++{
++	int err = 0;
++	u8 bpp = 0x30;
++
++	struct reg_pair map_pipe_control[] = {
++		/* Pipe X DT addr + 0x2*pipe_id */
++		{0x0314, 0x5E},  /* data_type1 */
++		{0x0315, 0x52},  /* data_type2 */
++		{0x0309, 0x01},  /* VC select */
++		{0x030A, 0x00},
++		{0x031C, 0x30},  /* BPP */
++		{0x0102, 0x0E},  /* LIM_HEART: Disabled */
++	};
++
++	if (data_type1 == GMSL_CSI_DT_RGB_888)
++		bpp = 0x18;
++
++	map_pipe_control[0].addr += 0x2 * pipe_id;
++	map_pipe_control[1].addr += 0x2 * pipe_id;
++	map_pipe_control[2].addr += 0x2 * pipe_id;
++	map_pipe_control[3].addr += 0x2 * pipe_id;
++	map_pipe_control[4].addr += 0x1 * pipe_id;
++	map_pipe_control[5].addr += 0x8 * pipe_id;
++
++	map_pipe_control[0].val = 0x40 | data_type1;
++	map_pipe_control[1].val = 0x40 | data_type2;
++	if (pipe_id == 0)
++		map_pipe_control[1].val |= 0x80;
++	map_pipe_control[2].val = 1 << vc_id;
++	map_pipe_control[3].val = 0x00;
++	map_pipe_control[4].val = bpp;
++	map_pipe_control[5].val = 0x0E;
++
++	err = max96717_set_registers(dev, map_pipe_control,
++				     ARRAY_SIZE(map_pipe_control));
++
++	return err;
++}
++
++/*
++ * max96717_init_settings - Initialize default pipe/streaming settings
++ *
++ * In Tunnel Mode, per-pipe DT config is not functionally needed
++ * but we configure pipes for d4xx compatibility.
++ * Default: 4 pipes with YUV422_8 + EMBED, VC0-3.
++ */
++int max96717_init_settings(struct device *dev)
++{
++	int err = 0;
++	int i;
++	struct max96717 *priv = dev_get_drvdata(dev);
++
++	struct reg_pair map_init[] = {
++		/* [XML seq] PIPE_EN soft reset first, then enable tunnel mode.
++		 * Note: FRONTTOP0 is bypassed in tunnel mode (per UG) —
++		 * CSI-2 input goes directly into the tunnel, no port config needed.
++		 */
++		{MAX96717_PIPE_EN_ADDR, MAX96717_SOFT_RESET},
++		{MAX96717_EXT11_ADDR, MAX96717_TUN_MODE_EN},
++		{MAX96717_PIPE_EN_ADDR, 0xF3},
++		{MAX96717_MIPI_RX1_ADDR, MAX96717_CSI_4_LANES},
++	};
++
++	mutex_lock(&priv->lock);
++
++	/*
++	 * [HW requirement] After CTRL0 + I2C translation writes in
++	 * setup_control, the MAX96717 needs settling time before
++	 * accepting writes to PIPE_EN (0x02) and FRONTTOP registers.
++	 */
++	usleep_range(5000, 6000);
++
++	err = max96717_set_registers(dev, map_init, ARRAY_SIZE(map_init));
++
++	for (i = 0; i < MAX96717_MAX_PIPES; i++)
++		err |= __max96717_set_pipe(dev, i, GMSL_CSI_DT_YUV422_8,
++					   GMSL_CSI_DT_EMBED, i);
++
++	mutex_unlock(&priv->lock);
++
++	return err;
++}
++EXPORT_SYMBOL(max96717_init_settings);
++
++int max96717_set_pipe(struct device *dev, int pipe_id,
++		      u8 data_type1, u8 data_type2, u32 vc_id)
++{
++	struct max96717 *priv = dev_get_drvdata(dev);
++	int err = 0;
++
++	if (pipe_id > (MAX96717_MAX_PIPES - 1)) {
++		dev_info(dev, "%s: input pipe_id: %d exceeds max96717 max pipes\n",
++			 __func__, pipe_id);
++		return -EINVAL;
++	}
++
++	dev_dbg(dev, "%s pipe_id %d, data_type1 %u, data_type2 %u, vc_id %u\n",
++		__func__, pipe_id, data_type1, data_type2, vc_id);
++
++	mutex_lock(&priv->lock);
++
++	err = __max96717_set_pipe(dev, pipe_id, data_type1, data_type2, vc_id);
++
++	mutex_unlock(&priv->lock);
++
++	return err;
++}
++EXPORT_SYMBOL(max96717_set_pipe);
++
++/**
++ * max96717_retrigger_tx - Toggle SER TX to restore tunnel detection after
++ * a DES ONESHOT.  DES ONESHOT resets the data path; the SER must cycle
++ * its TX enable for the DES to re-acquire the tunnel stream.
++ */
++void max96717_retrigger_tx(struct device *dev)
++{
++	max96717_write_reg(dev, MAX96717_PIPE_EN_ADDR, MAX96717_SOFT_RESET);
++	msleep(30);
++	max96717_write_reg(dev, MAX96717_PIPE_EN_ADDR, MAX96717_PIPE_EN_ALL);
++}
++EXPORT_SYMBOL(max96717_retrigger_tx);
++
++/* ===== Probe / Remove ===== */
++
++static struct regmap_config max96717_regmap_config = {
++	.reg_bits = 16,
++	.val_bits = 8,
++	.cache_type = REGCACHE_RBTREE,
++};
++
++static int max96717_probe(struct i2c_client *client,
++			   const struct i2c_device_id *id)
++{
++	struct max96717 *priv;
++	int err = 0;
++	struct device_node *node = client->dev.of_node;
++
++	dev_info(&client->dev, "[MAX96717]: probing GMSL2 Serializer (Tunnel Mode)\n");
++
++	priv = devm_kzalloc(&client->dev, sizeof(*priv), GFP_KERNEL);
++	if (!priv)
++		return -ENOMEM;
++
++	priv->i2c_client = client;
++	priv->regmap = devm_regmap_init_i2c(priv->i2c_client,
++					     &max96717_regmap_config);
++	if (IS_ERR(priv->regmap)) {
++		dev_err(&client->dev,
++			"regmap init failed: %ld\n", PTR_ERR(priv->regmap));
++		return -ENODEV;
++	}
++
++	mutex_init(&priv->lock);
++
++	if (of_get_property(node, "is-prim-ser", NULL)) {
++		if (prim_priv__) {
++			dev_err(&client->dev,
++				"prim-ser already exists\n");
++			return -EEXIST;
++		}
++
++		err = of_property_read_u32(node, "reg", &priv->def_addr);
++		if (err < 0) {
++			dev_err(&client->dev, "reg not found\n");
++			return -EINVAL;
++		}
++
++		prim_priv__ = priv;
++	}
++
++	dev_set_drvdata(&client->dev, priv);
++
++	dev_info(&client->dev, "%s: success\n", __func__);
++
++	return err;
++}
++
++static int max96717_remove(struct i2c_client *client)
++{
++	struct max96717 *priv;
++
++	if (client != NULL) {
++		priv = dev_get_drvdata(&client->dev);
++		mutex_destroy(&priv->lock);
++		i2c_unregister_device(client);
++		client = NULL;
++	}
++
++	return 0;
++}
++
++static const struct i2c_device_id max96717_id[] = {
++	{ "max96717", 0 },
++	{ },
++};
++
++static const struct of_device_id max96717_of_match[] = {
++	{ .compatible = "adi,max96717", },
++	{ .compatible = "maxim,max96717", },
++	{ },
++};
++MODULE_DEVICE_TABLE(of, max96717_of_match);
++MODULE_DEVICE_TABLE(i2c, max96717_id);
++
++static struct i2c_driver max96717_i2c_driver = {
++	.driver = {
++		.name = "max96717",
++		.owner = THIS_MODULE,
++		.of_match_table = of_match_ptr(max96717_of_match),
++	},
++	.probe = max96717_probe,
++	.remove = max96717_remove,
++	.id_table = max96717_id,
++};
++
++static int __init max96717_init(void)
++{
++	return i2c_add_driver(&max96717_i2c_driver);
++}
++
++static void __exit max96717_exit(void)
++{
++	i2c_del_driver(&max96717_i2c_driver);
++}
++
++module_init(max96717_init);
++module_exit(max96717_exit);
++
++MODULE_DESCRIPTION("GMSL2 Serializer driver max96717 (Tunnel Mode)");
++MODULE_AUTHOR("RealSense AI");
++MODULE_LICENSE("GPL v2");
+diff --git a/drivers/media/i2c/max96724.c b/drivers/media/i2c/max96724.c
+new file mode 100644
+index 0000000..7286ff4
+--- /dev/null
++++ b/drivers/media/i2c/max96724.c
+@@ -0,0 +1,1690 @@
++/*
++ * max96724.c - MAX96724 GMSL2 Quad Deserializer driver (Tunnel Mode)
++ *
++ * Copyright (c) 2026, RealSense, Inc.  All rights reserved.
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms and conditions of the GNU General Public License,
++ * version 2, as published by the Free Software Foundation.
++ *
++ * This program is distributed in the hope it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
++ * more details.
++ *
++ * You should have received a copy of the GNU General Public License
++ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
++ */
++
++
++#include <linux/gpio.h>
++#include <linux/module.h>
++#include <linux/of.h>
++#include <linux/of_device.h>
++#include <linux/of_gpio.h>
++#include <media/camera_common.h>
++#include <linux/module.h>
++#include <media/max96724.h>
++
++/* ================================================================
++ * Register Addresses
++ * ================================================================ */
++
++/* --- Device ID / Configuration --- */
++
++/* [UG p.3] REG0: Device ID (read-only, returns 0xA2) */
++#define MAX96724_DEV_ID_ADDR		0x00
++
++/* [Errata §5] ERRB master reset register */
++#define MAX96724_ERRB_MST_RST_ADDR	0x05
++
++/* [UG Table 3, p.11] 0x0006: GMSL Link/PHY Enable and Mode Select
++ *   bits[7:4]: PHY mode (0=GMSL1, 1=GMSL2) per link D/C/B/A
++ *   bits[3:0]: Link Enable per link D/C/B/A
++ */
++#define MAX96724_LINK_EN_ADDR		0x0006
++
++/* [UG Table 3, p.11] 0x0010: GMSL Link/PHY Rate Select (Links A&B)
++ *   bits[7:6]: Tx Rate Link B, bits[5:4]: Rx Rate Link B
++ *   bits[3:2]: Tx Rate Link A, bits[1:0]: Rx Rate Link A
++ *   Tx: 00=187.5Mbps, Rx: 01=3Gbps, 10=6Gbps
++ */
++#define MAX96724_LINK_RATE_AB_ADDR	0x0010
++
++/* [UG Table 3, p.12] 0x0011: GMSL Link/PHY Rate Select (Links C&D) */
++#define MAX96724_LINK_RATE_CD_ADDR	0x0011
++
++/* [UG p.13] 0x001A: Link A lock status (bit[3]=LOCK) */
++#define MAX96724_LINK_A_LOCK_ADDR	0x001A
++
++/* [UG Table 3, p.12] 0x0018: GMSL Link Reset
++ *   bits[7:4]: Link reset D/C/B/A, bits[3:0]: One-shot reset D/C/B/A
++ */
++#define MAX96724_ONESHOT_ADDR		0x0018
++
++/* [UG p.11] REG13: Soft Reset (write 0x40, wait 5ms) */
++#define MAX96724_REG13_ADDR		0x000D
++
++/* [Errata §5] Error Channel Power Up registers (required for 6Gbps)
++ *   Write 0x75 immediately after power-up for robust 6Gbps operation
++ */
++#define MAX96724_ERRCH_A_ADDR		0x1449
++#define MAX96724_ERRCH_B_ADDR		0x1549
++#define MAX96724_ERRCH_C_ADDR		0x1649
++#define MAX96724_ERRCH_D_ADDR		0x1749
++#define MAX96724_ERRCH_FORCE_ON		0x75
++
++/* --- I2C Control Channel / Errata --- */
++
++/* [Errata #2] Tunnel Mode SRAM LCRC error suppression
++ *   Set 0x458[7:4] = 0x0 to suppress spurious ERRB in tunnel mode
++ */
++#define MAX96724_SRAM_LCRC_ERR_ADDR	0x0458
++
++/* --- Video Pipe Selection --- */
++
++/*
++ *   bits[3:0] = Pipe 0 source (0x0=SIOA)
++ *   bits[7:4] = Pipe 1 source (0x1=SIOB)
++ */
++#define MAX96724_PIPE_SEL0_ADDR		0xF0
++
++/*
++ *   bits[3:0] = Pipe 2 source (0x2=SIOC)
++ *   bits[7:4] = Pipe 3 source (0x3=SIOD)
++ */
++#define MAX96724_PIPE_SEL1_ADDR		0xF1
++
++/*
++ *   bit[0]=Pipe 0, bit[1]=Pipe 1, bit[2]=Pipe 2, bit[3]=Pipe 3
++ */
++#define MAX96724_PIPE_EN_ADDR		0xF4
++
++/* --- Pipe Receiver / Tunnel Mode --- */
++
++/*
++ *   bit[5]=1: Tunnel Mode, bits[1:0]=11: 4-lane MIPI out
++ *   Stride: 0x12 per pipe (P0=0x100, P1=0x112, P2=0x124, P3=0x136)
++ */
++#define MAX96724_VID_RX0_P0_ADDR	0x100
++#define MAX96724_VID_RX6_P0_ADDR	0x106
++#define MAX96724_VID_RX_STRIDE		0x12
++
++#define MAX96724_VID_RX1_P0_ADDR	0x101
++
++/* --- CSI-2 Output (BACKTOP) --- */
++
++/* [UG p.19] BACKTOP: CSI-2 output port enable
++ *   0x040B bit[1]=CSIB_EN, bit[0]=CSIA_EN
++ */
++#define MAX96724_BACKTOP_EN_ADDR	0x040B
++
++/* --- MIPI DPLL (Data Rate) --- */
++
++/* [UG Table 12, p.27] MIPI PHY DPLL Freq registers
++ *   bits[4:0] = frequency in multiples of 100MHz
++ *   bit[5]    = DPLL enable (must be set for DPLL to lock)
++ *   E.g., 0x27 = 700MHz + enable = 700Mbps/lane D-PHY
++ *   E.g., 0x2F = 1500MHz + enable = 1.5Gbps/lane
++ */
++#define MAX96724_DPLL_FREQ0_ADDR	0x0415
++#define MAX96724_DPLL_FREQ1_ADDR	0x0418
++#define MAX96724_DPLL_FREQ2_ADDR	0x041B
++#define MAX96724_DPLL_FREQ3_ADDR	0x041E
++
++/* [UG] DPLL PHY reset control
++ *   0x1D00 = DPLL CSI PHY1 control
++ *   Write 0xF4 to disable/reset, 0xF5 to enable
++ */
++#define MAX96724_DPLL_CSI2_ADDR		0x1D00
++#define MAX96724_DPLL_DISABLE		0xF4
++#define MAX96724_DPLL_ENABLE		0xF5
++
++/* --- CSI-2 Output PHY Configuration --- */
++
++/* [UG Table 12, p.25] MIPI PHY Mode Select register
++ *   bit[0]: 4x2 mode, bit[2]: 2x4 mode (Port A=PHY0+1, Port B=PHY2+3)
++ *   bit[3]: 2x4 alt mode (Port B=PHY0+1, Port A=PHY2+3)
++ */
++#define MAX96724_CSI_OUT_CFG_ADDR	0x08A0
++
++/* [UG Table 12, p.25] MIPI PHY Enable register
++ *   bits[7:4]: Enable PHY 3/2/1/0 (1=enabled, 0=standby)
++ */
++#define MAX96724_CSI_PHY_EN_ADDR	0x08A2
++
++/* [UG Table 12, p.25] MIPI PHY 0 and 1 Lane Mapping */
++#define MAX96724_CSI_LANE_MAP1_ADDR	0x08A3
++
++/* [UG Table 12, p.26] MIPI PHY 2 and 3 Lane Mapping */
++#define MAX96724_CSI_LANE_MAP2_ADDR	0x08A4
++
++/* [UG p.22] Pipe-to-controller mapping (Method 1) */
++#define MAX96724_MIPI_CTRL_SEL_ADDR	0x08CA
++
++/* --- Lane Control per pipe (stride 0x40) --- */
++
++/*
++ *   0xC0 = 4-lane enabled
++ */
++#define MAX96724_LANE_CTRL0_ADDR	0x090A
++#define MAX96724_LANE_CTRL1_ADDR	0x094A
++#define MAX96724_LANE_CTRL2_ADDR	0x098A
++#define MAX96724_LANE_CTRL3_ADDR	0x09CA
++
++/* --- Pipe Mapping Registers (stride 0x40 per pipe) --- */
++
++/*
++ *   Base addresses for Pipe X (Pipe 0)
++ *   Stride: 0x40 per pipe
++ */
++#define MAX96724_TX11_PIPE_X_EN_ADDR		0x090B
++#define MAX96724_TX45_PIPE_X_DST_CTRL_ADDR	0x092D
++#define MAX96724_PIPE_X_SRC_0_MAP_ADDR		0x090D
++#define MAX96724_PIPE_X_DST_0_MAP_ADDR		0x090E
++#define MAX96724_PIPE_X_SRC_1_MAP_ADDR		0x090F
++#define MAX96724_PIPE_X_DST_1_MAP_ADDR		0x0910
++#define MAX96724_PIPE_X_SRC_2_MAP_ADDR		0x0911
++#define MAX96724_PIPE_X_DST_2_MAP_ADDR		0x0912
++#define MAX96724_PIPE_X_SRC_3_MAP_ADDR		0x0913
++#define MAX96724_PIPE_X_DST_3_MAP_ADDR		0x0914
++
++/* --- Stream Select --- */
++
++/*
++ *   Pipe X=0x0933, stride 0x40 per pipe
++ */
++#define MAX96724_PIPE_X_ST_SEL_ADDR	0x0933
++
++/* --- Extended Pipe Mapping (DST_CTRL2-4 / TX49) --- */
++
++/* [Excel: MIPI_TX46-48] Extended DST_CTRL for additional mapping pairs
++ *   All to PHY1 (0x55), same as TX45
++ *   Stride: 0x40 per pipe (base = Pipe X)
++ */
++#define MAX96724_TX46_PIPE_X_ADDR	0x092E
++#define MAX96724_TX47_PIPE_X_ADDR	0x092F
++#define MAX96724_TX48_PIPE_X_ADDR	0x0930
++
++/* [UG p.30 + Aardvark-verified] MIPI_TX49 synchronous concatenation control
++ *   In tunnel mode, this register MUST be 0x87 for MIPI TX output to function.
++ *   Verified: setting to 0x00 disables tunnel output entirely (0x8D0 all zeros).
++ *   Stride: 0x40 per pipe (base = Pipe X)
++ */
++#define MAX96724_TX49_PIPE_X_ADDR	0x0931
++#define MAX96724_TX49_CONCAT_4W		0x87
++
++/* --- Tunnel Mode per-pipe --- */
++
++/*
++ *   bit[0] = TUN_EN, Default=0x08, write 0x09 to enable
++ */
++#define MAX96724_PIPE0_TUN_EN_ADDR	0x0936
++#define MAX96724_PIPE1_TUN_EN_ADDR	0x0976
++#define MAX96724_PIPE2_TUN_EN_ADDR	0x09B6
++#define MAX96724_PIPE3_TUN_EN_ADDR	0x09F6
++
++/*
++ *   bit[6]: disable auto-tunnel-detect
++ *   bits[5:4]: TUN_DEST (00=PHY0, 01=PHY1, 10=PHY2, 11=PHY3)
++ */
++#define MAX96724_PIPE0_TUN_DEST_ADDR	0x0939
++#define MAX96724_PIPE1_TUN_DEST_ADDR	0x0979
++#define MAX96724_PIPE2_TUN_DEST_ADDR	0x09B9
++#define MAX96724_PIPE3_TUN_DEST_ADDR	0x09F9
++
++/* ================================================================
++ * Register Values
++ * ================================================================ */
++
++/* [UG p.12] Soft reset value (write to 0x000D) */
++#define MAX96724_SOFT_RESET		0x40
++
++/* [UG Table 3, p.11-12] Link Rate values for 0x0010/0x0011
++ *   Per link pair: bits[1:0]=RxA, [3:2]=TxA, [5:4]=RxB, [7:6]=TxB
++ *   Tx = 00 (187.5Mbps), Rx = 01 (3Gbps) or 10 (6Gbps)
++ *   3Gbps: Tx=00, Rx=01 → per pair 0x01, both pairs = 0x01 in low nibble
++ */
++#define MAX96724_LINK_RATE_3GBPS	0x01  /* Rx=3G, Tx=187.5M for one link pair */
++#define MAX96724_LINK_RATE_6GBPS	0x02  /* Rx=6G, Tx=187.5M for one link pair */
++
++/* [UG Table 3, p.11] 0x0006: Link enable / mode values
++ *   bits[7:4] = PHY mode (1=GMSL2 per link)
++ *   bits[3:0] = Link enable per link
++ *   0xF1 = all GMSL2-mode, only Link A enabled
++ *   0xFF = all GMSL2-mode, all 4 links enabled
++ */
++#define MAX96724_LINK_EN_SIOA		0xF1  /* GMSL2 all, enable Link A only */
++#define MAX96724_LINK_EN_ALL		0xFF  /* GMSL2 all, enable all links */
++
++/* [UG p.19] BACKTOP_EN (0x040B): CSI output port enable */
++#define MAX96724_BACKTOP_CSIB_EN	0x02
++#define MAX96724_BACKTOP_CSIA_EN	0x01
++
++/* [XML] VIDEO_RX0: DIS_PKT_DET=1 (bit0) required for tunnel mode.
++ *   Without it, DES rejects tunnel data as invalid GMSL2 video packets.
++ *   SEQ_MISS_EN=1 (bit4), LINE_CRC_EN=1 (bit1).  XML value: 0x33.
++ */
++#define MAX96724_VID_RX0_CFG_VAL	0x33
++#define MAX96724_VID_RX6_CFG_VAL	0x0A
++
++/* [gmsl_ser_des_guide §4.9] Tunnel mode enable (MIPI_TX54, 0x0936):
++ *   bit[0] = TUN_EN = 1
++ *   bit[3] = TUN_CONT (continuous tunnel mode, required per verified XML)
++ *   XML/Guide value: 0x09
++ */
++#define MAX96724_TUN_EN			0x09
++
++/* [gmsl_ser_des_guide §7.5] Tunnel controller destination (MIPI_TX57, 0x0939):
++ *   bit[7]: DIS_AUTO_SER_LANE_DET (1=manual)
++ *   bit[6]: DIS_AUTO_TUN_DET (1=manual)
++ *   bits[5:4]: TUN_DEST (00=PHY0, 01=PHY1, 10=PHY2, 11=PHY3)
++ *   Verified XML: 0x50 = manual detect + PHY1 destination
++ */
++#define MAX96724_TUN_DEST_CTRL0		0x40  /* Manual detect + PHY0 */
++#define MAX96724_TUN_DEST_CTRL1		0x50  /* Manual detect + PHY1 (Port A master) */
++
++/* [UG Table 12, p.25] CSI output mode values */
++#define MAX96724_CSI_MODE_2X4_VAL	0x08  /* bit[3] = 2x4 alt: Ctrl1→PHY0+1→PortA (Aardvark-verified) */
++#define MAX96724_CSI_MODE_4X2_VAL	0x01  /* bit[0] = 4x2 mode */
++
++#define MAX96724_CSI_PHY_EN_ALL		0xF0
++#define MAX96724_CSI_PHY_EN_01		0x30  /* PHY0+PHY1 only */
++#define MAX96724_CSI_PHY_EN_23		0xC0  /* PHY2+PHY3 only (Port A in 2x4 alt mode) */
++
++/* [UG Table 12, p.25-26] Lane mapping default */
++#define MAX96724_CSI_LANE_MAP_DEFAULT	0xE4
++
++/* [UG Table 12, p.26-27] Lane control: 4-lane enabled */
++#define MAX96724_LANE_CTRL_4LANE	0xC0
++
++/* [UG Table 12, p.26-27] Lane control: 2-lane enabled.
++ *   bits[7:6] = (num_lanes - 1): 01=2-lane(0x40), 11=4-lane(0xC0)
++ *   Ref: gmsl_ser_des_guide §8.2, E2E_enable_guide §5.6.4 */
++#define MAX96724_LANE_CTRL_2LANE	0x40
++
++/* [SC20190112 2-lane] CSI PHY enable: all PHYs powered for DPLL lock
++ *   stability.  Even though only PHY0 data lanes reach Orin, the MAX96724
++ *   DPLL requires all PHYs to be powered.  Tested: single PHY → PLL never locks. */
++#define MAX96724_CSI_PHY_EN_2LANE	0xF0
++
++/* [SC20190112 2-lane] DPLL for Controller 0 (drives PHY0, 2 lanes).
++ *   bits[4:0] = data-rate / 100 MHz.  1400 Mbps / 100 = 14 = 0x0E.
++ *   bit[5]    = DPLL enable = 1.
++ *   Result: 0x2E = 1400 Mbps/lane D-PHY. */
++#define MAX96724_DPLL_1400MBPS_CTRL0	0x2E
++
++/* [SC20190112 2-lane] TX49 pipeline concatenation for 2-wide mode.
++ *   In 4x2 mode each controller drives only 2 lanes.
++ *   UG p.30: synchronous concatenation control, 0x83 for 2W. */
++#define MAX96724_TX49_CONCAT_2W		0x83
++
++/* [UG Table 3, p.12] One-shot reset: all links */
++#define MAX96724_ONESHOT_ALL		0x0F
++
++/* [UG Table 4, p.15] Pipe source selection values
++ *   Encoding per pipe nibble in tunnel mode (Aardvark-verified):
++ *   0x22 routes all pipes from Link A in tunnel mode.
++ */
++#define MAX96724_PIPE_SEL0_SINGLE	0x22  /* All pipes from Link A (Aardvark-verified) */
++#define MAX96724_PIPE_SEL1_SINGLE	0x22  /* All pipes from Link A (Aardvark-verified) */
++#define MAX96724_PIPE_SEL0_DUAL		0x40  /* Pipe 0 ← A/X, Pipe 1 ← B/X */
++#define MAX96724_PIPE_SEL0_QUAD_LO	0x40  /* Pipe 0 ← A/X, Pipe 1 ← B/X */
++#define MAX96724_PIPE_SEL1_QUAD_HI	0xC8  /* Pipe 2 ← C/X, Pipe 3 ← D/X */
++
++/* Pipe enable values */
++#define MAX96724_PIPE_EN_1		0x01
++#define MAX96724_PIPE_EN_2		0x03
++#define MAX96724_PIPE_EN_4		0x0F
++
++/* Lane control map: bits[7:6] = (num_lanes - 1) */
++#define MAX96724_LANE_CTRL_MAP(num_lanes) \
++	((((num_lanes) - 1) << 6) & 0xC0)
++
++/* Reset all */
++#define MAX96724_RESET_ALL		0x80
++
++/* Stream ID invalid */
++#define MAX96724_INVAL_ST_ID		0xFF
++#define MAX96724_RESET_ST_ID		0x00
++#define MAX96724_ST_ID_SEL_INVALID	0xF
++
++/* Controller mapping: all mappings → Controller 0 (not working in tunnel mode) */
++#define MAX96724_ALL_MAP_CTRL0		0x00
++/* Controller mapping: all mappings → Controller 1 (Aardvark-verified working) */
++#define MAX96724_ALL_MAP_CTRL1		0x55
++
++/* ================================================================
++ * Data Structures
++ * ================================================================ */
++
++/* Quad GMSL: up to 4 sources */
++#define MAX96724_MAX_SOURCES		4
++#define MAX96724_MAX_PIPES		4
++
++#define MAX96724_PIPE_X			0
++#define MAX96724_PIPE_Y			1
++#define MAX96724_PIPE_Z			2
++#define MAX96724_PIPE_U			3
++#define MAX96724_PIPE_INVALID		0xF
++
++#define MAX96724_CSI_CTRL_0		0
++#define MAX96724_CSI_CTRL_1		1
++#define MAX96724_CSI_CTRL_2		2
++#define MAX96724_CSI_CTRL_3		3
++
++/* CSI mode values */
++#define MAX96724_CSI_MODE_4X2		0x01
++#define MAX96724_CSI_MODE_2X4		0x08  /* 2x4 alt: Ctrl1→PHY0+1→PortA (Aardvark-verified working) */
++#define MAX96724_CSI_MODE_2X4_ALT	0x04  /* 2x4 standard (Ctrl0→PHY0+1, not working in tunnel) */
++
++/* Lane map presets */
++#define MAX96724_LANE_MAP1_4X2		0x44
++#define MAX96724_LANE_MAP2_4X2		0x44
++#define MAX96724_LANE_MAP1_2X4		0xE4  /* PHY0+PHY1 lane map (Aardvark-verified) */
++#define MAX96724_LANE_MAP2_2X4		0xE4
++
++struct max96724_source_ctx {
++	struct gmsl_link_ctx *g_ctx;
++	bool st_enabled;
++};
++
++struct pipe_ctx {
++	u32 id;
++	u32 dt_type;
++	u32 dst_csi_ctrl;
++	u32 st_count;
++	u32 st_id_sel;
++};
++
++struct max96724 {
++	struct i2c_client *i2c_client;
++	struct regmap *regmap;
++	u32 num_src;
++	u32 max_src;
++	u32 num_src_found;
++	u32 src_link;
++	bool splitter_enabled;
++	struct max96724_source_ctx sources[MAX96724_MAX_SOURCES];
++	struct mutex lock;
++	u32 sdev_ref;
++	bool lane_setup;
++	bool link_setup;
++	struct pipe_ctx pipe[MAX96724_MAX_PIPES];
++	u8 csi_mode;
++	u8 lane_mp1;
++	u8 lane_mp2;
++	int reset_gpio;
++	int pw_ref;
++	struct regulator *vdd_cam_1v2;
++	u8 link_speed;  /* DT-configurable: 3 or 6 Gbps */
++};
++
++struct reg_pair {
++	u16 addr;
++	u8 val;
++};
++
++/* ================================================================
++ * Low-level I2C
++ * ================================================================ */
++
++static int max96724_write_reg(struct device *dev, u16 addr, u8 val)
++{
++	struct max96724 *priv;
++	int err;
++
++	priv = dev_get_drvdata(dev);
++
++	err = regmap_write(priv->regmap, addr, val);
++	if (err)
++		dev_err(dev, "%s:i2c write failed, 0x%x = %x\n",
++			__func__, addr, val);
++
++	/* delay before next i2c command as required for SERDES link */
++	usleep_range(100, 110);
++
++	return err;
++}
++
++static int max96724_set_registers(struct device *dev, struct reg_pair *map,
++				  u32 count)
++{
++	int err = 0;
++	u32 j;
++
++	for (j = 0; j < count; j++) {
++		err = max96724_write_reg(dev, map[j].addr, map[j].val);
++		if (err)
++			break;
++	}
++
++	return err;
++}
++
++/* ================================================================
++ * Internal Helpers
++ * ================================================================ */
++
++static int max96724_get_sdev_idx(struct device *dev,
++				 struct device *s_dev, unsigned int *idx)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++	unsigned int i;
++	int err = 0;
++
++	mutex_lock(&priv->lock);
++	for (i = 0; i < priv->max_src; i++) {
++		if (priv->sources[i].g_ctx->s_dev == s_dev)
++			break;
++	}
++	if (i == priv->max_src) {
++		dev_err(dev, "no sdev found\n");
++		err = -EINVAL;
++		goto ret;
++	}
++
++	if (idx)
++		*idx = i;
++
++ret:
++	mutex_unlock(&priv->lock);
++	return err;
++}
++
++static void max96724_pipes_reset(struct max96724 *priv)
++{
++	/*
++	 * Default pipe configuration for D5xx/SC1.2:
++	 * In tunnel mode, DT types are not used for filtering
++	 * but we initialize them for d4xx framework compatibility.
++	 */
++	struct pipe_ctx pipe_defaults[] = {
++		{MAX96724_PIPE_X, GMSL_CSI_DT_RAW_12,
++			MAX96724_CSI_CTRL_1, 0, MAX96724_INVAL_ST_ID},
++		{MAX96724_PIPE_Y, GMSL_CSI_DT_RAW_12,
++			MAX96724_CSI_CTRL_1, 0, MAX96724_INVAL_ST_ID},
++		{MAX96724_PIPE_Z, GMSL_CSI_DT_EMBED,
++			MAX96724_CSI_CTRL_1, 0, MAX96724_INVAL_ST_ID},
++		{MAX96724_PIPE_U, GMSL_CSI_DT_EMBED,
++			MAX96724_CSI_CTRL_1, 0, MAX96724_INVAL_ST_ID}
++	};
++
++	memcpy(priv->pipe, pipe_defaults, sizeof(pipe_defaults));
++}
++
++static void max96724_reset_ctx(struct max96724 *priv)
++{
++	unsigned int i;
++
++	priv->link_setup = false;
++	priv->lane_setup = false;
++	priv->num_src_found = 0;
++	priv->src_link = 0;
++	priv->splitter_enabled = false;
++	max96724_pipes_reset(priv);
++	for (i = 0; i < priv->num_src; i++)
++		priv->sources[i].st_enabled = false;
++}
++
++/* ================================================================
++ * Power Management
++ * ================================================================ */
++
++/*
++ * max96724_power_on - Power on the MAX96724 deserializer
++ */
++int max96724_power_on(struct device *dev)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++	int err = 0;
++
++	mutex_lock(&priv->lock);
++	if (priv->pw_ref == 0) {
++		usleep_range(1, 2);
++		if (priv->reset_gpio)
++			gpio_set_value(priv->reset_gpio, 0);
++
++		usleep_range(30, 50);
++
++		if (priv->vdd_cam_1v2) {
++			err = regulator_enable(priv->vdd_cam_1v2);
++			if (unlikely(err))
++				goto ret;
++		}
++
++		usleep_range(30, 50);
++
++		/* exit reset mode: XCLR */
++		if (priv->reset_gpio) {
++			gpio_set_value(priv->reset_gpio, 0);
++			usleep_range(30, 50);
++			gpio_set_value(priv->reset_gpio, 1);
++			usleep_range(30, 50);
++		}
++
++		msleep(20);
++	}
++
++	priv->pw_ref++;
++
++ret:
++	mutex_unlock(&priv->lock);
++	return err;
++}
++EXPORT_SYMBOL(max96724_power_on);
++
++void max96724_power_off(struct device *dev)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++
++	mutex_lock(&priv->lock);
++	priv->pw_ref--;
++
++	if (priv->pw_ref < 0)
++		priv->pw_ref = 0;
++
++	if (priv->pw_ref == 0) {
++		usleep_range(1, 2);
++		if (priv->reset_gpio)
++			gpio_set_value(priv->reset_gpio, 0);
++
++		if (priv->vdd_cam_1v2)
++			regulator_disable(priv->vdd_cam_1v2);
++	}
++
++	mutex_unlock(&priv->lock);
++}
++EXPORT_SYMBOL(max96724_power_off);
++
++/* ================================================================
++ * Link Setup
++ * ================================================================ */
++
++/*
++ * max96724_write_link - Configure a specific GMSL link
++ *
++ * [Users Guide, Link Initialization, p11-12]
++ *   Register 0x0006: Link Enable and Mode Select
++ *   Register 0x0010: Link Rate (Links A/B)
++ *
++ * The link speed is DT-configurable via the "gmsl-link-speed" property.
++ */
++static int max96724_write_link(struct device *dev, u32 link)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++	u8 link_rate_ab, link_rate_cd;
++	u8 link_en_val;
++
++	/*
++	 * [Aardvark-verified] Disable CSI output before link configuration
++	 * This prevents glitches on CSI bus during GMSL link setup.
++	 * Re-enabled in max96724_setup_streaming() after full pipeline config.
++	 */
++	max96724_write_reg(dev, MAX96724_BACKTOP_EN_ADDR, 0x00);
++
++	/* [UG Table 3 + Tech Overview REG26]
++	 * Register 0x0010:
++	 *   bits[7:2] = Link rate configuration
++	 *   bits[1:0] = I2C CC pass-through link select
++	 *     10 = route CC via SIOA (Link A)  [tech overview: 0x02 → SIOA]
++	 *     01 = route CC via SIOB (Link B)
++	 *
++	 * For 6G + Link A: bits[7:2]=001000, bits[1:0]=10 → 0x22
++	 * For 6G + Link B: bits[7:2]=001000, bits[1:0]=01 → 0x21
++	 * For 3G + Link A: bits[7:2]=000100, bits[1:0]=10 → 0x12 (? or 0x11)
++	 * For 3G + Link B: bits[7:2]=000100, bits[1:0]=01 → 0x11 (? or 0x09)
++	 */
++	if (priv->link_speed == 6) {
++		if (link == GMSL_SERDES_CSI_LINK_B) {
++			link_rate_ab = 0x21; /* 6G rate + CC via Link B */
++		} else {
++			link_rate_ab = 0x22; /* 6G rate + CC via Link A */
++		}
++		link_rate_cd = 0x22; /* C/D: 6G rate (CC routing don't care) */
++	} else {
++		if (link == GMSL_SERDES_CSI_LINK_B) {
++			link_rate_ab = 0x09; /* 3G rate + CC via Link B */
++		} else {
++			link_rate_ab = 0x12; /* 3G rate + CC via Link A */
++		}
++		link_rate_cd = 0x11; /* C/D: 3G rate */
++	}
++
++	if (link == GMSL_SERDES_CSI_LINK_A) {
++		link_en_val = MAX96724_LINK_EN_SIOA;
++	} else if (link == GMSL_SERDES_CSI_LINK_B) {
++		link_en_val = 0xF2; /* GMSL2 all, enable Link B only */
++	} else {
++		dev_err(dev, "%s: invalid gmsl link\n", __func__);
++		return -EINVAL;
++	}
++
++	/* [UG Table 3] Set link rates + CC routing */
++	max96724_write_reg(dev, MAX96724_LINK_RATE_AB_ADDR, link_rate_ab);
++	max96724_write_reg(dev, MAX96724_LINK_RATE_CD_ADDR, link_rate_cd);
++
++	/*
++	 * [XML-verified sequence] One-shot reset applies rate configuration
++	 * to the link state machine, then link enable starts training.
++	 * XML order: rate → ONE-SHOT → LINK_EN → wait 1000ms.
++	 * Note: Error channel registers omitted (not in reference XML).
++	 */
++	max96724_write_reg(dev, MAX96724_ONESHOT_ADDR,
++			   MAX96724_ONESHOT_ALL);
++	max96724_write_reg(dev, MAX96724_LINK_EN_ADDR, link_en_val);
++
++	/*
++	 * Wait for link lock.
++	 * [XML] Uses 1000ms regardless of link speed.
++	 * I2C pass-through CC requires fully trained link, not just PHY lock.
++	 */
++	msleep(1000);
++
++	/* Check link lock status on ALL ports for diagnostics */
++	{
++		unsigned int lock_a = 0, lock_b = 0, lock_c = 0, lock_d = 0;
++		unsigned int link_en = 0;
++		unsigned int reg10 = 0, reg11 = 0;
++
++		regmap_read(priv->regmap, 0x001A, &lock_a);
++		regmap_read(priv->regmap, 0x001B, &lock_b);
++		regmap_read(priv->regmap, 0x001C, &lock_c);
++		regmap_read(priv->regmap, 0x001D, &lock_d);
++		regmap_read(priv->regmap, MAX96724_LINK_EN_ADDR, &link_en);
++		regmap_read(priv->regmap, 0x0010, &reg10);
++		regmap_read(priv->regmap, 0x0011, &reg11);
++		dev_info(dev,
++			 "GMSL link status: EN=0x%02x A=0x%02x(%s) B=0x%02x(%s) C=0x%02x(%s) D=0x%02x(%s) REG10=0x%02x REG11=0x%02x\n",
++			 link_en,
++			 lock_a, (lock_a & 0x08) ? "LOCK" : "noLk",
++			 lock_b, (lock_b & 0x08) ? "LOCK" : "noLk",
++			 lock_c, (lock_c & 0x08) ? "LOCK" : "noLk",
++			 lock_d, (lock_d & 0x08) ? "LOCK" : "noLk",
++			 reg10, reg11);
++	}
++
++	return 0;
++}
++
++int max96724_setup_link(struct device *dev, struct device *s_dev)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++	int err = 0;
++	unsigned int i = 0;
++
++	err = max96724_get_sdev_idx(dev, s_dev, &i);
++	if (err)
++		return err;
++
++	mutex_lock(&priv->lock);
++
++	if (!priv->splitter_enabled) {
++		err = max96724_write_link(dev,
++					  priv->sources[i].g_ctx->serdes_csi_link);
++		if (err)
++			goto ret;
++
++		priv->link_setup = true;
++	}
++
++ret:
++	mutex_unlock(&priv->lock);
++	return err;
++}
++EXPORT_SYMBOL(max96724_setup_link);
++
++/* ================================================================
++ * Control Setup
++ * ================================================================ */
++
++/*
++ * max96724_setup_control - Configure deserializer control pipeline
++ *
++ * Enables splitter mode when multiple sources are present,
++ * configures tunnel mode on all active pipes, and sets up
++ * the MIPI CSI-2 output.
++ */
++int max96724_setup_control(struct device *dev, struct device *s_dev)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++	int err = 0;
++	unsigned int i = 0;
++
++	static const u16 tun_en_addrs[] = {
++		MAX96724_PIPE0_TUN_EN_ADDR,
++		MAX96724_PIPE1_TUN_EN_ADDR,
++		MAX96724_PIPE2_TUN_EN_ADDR,
++		MAX96724_PIPE3_TUN_EN_ADDR,
++	};
++
++	static const u16 tun_dest_addrs[] = {
++		MAX96724_PIPE0_TUN_DEST_ADDR,
++		MAX96724_PIPE1_TUN_DEST_ADDR,
++		MAX96724_PIPE2_TUN_DEST_ADDR,
++		MAX96724_PIPE3_TUN_DEST_ADDR,
++	};
++
++	err = max96724_get_sdev_idx(dev, s_dev, &i);
++	if (err)
++		return err;
++
++	mutex_lock(&priv->lock);
++
++	if (!priv->link_setup) {
++		dev_err(dev, "%s: invalid state\n", __func__);
++		err = -EINVAL;
++		goto error;
++	}
++
++	if (priv->sources[i].g_ctx->serdev_found) {
++		priv->num_src_found++;
++		priv->src_link = priv->sources[i].g_ctx->serdes_csi_link;
++	}
++
++	/* Enable splitter mode for multi-camera configurations */
++	if ((priv->max_src > 1U) &&
++	    (priv->num_src_found > 0U) &&
++	    (priv->splitter_enabled == false)) {
++		/*
++		 * [UG Table 3] Multi-camera: set link rates and enable all links
++		 */
++		u8 link_rate = (priv->link_speed == 6) ? 0x22 : 0x11;
++
++		max96724_write_reg(dev, MAX96724_LINK_RATE_AB_ADDR,
++				   link_rate);
++		max96724_write_reg(dev, MAX96724_LINK_RATE_CD_ADDR,
++				   link_rate);
++		max96724_write_reg(dev, MAX96724_LINK_EN_ADDR,
++				   MAX96724_LINK_EN_ALL);
++
++		/* [Errata #5] For 6Gbps: force Error Channel power-up */
++		if (priv->link_speed == 6) {
++			max96724_write_reg(dev, MAX96724_ERRCH_A_ADDR,
++					   MAX96724_ERRCH_FORCE_ON);
++			max96724_write_reg(dev, MAX96724_ERRCH_B_ADDR,
++					   MAX96724_ERRCH_FORCE_ON);
++			max96724_write_reg(dev, MAX96724_ERRCH_C_ADDR,
++					   MAX96724_ERRCH_FORCE_ON);
++			max96724_write_reg(dev, MAX96724_ERRCH_D_ADDR,
++					   MAX96724_ERRCH_FORCE_ON);
++		}
++
++		priv->splitter_enabled = true;
++
++		msleep(100);
++	}
++
++	/*
++	 * [SC20190112] Enable tunnel mode and route to Controller 1.
++	 *   - TUN_EN   (0x0936): 0x01 (TUN_EN=1)
++	 *   - TUN_DEST (0x0939): 0x10 = Controller 1
++	 *   CSI_OUT_CFG=0x08 (2x4 alt): Controller 1 → PHY0+1 → Port A → Orin
++	 */
++	{
++		for (i = 0; i < MAX96724_MAX_PIPES; i++) {
++			max96724_write_reg(dev, tun_en_addrs[i],
++					   MAX96724_TUN_EN);
++			max96724_write_reg(dev, tun_dest_addrs[i],
++					   MAX96724_TUN_DEST_CTRL1);
++		}
++	}
++
++	/*
++	 * [Errata #2] Tunnel Mode SRAM LCRC: disable ERRB for SRAM LCRC
++	 * errors in tunnel mode when frame/line counters are non-zero.
++	 * This prevents spurious ERRB assertions (no video corruption).
++	 */
++	max96724_write_reg(dev, MAX96724_SRAM_LCRC_ERR_ADDR, 0x00);
++
++	max96724_write_reg(dev, MAX96724_ONESHOT_ADDR,
++			   MAX96724_ONESHOT_ALL);
++
++	priv->sdev_ref++;
++
++	/* Reset splitter mode if not all devices found */
++	if ((priv->sdev_ref == priv->max_src) &&
++	    (priv->splitter_enabled == true) &&
++	    (priv->num_src_found > 0U) &&
++	    (priv->num_src_found < priv->max_src)) {
++		err = max96724_write_link(dev, priv->src_link);
++		if (err)
++			goto error;
++
++		priv->splitter_enabled = false;
++	}
++
++error:
++	mutex_unlock(&priv->lock);
++	return err;
++}
++EXPORT_SYMBOL(max96724_setup_control);
++
++int max96724_reset_control(struct device *dev, struct device *s_dev)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++	int err = 0;
++
++	mutex_lock(&priv->lock);
++	if (!priv->sdev_ref) {
++		dev_info(dev, "%s: dev is already in reset state\n", __func__);
++		goto ret;
++	}
++
++	priv->sdev_ref--;
++	if (priv->sdev_ref == 0) {
++		max96724_reset_ctx(priv);
++		max96724_write_reg(dev, MAX96724_REG13_ADDR,
++				   MAX96724_SOFT_RESET);
++
++		msleep(100);
++	}
++
++ret:
++	mutex_unlock(&priv->lock);
++	return err;
++}
++EXPORT_SYMBOL(max96724_reset_control);
++
++/* ================================================================
++ * Device Registration
++ * ================================================================ */
++
++int max96724_sdev_register(struct device *dev, struct gmsl_link_ctx *g_ctx)
++{
++	struct max96724 *priv = NULL;
++	unsigned int i;
++	int err = 0;
++
++	if (!dev || !g_ctx || !g_ctx->s_dev) {
++		dev_err(dev, "%s: invalid input params\n", __func__);
++		return -EINVAL;
++	}
++
++	priv = dev_get_drvdata(dev);
++
++	mutex_lock(&priv->lock);
++
++	if (priv->num_src > priv->max_src) {
++		dev_err(dev,
++			"%s: MAX96724 inputs size exhausted\n", __func__);
++		err = -ENOMEM;
++		goto error;
++	}
++
++	/* Check csi mode compatibility.
++	 * 2x4 DES → gmsl-link: 1x4 or 2x4.
++	 * 4x2 DES → gmsl-link: 1x4, 2x2, or 4x2.
++	 */
++	if (priv->csi_mode == MAX96724_CSI_MODE_2X4) {
++		if (!((g_ctx->csi_mode == GMSL_CSI_1X4_MODE) ||
++		      (g_ctx->csi_mode == GMSL_CSI_2X4_MODE))) {
++			dev_err(dev, "%s: csi mode not supported\n", __func__);
++			err = -EINVAL;
++			goto error;
++		}
++	} else {
++		/* 4x2 DES mode: accept 1x4, 2x2, or 4x2 gmsl-link mode */
++		if (!((g_ctx->csi_mode == GMSL_CSI_1X4_MODE) ||
++		      (g_ctx->csi_mode == GMSL_CSI_2X2_MODE) ||
++		      (g_ctx->csi_mode == GMSL_CSI_4X2_MODE))) {
++			dev_err(dev, "%s: csi mode not supported\n", __func__);
++			err = -EINVAL;
++			goto error;
++		}
++	}
++
++	for (i = 0; i < priv->num_src; i++) {
++		if (g_ctx->serdes_csi_link ==
++		    priv->sources[i].g_ctx->serdes_csi_link) {
++			dev_err(dev,
++				"%s: serdes csi link is in use\n", __func__);
++			err = -EINVAL;
++			goto error;
++		}
++		if (g_ctx->num_csi_lanes !=
++		    priv->sources[i].g_ctx->num_csi_lanes) {
++			dev_err(dev,
++				"%s: csi num lanes mismatch\n", __func__);
++			err = -EINVAL;
++			goto error;
++		}
++	}
++
++	priv->sources[priv->num_src].g_ctx = g_ctx;
++	priv->sources[priv->num_src].st_enabled = false;
++
++	priv->num_src++;
++
++error:
++	mutex_unlock(&priv->lock);
++	return err;
++}
++EXPORT_SYMBOL(max96724_sdev_register);
++
++int max96724_sdev_unregister(struct device *dev, struct device *s_dev)
++{
++	struct max96724 *priv = NULL;
++	int err = 0;
++	unsigned int i = 0;
++
++	if (!dev || !s_dev) {
++		dev_err(dev, "%s: invalid input params\n", __func__);
++		return -EINVAL;
++	}
++
++	priv = dev_get_drvdata(dev);
++	mutex_lock(&priv->lock);
++
++	if (priv->num_src == 0) {
++		dev_err(dev, "%s: no source found\n", __func__);
++		err = -ENODATA;
++		goto error;
++	}
++
++	for (i = 0; i < priv->num_src; i++) {
++		if (s_dev == priv->sources[i].g_ctx->s_dev) {
++			priv->sources[i].g_ctx = NULL;
++			break;
++		}
++	}
++
++	if (i == priv->num_src) {
++		dev_err(dev,
++			"%s: requested device not found\n", __func__);
++		err = -EINVAL;
++		goto error;
++	}
++	priv->num_src--;
++
++error:
++	mutex_unlock(&priv->lock);
++	return err;
++}
++EXPORT_SYMBOL(max96724_sdev_unregister);
++
++/* ================================================================
++ * Streaming Setup
++ * ================================================================ */
++
++/*
++ * max96724_setup_streaming - Configure CSI-2 output pipeline
++ *
++ * In Tunnel Mode, the MAX96724 outputs the reconstructed CSI-2 stream
++ * with all VCs and DTs preserved from the serializer.
++ *
++ * The pipeline configuration:
++ *   1. Configure pipe-to-link routing (which GMSL input → which pipe)
++ *   2. Enable tunnel mode on active pipes
++ *   3. Configure MIPI CSI-2 output lanes and PHY
++ *   4. Enable BACKTOP output port
++ *
++ */
++int max96724_setup_streaming(struct device *dev, struct device *s_dev)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++	struct gmsl_link_ctx *g_ctx;
++	int err = 0;
++	unsigned int i = 0;
++	unsigned int src_idx;
++
++	err = max96724_get_sdev_idx(dev, s_dev, &i);
++	if (err)
++		return err;
++
++	mutex_lock(&priv->lock);
++	if (priv->sources[i].st_enabled)
++		goto ret;
++
++	src_idx = i;
++	g_ctx = priv->sources[src_idx].g_ctx;
++
++	/*
++	 * [Aardvark-verified] Pipe source routing
++	 *   Single cam: all pipes from Link A (0x22/0x22)
++	 *   Disable pipes before configuration, enable at the end
++	 */
++	if (priv->max_src >= 4) {
++		max96724_write_reg(dev, MAX96724_PIPE_SEL0_ADDR,
++				   MAX96724_PIPE_SEL0_QUAD_LO);
++		max96724_write_reg(dev, MAX96724_PIPE_SEL1_ADDR,
++				   MAX96724_PIPE_SEL1_QUAD_HI);
++	} else if (priv->max_src >= 2) {
++		max96724_write_reg(dev, MAX96724_PIPE_SEL0_ADDR,
++				   MAX96724_PIPE_SEL0_DUAL);
++	} else {
++		max96724_write_reg(dev, MAX96724_PIPE_SEL0_ADDR,
++				   MAX96724_PIPE_SEL0_SINGLE);
++		max96724_write_reg(dev, MAX96724_PIPE_SEL1_ADDR,
++				   MAX96724_PIPE_SEL1_SINGLE);
++	}
++	/* Disable all pipes during configuration */
++	max96724_write_reg(dev, MAX96724_PIPE_EN_ADDR, 0x00);
++
++	/*
++	 * [SC20190112] CSI output: 2x4 alt mode (0x08) for Port A.
++	 * In 2x4 alt: Controller 1 is master for Port A.
++	 *   PHY0 (slave) → DA0/DA1 (data lanes to Orin)
++	 *   PHY1 (master) → CLKA (clock to Orin)
++	 * Both PHY0 and PHY1 must be enabled for Port A output.
++	 * TUN_DEST=0x10 routes tunnel pipes to Controller 1.
++	 */
++	max96724_write_reg(dev, MAX96724_CSI_OUT_CFG_ADDR,
++			   MAX96724_CSI_MODE_2X4_VAL);
++	max96724_write_reg(dev, MAX96724_CSI_PHY_EN_ADDR,
++			   MAX96724_CSI_PHY_EN_01);
++
++	max96724_write_reg(dev, MAX96724_CSI_LANE_MAP1_ADDR,
++			   priv->lane_mp1);
++	max96724_write_reg(dev, MAX96724_CSI_LANE_MAP2_ADDR,
++			   priv->lane_mp2);
++
++	/* [gmsl_ser_des_guide §6.1] MIPI_CTRL_SEL: all pipes → Controller 1.
++	 * Guide: "in tunneling mode the MIPI_CTRL_SEL_x bits must match TUN_DEST"
++	 * 0x55 = Pipe0→Ctrl1, Pipe1→Ctrl1, Pipe2→Ctrl1, Pipe3→Ctrl1 */
++	max96724_write_reg(dev, MAX96724_MIPI_CTRL_SEL_ADDR, 0x55);
++
++	/* [gmsl_ser_des_guide §8.2] LANE_CTRL on Controller 1 register (0x094A).
++	 * 0x40 = 2-lane. Also set Ctrl0 for completeness. */
++	max96724_write_reg(dev, MAX96724_LANE_CTRL0_ADDR,
++			   MAX96724_LANE_CTRL_2LANE);
++	max96724_write_reg(dev, MAX96724_LANE_CTRL1_ADDR,
++			   MAX96724_LANE_CTRL_2LANE);
++	max96724_write_reg(dev, MAX96724_LANE_CTRL2_ADDR,
++			   MAX96724_LANE_CTRL_2LANE);
++	max96724_write_reg(dev, MAX96724_LANE_CTRL3_ADDR,
++			   MAX96724_LANE_CTRL_2LANE);
++
++	/*
++	 * [SC20190112 2-lane] DPLL for Controller 1 (drives Port A via PHY1 clock).
++	 * FREQ1 (0x0418) = 0x2E = 1400 Mbps/lane + DPLL enable.
++	 * 2 lanes × 1400 Mbps = 2800 Mbps total ≥ camera 2L × 700M input.
++	 */
++	if (!priv->lane_setup) {
++		max96724_write_reg(dev, MAX96724_DPLL_CSI2_ADDR,
++				   MAX96724_DPLL_DISABLE);
++		max96724_write_reg(dev, MAX96724_DPLL_FREQ1_ADDR,
++				   MAX96724_DPLL_1400MBPS_CTRL0);
++		max96724_write_reg(dev, MAX96724_DPLL_CSI2_ADDR,
++				   MAX96724_DPLL_ENABLE);
++
++		priv->lane_setup = true;
++	}
++
++	/*
++	 * [Aardvark-verified] Stream ID select for all pipes
++	 * 0x0933 + 0x40*pipe = stream select register
++	 * Value 0x10 selects the appropriate stream for tunnel mode
++	 */
++	for (i = 0; i < MAX96724_MAX_PIPES; i++) {
++		max96724_write_reg(dev,
++				   MAX96724_PIPE_X_ST_SEL_ADDR + (0x40 * i),
++				   0x10);
++	}
++
++	/* BACKTOP: enable Controller 1 / CSI-B (0x02).
++	 * In 2x4 alt mode, Controller 1 is master for Port A → Orin CSI.
++	 */
++	max96724_write_reg(dev, MAX96724_BACKTOP_EN_ADDR,
++			   MAX96724_BACKTOP_CSIB_EN);
++
++	/* Keep all video receivers aligned with serializer heartbeat mode. */
++	for (i = 0; i < MAX96724_MAX_PIPES; i++) {
++		max96724_write_reg(dev,
++				   MAX96724_VID_RX0_P0_ADDR +
++				   (MAX96724_VID_RX_STRIDE * i),
++				   MAX96724_VID_RX0_CFG_VAL);
++		max96724_write_reg(dev,
++				   MAX96724_VID_RX6_P0_ADDR +
++				   (MAX96724_VID_RX_STRIDE * i),
++				   MAX96724_VID_RX6_CFG_VAL);
++	}
++
++	max96724_write_reg(dev, MAX96724_ONESHOT_ADDR,
++			   MAX96724_ONESHOT_ALL);
++
++	/* Enable all 4 pipes (Aardvark-verified: 0x0F at end) */
++	max96724_write_reg(dev, MAX96724_PIPE_EN_ADDR, MAX96724_PIPE_EN_4);
++
++	priv->sources[src_idx].st_enabled = true;
++
++ret:
++	mutex_unlock(&priv->lock);
++	return err;
++}
++EXPORT_SYMBOL(max96724_setup_streaming);
++
++/* ================================================================
++ * Start / Stop Streaming
++ * ================================================================ */
++
++int max96724_start_streaming(struct device *dev, struct device *s_dev)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++	struct gmsl_link_ctx *g_ctx;
++	struct gmsl_stream *g_stream;
++	int err = 0;
++	unsigned int i = 0;
++
++	err = max96724_get_sdev_idx(dev, s_dev, &i);
++	if (err)
++		return err;
++
++	mutex_lock(&priv->lock);
++	g_ctx = priv->sources[i].g_ctx;
++
++	for (i = 0; i < g_ctx->num_streams; i++) {
++		g_stream = &g_ctx->streams[i];
++
++		if (g_stream->des_pipe != MAX96724_PIPE_INVALID)
++			max96724_write_reg(dev, g_stream->des_pipe,
++					   g_stream->st_id_sel);
++	}
++	mutex_unlock(&priv->lock);
++
++	return 0;
++}
++EXPORT_SYMBOL(max96724_start_streaming);
++
++int max96724_stop_streaming(struct device *dev, struct device *s_dev)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++	struct gmsl_link_ctx *g_ctx;
++	struct gmsl_stream *g_stream;
++	int err = 0;
++	unsigned int i = 0;
++
++	err = max96724_get_sdev_idx(dev, s_dev, &i);
++	if (err)
++		return err;
++
++	mutex_lock(&priv->lock);
++	g_ctx = priv->sources[i].g_ctx;
++
++	for (i = 0; i < g_ctx->num_streams; i++) {
++		g_stream = &g_ctx->streams[i];
++
++		if (g_stream->des_pipe != MAX96724_PIPE_INVALID)
++			max96724_write_reg(dev, g_stream->des_pipe,
++					   MAX96724_RESET_ST_ID);
++	}
++
++	mutex_unlock(&priv->lock);
++
++	return 0;
++}
++EXPORT_SYMBOL(max96724_stop_streaming);
++
++/* ================================================================
++ * Pipe Management
++ * ================================================================ */
++
++int max96724_get_available_pipe_id(struct device *dev, int vc_id)
++{
++	int i;
++	int pipe_id = -ENOMEM;
++	struct max96724 *priv = dev_get_drvdata(dev);
++
++	mutex_lock(&priv->lock);
++	for (i = 0; i < MAX96724_MAX_PIPES; i++) {
++		if (i == vc_id && !priv->pipe[i].st_count) {
++			priv->pipe[i].st_count++;
++			pipe_id = i;
++			break;
++		}
++	}
++	mutex_unlock(&priv->lock);
++
++	return pipe_id;
++}
++EXPORT_SYMBOL(max96724_get_available_pipe_id);
++
++int max96724_release_pipe(struct device *dev, int pipe_id)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++
++	if (pipe_id < 0 || pipe_id >= MAX96724_MAX_PIPES)
++		return -EINVAL;
++
++	mutex_lock(&priv->lock);
++	priv->pipe[pipe_id].st_count = 0;
++	mutex_unlock(&priv->lock);
++
++	return 0;
++}
++EXPORT_SYMBOL(max96724_release_pipe);
++
++int max96724_get_ser_pipe_id(struct device *dev, int dser_pipe_id, int vc_id)
++{
++	/*
++	 * In Tunnel Mode with MAX96717, all VCs are carried in a single
++	 * tunnel pipe. The pipe mapping is 1:1 for d4xx compatibility.
++	 */
++	return dser_pipe_id;
++}
++EXPORT_SYMBOL(max96724_get_ser_pipe_id);
++
++void max96724_reset_oneshot(struct device *dev)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++
++	mutex_lock(&priv->lock);
++	if (priv->splitter_enabled) {
++		/* [UG] Multi-camera: reset all links */
++		u8 link_rate = (priv->link_speed == 6) ? 0x22 : 0x11;
++
++		max96724_write_reg(dev, MAX96724_LINK_RATE_AB_ADDR,
++				   link_rate);
++		max96724_write_reg(dev, MAX96724_LINK_RATE_CD_ADDR,
++				   link_rate);
++		max96724_write_reg(dev, MAX96724_LINK_EN_ADDR,
++				   MAX96724_LINK_EN_ALL);
++	} else {
++		max96724_write_reg(dev, MAX96724_ONESHOT_ADDR,
++				   MAX96724_ONESHOT_ALL);
++	}
++	msleep(100);
++
++	/* ONESHOT resets CSI config to defaults.
++	 * Restore 1x4a+2x2 2-lane config after every ONESHOT (per guide §7):
++	 *   CSI_OUT_CFG=0x08  1x4a+2x2: Controller 1 → PHY0+1 → Port A
++	 *   PHY_EN=0x30       PHY0+PHY1 (both needed for Port A)
++	 *   MIPI_CTRL_SEL=0x55 all pipes → Controller 1 (must match TUN_DEST)
++	 *   BACKTOP=0x02      CSIB_EN (Controller 1)
++	 *   TUN_EN=0x09       tunnel enable (per verified XML)
++	 *   TUN_DEST=0x50     manual detect + PHY1 (per verified XML)
++	 *   DPLL_FREQ1=0x2E   1400Mbps (Controller 1's DPLL)
++	 *   LANE_CTRL1=0x40   2-lane on Controller 1
++	 *   VID_RX0=0x33      disable pkt detect for tunnel mode
++	 */
++	max96724_write_reg(dev, MAX96724_CSI_OUT_CFG_ADDR,
++			   MAX96724_CSI_MODE_2X4_VAL);
++	max96724_write_reg(dev, MAX96724_CSI_PHY_EN_ADDR,
++			   MAX96724_CSI_PHY_EN_01);
++	max96724_write_reg(dev, MAX96724_MIPI_CTRL_SEL_ADDR, 0x55);
++	max96724_write_reg(dev, MAX96724_BACKTOP_EN_ADDR,
++			   MAX96724_BACKTOP_CSIB_EN);
++	/* Restore 2-lane count on all controllers (ONESHOT resets to default) */
++	max96724_write_reg(dev, MAX96724_LANE_CTRL0_ADDR,
++			   MAX96724_LANE_CTRL_2LANE);
++	max96724_write_reg(dev, MAX96724_LANE_CTRL1_ADDR,
++			   MAX96724_LANE_CTRL_2LANE);
++	max96724_write_reg(dev, MAX96724_LANE_CTRL2_ADDR,
++			   MAX96724_LANE_CTRL_2LANE);
++	max96724_write_reg(dev, MAX96724_LANE_CTRL3_ADDR,
++			   MAX96724_LANE_CTRL_2LANE);
++	max96724_write_reg(dev, MAX96724_DPLL_FREQ1_ADDR,
++			   MAX96724_DPLL_1400MBPS_CTRL0);
++	max96724_write_reg(dev, MAX96724_VID_RX0_P0_ADDR,
++			   MAX96724_VID_RX0_CFG_VAL);
++	/* Re-enable tunnel on all pipes (ONESHOT resets TUN_EN to 0x08=disabled) */
++	max96724_write_reg(dev, MAX96724_PIPE0_TUN_EN_ADDR, MAX96724_TUN_EN);
++	max96724_write_reg(dev, MAX96724_PIPE1_TUN_EN_ADDR, MAX96724_TUN_EN);
++	max96724_write_reg(dev, MAX96724_PIPE2_TUN_EN_ADDR, MAX96724_TUN_EN);
++	max96724_write_reg(dev, MAX96724_PIPE3_TUN_EN_ADDR, MAX96724_TUN_EN);
++	/* TUN_DEST: set to Controller 1 (0x10) for 2x4 alt / Port A */
++	max96724_write_reg(dev, MAX96724_PIPE0_TUN_DEST_ADDR,
++			   MAX96724_TUN_DEST_CTRL1);
++	max96724_write_reg(dev, MAX96724_PIPE1_TUN_DEST_ADDR,
++			   MAX96724_TUN_DEST_CTRL1);
++	max96724_write_reg(dev, MAX96724_PIPE2_TUN_DEST_ADDR,
++			   MAX96724_TUN_DEST_CTRL1);
++	max96724_write_reg(dev, MAX96724_PIPE3_TUN_DEST_ADDR,
++			   MAX96724_TUN_DEST_CTRL1);
++
++	msleep(200);
++	mutex_unlock(&priv->lock);
++}
++EXPORT_SYMBOL(max96724_reset_oneshot);
++
++/* ================================================================
++ * Init Settings / Set Pipe
++ * ================================================================ */
++
++/*
++ * __max96724_set_pipe - Configure per-pipe mapping registers
++ */
++static int __max96724_set_pipe(struct device *dev, int pipe_id,
++			       u8 data_type1, u8 data_type2, u32 vc_id)
++{
++	int err = 0;
++	int i;
++	u8 en_mapping_num = 0x0F;
++	u8 all_mapping_phy = MAX96724_ALL_MAP_CTRL1;  /* Controller 1 for 2x4 alt Port A mode */
++
++	struct reg_pair map_pipe_control[] = {
++		/* Enable 4 mappings for Pipe X */
++		{MAX96724_TX11_PIPE_X_EN_ADDR, 0x0F},
++		/* Map data_type1 on vc_id */
++		{MAX96724_PIPE_X_SRC_0_MAP_ADDR, 0x1E},
++		{MAX96724_PIPE_X_DST_0_MAP_ADDR, 0x1E},
++		/* Map frame start on vc_id */
++		{MAX96724_PIPE_X_SRC_1_MAP_ADDR, 0x00},
++		{MAX96724_PIPE_X_DST_1_MAP_ADDR, 0x00},
++		/* Map frame end on vc_id */
++		{MAX96724_PIPE_X_SRC_2_MAP_ADDR, 0x01},
++		{MAX96724_PIPE_X_DST_2_MAP_ADDR, 0x01},
++		/* Map data_type2 on vc_id */
++		{MAX96724_PIPE_X_SRC_3_MAP_ADDR, 0x12},
++		{MAX96724_PIPE_X_DST_3_MAP_ADDR, 0x12},
++		/* All mappings to Controller 1 (2x4 alt: Ctrl1 drives Port A) */
++		{MAX96724_TX45_PIPE_X_DST_CTRL_ADDR, MAX96724_ALL_MAP_CTRL1},
++		{MAX96724_TX46_PIPE_X_ADDR, MAX96724_ALL_MAP_CTRL1},
++		{MAX96724_TX47_PIPE_X_ADDR, MAX96724_ALL_MAP_CTRL1},
++		{MAX96724_TX48_PIPE_X_ADDR, MAX96724_ALL_MAP_CTRL1},
++		/* [SC20190112 2-lane] TX49: Pipeline concatenation 2W (2-lane output) */
++		{MAX96724_TX49_PIPE_X_ADDR, MAX96724_TX49_CONCAT_2W},
++		/*
++		 * Keep DES heartbeat handling aligned with the serializer's
++		 * LIM_HEART-disabled tunnel mode to avoid persistent VID_SEQ_ERR.
++		 */
++		{0x0100, MAX96724_VID_RX0_CFG_VAL},
++		{0x0106, MAX96724_VID_RX6_CFG_VAL},
++		/*
++		 * Pipe stream control (offset 0x36 per pipe block).
++		 * [gmsl_ser_des_guide §4.9] TUN_EN = 0x09 per verified XML.
++		 */
++		{0x0936, MAX96724_TUN_EN},
++	};
++
++	/* Adjust addresses for pipe offset (stride 0x40 per pipe)
++	 * Entries 0-13: TX11, SRC/DST maps, TX45-TX49 (all stride 0x40)
++	 * Entries 14-15: VID_RX0/6 (stride 0x12)
++	 * Entry 16: Pipe stream control (stride 0x40)
++	 */
++	for (i = 0; i < 14; i++)
++		map_pipe_control[i].addr += 0x40 * pipe_id;
++
++	/* [max9296.c pattern] VID_RX offset: 0x12 per pipe */
++	map_pipe_control[14].addr += 0x12 * pipe_id;
++	map_pipe_control[15].addr += 0x12 * pipe_id;
++
++	/* Pipe stream control: stride 0x40 */
++	map_pipe_control[16].addr += 0x40 * pipe_id;
++
++	if (data_type2 == 0x0) {
++		en_mapping_num = 0x07;
++		all_mapping_phy = 0x15;  /* 3 mappings to Controller 1 */
++	}
++
++	map_pipe_control[0].val = en_mapping_num;
++	/* SRC: match incoming VC from camera (vc_id) */
++	map_pipe_control[1].val = (vc_id << 6) | data_type1;
++	/* DST: preserve VC — NVCSI/VI endpoints expect matching vc-id */
++	map_pipe_control[2].val = (vc_id << 6) | data_type1;
++	map_pipe_control[3].val = (vc_id << 6) | 0x00;
++	map_pipe_control[4].val = (vc_id << 6) | 0x00;
++	map_pipe_control[5].val = (vc_id << 6) | 0x01;
++	map_pipe_control[6].val = (vc_id << 6) | 0x01;
++	map_pipe_control[7].val = (vc_id << 6) | data_type2;
++	map_pipe_control[8].val = (vc_id << 6) | data_type2;
++	map_pipe_control[9].val = all_mapping_phy;
++	/* TX46-TX48 keep 0x55 (Ctrl1) from initializer */
++	/* TX49 keeps 0x83 (2W concat) from initializer */
++	/* VID_RX (entry 14) and pipe stream ctrl (entry 15) keep init values */
++
++	err = max96724_set_registers(dev, map_pipe_control,
++				     ARRAY_SIZE(map_pipe_control));
++
++	return err;
++}
++
++/*
++ * max96724_init_settings - Initialize default pipe and tunnel configuration
++ *
++ * Sets up all 4 pipes with default YUV422_8 + EMBED for VC0-3,
++ * matching the d4xx framework expectations.
++ *
++ */
++int max96724_init_settings(struct device *dev)
++{
++	int err = 0;
++	int i;
++	struct max96724 *priv = dev_get_drvdata(dev);
++
++	mutex_lock(&priv->lock);
++
++	for (i = 0; i < MAX96724_MAX_PIPES; i++)
++		err |= __max96724_set_pipe(dev, i, GMSL_CSI_DT_YUV422_8,
++					   GMSL_CSI_DT_EMBED, i);
++
++	mutex_unlock(&priv->lock);
++
++	return err;
++}
++EXPORT_SYMBOL(max96724_init_settings);
++
++int max96724_bind_ser_to_dser_pipe(struct device *dev, int dser_pipe_id,
++				   int ser_pipe_id, u32 vc_id)
++{
++	/* In Tunnel Mode, pipe mapping is 1:1 (each camera → one pipe) */
++	return 0;
++}
++EXPORT_SYMBOL(max96724_bind_ser_to_dser_pipe);
++
++int max96724_set_pipe(struct device *dev, int pipe_id,
++		      u8 data_type1, u8 data_type2, u32 vc_id)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++	int err = 0;
++
++	if (pipe_id > (MAX96724_MAX_PIPES - 1)) {
++		dev_info(dev, "%s: input pipe_id: %d exceeds max96724 max pipes\n",
++			 __func__, pipe_id);
++		return -EINVAL;
++	}
++
++	dev_dbg(dev, "%s pipe_id %d, data_type1 %u, data_type2 %u, vc_id %u\n",
++		__func__, pipe_id, data_type1, data_type2, vc_id);
++
++	mutex_lock(&priv->lock);
++
++	err = __max96724_set_pipe(dev, pipe_id, data_type1, data_type2, vc_id);
++
++	mutex_unlock(&priv->lock);
++
++	return err;
++}
++EXPORT_SYMBOL(max96724_set_pipe);
++
++/* ================================================================
++ * Device Tree Parsing
++ * ================================================================ */
++
++static const struct of_device_id max96724_of_match[] = {
++	{ .compatible = "adi,max96724", },
++	{ },
++};
++MODULE_DEVICE_TABLE(of, max96724_of_match);
++
++static int max96724_parse_dt(struct max96724 *priv,
++			     struct i2c_client *client)
++{
++	struct device_node *node = client->dev.of_node;
++	int err = 0;
++	const char *str_value;
++	int value;
++	const struct of_device_id *match;
++
++	if (!node)
++		return -EINVAL;
++
++	match = of_match_device(max96724_of_match, &client->dev);
++	if (!match) {
++		dev_err(&client->dev, "Failed to find matching dt id\n");
++		return -EFAULT;
++	}
++
++	/* CSI mode: "2x4" or "4x2" */
++	err = of_property_read_string(node, "csi-mode", &str_value);
++	if (err < 0) {
++		dev_err(&client->dev, "csi-mode property not found\n");
++		return err;
++	}
++
++	if (!strcmp(str_value, "2x4")) {
++		priv->csi_mode = MAX96724_CSI_MODE_2X4;
++		priv->lane_mp1 = MAX96724_LANE_MAP1_2X4;
++		priv->lane_mp2 = MAX96724_LANE_MAP2_2X4;
++	} else if (!strcmp(str_value, "4x2")) {
++		priv->csi_mode = MAX96724_CSI_MODE_4X2;
++		priv->lane_mp1 = MAX96724_LANE_MAP1_4X2;
++		priv->lane_mp2 = MAX96724_LANE_MAP2_4X2;
++	} else {
++		dev_err(&client->dev, "invalid csi mode\n");
++		return -EINVAL;
++	}
++
++	/* Max sources */
++	err = of_property_read_u32(node, "max-src", &value);
++	if (err < 0) {
++		dev_err(&client->dev, "No max-src info\n");
++		return err;
++	}
++	priv->max_src = value;
++
++	/* Reset GPIO */
++	priv->reset_gpio = of_get_named_gpio(node, "reset-gpios", 0);
++	if (priv->reset_gpio < 0) {
++		dev_err(&client->dev, "reset-gpios not found %d\n", err);
++		return err;
++	}
++
++	/* [User requirement] GMSL link speed from DT: 3 or 6 (Gbps) */
++	err = of_property_read_u32(node, "gmsl-link-speed", &value);
++	if (err < 0) {
++		/* Default to 3 Gbps if not specified */
++		priv->link_speed = 3;
++		dev_info(&client->dev,
++			 "gmsl-link-speed not specified, defaulting to 3 Gbps\n");
++	} else {
++		if (value != 3 && value != 6) {
++			dev_err(&client->dev,
++				"invalid gmsl-link-speed %d (must be 3 or 6)\n",
++				value);
++			return -EINVAL;
++		}
++		priv->link_speed = value;
++	}
++
++	/* 1.2V regulator (optional) */
++	if (of_get_property(node, "vdd_cam_1v2-supply", NULL)) {
++		priv->vdd_cam_1v2 = regulator_get(&client->dev, "vdd_cam_1v2");
++		if (IS_ERR(priv->vdd_cam_1v2)) {
++			dev_err(&client->dev,
++				"vdd_cam_1v2 regulator get failed\n");
++			err = PTR_ERR(priv->vdd_cam_1v2);
++			priv->vdd_cam_1v2 = NULL;
++			return err;
++		}
++	} else {
++		priv->vdd_cam_1v2 = NULL;
++	}
++
++	return 0;
++}
++
++/* ================================================================
++ * Probe / Remove
++ * ================================================================ */
++
++static struct regmap_config max96724_regmap_config = {
++	.reg_bits = 16,
++	.val_bits = 8,
++	.cache_type = REGCACHE_RBTREE,
++};
++
++static int max96724_probe(struct i2c_client *client,
++			   const struct i2c_device_id *id)
++{
++	struct max96724 *priv;
++	int err = 0;
++
++	dev_info(&client->dev,
++		 "[MAX96724]: probing Quad GMSL2 Deserializer (Tunnel Mode)\n");
++
++	priv = devm_kzalloc(&client->dev, sizeof(*priv), GFP_KERNEL);
++	if (!priv)
++		return -ENOMEM;
++
++	priv->i2c_client = client;
++	priv->regmap = devm_regmap_init_i2c(priv->i2c_client,
++					     &max96724_regmap_config);
++	if (IS_ERR(priv->regmap)) {
++		dev_err(&client->dev,
++			"regmap init failed: %ld\n", PTR_ERR(priv->regmap));
++		return -ENODEV;
++	}
++
++	err = max96724_parse_dt(priv, client);
++	if (err) {
++		dev_err(&client->dev, "unable to parse dt\n");
++		return -EFAULT;
++	}
++
++	max96724_pipes_reset(priv);
++
++	if (priv->max_src > MAX96724_MAX_SOURCES) {
++		dev_err(&client->dev,
++			"max sources more than currently supported\n");
++		return -EINVAL;
++	}
++
++	mutex_init(&priv->lock);
++
++	dev_set_drvdata(&client->dev, priv);
++
++	dev_info(&client->dev, "%s: success (link_speed=%d Gbps, max_src=%d)\n",
++		 __func__, priv->link_speed, priv->max_src);
++
++	return err;
++}
++
++static int max96724_remove(struct i2c_client *client)
++{
++	struct max96724 *priv;
++
++	if (client != NULL) {
++		priv = dev_get_drvdata(&client->dev);
++		mutex_destroy(&priv->lock);
++		i2c_unregister_device(client);
++		client = NULL;
++	}
++
++	return 0;
++}
++
++static const struct i2c_device_id max96724_id[] = {
++	{ "max96724", 0 },
++	{ },
++};
++
++MODULE_DEVICE_TABLE(i2c, max96724_id);
++
++static struct i2c_driver max96724_i2c_driver = {
++	.driver = {
++		.name = "max96724",
++		.owner = THIS_MODULE,
++		.of_match_table = of_match_ptr(max96724_of_match),
++	},
++	.probe = max96724_probe,
++	.remove = max96724_remove,
++	.id_table = max96724_id,
++};
++
++static int __init max96724_init(void)
++{
++	return i2c_add_driver(&max96724_i2c_driver);
++}
++
++static void __exit max96724_exit(void)
++{
++	i2c_del_driver(&max96724_i2c_driver);
++}
++
++module_init(max96724_init);
++module_exit(max96724_exit);
++
++MODULE_DESCRIPTION("Quad GMSL2 Deserializer driver max96724 (Tunnel Mode)");
++MODULE_AUTHOR("RealSense AI");
++MODULE_LICENSE("GPL v2");
+diff --git a/include/media/max96717.h b/include/media/max96717.h
+new file mode 100644
+index 0000000..65bf930
+--- /dev/null
++++ b/include/media/max96717.h
+@@ -0,0 +1,151 @@
++/*
++ * max96717.c - MAX96717 GMSL2 Serializer driver (Tunnel Mode)
++ *
++ * Copyright (c) 2026, RealSense, Inc.  All rights reserved.
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms and conditions of the GNU General Public License,
++ * version 2, as published by the Free Software Foundation.
++ *
++ * This program is distributed in the hope it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
++ * more details.
++ *
++ * You should have received a copy of the GNU General Public License
++ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
++ */
++
++/**
++ * @file
++ * <b>MAX96717 API: For Analog Devices MAX96717 GMSL2 serializer</b>
++ *
++ * @b Description: Defines elements used to set up and use an
++ *  Analog Devices MAX96717 GMSL2 serializer in Tunnel Mode.
++ */
++
++#ifndef __MAX96717_H__
++#define __MAX96717_H__
++
++#include <linux/types.h>
++#include <media/gmsl-link.h>
++
++/**
++ * \defgroup max96717 MAX96717 serializer driver
++ *
++ * Controls the MAX96717 GMSL2 serializer module (Tunnel Mode).
++ *
++ * @ingroup serdes_group
++ * @{
++ */
++
++/**
++ * @brief  Configures a single pipe on the serializer.
++ *
++ * In Tunnel Mode, per-pipe DT/VC filtering is not active on the serializer
++ * side (all VCs are tunneled transparently). This function maintains API
++ * compatibility with the d4xx sensor driver framework.
++ *
++ * @param  [in]  dev          The serializer device handle.
++ * @param  [in]  pipe_id      Pipe index (0..3).
++ * @param  [in]  data_type1   Primary CSI-2 data type.
++ * @param  [in]  data_type2   Secondary CSI-2 data type (e.g. embedded).
++ * @param  [in]  vc_id        Virtual channel ID.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96717_set_pipe(struct device *dev, int pipe_id, u8 data_type1,
++		      u8 data_type2, u32 vc_id);
++
++/**
++ * @brief  Toggle SER TX to restore tunnel detection after DES ONESHOT.
++ *
++ * A DES ONESHOT resets the video data path. The serializer must cycle
++ * its TX enable (REG2 0x03→0x43) for the deserializer to re-acquire
++ * the tunnel stream.
++ *
++ * @param  [in]  dev          The serializer device handle.
++ */
++void max96717_retrigger_tx(struct device *dev);
++
++/**
++ * @brief  Powers on the serializer and performs I2C overrides
++ * for sensor and serializer devices.
++ *
++ * Must be called after the deserializer's max96724_setup_link().
++ *
++ * @param  [in]  dev          The serializer device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96717_setup_control(struct device *dev);
++
++/**
++ * @brief  Reverts I2C overrides and resets the serializer.
++ *
++ * @param  [in]  dev          The serializer device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96717_reset_control(struct device *dev);
++
++/**
++ * @brief  Pairs a sensor device with the serializer.
++ *
++ * To be called by the sensor client driver.
++ *
++ * @param  [in]  dev          The serializer device handle.
++ * @param  [in]  g_ctx        The gmsl_link_ctx structure handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96717_sdev_pair(struct device *dev, struct gmsl_link_ctx *g_ctx);
++
++/**
++ * @brief  Unpairs a sensor device from the serializer.
++ *
++ * @param  [in]  dev          The serializer device handle.
++ * @param  [in]  s_dev        The sensor device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96717_sdev_unpair(struct device *dev, struct device *s_dev);
++
++/**
++ * @brief  Sets up the serializer's internal streaming pipeline.
++ *
++ * Configures CSI-2 input mode, lane mapping, and enables Tunnel Mode
++ * (EXT11[7]=1 at register 0x0383).
++ *
++ * @param  [in]  dev          The serializer device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96717_setup_streaming(struct device *dev);
++
++/**
++ * @brief  Applies initial register settings for the serializer.
++ *
++ * Configures default pipe settings and Tunnel Mode registers.
++ *
++ * @param  [in]  dev          The serializer device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96717_init_settings(struct device *dev);
++
++/**
++ * @brief  No-op hook for GPIO-over-GMSL tunneling for FSIN/FOUT signals.
++ *
++ * The signal map is documented, but the concrete MFP_CFG values are
++ * not available yet. This hook currently logs and returns success.
++ *
++ * @param  [in]  dev          The serializer device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96717_setup_gpio_tunneling(struct device *dev);
++
++/** @} */
++
++#endif  /* __MAX96717_H__ */
+diff --git a/include/media/max96724.h b/include/media/max96724.h
+new file mode 100644
+index 0000000..dc5a8ea
+--- /dev/null
++++ b/include/media/max96724.h
+@@ -0,0 +1,183 @@
++/*
++ * max96717.c - MAX96717 GMSL2 Serializer driver (Tunnel Mode)
++ *
++ * Copyright (c) 2026, RealSense, Inc.  All rights reserved.
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms and conditions of the GNU General Public License,
++ * version 2, as published by the Free Software Foundation.
++ *
++ * This program is distributed in the hope it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
++ * more details.
++ *
++ * You should have received a copy of the GNU General Public License
++ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
++ */
++
++/**
++ * @file
++ * <b>MAX96724 API: For Analog Devices MAX96724 GMSL2 quad deserializer</b>
++ *
++ * @b Description: Defines elements used to set up and use an
++ *  Analog Devices MAX96724 quad GMSL2 deserializer in Tunnel Mode.
++ */
++
++#ifndef __MAX96724_H__
++#define __MAX96724_H__
++
++#include <linux/types.h>
++#include <media/gmsl-link.h>
++
++/**
++ * \defgroup max96724 MAX96724 deserializer driver
++ *
++ * Controls the MAX96724 quad GMSL2 deserializer module (Tunnel Mode).
++ *
++ * @ingroup serdes_group
++ * @{
++ */
++
++int max96724_get_available_pipe_id(struct device *dev, int vc_id);
++int max96724_get_ser_pipe_id(struct device *dev, int dser_pipe_id, int vc_id);
++int max96724_set_pipe(struct device *dev, int pipe_id, u8 data_type1,
++		      u8 data_type2, u32 vc_id);
++int max96724_release_pipe(struct device *dev, int pipe_id);
++void max96724_reset_oneshot(struct device *dev);
++
++/**
++ * @brief  Puts the deserializer in single exclusive link mode.
++ *
++ * @param  [in]  dev          The deserializer device handle.
++ * @param  [in]  s_dev        The sensor device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96724_setup_link(struct device *dev, struct device *s_dev);
++
++/**
++ * @brief  Sets up the deserializer link's control pipeline.
++ *
++ * Configures I2C pass-through, splitter mode if needed, and
++ * enables the tunnel mode pipe routing for the source.
++ *
++ * @param  [in]  dev          The deserializer device handle.
++ * @param  [in]  s_dev        The sensor device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96724_setup_control(struct device *dev, struct device *s_dev);
++
++/**
++ * @brief  Resets the deserializer link control pipeline.
++ *
++ * @param  [in]  dev          The deserializer device handle.
++ * @param  [in]  s_dev        The sensor device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96724_reset_control(struct device *dev, struct device *s_dev);
++
++/**
++ * @brief  Registers a source sensor device with the deserializer.
++ *
++ * @param  [in]  dev          The deserializer device handle.
++ * @param  [in]  g_ctx        The gmsl_link_ctx structure handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96724_sdev_register(struct device *dev, struct gmsl_link_ctx *g_ctx);
++
++/**
++ * @brief  Unregisters a source sensor device from the deserializer.
++ *
++ * @param  [in]  dev          The deserializer device handle.
++ * @param  [in]  s_dev        The sensor device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96724_sdev_unregister(struct device *dev, struct device *s_dev);
++
++/**
++ * @brief  Configures the internal streaming pipeline.
++ *
++ * Sets up tunnel mode pipe routing, CSI-2 output lane configuration,
++ * and MIPI PHY settings.
++ *
++ * @param  [in]  dev          The deserializer device handle.
++ * @param  [in]  s_dev        The sensor device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96724_setup_streaming(struct device *dev, struct device *s_dev);
++
++/**
++ * @brief  Enables streaming for a source sensor.
++ *
++ * @param  [in]  dev          The deserializer device handle.
++ * @param  [in]  s_dev        The sensor device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96724_start_streaming(struct device *dev, struct device *s_dev);
++
++/**
++ * @brief  Disables streaming for a source sensor.
++ *
++ * @param  [in]  dev          The deserializer device handle.
++ * @param  [in]  s_dev        The sensor device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96724_stop_streaming(struct device *dev, struct device *s_dev);
++
++/**
++ * @brief  Powers on the MAX96724 deserializer module.
++ *
++ * Asserts shared reset GPIO and powers on the regulator.
++ *
++ * @param  [in]  dev          The deserializer device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96724_power_on(struct device *dev);
++
++/**
++ * @brief  Powers off the MAX96724 deserializer module.
++ *
++ * @param  [in]  dev          The deserializer device handle.
++ */
++void max96724_power_off(struct device *dev);
++
++/**
++ * @brief  Applies initial register settings for the deserializer.
++ *
++ * Configures default pipe mappings, tunnel mode, and CSI output for
++ * the D5xx/SC1.2 use case.
++ *
++ * @param  [in]  dev          The deserializer device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96724_init_settings(struct device *dev);
++
++/**
++ * @brief  Maps deserializer pipe ID to serializer pipe ID.
++ *
++ * In tunnel mode with MAX96717, all data flows through a single pipe
++ * per camera, so the mapping is 1:1.
++ *
++ * @param  [in]  dev             The deserializer device handle.
++ * @param  [in]  dser_pipe_id    Deserializer pipe ID.
++ * @param  [in]  ser_pipe_id     Serializer pipe ID.
++ * @param  [in]  vc_id           VC ID associated with this pipe.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96724_bind_ser_to_dser_pipe(struct device *dev, int dser_pipe_id,
++				   int ser_pipe_id, u32 vc_id);
++
++/** @} */
++
++#endif  /* __MAX96724_H__ */
+-- 
+2.25.1
+

--- a/nvidia-oot/6.1/0011-Add-MAX96717-serializer-and-MAX96724-deserializer-dr.patch
+++ b/nvidia-oot/6.1/0011-Add-MAX96717-serializer-and-MAX96724-deserializer-dr.patch
@@ -1,0 +1,2896 @@
+From 40fac9b67ddea60055961d32fa89fe8f608396ff Mon Sep 17 00:00:00 2001
+From: RealSense AI <realsense@realsenseai.com>
+Date: Tue, 12 May 2026 17:06:23 +0800
+Subject: [PATCH] Add MAX96717 serializer and MAX96724 deserializer drivers for
+ tunnel mode
+
+Add MAX96717 GMSL2 serializer and MAX96724 GMSL2 quad deserializer
+drivers for Tunnel Mode operation with D5xx cameras.
+
+MAX96717 serializer features:
+- CSI-2 input with 2/4 lane support
+- Tunnel Mode encapsulation of full CSI-2 byte stream
+- I2C address translation for sensor passthrough
+- GPIO-over-GMSL tunneling hook for FSIN/FOUT signals
+
+MAX96724 quad deserializer features:
+- Up to 4 GMSL2 links (quad camera support)
+- Configurable link speed (3 Gbps / 6 Gbps via DT)
+- Tunnel Mode pipe routing and CSI-2 output
+- 2x4 and 4x2 CSI output mode support
+- Power management with GPIO reset and regulator control
+
+Signed-off-by: RealSense AI <realsense@realsenseai.com>
+---
+ drivers/media/i2c/Makefile   |    2 +
+ drivers/media/i2c/max96717.c |  797 ++++++++++++++++
+ drivers/media/i2c/max96724.c | 1690 ++++++++++++++++++++++++++++++++++
+ include/media/max96717.h     |  151 +++
+ include/media/max96724.h     |  183 +++
+ 5 files changed, 2823 insertions(+)
+ create mode 100644 drivers/media/i2c/max96717.c
+ create mode 100644 drivers/media/i2c/max96724.c
+ create mode 100644 include/media/max96717.h
+ create mode 100644 include/media/max96724.h
+
+diff --git a/drivers/media/i2c/Makefile b/drivers/media/i2c/Makefile
+index b284938..947e6e9 100644
+--- a/drivers/media/i2c/Makefile
++++ b/drivers/media/i2c/Makefile
+@@ -8,6 +8,8 @@ obj-m += max9296.o
+ subdir-ccflags-y += -DCONFIG_VIDEO_D4XX_SERDES
+ subdir-ccflags-y += -DCONFIG_TEGRA_CAMERA_PLATFORM
+ obj-m += d4xx.o
++obj-m += max96717.o
++obj-m += max96724.o
+ ifeq ($(findstring ack_src,$(NV_BUILD_KERNEL_OPTIONS)),)
+ obj-m += max96712.o
+ 
+diff --git a/drivers/media/i2c/max96717.c b/drivers/media/i2c/max96717.c
+new file mode 100644
+index 0000000..78d8a01
+--- /dev/null
++++ b/drivers/media/i2c/max96717.c
+@@ -0,0 +1,797 @@
++/*
++ * max96717.c - MAX96717 GMSL2 Serializer driver (Tunnel Mode)
++ *
++ * Copyright (c) 2026, RealSense, Inc.  All rights reserved.
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms and conditions of the GNU General Public License,
++ * version 2, as published by the Free Software Foundation.
++ *
++ * This program is distributed in the hope it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
++ * more details.
++ *
++ * You should have received a copy of the GNU General Public License
++ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
++ */
++
++/*
++ * Register Reference Sources:
++ * [PPTX]  = GMSL_MAX96717_MAX96724_TechOverview - V1.pptx
++ * [XML]   = MAX96717_MAX96724_HKR_EVB_700mbps_tunnel_mode_basedonexcelsheet_D585.xml
++ *
++ * Every register address and value below is traceable to one of these sources.
++ */
++
++#include <media/camera_common.h>
++#include <linux/module.h>
++#include <media/max96717.h>
++
++/* ===== Register Addresses ===== */
++
++/* [PPTX slide 7] REG0: Device ID (read-only, returns 0x40) */
++#define MAX96717_DEV_ADDR		0x00
++
++/* [PPTX slide 7] REG1: Link Speed
++ *   bit[3]=1: 3 Gbps, bit[4]=1: 6 Gbps
++ */
++#define MAX96717_REG1_ADDR		0x01
++
++/* [PPTX slide 7 / XML 0x0002] PIPE_EN: Pipe enable / soft reset
++ *   [XML] 0x03 = soft reset, 0x43 = pipes enabled + video init
++ *   [PPTX slide 7] Matches MAX9295 PIPE_EN at 0x02
++ */
++#define MAX96717_PIPE_EN_ADDR		0x02
++
++/* [PPTX slide 7] CTRL0: GMSL2 TX Control
++ *   bit[5]=1: GMSL2 mode, bit[0]=1: enable transmitter
++ *   0x21 = GMSL2 mode + TX enable on Link A
++ */
++#define MAX96717_CTRL0_ADDR		0x10
++
++/* [PPTX slide 7] CTRL3: Start Video - final enable bit
++ *   bit[0]=1: activate video stream
++ */
++#define MAX96717_CTRL3_ADDR		0x13
++
++/* [PPTX slide 7] TX1: FEC Enable
++ *   bit[6]=1: Reed-Solomon FEC enabled
++ */
++#define MAX96717_TX1_ADDR		0x29
++
++/* [MAX96724 Users Guide, I2C Broadcasting section, p44-46]
++ * MAX96717 I2C address translation registers (GMSL2 standard):
++ *   SRC_A / DST_A (0x42/0x43): Translation pair A (SER broadcast addr)
++ *   SRC_B / DST_B (0x44/0x45): Translation pair B (sensor passthrough)
++ *
++ * When host writes to SRC_B address, the MAX96717 translates it to
++ * DST_B and forwards via GMSL back-channel to the remote sensor.
++ *
++ */
++#define MAX96717_SRC_A_ADDR		0x42
++#define MAX96717_DST_A_ADDR		0x43
++#define MAX96717_I2C4_ADDR		0x44	/* SRC_B: sensor proxy addr */
++#define MAX96717_I2C5_ADDR		0x45	/* DST_B: sensor default addr */
++
++/* [PPTX slide 14] TX_STR_SEL: Stream ID select
++ *   bits[1:0]: stream ID for DES pipe routing
++ */
++#define MAX96717_TX_STR_SEL_ADDR	0x5B
++
++/* [PPTX slide 7 / XML 0x0110-0x0111] VIDEO_TX0/TX1: Video TX path config
++ *   [XML] 0x0110=0xE9, 0x0111=0x10 for tunnel mode data path
++ */
++#define MAX96717_VIDEO_TX0_ADDR		0x110
++#define MAX96717_VIDEO_TX1_ADDR		0x111
++
++/* [PPTX slide 7] FRONTTOP_0: Front-end topology
++ *   0x12 = single CSI-2 port A, all VCs pass through
++ */
++#define MAX96717_FRONTTOP0_ADDR		0x308
++
++/* [XML / PPTX slide 7] MIPI_RX0-RX3: CSI-2 receiver configuration
++ *   RX0 (0x330): CSI mode (0x00 = D-PHY controller A)
++ *   RX1 (0x331): Lane count - [PPTX slide 14] ctrl1_num_lanes bits[5:4]
++ *                 [XML] 0x30 = bits[5:4]=11 (4 lanes)
++ *   RX2 (0x332): Lane mapping - [XML] 0xE0 = default 1x4 map
++ *   RX3 (0x333): Lane mapping - [XML] 0x04 = default 1x4 map
++ */
++#define MAX96717_MIPI_RX0_ADDR		0x330
++#define MAX96717_MIPI_RX1_ADDR		0x331
++#define MAX96717_MIPI_RX2_ADDR		0x332
++#define MAX96717_MIPI_RX3_ADDR		0x333
++
++/* [PPTX slide 7 / slide 14] EXT11: TUNNEL MODE ENABLE
++ *   bit[7]=1: Tun_Mode = ON  *** CRITICAL REGISTER ***
++ *   [PPTX slide 7] 0x383 = 0x80
++ */
++#define MAX96717_EXT11_ADDR		0x383
++
++/* ===== Register Values ===== */
++
++/* [XML] Soft reset value for PIPE_EN register */
++#define MAX96717_SOFT_RESET		0x03
++
++/* [XML] Final enable: pipes enabled + video init */
++#define MAX96717_PIPE_EN_ALL		0x43
++
++/* [PPTX slide 7] CTRL0: GMSL2 mode + TX enable (Link A) */
++#define MAX96717_CTRL0_LINK_A		0x21
++/* CTRL0: GMSL2 mode + TX enable (Link B) */
++#define MAX96717_CTRL0_LINK_B		0x22
++
++/* [PPTX slide 7] CTRL0 reset all */
++#define MAX96717_RESET_ALL		0x80
++
++/* [PPTX slide 7] EXT11 tunnel mode enable value */
++#define MAX96717_TUN_MODE_EN		0x80
++
++/* [XML] VIDEO_TX0 tunnel mode data path enable */
++#define MAX96717_VIDEO_TX0_TUN		0xE9
++/* [XML] VIDEO_TX1 tunnel mode config */
++#define MAX96717_VIDEO_TX1_TUN		0x10
++
++/* [XML / PPTX slide 14] MIPI RX1: 4-lane CSI-2, bits[5:4]=11 */
++#define MAX96717_CSI_4_LANES		0x30
++/* 2-lane CSI-2, bits[5:4]=01 */
++#define MAX96717_CSI_2_LANES		0x10
++
++/* [XML] Lane mapping for 1x4 mode (matches MAX9295 1x4 values) */
++#define MAX96717_CSI_1X4_LANE_MAP1	0xE0
++#define MAX96717_CSI_1X4_LANE_MAP2	0x04
++
++/* [PPTX slide 7] FRONTTOP_0: single port A, all VCs */
++#define MAX96717_FRONTTOP0_PORT_A	0x12
++
++/* [XML] MIPI_RX0: CSI reset on + non-continuous clock */
++#define MAX96717_MIPI_RX0_RESET		0x08
++/* [PPTX slide 7] MIPI_RX0: Normal operation */
++#define MAX96717_MIPI_RX0_NORMAL	0x00
++
++/* [PPTX slide 9] REG1: 3 Gbps link speed, bit[3]=1 */
++#define MAX96717_LINK_SPEED_3GBPS	0x08
++/* [PPTX slide 9] REG1: 6 Gbps link speed, bit[4]=1 */
++#define MAX96717_LINK_SPEED_6GBPS	0x10
++
++/* [XML] EXT11 tunnel mode pre-config (0x0383=0x80) */
++#define MAX96717_EXT11_TUN_PRE		0x80
++
++#define MAX96717_MAX_PIPES		4
++
++/* ===== Data Structures ===== */
++
++struct max96717_client_ctx {
++	struct gmsl_link_ctx *g_ctx;
++	bool st_done;
++};
++
++struct max96717 {
++	struct i2c_client *i2c_client;
++	struct regmap *regmap;
++	struct max96717_client_ctx g_client;
++	struct mutex lock;
++	/* primary serializer properties */
++	__u32 def_addr;
++	__u32 pst2_ref;
++};
++
++static struct max96717 *prim_priv__;
++
++struct reg_pair {
++	u16 addr;
++	u8 val;
++};
++
++/* ===== Low-level I2C ===== */
++
++static int max96717_write_reg(struct device *dev, u16 addr, u8 val)
++{
++	struct max96717 *priv = dev_get_drvdata(dev);
++	int err;
++
++	err = regmap_write(priv->regmap, addr, val);
++	if (err)
++		dev_err(dev, "%s:i2c write failed, 0x%x = %x\n",
++			__func__, addr, val);
++
++	/* delay before next i2c command as required for SERDES link */
++	usleep_range(100, 110);
++
++	return err;
++}
++
++static int max96717_set_registers(struct device *dev, struct reg_pair *map,
++				  u32 count)
++{
++	int err = 0;
++	u32 j;
++
++	for (j = 0; j < count; j++) {
++		err = max96717_write_reg(dev, map[j].addr, map[j].val);
++		if (err)
++			break;
++	}
++
++	return err;
++}
++
++/* ===== Streaming Setup ===== */
++
++/*
++ * max96717_setup_streaming - Configure CSI-2 input and enable Tunnel Mode
++ *
++ * In Tunnel Mode (unlike MAX9295 Pixel Mode), the serializer encapsulates
++ * the entire CSI-2 byte stream verbatim into a single GMSL2 tunnel.
++ * All VCs (VC0-VC3) are preserved end-to-end.
++ */
++int max96717_setup_streaming(struct device *dev)
++{
++	struct max96717 *priv = dev_get_drvdata(dev);
++	int err = 0;
++	struct gmsl_link_ctx *g_ctx;
++	u32 lane_count;
++
++	/*
++	 * [XML] Full initialization sequence:
++	 *   0x0002 = 0x03  (soft reset)
++	 *   0x0383 = 0x80  (tunnel mode enable)
++	 *   0x0331 = 0x30  (4-lane CSI)
++	 *   0x0332 = 0xE0  (lane map1)
++	 *   0x0333 = 0x04  (lane map2)
++	 *   0x0110 = 0xE9  (video TX0 tunnel path)
++	 *   0x0111 = 0x10  (video TX1 tunnel config)
++	 *   0x0330 = 0x08  (CSI reset on)
++	 *   0x0330 = 0x00  (CSI reset off)
++	 *   0x0002 = 0x43  (final enable)
++	 */
++	struct reg_pair tunnel_init[] = {
++		/* [PPTX slide 7] EXT11: Tunnel Mode Enable */
++		{MAX96717_EXT11_ADDR, MAX96717_TUN_MODE_EN},
++		/* [XML] VIDEO_TX0/TX1: tunnel data path */
++		{MAX96717_VIDEO_TX0_ADDR, MAX96717_VIDEO_TX0_TUN},
++		{MAX96717_VIDEO_TX1_ADDR, MAX96717_VIDEO_TX1_TUN},
++	};
++
++	mutex_lock(&priv->lock);
++
++	if (!priv->g_client.g_ctx) {
++		dev_err(dev, "%s: no sdev client found\n", __func__);
++		err = -EINVAL;
++		goto error;
++	}
++
++	if (priv->g_client.st_done) {
++		dev_dbg(dev, "%s: stream setup is already done\n", __func__);
++		goto error;
++	}
++
++	g_ctx = priv->g_client.g_ctx;
++
++	/*
++	 * [Aardvark-verified] Soft reset before tunnel mode configuration
++	 * Clears stale pipe/CSI state for clean initialization.
++	 * Aardvark: 0x0002=0x03, sleep 30ms, then proceed with config.
++	 */
++	max96717_write_reg(dev, MAX96717_PIPE_EN_ADDR, MAX96717_SOFT_RESET);
++	msleep(30);
++
++	/*
++	 * [PPTX slide 14] ctrl1_num_lanes at 0x0331 bits[5:4]
++	 * [XML] 0x0331 = 0x30 for 4-lane
++	 * MAX96717 supports 1x4 mode only (single 4-lane D-PHY input)
++	 */
++	lane_count = (g_ctx->num_csi_lanes == 4) ?
++		MAX96717_CSI_4_LANES : MAX96717_CSI_2_LANES;
++
++	max96717_write_reg(dev, MAX96717_MIPI_RX1_ADDR, lane_count);
++
++	/* [XML] Lane mapping: 1x4 mode default */
++	max96717_write_reg(dev, MAX96717_MIPI_RX2_ADDR,
++			   MAX96717_CSI_1X4_LANE_MAP1);
++	max96717_write_reg(dev, MAX96717_MIPI_RX3_ADDR,
++			   MAX96717_CSI_1X4_LANE_MAP2);
++
++	/* Enable tunnel mode and configure video TX path */
++	err = max96717_set_registers(dev, tunnel_init,
++				     ARRAY_SIZE(tunnel_init));
++	if (err)
++		goto error;
++
++	/* [Aardvark-verified] CSI reset cycle with 2ms delay */
++	max96717_write_reg(dev, MAX96717_MIPI_RX0_ADDR,
++			   MAX96717_MIPI_RX0_RESET);
++	usleep_range(2000, 2100);
++	max96717_write_reg(dev, MAX96717_MIPI_RX0_ADDR,
++			   MAX96717_MIPI_RX0_NORMAL);
++
++	/* [XML] Final enable: pipes on + video init */
++	max96717_write_reg(dev, MAX96717_PIPE_EN_ADDR,
++			   MAX96717_PIPE_EN_ALL);
++
++	priv->g_client.st_done = true;
++
++error:
++	mutex_unlock(&priv->lock);
++	return err;
++}
++EXPORT_SYMBOL(max96717_setup_streaming);
++
++/* ===== Control Setup ===== */
++
++/*
++ * max96717_setup_control - Set up I2C address translation and link control
++ *
++ * Steps:
++ *   1. Reassign serializer I2C address via DEV_ADDR (reg 0x00)
++ *   2. Configure GMSL2 link mode via CTRL0 (reg 0x10)
++ *   3. Set I2C address translation for sensor passthrough:
++ *      I2C4/SRC_B (0x44) <- (sdev_reg << 1): proxy addr visible to host
++ *      I2C5/DST_B (0x45) <- (sdev_def << 1): real addr on back-channel
++ *
++ * This lets the Orin host access the D5xx sensor (def-addr 0x42) via
++ * the aliased proxy address (e.g. 0x1a) through the GMSL link.
++ *
++ */
++int max96717_setup_control(struct device *dev)
++{
++	struct max96717 *priv = dev_get_drvdata(dev);
++	int err = 0;
++	struct gmsl_link_ctx *g_ctx;
++
++	mutex_lock(&priv->lock);
++
++	if (!priv->g_client.g_ctx) {
++		dev_err(dev, "%s: no sensor dev client found\n", __func__);
++		err = -EINVAL;
++		goto error;
++	}
++
++	g_ctx = priv->g_client.g_ctx;
++
++	if (prim_priv__) {
++		/*
++		 * [HW note] The MAX96717 retains its I2C address across
++		 * reboots (PoC stays on).  If already at the aliased address,
++		 * the DEV_ADDR write to 0x40 NACKs.  Skip reassignment when
++		 * the primary and alias are the same physical device and the
++		 * serializer is already responsive at a non-default address.
++		 *
++		 * For cold-start (first power-on), this write is required.
++		 * We detect "already reassigned" by trying a read first:
++		 * if the primary address (0x40) NACKs, skip the reassign.
++		 */
++		unsigned int dev_id;
++		int probe_ret;
++
++		probe_ret = regmap_read(prim_priv__->regmap,
++					MAX96717_DEV_ADDR, &dev_id);
++		if (probe_ret == 0) {
++			/* Primary address (0x40) still responsive — do reassign */
++			max96717_write_reg(&prim_priv__->i2c_client->dev,
++					   MAX96717_DEV_ADDR,
++					   (g_ctx->ser_reg << 1));
++		} else {
++			dev_info(&prim_priv__->i2c_client->dev,
++				 "%s: SER already reassigned (addr 0x40 NACK), skipping DEV_ADDR write\n",
++				 __func__);
++		}
++	}
++
++	/* [PPTX slide 7] CTRL0: GMSL2 mode + TX enable */
++	if (g_ctx->serdes_csi_link == GMSL_SERDES_CSI_LINK_A)
++		err = max96717_write_reg(dev, MAX96717_CTRL0_ADDR,
++					 MAX96717_CTRL0_LINK_A);
++	else
++		err = max96717_write_reg(dev, MAX96717_CTRL0_ADDR,
++					 MAX96717_CTRL0_LINK_B);
++
++	if (err) {
++		dev_err(dev, "%s: ERROR: ser device not found\n", __func__);
++		goto error;
++	}
++
++	/* delay to settle link */
++	msleep(100);
++
++	/*
++	 * I2C address translation for sensor passthrough.
++	 * [MAX96724 Users Guide, I2C Broadcasting, p44-46]
++	 *
++	 * I2C4 / SRC_B (0x44): sensor proxy addr visible to Orin host
++	 * I2C5 / DST_B (0x45): sensor real addr on GMSL back-channel
++	 *
++	 * When host sends I2C to sdev_reg (e.g., 0x1a), the MAX96717
++	 * translates it to sdev_def (e.g., 0x42) and forwards via GMSL
++	 * back-channel to the HKR sensor.
++	 */
++	max96717_write_reg(dev, MAX96717_I2C4_ADDR,
++			   (g_ctx->sdev_reg << 1));
++	max96717_write_reg(dev, MAX96717_I2C5_ADDR,
++			   (g_ctx->sdev_def << 1));
++
++	/* dev addr pass-through ref */
++	if (prim_priv__)
++		prim_priv__->pst2_ref++;
++
++	g_ctx->serdev_found = true;
++
++error:
++	mutex_unlock(&priv->lock);
++	return err;
++}
++EXPORT_SYMBOL(max96717_setup_control);
++
++/* ===== GPIO Tunneling ===== */
++
++/*
++ * max96717_setup_gpio_tunneling - GPIO-over-GMSL no-op hook
++ *
++ * [PPTX slide 10] GPIO Signal Mapping:
++ *   MFP0 → GPIO0: FSIN (DES→SER, frame sync in)
++ *   MFP1 → GPIO1: FOUT/STROBE (SER→DES, frame sync out)
++ *   MFP4 → GPIO4: RESET_N (DES→SER, hard reset)
++ *   MFP5 → GPIO5: IRQ (SER→DES, interrupt request)
++ *   MFP6 → GPIO6: ZV_SYNC (DES→SER, IR stereo sync)
++ *
++ * The PPTX defines the signal mapping and MFP_CFG register range,
++ * but not the confirmed direction/function values. Keep this as
++ * an explicit no-op hook until the MAX96717 GPIO register values
++ * are available from ADI.
++ */
++int max96717_setup_gpio_tunneling(struct device *dev)
++{
++	struct max96717 *priv = dev_get_drvdata(dev);
++	int err = 0;
++
++	mutex_lock(&priv->lock);
++
++	dev_info(dev, "%s: GPIO tunneling hook is a no-op; MFP_CFG values are not defined yet\n",
++		 __func__);
++
++	mutex_unlock(&priv->lock);
++
++	return err;
++}
++EXPORT_SYMBOL(max96717_setup_gpio_tunneling);
++
++/* ===== Reset Control ===== */
++
++int max96717_reset_control(struct device *dev)
++{
++	struct max96717 *priv = dev_get_drvdata(dev);
++	int err = 0;
++
++	mutex_lock(&priv->lock);
++	if (!priv->g_client.g_ctx) {
++		dev_err(dev, "%s: no sdev client found\n", __func__);
++		err = -EINVAL;
++		goto error;
++	}
++
++	priv->g_client.st_done = false;
++
++	if (prim_priv__) {
++		prim_priv__->pst2_ref--;
++
++		max96717_write_reg(dev, MAX96717_DEV_ADDR,
++				   (prim_priv__->def_addr << 1));
++		if (prim_priv__->pst2_ref == 0)
++			max96717_write_reg(&prim_priv__->i2c_client->dev,
++					   MAX96717_CTRL0_ADDR,
++					   MAX96717_RESET_ALL);
++	}
++
++error:
++	mutex_unlock(&priv->lock);
++	return err;
++}
++EXPORT_SYMBOL(max96717_reset_control);
++
++/* ===== Device Pairing ===== */
++
++int max96717_sdev_pair(struct device *dev, struct gmsl_link_ctx *g_ctx)
++{
++	struct max96717 *priv;
++	int err = 0;
++
++	if (!dev || !g_ctx || !g_ctx->s_dev) {
++		dev_err(dev, "%s: invalid input params\n", __func__);
++		return -EINVAL;
++	}
++
++	priv = dev_get_drvdata(dev);
++	mutex_lock(&priv->lock);
++	if (priv->g_client.g_ctx) {
++		/* Already paired — tolerate if this is a re-probe of
++		 * the same camera after a failed first attempt.
++		 * Simply overwrite with the new g_ctx.
++		 */
++		dev_warn(dev, "%s: re-pairing (previous probe may have failed)\n",
++			 __func__);
++	}
++
++	priv->g_client.st_done = false;
++	priv->g_client.g_ctx = g_ctx;
++
++	/* mutex_unlock in error path, but we have none — inline the unlock */
++	mutex_unlock(&priv->lock);
++	return err;
++}
++EXPORT_SYMBOL(max96717_sdev_pair);
++
++int max96717_sdev_unpair(struct device *dev, struct device *s_dev)
++{
++	struct max96717 *priv = NULL;
++	int err = 0;
++
++	if (!dev || !s_dev) {
++		dev_err(dev, "%s: invalid input params\n", __func__);
++		return -EINVAL;
++	}
++
++	priv = dev_get_drvdata(dev);
++
++	mutex_lock(&priv->lock);
++
++	if (!priv->g_client.g_ctx) {
++		dev_dbg(dev, "%s: device is not paired\n", __func__);
++		err = 0; /* Not an error — already unpaired */
++		goto error;
++	}
++
++	if (priv->g_client.g_ctx->s_dev != s_dev) {
++		dev_warn(dev, "%s: s_dev mismatch, clearing anyway\n", __func__);
++	}
++
++	priv->g_client.g_ctx = NULL;
++	priv->g_client.st_done = false;
++
++error:
++	mutex_unlock(&priv->lock);
++	return err;
++}
++EXPORT_SYMBOL(max96717_sdev_unpair);
++
++/* ===== Pipe Configuration ===== */
++
++/*
++ * __max96717_set_pipe - Configure a single pipe's DT/VC mapping
++ *
++ * In Tunnel Mode, per-pipe DT/VC filtering is bypassed on the serializer。
++ * However, we still write the registers for d4xx framework compatibility.
++ *
++ */
++static int __max96717_set_pipe(struct device *dev, int pipe_id, u8 data_type1,
++			       u8 data_type2, u32 vc_id)
++{
++	int err = 0;
++	u8 bpp = 0x30;
++
++	struct reg_pair map_pipe_control[] = {
++		/* Pipe X DT addr + 0x2*pipe_id */
++		{0x0314, 0x5E},  /* data_type1 */
++		{0x0315, 0x52},  /* data_type2 */
++		{0x0309, 0x01},  /* VC select */
++		{0x030A, 0x00},
++		{0x031C, 0x30},  /* BPP */
++		{0x0102, 0x0E},  /* LIM_HEART: Disabled */
++	};
++
++	if (data_type1 == GMSL_CSI_DT_RGB_888)
++		bpp = 0x18;
++
++	map_pipe_control[0].addr += 0x2 * pipe_id;
++	map_pipe_control[1].addr += 0x2 * pipe_id;
++	map_pipe_control[2].addr += 0x2 * pipe_id;
++	map_pipe_control[3].addr += 0x2 * pipe_id;
++	map_pipe_control[4].addr += 0x1 * pipe_id;
++	map_pipe_control[5].addr += 0x8 * pipe_id;
++
++	map_pipe_control[0].val = 0x40 | data_type1;
++	map_pipe_control[1].val = 0x40 | data_type2;
++	if (pipe_id == 0)
++		map_pipe_control[1].val |= 0x80;
++	map_pipe_control[2].val = 1 << vc_id;
++	map_pipe_control[3].val = 0x00;
++	map_pipe_control[4].val = bpp;
++	map_pipe_control[5].val = 0x0E;
++
++	err = max96717_set_registers(dev, map_pipe_control,
++				     ARRAY_SIZE(map_pipe_control));
++
++	return err;
++}
++
++/*
++ * max96717_init_settings - Initialize default pipe/streaming settings
++ *
++ * In Tunnel Mode, per-pipe DT config is not functionally needed
++ * but we configure pipes for d4xx compatibility.
++ * Default: 4 pipes with YUV422_8 + EMBED, VC0-3.
++ */
++int max96717_init_settings(struct device *dev)
++{
++	int err = 0;
++	int i;
++	struct max96717 *priv = dev_get_drvdata(dev);
++
++	struct reg_pair map_init[] = {
++		/* [XML seq] PIPE_EN soft reset first, then enable tunnel mode.
++		 * Note: FRONTTOP0 is bypassed in tunnel mode (per UG) —
++		 * CSI-2 input goes directly into the tunnel, no port config needed.
++		 */
++		{MAX96717_PIPE_EN_ADDR, MAX96717_SOFT_RESET},
++		{MAX96717_EXT11_ADDR, MAX96717_TUN_MODE_EN},
++		{MAX96717_PIPE_EN_ADDR, 0xF3},
++		{MAX96717_MIPI_RX1_ADDR, MAX96717_CSI_4_LANES},
++	};
++
++	mutex_lock(&priv->lock);
++
++	/*
++	 * [HW requirement] After CTRL0 + I2C translation writes in
++	 * setup_control, the MAX96717 needs settling time before
++	 * accepting writes to PIPE_EN (0x02) and FRONTTOP registers.
++	 */
++	usleep_range(5000, 6000);
++
++	err = max96717_set_registers(dev, map_init, ARRAY_SIZE(map_init));
++
++	for (i = 0; i < MAX96717_MAX_PIPES; i++)
++		err |= __max96717_set_pipe(dev, i, GMSL_CSI_DT_YUV422_8,
++					   GMSL_CSI_DT_EMBED, i);
++
++	mutex_unlock(&priv->lock);
++
++	return err;
++}
++EXPORT_SYMBOL(max96717_init_settings);
++
++int max96717_set_pipe(struct device *dev, int pipe_id,
++		      u8 data_type1, u8 data_type2, u32 vc_id)
++{
++	struct max96717 *priv = dev_get_drvdata(dev);
++	int err = 0;
++
++	if (pipe_id > (MAX96717_MAX_PIPES - 1)) {
++		dev_info(dev, "%s: input pipe_id: %d exceeds max96717 max pipes\n",
++			 __func__, pipe_id);
++		return -EINVAL;
++	}
++
++	dev_dbg(dev, "%s pipe_id %d, data_type1 %u, data_type2 %u, vc_id %u\n",
++		__func__, pipe_id, data_type1, data_type2, vc_id);
++
++	mutex_lock(&priv->lock);
++
++	err = __max96717_set_pipe(dev, pipe_id, data_type1, data_type2, vc_id);
++
++	mutex_unlock(&priv->lock);
++
++	return err;
++}
++EXPORT_SYMBOL(max96717_set_pipe);
++
++/**
++ * max96717_retrigger_tx - Toggle SER TX to restore tunnel detection after
++ * a DES ONESHOT.  DES ONESHOT resets the data path; the SER must cycle
++ * its TX enable for the DES to re-acquire the tunnel stream.
++ */
++void max96717_retrigger_tx(struct device *dev)
++{
++	max96717_write_reg(dev, MAX96717_PIPE_EN_ADDR, MAX96717_SOFT_RESET);
++	msleep(30);
++	max96717_write_reg(dev, MAX96717_PIPE_EN_ADDR, MAX96717_PIPE_EN_ALL);
++}
++EXPORT_SYMBOL(max96717_retrigger_tx);
++
++/* ===== Probe / Remove ===== */
++
++static struct regmap_config max96717_regmap_config = {
++	.reg_bits = 16,
++	.val_bits = 8,
++	.cache_type = REGCACHE_RBTREE,
++};
++
++static int max96717_probe(struct i2c_client *client,
++			   const struct i2c_device_id *id)
++{
++	struct max96717 *priv;
++	int err = 0;
++	struct device_node *node = client->dev.of_node;
++
++	dev_info(&client->dev, "[MAX96717]: probing GMSL2 Serializer (Tunnel Mode)\n");
++
++	priv = devm_kzalloc(&client->dev, sizeof(*priv), GFP_KERNEL);
++	if (!priv)
++		return -ENOMEM;
++
++	priv->i2c_client = client;
++	priv->regmap = devm_regmap_init_i2c(priv->i2c_client,
++					     &max96717_regmap_config);
++	if (IS_ERR(priv->regmap)) {
++		dev_err(&client->dev,
++			"regmap init failed: %ld\n", PTR_ERR(priv->regmap));
++		return -ENODEV;
++	}
++
++	mutex_init(&priv->lock);
++
++	if (of_get_property(node, "is-prim-ser", NULL)) {
++		if (prim_priv__) {
++			dev_err(&client->dev,
++				"prim-ser already exists\n");
++			return -EEXIST;
++		}
++
++		err = of_property_read_u32(node, "reg", &priv->def_addr);
++		if (err < 0) {
++			dev_err(&client->dev, "reg not found\n");
++			return -EINVAL;
++		}
++
++		prim_priv__ = priv;
++	}
++
++	dev_set_drvdata(&client->dev, priv);
++
++	dev_info(&client->dev, "%s: success\n", __func__);
++
++	return err;
++}
++
++static int max96717_remove(struct i2c_client *client)
++{
++	struct max96717 *priv;
++
++	if (client != NULL) {
++		priv = dev_get_drvdata(&client->dev);
++		mutex_destroy(&priv->lock);
++		i2c_unregister_device(client);
++		client = NULL;
++	}
++
++	return 0;
++}
++
++static const struct i2c_device_id max96717_id[] = {
++	{ "max96717", 0 },
++	{ },
++};
++
++static const struct of_device_id max96717_of_match[] = {
++	{ .compatible = "adi,max96717", },
++	{ .compatible = "maxim,max96717", },
++	{ },
++};
++MODULE_DEVICE_TABLE(of, max96717_of_match);
++MODULE_DEVICE_TABLE(i2c, max96717_id);
++
++static struct i2c_driver max96717_i2c_driver = {
++	.driver = {
++		.name = "max96717",
++		.owner = THIS_MODULE,
++		.of_match_table = of_match_ptr(max96717_of_match),
++	},
++	.probe = max96717_probe,
++	.remove = max96717_remove,
++	.id_table = max96717_id,
++};
++
++static int __init max96717_init(void)
++{
++	return i2c_add_driver(&max96717_i2c_driver);
++}
++
++static void __exit max96717_exit(void)
++{
++	i2c_del_driver(&max96717_i2c_driver);
++}
++
++module_init(max96717_init);
++module_exit(max96717_exit);
++
++MODULE_DESCRIPTION("GMSL2 Serializer driver max96717 (Tunnel Mode)");
++MODULE_AUTHOR("RealSense AI");
++MODULE_LICENSE("GPL v2");
+diff --git a/drivers/media/i2c/max96724.c b/drivers/media/i2c/max96724.c
+new file mode 100644
+index 0000000..7286ff4
+--- /dev/null
++++ b/drivers/media/i2c/max96724.c
+@@ -0,0 +1,1690 @@
++/*
++ * max96724.c - MAX96724 GMSL2 Quad Deserializer driver (Tunnel Mode)
++ *
++ * Copyright (c) 2026, RealSense, Inc.  All rights reserved.
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms and conditions of the GNU General Public License,
++ * version 2, as published by the Free Software Foundation.
++ *
++ * This program is distributed in the hope it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
++ * more details.
++ *
++ * You should have received a copy of the GNU General Public License
++ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
++ */
++
++
++#include <linux/gpio.h>
++#include <linux/module.h>
++#include <linux/of.h>
++#include <linux/of_device.h>
++#include <linux/of_gpio.h>
++#include <media/camera_common.h>
++#include <linux/module.h>
++#include <media/max96724.h>
++
++/* ================================================================
++ * Register Addresses
++ * ================================================================ */
++
++/* --- Device ID / Configuration --- */
++
++/* [UG p.3] REG0: Device ID (read-only, returns 0xA2) */
++#define MAX96724_DEV_ID_ADDR		0x00
++
++/* [Errata §5] ERRB master reset register */
++#define MAX96724_ERRB_MST_RST_ADDR	0x05
++
++/* [UG Table 3, p.11] 0x0006: GMSL Link/PHY Enable and Mode Select
++ *   bits[7:4]: PHY mode (0=GMSL1, 1=GMSL2) per link D/C/B/A
++ *   bits[3:0]: Link Enable per link D/C/B/A
++ */
++#define MAX96724_LINK_EN_ADDR		0x0006
++
++/* [UG Table 3, p.11] 0x0010: GMSL Link/PHY Rate Select (Links A&B)
++ *   bits[7:6]: Tx Rate Link B, bits[5:4]: Rx Rate Link B
++ *   bits[3:2]: Tx Rate Link A, bits[1:0]: Rx Rate Link A
++ *   Tx: 00=187.5Mbps, Rx: 01=3Gbps, 10=6Gbps
++ */
++#define MAX96724_LINK_RATE_AB_ADDR	0x0010
++
++/* [UG Table 3, p.12] 0x0011: GMSL Link/PHY Rate Select (Links C&D) */
++#define MAX96724_LINK_RATE_CD_ADDR	0x0011
++
++/* [UG p.13] 0x001A: Link A lock status (bit[3]=LOCK) */
++#define MAX96724_LINK_A_LOCK_ADDR	0x001A
++
++/* [UG Table 3, p.12] 0x0018: GMSL Link Reset
++ *   bits[7:4]: Link reset D/C/B/A, bits[3:0]: One-shot reset D/C/B/A
++ */
++#define MAX96724_ONESHOT_ADDR		0x0018
++
++/* [UG p.11] REG13: Soft Reset (write 0x40, wait 5ms) */
++#define MAX96724_REG13_ADDR		0x000D
++
++/* [Errata §5] Error Channel Power Up registers (required for 6Gbps)
++ *   Write 0x75 immediately after power-up for robust 6Gbps operation
++ */
++#define MAX96724_ERRCH_A_ADDR		0x1449
++#define MAX96724_ERRCH_B_ADDR		0x1549
++#define MAX96724_ERRCH_C_ADDR		0x1649
++#define MAX96724_ERRCH_D_ADDR		0x1749
++#define MAX96724_ERRCH_FORCE_ON		0x75
++
++/* --- I2C Control Channel / Errata --- */
++
++/* [Errata #2] Tunnel Mode SRAM LCRC error suppression
++ *   Set 0x458[7:4] = 0x0 to suppress spurious ERRB in tunnel mode
++ */
++#define MAX96724_SRAM_LCRC_ERR_ADDR	0x0458
++
++/* --- Video Pipe Selection --- */
++
++/*
++ *   bits[3:0] = Pipe 0 source (0x0=SIOA)
++ *   bits[7:4] = Pipe 1 source (0x1=SIOB)
++ */
++#define MAX96724_PIPE_SEL0_ADDR		0xF0
++
++/*
++ *   bits[3:0] = Pipe 2 source (0x2=SIOC)
++ *   bits[7:4] = Pipe 3 source (0x3=SIOD)
++ */
++#define MAX96724_PIPE_SEL1_ADDR		0xF1
++
++/*
++ *   bit[0]=Pipe 0, bit[1]=Pipe 1, bit[2]=Pipe 2, bit[3]=Pipe 3
++ */
++#define MAX96724_PIPE_EN_ADDR		0xF4
++
++/* --- Pipe Receiver / Tunnel Mode --- */
++
++/*
++ *   bit[5]=1: Tunnel Mode, bits[1:0]=11: 4-lane MIPI out
++ *   Stride: 0x12 per pipe (P0=0x100, P1=0x112, P2=0x124, P3=0x136)
++ */
++#define MAX96724_VID_RX0_P0_ADDR	0x100
++#define MAX96724_VID_RX6_P0_ADDR	0x106
++#define MAX96724_VID_RX_STRIDE		0x12
++
++#define MAX96724_VID_RX1_P0_ADDR	0x101
++
++/* --- CSI-2 Output (BACKTOP) --- */
++
++/* [UG p.19] BACKTOP: CSI-2 output port enable
++ *   0x040B bit[1]=CSIB_EN, bit[0]=CSIA_EN
++ */
++#define MAX96724_BACKTOP_EN_ADDR	0x040B
++
++/* --- MIPI DPLL (Data Rate) --- */
++
++/* [UG Table 12, p.27] MIPI PHY DPLL Freq registers
++ *   bits[4:0] = frequency in multiples of 100MHz
++ *   bit[5]    = DPLL enable (must be set for DPLL to lock)
++ *   E.g., 0x27 = 700MHz + enable = 700Mbps/lane D-PHY
++ *   E.g., 0x2F = 1500MHz + enable = 1.5Gbps/lane
++ */
++#define MAX96724_DPLL_FREQ0_ADDR	0x0415
++#define MAX96724_DPLL_FREQ1_ADDR	0x0418
++#define MAX96724_DPLL_FREQ2_ADDR	0x041B
++#define MAX96724_DPLL_FREQ3_ADDR	0x041E
++
++/* [UG] DPLL PHY reset control
++ *   0x1D00 = DPLL CSI PHY1 control
++ *   Write 0xF4 to disable/reset, 0xF5 to enable
++ */
++#define MAX96724_DPLL_CSI2_ADDR		0x1D00
++#define MAX96724_DPLL_DISABLE		0xF4
++#define MAX96724_DPLL_ENABLE		0xF5
++
++/* --- CSI-2 Output PHY Configuration --- */
++
++/* [UG Table 12, p.25] MIPI PHY Mode Select register
++ *   bit[0]: 4x2 mode, bit[2]: 2x4 mode (Port A=PHY0+1, Port B=PHY2+3)
++ *   bit[3]: 2x4 alt mode (Port B=PHY0+1, Port A=PHY2+3)
++ */
++#define MAX96724_CSI_OUT_CFG_ADDR	0x08A0
++
++/* [UG Table 12, p.25] MIPI PHY Enable register
++ *   bits[7:4]: Enable PHY 3/2/1/0 (1=enabled, 0=standby)
++ */
++#define MAX96724_CSI_PHY_EN_ADDR	0x08A2
++
++/* [UG Table 12, p.25] MIPI PHY 0 and 1 Lane Mapping */
++#define MAX96724_CSI_LANE_MAP1_ADDR	0x08A3
++
++/* [UG Table 12, p.26] MIPI PHY 2 and 3 Lane Mapping */
++#define MAX96724_CSI_LANE_MAP2_ADDR	0x08A4
++
++/* [UG p.22] Pipe-to-controller mapping (Method 1) */
++#define MAX96724_MIPI_CTRL_SEL_ADDR	0x08CA
++
++/* --- Lane Control per pipe (stride 0x40) --- */
++
++/*
++ *   0xC0 = 4-lane enabled
++ */
++#define MAX96724_LANE_CTRL0_ADDR	0x090A
++#define MAX96724_LANE_CTRL1_ADDR	0x094A
++#define MAX96724_LANE_CTRL2_ADDR	0x098A
++#define MAX96724_LANE_CTRL3_ADDR	0x09CA
++
++/* --- Pipe Mapping Registers (stride 0x40 per pipe) --- */
++
++/*
++ *   Base addresses for Pipe X (Pipe 0)
++ *   Stride: 0x40 per pipe
++ */
++#define MAX96724_TX11_PIPE_X_EN_ADDR		0x090B
++#define MAX96724_TX45_PIPE_X_DST_CTRL_ADDR	0x092D
++#define MAX96724_PIPE_X_SRC_0_MAP_ADDR		0x090D
++#define MAX96724_PIPE_X_DST_0_MAP_ADDR		0x090E
++#define MAX96724_PIPE_X_SRC_1_MAP_ADDR		0x090F
++#define MAX96724_PIPE_X_DST_1_MAP_ADDR		0x0910
++#define MAX96724_PIPE_X_SRC_2_MAP_ADDR		0x0911
++#define MAX96724_PIPE_X_DST_2_MAP_ADDR		0x0912
++#define MAX96724_PIPE_X_SRC_3_MAP_ADDR		0x0913
++#define MAX96724_PIPE_X_DST_3_MAP_ADDR		0x0914
++
++/* --- Stream Select --- */
++
++/*
++ *   Pipe X=0x0933, stride 0x40 per pipe
++ */
++#define MAX96724_PIPE_X_ST_SEL_ADDR	0x0933
++
++/* --- Extended Pipe Mapping (DST_CTRL2-4 / TX49) --- */
++
++/* [Excel: MIPI_TX46-48] Extended DST_CTRL for additional mapping pairs
++ *   All to PHY1 (0x55), same as TX45
++ *   Stride: 0x40 per pipe (base = Pipe X)
++ */
++#define MAX96724_TX46_PIPE_X_ADDR	0x092E
++#define MAX96724_TX47_PIPE_X_ADDR	0x092F
++#define MAX96724_TX48_PIPE_X_ADDR	0x0930
++
++/* [UG p.30 + Aardvark-verified] MIPI_TX49 synchronous concatenation control
++ *   In tunnel mode, this register MUST be 0x87 for MIPI TX output to function.
++ *   Verified: setting to 0x00 disables tunnel output entirely (0x8D0 all zeros).
++ *   Stride: 0x40 per pipe (base = Pipe X)
++ */
++#define MAX96724_TX49_PIPE_X_ADDR	0x0931
++#define MAX96724_TX49_CONCAT_4W		0x87
++
++/* --- Tunnel Mode per-pipe --- */
++
++/*
++ *   bit[0] = TUN_EN, Default=0x08, write 0x09 to enable
++ */
++#define MAX96724_PIPE0_TUN_EN_ADDR	0x0936
++#define MAX96724_PIPE1_TUN_EN_ADDR	0x0976
++#define MAX96724_PIPE2_TUN_EN_ADDR	0x09B6
++#define MAX96724_PIPE3_TUN_EN_ADDR	0x09F6
++
++/*
++ *   bit[6]: disable auto-tunnel-detect
++ *   bits[5:4]: TUN_DEST (00=PHY0, 01=PHY1, 10=PHY2, 11=PHY3)
++ */
++#define MAX96724_PIPE0_TUN_DEST_ADDR	0x0939
++#define MAX96724_PIPE1_TUN_DEST_ADDR	0x0979
++#define MAX96724_PIPE2_TUN_DEST_ADDR	0x09B9
++#define MAX96724_PIPE3_TUN_DEST_ADDR	0x09F9
++
++/* ================================================================
++ * Register Values
++ * ================================================================ */
++
++/* [UG p.12] Soft reset value (write to 0x000D) */
++#define MAX96724_SOFT_RESET		0x40
++
++/* [UG Table 3, p.11-12] Link Rate values for 0x0010/0x0011
++ *   Per link pair: bits[1:0]=RxA, [3:2]=TxA, [5:4]=RxB, [7:6]=TxB
++ *   Tx = 00 (187.5Mbps), Rx = 01 (3Gbps) or 10 (6Gbps)
++ *   3Gbps: Tx=00, Rx=01 → per pair 0x01, both pairs = 0x01 in low nibble
++ */
++#define MAX96724_LINK_RATE_3GBPS	0x01  /* Rx=3G, Tx=187.5M for one link pair */
++#define MAX96724_LINK_RATE_6GBPS	0x02  /* Rx=6G, Tx=187.5M for one link pair */
++
++/* [UG Table 3, p.11] 0x0006: Link enable / mode values
++ *   bits[7:4] = PHY mode (1=GMSL2 per link)
++ *   bits[3:0] = Link enable per link
++ *   0xF1 = all GMSL2-mode, only Link A enabled
++ *   0xFF = all GMSL2-mode, all 4 links enabled
++ */
++#define MAX96724_LINK_EN_SIOA		0xF1  /* GMSL2 all, enable Link A only */
++#define MAX96724_LINK_EN_ALL		0xFF  /* GMSL2 all, enable all links */
++
++/* [UG p.19] BACKTOP_EN (0x040B): CSI output port enable */
++#define MAX96724_BACKTOP_CSIB_EN	0x02
++#define MAX96724_BACKTOP_CSIA_EN	0x01
++
++/* [XML] VIDEO_RX0: DIS_PKT_DET=1 (bit0) required for tunnel mode.
++ *   Without it, DES rejects tunnel data as invalid GMSL2 video packets.
++ *   SEQ_MISS_EN=1 (bit4), LINE_CRC_EN=1 (bit1).  XML value: 0x33.
++ */
++#define MAX96724_VID_RX0_CFG_VAL	0x33
++#define MAX96724_VID_RX6_CFG_VAL	0x0A
++
++/* [gmsl_ser_des_guide §4.9] Tunnel mode enable (MIPI_TX54, 0x0936):
++ *   bit[0] = TUN_EN = 1
++ *   bit[3] = TUN_CONT (continuous tunnel mode, required per verified XML)
++ *   XML/Guide value: 0x09
++ */
++#define MAX96724_TUN_EN			0x09
++
++/* [gmsl_ser_des_guide §7.5] Tunnel controller destination (MIPI_TX57, 0x0939):
++ *   bit[7]: DIS_AUTO_SER_LANE_DET (1=manual)
++ *   bit[6]: DIS_AUTO_TUN_DET (1=manual)
++ *   bits[5:4]: TUN_DEST (00=PHY0, 01=PHY1, 10=PHY2, 11=PHY3)
++ *   Verified XML: 0x50 = manual detect + PHY1 destination
++ */
++#define MAX96724_TUN_DEST_CTRL0		0x40  /* Manual detect + PHY0 */
++#define MAX96724_TUN_DEST_CTRL1		0x50  /* Manual detect + PHY1 (Port A master) */
++
++/* [UG Table 12, p.25] CSI output mode values */
++#define MAX96724_CSI_MODE_2X4_VAL	0x08  /* bit[3] = 2x4 alt: Ctrl1→PHY0+1→PortA (Aardvark-verified) */
++#define MAX96724_CSI_MODE_4X2_VAL	0x01  /* bit[0] = 4x2 mode */
++
++#define MAX96724_CSI_PHY_EN_ALL		0xF0
++#define MAX96724_CSI_PHY_EN_01		0x30  /* PHY0+PHY1 only */
++#define MAX96724_CSI_PHY_EN_23		0xC0  /* PHY2+PHY3 only (Port A in 2x4 alt mode) */
++
++/* [UG Table 12, p.25-26] Lane mapping default */
++#define MAX96724_CSI_LANE_MAP_DEFAULT	0xE4
++
++/* [UG Table 12, p.26-27] Lane control: 4-lane enabled */
++#define MAX96724_LANE_CTRL_4LANE	0xC0
++
++/* [UG Table 12, p.26-27] Lane control: 2-lane enabled.
++ *   bits[7:6] = (num_lanes - 1): 01=2-lane(0x40), 11=4-lane(0xC0)
++ *   Ref: gmsl_ser_des_guide §8.2, E2E_enable_guide §5.6.4 */
++#define MAX96724_LANE_CTRL_2LANE	0x40
++
++/* [SC20190112 2-lane] CSI PHY enable: all PHYs powered for DPLL lock
++ *   stability.  Even though only PHY0 data lanes reach Orin, the MAX96724
++ *   DPLL requires all PHYs to be powered.  Tested: single PHY → PLL never locks. */
++#define MAX96724_CSI_PHY_EN_2LANE	0xF0
++
++/* [SC20190112 2-lane] DPLL for Controller 0 (drives PHY0, 2 lanes).
++ *   bits[4:0] = data-rate / 100 MHz.  1400 Mbps / 100 = 14 = 0x0E.
++ *   bit[5]    = DPLL enable = 1.
++ *   Result: 0x2E = 1400 Mbps/lane D-PHY. */
++#define MAX96724_DPLL_1400MBPS_CTRL0	0x2E
++
++/* [SC20190112 2-lane] TX49 pipeline concatenation for 2-wide mode.
++ *   In 4x2 mode each controller drives only 2 lanes.
++ *   UG p.30: synchronous concatenation control, 0x83 for 2W. */
++#define MAX96724_TX49_CONCAT_2W		0x83
++
++/* [UG Table 3, p.12] One-shot reset: all links */
++#define MAX96724_ONESHOT_ALL		0x0F
++
++/* [UG Table 4, p.15] Pipe source selection values
++ *   Encoding per pipe nibble in tunnel mode (Aardvark-verified):
++ *   0x22 routes all pipes from Link A in tunnel mode.
++ */
++#define MAX96724_PIPE_SEL0_SINGLE	0x22  /* All pipes from Link A (Aardvark-verified) */
++#define MAX96724_PIPE_SEL1_SINGLE	0x22  /* All pipes from Link A (Aardvark-verified) */
++#define MAX96724_PIPE_SEL0_DUAL		0x40  /* Pipe 0 ← A/X, Pipe 1 ← B/X */
++#define MAX96724_PIPE_SEL0_QUAD_LO	0x40  /* Pipe 0 ← A/X, Pipe 1 ← B/X */
++#define MAX96724_PIPE_SEL1_QUAD_HI	0xC8  /* Pipe 2 ← C/X, Pipe 3 ← D/X */
++
++/* Pipe enable values */
++#define MAX96724_PIPE_EN_1		0x01
++#define MAX96724_PIPE_EN_2		0x03
++#define MAX96724_PIPE_EN_4		0x0F
++
++/* Lane control map: bits[7:6] = (num_lanes - 1) */
++#define MAX96724_LANE_CTRL_MAP(num_lanes) \
++	((((num_lanes) - 1) << 6) & 0xC0)
++
++/* Reset all */
++#define MAX96724_RESET_ALL		0x80
++
++/* Stream ID invalid */
++#define MAX96724_INVAL_ST_ID		0xFF
++#define MAX96724_RESET_ST_ID		0x00
++#define MAX96724_ST_ID_SEL_INVALID	0xF
++
++/* Controller mapping: all mappings → Controller 0 (not working in tunnel mode) */
++#define MAX96724_ALL_MAP_CTRL0		0x00
++/* Controller mapping: all mappings → Controller 1 (Aardvark-verified working) */
++#define MAX96724_ALL_MAP_CTRL1		0x55
++
++/* ================================================================
++ * Data Structures
++ * ================================================================ */
++
++/* Quad GMSL: up to 4 sources */
++#define MAX96724_MAX_SOURCES		4
++#define MAX96724_MAX_PIPES		4
++
++#define MAX96724_PIPE_X			0
++#define MAX96724_PIPE_Y			1
++#define MAX96724_PIPE_Z			2
++#define MAX96724_PIPE_U			3
++#define MAX96724_PIPE_INVALID		0xF
++
++#define MAX96724_CSI_CTRL_0		0
++#define MAX96724_CSI_CTRL_1		1
++#define MAX96724_CSI_CTRL_2		2
++#define MAX96724_CSI_CTRL_3		3
++
++/* CSI mode values */
++#define MAX96724_CSI_MODE_4X2		0x01
++#define MAX96724_CSI_MODE_2X4		0x08  /* 2x4 alt: Ctrl1→PHY0+1→PortA (Aardvark-verified working) */
++#define MAX96724_CSI_MODE_2X4_ALT	0x04  /* 2x4 standard (Ctrl0→PHY0+1, not working in tunnel) */
++
++/* Lane map presets */
++#define MAX96724_LANE_MAP1_4X2		0x44
++#define MAX96724_LANE_MAP2_4X2		0x44
++#define MAX96724_LANE_MAP1_2X4		0xE4  /* PHY0+PHY1 lane map (Aardvark-verified) */
++#define MAX96724_LANE_MAP2_2X4		0xE4
++
++struct max96724_source_ctx {
++	struct gmsl_link_ctx *g_ctx;
++	bool st_enabled;
++};
++
++struct pipe_ctx {
++	u32 id;
++	u32 dt_type;
++	u32 dst_csi_ctrl;
++	u32 st_count;
++	u32 st_id_sel;
++};
++
++struct max96724 {
++	struct i2c_client *i2c_client;
++	struct regmap *regmap;
++	u32 num_src;
++	u32 max_src;
++	u32 num_src_found;
++	u32 src_link;
++	bool splitter_enabled;
++	struct max96724_source_ctx sources[MAX96724_MAX_SOURCES];
++	struct mutex lock;
++	u32 sdev_ref;
++	bool lane_setup;
++	bool link_setup;
++	struct pipe_ctx pipe[MAX96724_MAX_PIPES];
++	u8 csi_mode;
++	u8 lane_mp1;
++	u8 lane_mp2;
++	int reset_gpio;
++	int pw_ref;
++	struct regulator *vdd_cam_1v2;
++	u8 link_speed;  /* DT-configurable: 3 or 6 Gbps */
++};
++
++struct reg_pair {
++	u16 addr;
++	u8 val;
++};
++
++/* ================================================================
++ * Low-level I2C
++ * ================================================================ */
++
++static int max96724_write_reg(struct device *dev, u16 addr, u8 val)
++{
++	struct max96724 *priv;
++	int err;
++
++	priv = dev_get_drvdata(dev);
++
++	err = regmap_write(priv->regmap, addr, val);
++	if (err)
++		dev_err(dev, "%s:i2c write failed, 0x%x = %x\n",
++			__func__, addr, val);
++
++	/* delay before next i2c command as required for SERDES link */
++	usleep_range(100, 110);
++
++	return err;
++}
++
++static int max96724_set_registers(struct device *dev, struct reg_pair *map,
++				  u32 count)
++{
++	int err = 0;
++	u32 j;
++
++	for (j = 0; j < count; j++) {
++		err = max96724_write_reg(dev, map[j].addr, map[j].val);
++		if (err)
++			break;
++	}
++
++	return err;
++}
++
++/* ================================================================
++ * Internal Helpers
++ * ================================================================ */
++
++static int max96724_get_sdev_idx(struct device *dev,
++				 struct device *s_dev, unsigned int *idx)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++	unsigned int i;
++	int err = 0;
++
++	mutex_lock(&priv->lock);
++	for (i = 0; i < priv->max_src; i++) {
++		if (priv->sources[i].g_ctx->s_dev == s_dev)
++			break;
++	}
++	if (i == priv->max_src) {
++		dev_err(dev, "no sdev found\n");
++		err = -EINVAL;
++		goto ret;
++	}
++
++	if (idx)
++		*idx = i;
++
++ret:
++	mutex_unlock(&priv->lock);
++	return err;
++}
++
++static void max96724_pipes_reset(struct max96724 *priv)
++{
++	/*
++	 * Default pipe configuration for D5xx/SC1.2:
++	 * In tunnel mode, DT types are not used for filtering
++	 * but we initialize them for d4xx framework compatibility.
++	 */
++	struct pipe_ctx pipe_defaults[] = {
++		{MAX96724_PIPE_X, GMSL_CSI_DT_RAW_12,
++			MAX96724_CSI_CTRL_1, 0, MAX96724_INVAL_ST_ID},
++		{MAX96724_PIPE_Y, GMSL_CSI_DT_RAW_12,
++			MAX96724_CSI_CTRL_1, 0, MAX96724_INVAL_ST_ID},
++		{MAX96724_PIPE_Z, GMSL_CSI_DT_EMBED,
++			MAX96724_CSI_CTRL_1, 0, MAX96724_INVAL_ST_ID},
++		{MAX96724_PIPE_U, GMSL_CSI_DT_EMBED,
++			MAX96724_CSI_CTRL_1, 0, MAX96724_INVAL_ST_ID}
++	};
++
++	memcpy(priv->pipe, pipe_defaults, sizeof(pipe_defaults));
++}
++
++static void max96724_reset_ctx(struct max96724 *priv)
++{
++	unsigned int i;
++
++	priv->link_setup = false;
++	priv->lane_setup = false;
++	priv->num_src_found = 0;
++	priv->src_link = 0;
++	priv->splitter_enabled = false;
++	max96724_pipes_reset(priv);
++	for (i = 0; i < priv->num_src; i++)
++		priv->sources[i].st_enabled = false;
++}
++
++/* ================================================================
++ * Power Management
++ * ================================================================ */
++
++/*
++ * max96724_power_on - Power on the MAX96724 deserializer
++ */
++int max96724_power_on(struct device *dev)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++	int err = 0;
++
++	mutex_lock(&priv->lock);
++	if (priv->pw_ref == 0) {
++		usleep_range(1, 2);
++		if (priv->reset_gpio)
++			gpio_set_value(priv->reset_gpio, 0);
++
++		usleep_range(30, 50);
++
++		if (priv->vdd_cam_1v2) {
++			err = regulator_enable(priv->vdd_cam_1v2);
++			if (unlikely(err))
++				goto ret;
++		}
++
++		usleep_range(30, 50);
++
++		/* exit reset mode: XCLR */
++		if (priv->reset_gpio) {
++			gpio_set_value(priv->reset_gpio, 0);
++			usleep_range(30, 50);
++			gpio_set_value(priv->reset_gpio, 1);
++			usleep_range(30, 50);
++		}
++
++		msleep(20);
++	}
++
++	priv->pw_ref++;
++
++ret:
++	mutex_unlock(&priv->lock);
++	return err;
++}
++EXPORT_SYMBOL(max96724_power_on);
++
++void max96724_power_off(struct device *dev)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++
++	mutex_lock(&priv->lock);
++	priv->pw_ref--;
++
++	if (priv->pw_ref < 0)
++		priv->pw_ref = 0;
++
++	if (priv->pw_ref == 0) {
++		usleep_range(1, 2);
++		if (priv->reset_gpio)
++			gpio_set_value(priv->reset_gpio, 0);
++
++		if (priv->vdd_cam_1v2)
++			regulator_disable(priv->vdd_cam_1v2);
++	}
++
++	mutex_unlock(&priv->lock);
++}
++EXPORT_SYMBOL(max96724_power_off);
++
++/* ================================================================
++ * Link Setup
++ * ================================================================ */
++
++/*
++ * max96724_write_link - Configure a specific GMSL link
++ *
++ * [Users Guide, Link Initialization, p11-12]
++ *   Register 0x0006: Link Enable and Mode Select
++ *   Register 0x0010: Link Rate (Links A/B)
++ *
++ * The link speed is DT-configurable via the "gmsl-link-speed" property.
++ */
++static int max96724_write_link(struct device *dev, u32 link)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++	u8 link_rate_ab, link_rate_cd;
++	u8 link_en_val;
++
++	/*
++	 * [Aardvark-verified] Disable CSI output before link configuration
++	 * This prevents glitches on CSI bus during GMSL link setup.
++	 * Re-enabled in max96724_setup_streaming() after full pipeline config.
++	 */
++	max96724_write_reg(dev, MAX96724_BACKTOP_EN_ADDR, 0x00);
++
++	/* [UG Table 3 + Tech Overview REG26]
++	 * Register 0x0010:
++	 *   bits[7:2] = Link rate configuration
++	 *   bits[1:0] = I2C CC pass-through link select
++	 *     10 = route CC via SIOA (Link A)  [tech overview: 0x02 → SIOA]
++	 *     01 = route CC via SIOB (Link B)
++	 *
++	 * For 6G + Link A: bits[7:2]=001000, bits[1:0]=10 → 0x22
++	 * For 6G + Link B: bits[7:2]=001000, bits[1:0]=01 → 0x21
++	 * For 3G + Link A: bits[7:2]=000100, bits[1:0]=10 → 0x12 (? or 0x11)
++	 * For 3G + Link B: bits[7:2]=000100, bits[1:0]=01 → 0x11 (? or 0x09)
++	 */
++	if (priv->link_speed == 6) {
++		if (link == GMSL_SERDES_CSI_LINK_B) {
++			link_rate_ab = 0x21; /* 6G rate + CC via Link B */
++		} else {
++			link_rate_ab = 0x22; /* 6G rate + CC via Link A */
++		}
++		link_rate_cd = 0x22; /* C/D: 6G rate (CC routing don't care) */
++	} else {
++		if (link == GMSL_SERDES_CSI_LINK_B) {
++			link_rate_ab = 0x09; /* 3G rate + CC via Link B */
++		} else {
++			link_rate_ab = 0x12; /* 3G rate + CC via Link A */
++		}
++		link_rate_cd = 0x11; /* C/D: 3G rate */
++	}
++
++	if (link == GMSL_SERDES_CSI_LINK_A) {
++		link_en_val = MAX96724_LINK_EN_SIOA;
++	} else if (link == GMSL_SERDES_CSI_LINK_B) {
++		link_en_val = 0xF2; /* GMSL2 all, enable Link B only */
++	} else {
++		dev_err(dev, "%s: invalid gmsl link\n", __func__);
++		return -EINVAL;
++	}
++
++	/* [UG Table 3] Set link rates + CC routing */
++	max96724_write_reg(dev, MAX96724_LINK_RATE_AB_ADDR, link_rate_ab);
++	max96724_write_reg(dev, MAX96724_LINK_RATE_CD_ADDR, link_rate_cd);
++
++	/*
++	 * [XML-verified sequence] One-shot reset applies rate configuration
++	 * to the link state machine, then link enable starts training.
++	 * XML order: rate → ONE-SHOT → LINK_EN → wait 1000ms.
++	 * Note: Error channel registers omitted (not in reference XML).
++	 */
++	max96724_write_reg(dev, MAX96724_ONESHOT_ADDR,
++			   MAX96724_ONESHOT_ALL);
++	max96724_write_reg(dev, MAX96724_LINK_EN_ADDR, link_en_val);
++
++	/*
++	 * Wait for link lock.
++	 * [XML] Uses 1000ms regardless of link speed.
++	 * I2C pass-through CC requires fully trained link, not just PHY lock.
++	 */
++	msleep(1000);
++
++	/* Check link lock status on ALL ports for diagnostics */
++	{
++		unsigned int lock_a = 0, lock_b = 0, lock_c = 0, lock_d = 0;
++		unsigned int link_en = 0;
++		unsigned int reg10 = 0, reg11 = 0;
++
++		regmap_read(priv->regmap, 0x001A, &lock_a);
++		regmap_read(priv->regmap, 0x001B, &lock_b);
++		regmap_read(priv->regmap, 0x001C, &lock_c);
++		regmap_read(priv->regmap, 0x001D, &lock_d);
++		regmap_read(priv->regmap, MAX96724_LINK_EN_ADDR, &link_en);
++		regmap_read(priv->regmap, 0x0010, &reg10);
++		regmap_read(priv->regmap, 0x0011, &reg11);
++		dev_info(dev,
++			 "GMSL link status: EN=0x%02x A=0x%02x(%s) B=0x%02x(%s) C=0x%02x(%s) D=0x%02x(%s) REG10=0x%02x REG11=0x%02x\n",
++			 link_en,
++			 lock_a, (lock_a & 0x08) ? "LOCK" : "noLk",
++			 lock_b, (lock_b & 0x08) ? "LOCK" : "noLk",
++			 lock_c, (lock_c & 0x08) ? "LOCK" : "noLk",
++			 lock_d, (lock_d & 0x08) ? "LOCK" : "noLk",
++			 reg10, reg11);
++	}
++
++	return 0;
++}
++
++int max96724_setup_link(struct device *dev, struct device *s_dev)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++	int err = 0;
++	unsigned int i = 0;
++
++	err = max96724_get_sdev_idx(dev, s_dev, &i);
++	if (err)
++		return err;
++
++	mutex_lock(&priv->lock);
++
++	if (!priv->splitter_enabled) {
++		err = max96724_write_link(dev,
++					  priv->sources[i].g_ctx->serdes_csi_link);
++		if (err)
++			goto ret;
++
++		priv->link_setup = true;
++	}
++
++ret:
++	mutex_unlock(&priv->lock);
++	return err;
++}
++EXPORT_SYMBOL(max96724_setup_link);
++
++/* ================================================================
++ * Control Setup
++ * ================================================================ */
++
++/*
++ * max96724_setup_control - Configure deserializer control pipeline
++ *
++ * Enables splitter mode when multiple sources are present,
++ * configures tunnel mode on all active pipes, and sets up
++ * the MIPI CSI-2 output.
++ */
++int max96724_setup_control(struct device *dev, struct device *s_dev)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++	int err = 0;
++	unsigned int i = 0;
++
++	static const u16 tun_en_addrs[] = {
++		MAX96724_PIPE0_TUN_EN_ADDR,
++		MAX96724_PIPE1_TUN_EN_ADDR,
++		MAX96724_PIPE2_TUN_EN_ADDR,
++		MAX96724_PIPE3_TUN_EN_ADDR,
++	};
++
++	static const u16 tun_dest_addrs[] = {
++		MAX96724_PIPE0_TUN_DEST_ADDR,
++		MAX96724_PIPE1_TUN_DEST_ADDR,
++		MAX96724_PIPE2_TUN_DEST_ADDR,
++		MAX96724_PIPE3_TUN_DEST_ADDR,
++	};
++
++	err = max96724_get_sdev_idx(dev, s_dev, &i);
++	if (err)
++		return err;
++
++	mutex_lock(&priv->lock);
++
++	if (!priv->link_setup) {
++		dev_err(dev, "%s: invalid state\n", __func__);
++		err = -EINVAL;
++		goto error;
++	}
++
++	if (priv->sources[i].g_ctx->serdev_found) {
++		priv->num_src_found++;
++		priv->src_link = priv->sources[i].g_ctx->serdes_csi_link;
++	}
++
++	/* Enable splitter mode for multi-camera configurations */
++	if ((priv->max_src > 1U) &&
++	    (priv->num_src_found > 0U) &&
++	    (priv->splitter_enabled == false)) {
++		/*
++		 * [UG Table 3] Multi-camera: set link rates and enable all links
++		 */
++		u8 link_rate = (priv->link_speed == 6) ? 0x22 : 0x11;
++
++		max96724_write_reg(dev, MAX96724_LINK_RATE_AB_ADDR,
++				   link_rate);
++		max96724_write_reg(dev, MAX96724_LINK_RATE_CD_ADDR,
++				   link_rate);
++		max96724_write_reg(dev, MAX96724_LINK_EN_ADDR,
++				   MAX96724_LINK_EN_ALL);
++
++		/* [Errata #5] For 6Gbps: force Error Channel power-up */
++		if (priv->link_speed == 6) {
++			max96724_write_reg(dev, MAX96724_ERRCH_A_ADDR,
++					   MAX96724_ERRCH_FORCE_ON);
++			max96724_write_reg(dev, MAX96724_ERRCH_B_ADDR,
++					   MAX96724_ERRCH_FORCE_ON);
++			max96724_write_reg(dev, MAX96724_ERRCH_C_ADDR,
++					   MAX96724_ERRCH_FORCE_ON);
++			max96724_write_reg(dev, MAX96724_ERRCH_D_ADDR,
++					   MAX96724_ERRCH_FORCE_ON);
++		}
++
++		priv->splitter_enabled = true;
++
++		msleep(100);
++	}
++
++	/*
++	 * [SC20190112] Enable tunnel mode and route to Controller 1.
++	 *   - TUN_EN   (0x0936): 0x01 (TUN_EN=1)
++	 *   - TUN_DEST (0x0939): 0x10 = Controller 1
++	 *   CSI_OUT_CFG=0x08 (2x4 alt): Controller 1 → PHY0+1 → Port A → Orin
++	 */
++	{
++		for (i = 0; i < MAX96724_MAX_PIPES; i++) {
++			max96724_write_reg(dev, tun_en_addrs[i],
++					   MAX96724_TUN_EN);
++			max96724_write_reg(dev, tun_dest_addrs[i],
++					   MAX96724_TUN_DEST_CTRL1);
++		}
++	}
++
++	/*
++	 * [Errata #2] Tunnel Mode SRAM LCRC: disable ERRB for SRAM LCRC
++	 * errors in tunnel mode when frame/line counters are non-zero.
++	 * This prevents spurious ERRB assertions (no video corruption).
++	 */
++	max96724_write_reg(dev, MAX96724_SRAM_LCRC_ERR_ADDR, 0x00);
++
++	max96724_write_reg(dev, MAX96724_ONESHOT_ADDR,
++			   MAX96724_ONESHOT_ALL);
++
++	priv->sdev_ref++;
++
++	/* Reset splitter mode if not all devices found */
++	if ((priv->sdev_ref == priv->max_src) &&
++	    (priv->splitter_enabled == true) &&
++	    (priv->num_src_found > 0U) &&
++	    (priv->num_src_found < priv->max_src)) {
++		err = max96724_write_link(dev, priv->src_link);
++		if (err)
++			goto error;
++
++		priv->splitter_enabled = false;
++	}
++
++error:
++	mutex_unlock(&priv->lock);
++	return err;
++}
++EXPORT_SYMBOL(max96724_setup_control);
++
++int max96724_reset_control(struct device *dev, struct device *s_dev)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++	int err = 0;
++
++	mutex_lock(&priv->lock);
++	if (!priv->sdev_ref) {
++		dev_info(dev, "%s: dev is already in reset state\n", __func__);
++		goto ret;
++	}
++
++	priv->sdev_ref--;
++	if (priv->sdev_ref == 0) {
++		max96724_reset_ctx(priv);
++		max96724_write_reg(dev, MAX96724_REG13_ADDR,
++				   MAX96724_SOFT_RESET);
++
++		msleep(100);
++	}
++
++ret:
++	mutex_unlock(&priv->lock);
++	return err;
++}
++EXPORT_SYMBOL(max96724_reset_control);
++
++/* ================================================================
++ * Device Registration
++ * ================================================================ */
++
++int max96724_sdev_register(struct device *dev, struct gmsl_link_ctx *g_ctx)
++{
++	struct max96724 *priv = NULL;
++	unsigned int i;
++	int err = 0;
++
++	if (!dev || !g_ctx || !g_ctx->s_dev) {
++		dev_err(dev, "%s: invalid input params\n", __func__);
++		return -EINVAL;
++	}
++
++	priv = dev_get_drvdata(dev);
++
++	mutex_lock(&priv->lock);
++
++	if (priv->num_src > priv->max_src) {
++		dev_err(dev,
++			"%s: MAX96724 inputs size exhausted\n", __func__);
++		err = -ENOMEM;
++		goto error;
++	}
++
++	/* Check csi mode compatibility.
++	 * 2x4 DES → gmsl-link: 1x4 or 2x4.
++	 * 4x2 DES → gmsl-link: 1x4, 2x2, or 4x2.
++	 */
++	if (priv->csi_mode == MAX96724_CSI_MODE_2X4) {
++		if (!((g_ctx->csi_mode == GMSL_CSI_1X4_MODE) ||
++		      (g_ctx->csi_mode == GMSL_CSI_2X4_MODE))) {
++			dev_err(dev, "%s: csi mode not supported\n", __func__);
++			err = -EINVAL;
++			goto error;
++		}
++	} else {
++		/* 4x2 DES mode: accept 1x4, 2x2, or 4x2 gmsl-link mode */
++		if (!((g_ctx->csi_mode == GMSL_CSI_1X4_MODE) ||
++		      (g_ctx->csi_mode == GMSL_CSI_2X2_MODE) ||
++		      (g_ctx->csi_mode == GMSL_CSI_4X2_MODE))) {
++			dev_err(dev, "%s: csi mode not supported\n", __func__);
++			err = -EINVAL;
++			goto error;
++		}
++	}
++
++	for (i = 0; i < priv->num_src; i++) {
++		if (g_ctx->serdes_csi_link ==
++		    priv->sources[i].g_ctx->serdes_csi_link) {
++			dev_err(dev,
++				"%s: serdes csi link is in use\n", __func__);
++			err = -EINVAL;
++			goto error;
++		}
++		if (g_ctx->num_csi_lanes !=
++		    priv->sources[i].g_ctx->num_csi_lanes) {
++			dev_err(dev,
++				"%s: csi num lanes mismatch\n", __func__);
++			err = -EINVAL;
++			goto error;
++		}
++	}
++
++	priv->sources[priv->num_src].g_ctx = g_ctx;
++	priv->sources[priv->num_src].st_enabled = false;
++
++	priv->num_src++;
++
++error:
++	mutex_unlock(&priv->lock);
++	return err;
++}
++EXPORT_SYMBOL(max96724_sdev_register);
++
++int max96724_sdev_unregister(struct device *dev, struct device *s_dev)
++{
++	struct max96724 *priv = NULL;
++	int err = 0;
++	unsigned int i = 0;
++
++	if (!dev || !s_dev) {
++		dev_err(dev, "%s: invalid input params\n", __func__);
++		return -EINVAL;
++	}
++
++	priv = dev_get_drvdata(dev);
++	mutex_lock(&priv->lock);
++
++	if (priv->num_src == 0) {
++		dev_err(dev, "%s: no source found\n", __func__);
++		err = -ENODATA;
++		goto error;
++	}
++
++	for (i = 0; i < priv->num_src; i++) {
++		if (s_dev == priv->sources[i].g_ctx->s_dev) {
++			priv->sources[i].g_ctx = NULL;
++			break;
++		}
++	}
++
++	if (i == priv->num_src) {
++		dev_err(dev,
++			"%s: requested device not found\n", __func__);
++		err = -EINVAL;
++		goto error;
++	}
++	priv->num_src--;
++
++error:
++	mutex_unlock(&priv->lock);
++	return err;
++}
++EXPORT_SYMBOL(max96724_sdev_unregister);
++
++/* ================================================================
++ * Streaming Setup
++ * ================================================================ */
++
++/*
++ * max96724_setup_streaming - Configure CSI-2 output pipeline
++ *
++ * In Tunnel Mode, the MAX96724 outputs the reconstructed CSI-2 stream
++ * with all VCs and DTs preserved from the serializer.
++ *
++ * The pipeline configuration:
++ *   1. Configure pipe-to-link routing (which GMSL input → which pipe)
++ *   2. Enable tunnel mode on active pipes
++ *   3. Configure MIPI CSI-2 output lanes and PHY
++ *   4. Enable BACKTOP output port
++ *
++ */
++int max96724_setup_streaming(struct device *dev, struct device *s_dev)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++	struct gmsl_link_ctx *g_ctx;
++	int err = 0;
++	unsigned int i = 0;
++	unsigned int src_idx;
++
++	err = max96724_get_sdev_idx(dev, s_dev, &i);
++	if (err)
++		return err;
++
++	mutex_lock(&priv->lock);
++	if (priv->sources[i].st_enabled)
++		goto ret;
++
++	src_idx = i;
++	g_ctx = priv->sources[src_idx].g_ctx;
++
++	/*
++	 * [Aardvark-verified] Pipe source routing
++	 *   Single cam: all pipes from Link A (0x22/0x22)
++	 *   Disable pipes before configuration, enable at the end
++	 */
++	if (priv->max_src >= 4) {
++		max96724_write_reg(dev, MAX96724_PIPE_SEL0_ADDR,
++				   MAX96724_PIPE_SEL0_QUAD_LO);
++		max96724_write_reg(dev, MAX96724_PIPE_SEL1_ADDR,
++				   MAX96724_PIPE_SEL1_QUAD_HI);
++	} else if (priv->max_src >= 2) {
++		max96724_write_reg(dev, MAX96724_PIPE_SEL0_ADDR,
++				   MAX96724_PIPE_SEL0_DUAL);
++	} else {
++		max96724_write_reg(dev, MAX96724_PIPE_SEL0_ADDR,
++				   MAX96724_PIPE_SEL0_SINGLE);
++		max96724_write_reg(dev, MAX96724_PIPE_SEL1_ADDR,
++				   MAX96724_PIPE_SEL1_SINGLE);
++	}
++	/* Disable all pipes during configuration */
++	max96724_write_reg(dev, MAX96724_PIPE_EN_ADDR, 0x00);
++
++	/*
++	 * [SC20190112] CSI output: 2x4 alt mode (0x08) for Port A.
++	 * In 2x4 alt: Controller 1 is master for Port A.
++	 *   PHY0 (slave) → DA0/DA1 (data lanes to Orin)
++	 *   PHY1 (master) → CLKA (clock to Orin)
++	 * Both PHY0 and PHY1 must be enabled for Port A output.
++	 * TUN_DEST=0x10 routes tunnel pipes to Controller 1.
++	 */
++	max96724_write_reg(dev, MAX96724_CSI_OUT_CFG_ADDR,
++			   MAX96724_CSI_MODE_2X4_VAL);
++	max96724_write_reg(dev, MAX96724_CSI_PHY_EN_ADDR,
++			   MAX96724_CSI_PHY_EN_01);
++
++	max96724_write_reg(dev, MAX96724_CSI_LANE_MAP1_ADDR,
++			   priv->lane_mp1);
++	max96724_write_reg(dev, MAX96724_CSI_LANE_MAP2_ADDR,
++			   priv->lane_mp2);
++
++	/* [gmsl_ser_des_guide §6.1] MIPI_CTRL_SEL: all pipes → Controller 1.
++	 * Guide: "in tunneling mode the MIPI_CTRL_SEL_x bits must match TUN_DEST"
++	 * 0x55 = Pipe0→Ctrl1, Pipe1→Ctrl1, Pipe2→Ctrl1, Pipe3→Ctrl1 */
++	max96724_write_reg(dev, MAX96724_MIPI_CTRL_SEL_ADDR, 0x55);
++
++	/* [gmsl_ser_des_guide §8.2] LANE_CTRL on Controller 1 register (0x094A).
++	 * 0x40 = 2-lane. Also set Ctrl0 for completeness. */
++	max96724_write_reg(dev, MAX96724_LANE_CTRL0_ADDR,
++			   MAX96724_LANE_CTRL_2LANE);
++	max96724_write_reg(dev, MAX96724_LANE_CTRL1_ADDR,
++			   MAX96724_LANE_CTRL_2LANE);
++	max96724_write_reg(dev, MAX96724_LANE_CTRL2_ADDR,
++			   MAX96724_LANE_CTRL_2LANE);
++	max96724_write_reg(dev, MAX96724_LANE_CTRL3_ADDR,
++			   MAX96724_LANE_CTRL_2LANE);
++
++	/*
++	 * [SC20190112 2-lane] DPLL for Controller 1 (drives Port A via PHY1 clock).
++	 * FREQ1 (0x0418) = 0x2E = 1400 Mbps/lane + DPLL enable.
++	 * 2 lanes × 1400 Mbps = 2800 Mbps total ≥ camera 2L × 700M input.
++	 */
++	if (!priv->lane_setup) {
++		max96724_write_reg(dev, MAX96724_DPLL_CSI2_ADDR,
++				   MAX96724_DPLL_DISABLE);
++		max96724_write_reg(dev, MAX96724_DPLL_FREQ1_ADDR,
++				   MAX96724_DPLL_1400MBPS_CTRL0);
++		max96724_write_reg(dev, MAX96724_DPLL_CSI2_ADDR,
++				   MAX96724_DPLL_ENABLE);
++
++		priv->lane_setup = true;
++	}
++
++	/*
++	 * [Aardvark-verified] Stream ID select for all pipes
++	 * 0x0933 + 0x40*pipe = stream select register
++	 * Value 0x10 selects the appropriate stream for tunnel mode
++	 */
++	for (i = 0; i < MAX96724_MAX_PIPES; i++) {
++		max96724_write_reg(dev,
++				   MAX96724_PIPE_X_ST_SEL_ADDR + (0x40 * i),
++				   0x10);
++	}
++
++	/* BACKTOP: enable Controller 1 / CSI-B (0x02).
++	 * In 2x4 alt mode, Controller 1 is master for Port A → Orin CSI.
++	 */
++	max96724_write_reg(dev, MAX96724_BACKTOP_EN_ADDR,
++			   MAX96724_BACKTOP_CSIB_EN);
++
++	/* Keep all video receivers aligned with serializer heartbeat mode. */
++	for (i = 0; i < MAX96724_MAX_PIPES; i++) {
++		max96724_write_reg(dev,
++				   MAX96724_VID_RX0_P0_ADDR +
++				   (MAX96724_VID_RX_STRIDE * i),
++				   MAX96724_VID_RX0_CFG_VAL);
++		max96724_write_reg(dev,
++				   MAX96724_VID_RX6_P0_ADDR +
++				   (MAX96724_VID_RX_STRIDE * i),
++				   MAX96724_VID_RX6_CFG_VAL);
++	}
++
++	max96724_write_reg(dev, MAX96724_ONESHOT_ADDR,
++			   MAX96724_ONESHOT_ALL);
++
++	/* Enable all 4 pipes (Aardvark-verified: 0x0F at end) */
++	max96724_write_reg(dev, MAX96724_PIPE_EN_ADDR, MAX96724_PIPE_EN_4);
++
++	priv->sources[src_idx].st_enabled = true;
++
++ret:
++	mutex_unlock(&priv->lock);
++	return err;
++}
++EXPORT_SYMBOL(max96724_setup_streaming);
++
++/* ================================================================
++ * Start / Stop Streaming
++ * ================================================================ */
++
++int max96724_start_streaming(struct device *dev, struct device *s_dev)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++	struct gmsl_link_ctx *g_ctx;
++	struct gmsl_stream *g_stream;
++	int err = 0;
++	unsigned int i = 0;
++
++	err = max96724_get_sdev_idx(dev, s_dev, &i);
++	if (err)
++		return err;
++
++	mutex_lock(&priv->lock);
++	g_ctx = priv->sources[i].g_ctx;
++
++	for (i = 0; i < g_ctx->num_streams; i++) {
++		g_stream = &g_ctx->streams[i];
++
++		if (g_stream->des_pipe != MAX96724_PIPE_INVALID)
++			max96724_write_reg(dev, g_stream->des_pipe,
++					   g_stream->st_id_sel);
++	}
++	mutex_unlock(&priv->lock);
++
++	return 0;
++}
++EXPORT_SYMBOL(max96724_start_streaming);
++
++int max96724_stop_streaming(struct device *dev, struct device *s_dev)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++	struct gmsl_link_ctx *g_ctx;
++	struct gmsl_stream *g_stream;
++	int err = 0;
++	unsigned int i = 0;
++
++	err = max96724_get_sdev_idx(dev, s_dev, &i);
++	if (err)
++		return err;
++
++	mutex_lock(&priv->lock);
++	g_ctx = priv->sources[i].g_ctx;
++
++	for (i = 0; i < g_ctx->num_streams; i++) {
++		g_stream = &g_ctx->streams[i];
++
++		if (g_stream->des_pipe != MAX96724_PIPE_INVALID)
++			max96724_write_reg(dev, g_stream->des_pipe,
++					   MAX96724_RESET_ST_ID);
++	}
++
++	mutex_unlock(&priv->lock);
++
++	return 0;
++}
++EXPORT_SYMBOL(max96724_stop_streaming);
++
++/* ================================================================
++ * Pipe Management
++ * ================================================================ */
++
++int max96724_get_available_pipe_id(struct device *dev, int vc_id)
++{
++	int i;
++	int pipe_id = -ENOMEM;
++	struct max96724 *priv = dev_get_drvdata(dev);
++
++	mutex_lock(&priv->lock);
++	for (i = 0; i < MAX96724_MAX_PIPES; i++) {
++		if (i == vc_id && !priv->pipe[i].st_count) {
++			priv->pipe[i].st_count++;
++			pipe_id = i;
++			break;
++		}
++	}
++	mutex_unlock(&priv->lock);
++
++	return pipe_id;
++}
++EXPORT_SYMBOL(max96724_get_available_pipe_id);
++
++int max96724_release_pipe(struct device *dev, int pipe_id)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++
++	if (pipe_id < 0 || pipe_id >= MAX96724_MAX_PIPES)
++		return -EINVAL;
++
++	mutex_lock(&priv->lock);
++	priv->pipe[pipe_id].st_count = 0;
++	mutex_unlock(&priv->lock);
++
++	return 0;
++}
++EXPORT_SYMBOL(max96724_release_pipe);
++
++int max96724_get_ser_pipe_id(struct device *dev, int dser_pipe_id, int vc_id)
++{
++	/*
++	 * In Tunnel Mode with MAX96717, all VCs are carried in a single
++	 * tunnel pipe. The pipe mapping is 1:1 for d4xx compatibility.
++	 */
++	return dser_pipe_id;
++}
++EXPORT_SYMBOL(max96724_get_ser_pipe_id);
++
++void max96724_reset_oneshot(struct device *dev)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++
++	mutex_lock(&priv->lock);
++	if (priv->splitter_enabled) {
++		/* [UG] Multi-camera: reset all links */
++		u8 link_rate = (priv->link_speed == 6) ? 0x22 : 0x11;
++
++		max96724_write_reg(dev, MAX96724_LINK_RATE_AB_ADDR,
++				   link_rate);
++		max96724_write_reg(dev, MAX96724_LINK_RATE_CD_ADDR,
++				   link_rate);
++		max96724_write_reg(dev, MAX96724_LINK_EN_ADDR,
++				   MAX96724_LINK_EN_ALL);
++	} else {
++		max96724_write_reg(dev, MAX96724_ONESHOT_ADDR,
++				   MAX96724_ONESHOT_ALL);
++	}
++	msleep(100);
++
++	/* ONESHOT resets CSI config to defaults.
++	 * Restore 1x4a+2x2 2-lane config after every ONESHOT (per guide §7):
++	 *   CSI_OUT_CFG=0x08  1x4a+2x2: Controller 1 → PHY0+1 → Port A
++	 *   PHY_EN=0x30       PHY0+PHY1 (both needed for Port A)
++	 *   MIPI_CTRL_SEL=0x55 all pipes → Controller 1 (must match TUN_DEST)
++	 *   BACKTOP=0x02      CSIB_EN (Controller 1)
++	 *   TUN_EN=0x09       tunnel enable (per verified XML)
++	 *   TUN_DEST=0x50     manual detect + PHY1 (per verified XML)
++	 *   DPLL_FREQ1=0x2E   1400Mbps (Controller 1's DPLL)
++	 *   LANE_CTRL1=0x40   2-lane on Controller 1
++	 *   VID_RX0=0x33      disable pkt detect for tunnel mode
++	 */
++	max96724_write_reg(dev, MAX96724_CSI_OUT_CFG_ADDR,
++			   MAX96724_CSI_MODE_2X4_VAL);
++	max96724_write_reg(dev, MAX96724_CSI_PHY_EN_ADDR,
++			   MAX96724_CSI_PHY_EN_01);
++	max96724_write_reg(dev, MAX96724_MIPI_CTRL_SEL_ADDR, 0x55);
++	max96724_write_reg(dev, MAX96724_BACKTOP_EN_ADDR,
++			   MAX96724_BACKTOP_CSIB_EN);
++	/* Restore 2-lane count on all controllers (ONESHOT resets to default) */
++	max96724_write_reg(dev, MAX96724_LANE_CTRL0_ADDR,
++			   MAX96724_LANE_CTRL_2LANE);
++	max96724_write_reg(dev, MAX96724_LANE_CTRL1_ADDR,
++			   MAX96724_LANE_CTRL_2LANE);
++	max96724_write_reg(dev, MAX96724_LANE_CTRL2_ADDR,
++			   MAX96724_LANE_CTRL_2LANE);
++	max96724_write_reg(dev, MAX96724_LANE_CTRL3_ADDR,
++			   MAX96724_LANE_CTRL_2LANE);
++	max96724_write_reg(dev, MAX96724_DPLL_FREQ1_ADDR,
++			   MAX96724_DPLL_1400MBPS_CTRL0);
++	max96724_write_reg(dev, MAX96724_VID_RX0_P0_ADDR,
++			   MAX96724_VID_RX0_CFG_VAL);
++	/* Re-enable tunnel on all pipes (ONESHOT resets TUN_EN to 0x08=disabled) */
++	max96724_write_reg(dev, MAX96724_PIPE0_TUN_EN_ADDR, MAX96724_TUN_EN);
++	max96724_write_reg(dev, MAX96724_PIPE1_TUN_EN_ADDR, MAX96724_TUN_EN);
++	max96724_write_reg(dev, MAX96724_PIPE2_TUN_EN_ADDR, MAX96724_TUN_EN);
++	max96724_write_reg(dev, MAX96724_PIPE3_TUN_EN_ADDR, MAX96724_TUN_EN);
++	/* TUN_DEST: set to Controller 1 (0x10) for 2x4 alt / Port A */
++	max96724_write_reg(dev, MAX96724_PIPE0_TUN_DEST_ADDR,
++			   MAX96724_TUN_DEST_CTRL1);
++	max96724_write_reg(dev, MAX96724_PIPE1_TUN_DEST_ADDR,
++			   MAX96724_TUN_DEST_CTRL1);
++	max96724_write_reg(dev, MAX96724_PIPE2_TUN_DEST_ADDR,
++			   MAX96724_TUN_DEST_CTRL1);
++	max96724_write_reg(dev, MAX96724_PIPE3_TUN_DEST_ADDR,
++			   MAX96724_TUN_DEST_CTRL1);
++
++	msleep(200);
++	mutex_unlock(&priv->lock);
++}
++EXPORT_SYMBOL(max96724_reset_oneshot);
++
++/* ================================================================
++ * Init Settings / Set Pipe
++ * ================================================================ */
++
++/*
++ * __max96724_set_pipe - Configure per-pipe mapping registers
++ */
++static int __max96724_set_pipe(struct device *dev, int pipe_id,
++			       u8 data_type1, u8 data_type2, u32 vc_id)
++{
++	int err = 0;
++	int i;
++	u8 en_mapping_num = 0x0F;
++	u8 all_mapping_phy = MAX96724_ALL_MAP_CTRL1;  /* Controller 1 for 2x4 alt Port A mode */
++
++	struct reg_pair map_pipe_control[] = {
++		/* Enable 4 mappings for Pipe X */
++		{MAX96724_TX11_PIPE_X_EN_ADDR, 0x0F},
++		/* Map data_type1 on vc_id */
++		{MAX96724_PIPE_X_SRC_0_MAP_ADDR, 0x1E},
++		{MAX96724_PIPE_X_DST_0_MAP_ADDR, 0x1E},
++		/* Map frame start on vc_id */
++		{MAX96724_PIPE_X_SRC_1_MAP_ADDR, 0x00},
++		{MAX96724_PIPE_X_DST_1_MAP_ADDR, 0x00},
++		/* Map frame end on vc_id */
++		{MAX96724_PIPE_X_SRC_2_MAP_ADDR, 0x01},
++		{MAX96724_PIPE_X_DST_2_MAP_ADDR, 0x01},
++		/* Map data_type2 on vc_id */
++		{MAX96724_PIPE_X_SRC_3_MAP_ADDR, 0x12},
++		{MAX96724_PIPE_X_DST_3_MAP_ADDR, 0x12},
++		/* All mappings to Controller 1 (2x4 alt: Ctrl1 drives Port A) */
++		{MAX96724_TX45_PIPE_X_DST_CTRL_ADDR, MAX96724_ALL_MAP_CTRL1},
++		{MAX96724_TX46_PIPE_X_ADDR, MAX96724_ALL_MAP_CTRL1},
++		{MAX96724_TX47_PIPE_X_ADDR, MAX96724_ALL_MAP_CTRL1},
++		{MAX96724_TX48_PIPE_X_ADDR, MAX96724_ALL_MAP_CTRL1},
++		/* [SC20190112 2-lane] TX49: Pipeline concatenation 2W (2-lane output) */
++		{MAX96724_TX49_PIPE_X_ADDR, MAX96724_TX49_CONCAT_2W},
++		/*
++		 * Keep DES heartbeat handling aligned with the serializer's
++		 * LIM_HEART-disabled tunnel mode to avoid persistent VID_SEQ_ERR.
++		 */
++		{0x0100, MAX96724_VID_RX0_CFG_VAL},
++		{0x0106, MAX96724_VID_RX6_CFG_VAL},
++		/*
++		 * Pipe stream control (offset 0x36 per pipe block).
++		 * [gmsl_ser_des_guide §4.9] TUN_EN = 0x09 per verified XML.
++		 */
++		{0x0936, MAX96724_TUN_EN},
++	};
++
++	/* Adjust addresses for pipe offset (stride 0x40 per pipe)
++	 * Entries 0-13: TX11, SRC/DST maps, TX45-TX49 (all stride 0x40)
++	 * Entries 14-15: VID_RX0/6 (stride 0x12)
++	 * Entry 16: Pipe stream control (stride 0x40)
++	 */
++	for (i = 0; i < 14; i++)
++		map_pipe_control[i].addr += 0x40 * pipe_id;
++
++	/* [max9296.c pattern] VID_RX offset: 0x12 per pipe */
++	map_pipe_control[14].addr += 0x12 * pipe_id;
++	map_pipe_control[15].addr += 0x12 * pipe_id;
++
++	/* Pipe stream control: stride 0x40 */
++	map_pipe_control[16].addr += 0x40 * pipe_id;
++
++	if (data_type2 == 0x0) {
++		en_mapping_num = 0x07;
++		all_mapping_phy = 0x15;  /* 3 mappings to Controller 1 */
++	}
++
++	map_pipe_control[0].val = en_mapping_num;
++	/* SRC: match incoming VC from camera (vc_id) */
++	map_pipe_control[1].val = (vc_id << 6) | data_type1;
++	/* DST: preserve VC — NVCSI/VI endpoints expect matching vc-id */
++	map_pipe_control[2].val = (vc_id << 6) | data_type1;
++	map_pipe_control[3].val = (vc_id << 6) | 0x00;
++	map_pipe_control[4].val = (vc_id << 6) | 0x00;
++	map_pipe_control[5].val = (vc_id << 6) | 0x01;
++	map_pipe_control[6].val = (vc_id << 6) | 0x01;
++	map_pipe_control[7].val = (vc_id << 6) | data_type2;
++	map_pipe_control[8].val = (vc_id << 6) | data_type2;
++	map_pipe_control[9].val = all_mapping_phy;
++	/* TX46-TX48 keep 0x55 (Ctrl1) from initializer */
++	/* TX49 keeps 0x83 (2W concat) from initializer */
++	/* VID_RX (entry 14) and pipe stream ctrl (entry 15) keep init values */
++
++	err = max96724_set_registers(dev, map_pipe_control,
++				     ARRAY_SIZE(map_pipe_control));
++
++	return err;
++}
++
++/*
++ * max96724_init_settings - Initialize default pipe and tunnel configuration
++ *
++ * Sets up all 4 pipes with default YUV422_8 + EMBED for VC0-3,
++ * matching the d4xx framework expectations.
++ *
++ */
++int max96724_init_settings(struct device *dev)
++{
++	int err = 0;
++	int i;
++	struct max96724 *priv = dev_get_drvdata(dev);
++
++	mutex_lock(&priv->lock);
++
++	for (i = 0; i < MAX96724_MAX_PIPES; i++)
++		err |= __max96724_set_pipe(dev, i, GMSL_CSI_DT_YUV422_8,
++					   GMSL_CSI_DT_EMBED, i);
++
++	mutex_unlock(&priv->lock);
++
++	return err;
++}
++EXPORT_SYMBOL(max96724_init_settings);
++
++int max96724_bind_ser_to_dser_pipe(struct device *dev, int dser_pipe_id,
++				   int ser_pipe_id, u32 vc_id)
++{
++	/* In Tunnel Mode, pipe mapping is 1:1 (each camera → one pipe) */
++	return 0;
++}
++EXPORT_SYMBOL(max96724_bind_ser_to_dser_pipe);
++
++int max96724_set_pipe(struct device *dev, int pipe_id,
++		      u8 data_type1, u8 data_type2, u32 vc_id)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++	int err = 0;
++
++	if (pipe_id > (MAX96724_MAX_PIPES - 1)) {
++		dev_info(dev, "%s: input pipe_id: %d exceeds max96724 max pipes\n",
++			 __func__, pipe_id);
++		return -EINVAL;
++	}
++
++	dev_dbg(dev, "%s pipe_id %d, data_type1 %u, data_type2 %u, vc_id %u\n",
++		__func__, pipe_id, data_type1, data_type2, vc_id);
++
++	mutex_lock(&priv->lock);
++
++	err = __max96724_set_pipe(dev, pipe_id, data_type1, data_type2, vc_id);
++
++	mutex_unlock(&priv->lock);
++
++	return err;
++}
++EXPORT_SYMBOL(max96724_set_pipe);
++
++/* ================================================================
++ * Device Tree Parsing
++ * ================================================================ */
++
++static const struct of_device_id max96724_of_match[] = {
++	{ .compatible = "adi,max96724", },
++	{ },
++};
++MODULE_DEVICE_TABLE(of, max96724_of_match);
++
++static int max96724_parse_dt(struct max96724 *priv,
++			     struct i2c_client *client)
++{
++	struct device_node *node = client->dev.of_node;
++	int err = 0;
++	const char *str_value;
++	int value;
++	const struct of_device_id *match;
++
++	if (!node)
++		return -EINVAL;
++
++	match = of_match_device(max96724_of_match, &client->dev);
++	if (!match) {
++		dev_err(&client->dev, "Failed to find matching dt id\n");
++		return -EFAULT;
++	}
++
++	/* CSI mode: "2x4" or "4x2" */
++	err = of_property_read_string(node, "csi-mode", &str_value);
++	if (err < 0) {
++		dev_err(&client->dev, "csi-mode property not found\n");
++		return err;
++	}
++
++	if (!strcmp(str_value, "2x4")) {
++		priv->csi_mode = MAX96724_CSI_MODE_2X4;
++		priv->lane_mp1 = MAX96724_LANE_MAP1_2X4;
++		priv->lane_mp2 = MAX96724_LANE_MAP2_2X4;
++	} else if (!strcmp(str_value, "4x2")) {
++		priv->csi_mode = MAX96724_CSI_MODE_4X2;
++		priv->lane_mp1 = MAX96724_LANE_MAP1_4X2;
++		priv->lane_mp2 = MAX96724_LANE_MAP2_4X2;
++	} else {
++		dev_err(&client->dev, "invalid csi mode\n");
++		return -EINVAL;
++	}
++
++	/* Max sources */
++	err = of_property_read_u32(node, "max-src", &value);
++	if (err < 0) {
++		dev_err(&client->dev, "No max-src info\n");
++		return err;
++	}
++	priv->max_src = value;
++
++	/* Reset GPIO */
++	priv->reset_gpio = of_get_named_gpio(node, "reset-gpios", 0);
++	if (priv->reset_gpio < 0) {
++		dev_err(&client->dev, "reset-gpios not found %d\n", err);
++		return err;
++	}
++
++	/* [User requirement] GMSL link speed from DT: 3 or 6 (Gbps) */
++	err = of_property_read_u32(node, "gmsl-link-speed", &value);
++	if (err < 0) {
++		/* Default to 3 Gbps if not specified */
++		priv->link_speed = 3;
++		dev_info(&client->dev,
++			 "gmsl-link-speed not specified, defaulting to 3 Gbps\n");
++	} else {
++		if (value != 3 && value != 6) {
++			dev_err(&client->dev,
++				"invalid gmsl-link-speed %d (must be 3 or 6)\n",
++				value);
++			return -EINVAL;
++		}
++		priv->link_speed = value;
++	}
++
++	/* 1.2V regulator (optional) */
++	if (of_get_property(node, "vdd_cam_1v2-supply", NULL)) {
++		priv->vdd_cam_1v2 = regulator_get(&client->dev, "vdd_cam_1v2");
++		if (IS_ERR(priv->vdd_cam_1v2)) {
++			dev_err(&client->dev,
++				"vdd_cam_1v2 regulator get failed\n");
++			err = PTR_ERR(priv->vdd_cam_1v2);
++			priv->vdd_cam_1v2 = NULL;
++			return err;
++		}
++	} else {
++		priv->vdd_cam_1v2 = NULL;
++	}
++
++	return 0;
++}
++
++/* ================================================================
++ * Probe / Remove
++ * ================================================================ */
++
++static struct regmap_config max96724_regmap_config = {
++	.reg_bits = 16,
++	.val_bits = 8,
++	.cache_type = REGCACHE_RBTREE,
++};
++
++static int max96724_probe(struct i2c_client *client,
++			   const struct i2c_device_id *id)
++{
++	struct max96724 *priv;
++	int err = 0;
++
++	dev_info(&client->dev,
++		 "[MAX96724]: probing Quad GMSL2 Deserializer (Tunnel Mode)\n");
++
++	priv = devm_kzalloc(&client->dev, sizeof(*priv), GFP_KERNEL);
++	if (!priv)
++		return -ENOMEM;
++
++	priv->i2c_client = client;
++	priv->regmap = devm_regmap_init_i2c(priv->i2c_client,
++					     &max96724_regmap_config);
++	if (IS_ERR(priv->regmap)) {
++		dev_err(&client->dev,
++			"regmap init failed: %ld\n", PTR_ERR(priv->regmap));
++		return -ENODEV;
++	}
++
++	err = max96724_parse_dt(priv, client);
++	if (err) {
++		dev_err(&client->dev, "unable to parse dt\n");
++		return -EFAULT;
++	}
++
++	max96724_pipes_reset(priv);
++
++	if (priv->max_src > MAX96724_MAX_SOURCES) {
++		dev_err(&client->dev,
++			"max sources more than currently supported\n");
++		return -EINVAL;
++	}
++
++	mutex_init(&priv->lock);
++
++	dev_set_drvdata(&client->dev, priv);
++
++	dev_info(&client->dev, "%s: success (link_speed=%d Gbps, max_src=%d)\n",
++		 __func__, priv->link_speed, priv->max_src);
++
++	return err;
++}
++
++static int max96724_remove(struct i2c_client *client)
++{
++	struct max96724 *priv;
++
++	if (client != NULL) {
++		priv = dev_get_drvdata(&client->dev);
++		mutex_destroy(&priv->lock);
++		i2c_unregister_device(client);
++		client = NULL;
++	}
++
++	return 0;
++}
++
++static const struct i2c_device_id max96724_id[] = {
++	{ "max96724", 0 },
++	{ },
++};
++
++MODULE_DEVICE_TABLE(i2c, max96724_id);
++
++static struct i2c_driver max96724_i2c_driver = {
++	.driver = {
++		.name = "max96724",
++		.owner = THIS_MODULE,
++		.of_match_table = of_match_ptr(max96724_of_match),
++	},
++	.probe = max96724_probe,
++	.remove = max96724_remove,
++	.id_table = max96724_id,
++};
++
++static int __init max96724_init(void)
++{
++	return i2c_add_driver(&max96724_i2c_driver);
++}
++
++static void __exit max96724_exit(void)
++{
++	i2c_del_driver(&max96724_i2c_driver);
++}
++
++module_init(max96724_init);
++module_exit(max96724_exit);
++
++MODULE_DESCRIPTION("Quad GMSL2 Deserializer driver max96724 (Tunnel Mode)");
++MODULE_AUTHOR("RealSense AI");
++MODULE_LICENSE("GPL v2");
+diff --git a/include/media/max96717.h b/include/media/max96717.h
+new file mode 100644
+index 0000000..65bf930
+--- /dev/null
++++ b/include/media/max96717.h
+@@ -0,0 +1,151 @@
++/*
++ * max96717.c - MAX96717 GMSL2 Serializer driver (Tunnel Mode)
++ *
++ * Copyright (c) 2026, RealSense, Inc.  All rights reserved.
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms and conditions of the GNU General Public License,
++ * version 2, as published by the Free Software Foundation.
++ *
++ * This program is distributed in the hope it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
++ * more details.
++ *
++ * You should have received a copy of the GNU General Public License
++ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
++ */
++
++/**
++ * @file
++ * <b>MAX96717 API: For Analog Devices MAX96717 GMSL2 serializer</b>
++ *
++ * @b Description: Defines elements used to set up and use an
++ *  Analog Devices MAX96717 GMSL2 serializer in Tunnel Mode.
++ */
++
++#ifndef __MAX96717_H__
++#define __MAX96717_H__
++
++#include <linux/types.h>
++#include <media/gmsl-link.h>
++
++/**
++ * \defgroup max96717 MAX96717 serializer driver
++ *
++ * Controls the MAX96717 GMSL2 serializer module (Tunnel Mode).
++ *
++ * @ingroup serdes_group
++ * @{
++ */
++
++/**
++ * @brief  Configures a single pipe on the serializer.
++ *
++ * In Tunnel Mode, per-pipe DT/VC filtering is not active on the serializer
++ * side (all VCs are tunneled transparently). This function maintains API
++ * compatibility with the d4xx sensor driver framework.
++ *
++ * @param  [in]  dev          The serializer device handle.
++ * @param  [in]  pipe_id      Pipe index (0..3).
++ * @param  [in]  data_type1   Primary CSI-2 data type.
++ * @param  [in]  data_type2   Secondary CSI-2 data type (e.g. embedded).
++ * @param  [in]  vc_id        Virtual channel ID.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96717_set_pipe(struct device *dev, int pipe_id, u8 data_type1,
++		      u8 data_type2, u32 vc_id);
++
++/**
++ * @brief  Toggle SER TX to restore tunnel detection after DES ONESHOT.
++ *
++ * A DES ONESHOT resets the video data path. The serializer must cycle
++ * its TX enable (REG2 0x03→0x43) for the deserializer to re-acquire
++ * the tunnel stream.
++ *
++ * @param  [in]  dev          The serializer device handle.
++ */
++void max96717_retrigger_tx(struct device *dev);
++
++/**
++ * @brief  Powers on the serializer and performs I2C overrides
++ * for sensor and serializer devices.
++ *
++ * Must be called after the deserializer's max96724_setup_link().
++ *
++ * @param  [in]  dev          The serializer device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96717_setup_control(struct device *dev);
++
++/**
++ * @brief  Reverts I2C overrides and resets the serializer.
++ *
++ * @param  [in]  dev          The serializer device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96717_reset_control(struct device *dev);
++
++/**
++ * @brief  Pairs a sensor device with the serializer.
++ *
++ * To be called by the sensor client driver.
++ *
++ * @param  [in]  dev          The serializer device handle.
++ * @param  [in]  g_ctx        The gmsl_link_ctx structure handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96717_sdev_pair(struct device *dev, struct gmsl_link_ctx *g_ctx);
++
++/**
++ * @brief  Unpairs a sensor device from the serializer.
++ *
++ * @param  [in]  dev          The serializer device handle.
++ * @param  [in]  s_dev        The sensor device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96717_sdev_unpair(struct device *dev, struct device *s_dev);
++
++/**
++ * @brief  Sets up the serializer's internal streaming pipeline.
++ *
++ * Configures CSI-2 input mode, lane mapping, and enables Tunnel Mode
++ * (EXT11[7]=1 at register 0x0383).
++ *
++ * @param  [in]  dev          The serializer device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96717_setup_streaming(struct device *dev);
++
++/**
++ * @brief  Applies initial register settings for the serializer.
++ *
++ * Configures default pipe settings and Tunnel Mode registers.
++ *
++ * @param  [in]  dev          The serializer device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96717_init_settings(struct device *dev);
++
++/**
++ * @brief  No-op hook for GPIO-over-GMSL tunneling for FSIN/FOUT signals.
++ *
++ * The signal map is documented, but the concrete MFP_CFG values are
++ * not available yet. This hook currently logs and returns success.
++ *
++ * @param  [in]  dev          The serializer device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96717_setup_gpio_tunneling(struct device *dev);
++
++/** @} */
++
++#endif  /* __MAX96717_H__ */
+diff --git a/include/media/max96724.h b/include/media/max96724.h
+new file mode 100644
+index 0000000..dc5a8ea
+--- /dev/null
++++ b/include/media/max96724.h
+@@ -0,0 +1,183 @@
++/*
++ * max96717.c - MAX96717 GMSL2 Serializer driver (Tunnel Mode)
++ *
++ * Copyright (c) 2026, RealSense, Inc.  All rights reserved.
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms and conditions of the GNU General Public License,
++ * version 2, as published by the Free Software Foundation.
++ *
++ * This program is distributed in the hope it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
++ * more details.
++ *
++ * You should have received a copy of the GNU General Public License
++ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
++ */
++
++/**
++ * @file
++ * <b>MAX96724 API: For Analog Devices MAX96724 GMSL2 quad deserializer</b>
++ *
++ * @b Description: Defines elements used to set up and use an
++ *  Analog Devices MAX96724 quad GMSL2 deserializer in Tunnel Mode.
++ */
++
++#ifndef __MAX96724_H__
++#define __MAX96724_H__
++
++#include <linux/types.h>
++#include <media/gmsl-link.h>
++
++/**
++ * \defgroup max96724 MAX96724 deserializer driver
++ *
++ * Controls the MAX96724 quad GMSL2 deserializer module (Tunnel Mode).
++ *
++ * @ingroup serdes_group
++ * @{
++ */
++
++int max96724_get_available_pipe_id(struct device *dev, int vc_id);
++int max96724_get_ser_pipe_id(struct device *dev, int dser_pipe_id, int vc_id);
++int max96724_set_pipe(struct device *dev, int pipe_id, u8 data_type1,
++		      u8 data_type2, u32 vc_id);
++int max96724_release_pipe(struct device *dev, int pipe_id);
++void max96724_reset_oneshot(struct device *dev);
++
++/**
++ * @brief  Puts the deserializer in single exclusive link mode.
++ *
++ * @param  [in]  dev          The deserializer device handle.
++ * @param  [in]  s_dev        The sensor device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96724_setup_link(struct device *dev, struct device *s_dev);
++
++/**
++ * @brief  Sets up the deserializer link's control pipeline.
++ *
++ * Configures I2C pass-through, splitter mode if needed, and
++ * enables the tunnel mode pipe routing for the source.
++ *
++ * @param  [in]  dev          The deserializer device handle.
++ * @param  [in]  s_dev        The sensor device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96724_setup_control(struct device *dev, struct device *s_dev);
++
++/**
++ * @brief  Resets the deserializer link control pipeline.
++ *
++ * @param  [in]  dev          The deserializer device handle.
++ * @param  [in]  s_dev        The sensor device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96724_reset_control(struct device *dev, struct device *s_dev);
++
++/**
++ * @brief  Registers a source sensor device with the deserializer.
++ *
++ * @param  [in]  dev          The deserializer device handle.
++ * @param  [in]  g_ctx        The gmsl_link_ctx structure handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96724_sdev_register(struct device *dev, struct gmsl_link_ctx *g_ctx);
++
++/**
++ * @brief  Unregisters a source sensor device from the deserializer.
++ *
++ * @param  [in]  dev          The deserializer device handle.
++ * @param  [in]  s_dev        The sensor device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96724_sdev_unregister(struct device *dev, struct device *s_dev);
++
++/**
++ * @brief  Configures the internal streaming pipeline.
++ *
++ * Sets up tunnel mode pipe routing, CSI-2 output lane configuration,
++ * and MIPI PHY settings.
++ *
++ * @param  [in]  dev          The deserializer device handle.
++ * @param  [in]  s_dev        The sensor device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96724_setup_streaming(struct device *dev, struct device *s_dev);
++
++/**
++ * @brief  Enables streaming for a source sensor.
++ *
++ * @param  [in]  dev          The deserializer device handle.
++ * @param  [in]  s_dev        The sensor device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96724_start_streaming(struct device *dev, struct device *s_dev);
++
++/**
++ * @brief  Disables streaming for a source sensor.
++ *
++ * @param  [in]  dev          The deserializer device handle.
++ * @param  [in]  s_dev        The sensor device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96724_stop_streaming(struct device *dev, struct device *s_dev);
++
++/**
++ * @brief  Powers on the MAX96724 deserializer module.
++ *
++ * Asserts shared reset GPIO and powers on the regulator.
++ *
++ * @param  [in]  dev          The deserializer device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96724_power_on(struct device *dev);
++
++/**
++ * @brief  Powers off the MAX96724 deserializer module.
++ *
++ * @param  [in]  dev          The deserializer device handle.
++ */
++void max96724_power_off(struct device *dev);
++
++/**
++ * @brief  Applies initial register settings for the deserializer.
++ *
++ * Configures default pipe mappings, tunnel mode, and CSI output for
++ * the D5xx/SC1.2 use case.
++ *
++ * @param  [in]  dev          The deserializer device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96724_init_settings(struct device *dev);
++
++/**
++ * @brief  Maps deserializer pipe ID to serializer pipe ID.
++ *
++ * In tunnel mode with MAX96717, all data flows through a single pipe
++ * per camera, so the mapping is 1:1.
++ *
++ * @param  [in]  dev             The deserializer device handle.
++ * @param  [in]  dser_pipe_id    Deserializer pipe ID.
++ * @param  [in]  ser_pipe_id     Serializer pipe ID.
++ * @param  [in]  vc_id           VC ID associated with this pipe.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96724_bind_ser_to_dser_pipe(struct device *dev, int dser_pipe_id,
++				   int ser_pipe_id, u32 vc_id);
++
++/** @} */
++
++#endif  /* __MAX96724_H__ */
+-- 
+2.25.1
+

--- a/nvidia-oot/6.2/0011-Add-MAX96717-serializer-and-MAX96724-deserializer-dr.patch
+++ b/nvidia-oot/6.2/0011-Add-MAX96717-serializer-and-MAX96724-deserializer-dr.patch
@@ -1,0 +1,2896 @@
+From 40fac9b67ddea60055961d32fa89fe8f608396ff Mon Sep 17 00:00:00 2001
+From: RealSense AI <realsense@realsenseai.com>
+Date: Tue, 12 May 2026 17:06:23 +0800
+Subject: [PATCH] Add MAX96717 serializer and MAX96724 deserializer drivers for
+ tunnel mode
+
+Add MAX96717 GMSL2 serializer and MAX96724 GMSL2 quad deserializer
+drivers for Tunnel Mode operation with D5xx cameras.
+
+MAX96717 serializer features:
+- CSI-2 input with 2/4 lane support
+- Tunnel Mode encapsulation of full CSI-2 byte stream
+- I2C address translation for sensor passthrough
+- GPIO-over-GMSL tunneling hook for FSIN/FOUT signals
+
+MAX96724 quad deserializer features:
+- Up to 4 GMSL2 links (quad camera support)
+- Configurable link speed (3 Gbps / 6 Gbps via DT)
+- Tunnel Mode pipe routing and CSI-2 output
+- 2x4 and 4x2 CSI output mode support
+- Power management with GPIO reset and regulator control
+
+Signed-off-by: RealSense AI <realsense@realsenseai.com>
+---
+ drivers/media/i2c/Makefile   |    2 +
+ drivers/media/i2c/max96717.c |  797 ++++++++++++++++
+ drivers/media/i2c/max96724.c | 1690 ++++++++++++++++++++++++++++++++++
+ include/media/max96717.h     |  151 +++
+ include/media/max96724.h     |  183 +++
+ 5 files changed, 2823 insertions(+)
+ create mode 100644 drivers/media/i2c/max96717.c
+ create mode 100644 drivers/media/i2c/max96724.c
+ create mode 100644 include/media/max96717.h
+ create mode 100644 include/media/max96724.h
+
+diff --git a/drivers/media/i2c/Makefile b/drivers/media/i2c/Makefile
+index b284938..947e6e9 100644
+--- a/drivers/media/i2c/Makefile
++++ b/drivers/media/i2c/Makefile
+@@ -8,6 +8,8 @@ obj-m += max9296.o
+ subdir-ccflags-y += -DCONFIG_VIDEO_D4XX_SERDES
+ subdir-ccflags-y += -DCONFIG_TEGRA_CAMERA_PLATFORM
+ obj-m += d4xx.o
++obj-m += max96717.o
++obj-m += max96724.o
+ ifeq ($(findstring ack_src,$(NV_BUILD_KERNEL_OPTIONS)),)
+ obj-m += max96712.o
+ 
+diff --git a/drivers/media/i2c/max96717.c b/drivers/media/i2c/max96717.c
+new file mode 100644
+index 0000000..78d8a01
+--- /dev/null
++++ b/drivers/media/i2c/max96717.c
+@@ -0,0 +1,797 @@
++/*
++ * max96717.c - MAX96717 GMSL2 Serializer driver (Tunnel Mode)
++ *
++ * Copyright (c) 2026, RealSense, Inc.  All rights reserved.
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms and conditions of the GNU General Public License,
++ * version 2, as published by the Free Software Foundation.
++ *
++ * This program is distributed in the hope it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
++ * more details.
++ *
++ * You should have received a copy of the GNU General Public License
++ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
++ */
++
++/*
++ * Register Reference Sources:
++ * [PPTX]  = GMSL_MAX96717_MAX96724_TechOverview - V1.pptx
++ * [XML]   = MAX96717_MAX96724_HKR_EVB_700mbps_tunnel_mode_basedonexcelsheet_D585.xml
++ *
++ * Every register address and value below is traceable to one of these sources.
++ */
++
++#include <media/camera_common.h>
++#include <linux/module.h>
++#include <media/max96717.h>
++
++/* ===== Register Addresses ===== */
++
++/* [PPTX slide 7] REG0: Device ID (read-only, returns 0x40) */
++#define MAX96717_DEV_ADDR		0x00
++
++/* [PPTX slide 7] REG1: Link Speed
++ *   bit[3]=1: 3 Gbps, bit[4]=1: 6 Gbps
++ */
++#define MAX96717_REG1_ADDR		0x01
++
++/* [PPTX slide 7 / XML 0x0002] PIPE_EN: Pipe enable / soft reset
++ *   [XML] 0x03 = soft reset, 0x43 = pipes enabled + video init
++ *   [PPTX slide 7] Matches MAX9295 PIPE_EN at 0x02
++ */
++#define MAX96717_PIPE_EN_ADDR		0x02
++
++/* [PPTX slide 7] CTRL0: GMSL2 TX Control
++ *   bit[5]=1: GMSL2 mode, bit[0]=1: enable transmitter
++ *   0x21 = GMSL2 mode + TX enable on Link A
++ */
++#define MAX96717_CTRL0_ADDR		0x10
++
++/* [PPTX slide 7] CTRL3: Start Video - final enable bit
++ *   bit[0]=1: activate video stream
++ */
++#define MAX96717_CTRL3_ADDR		0x13
++
++/* [PPTX slide 7] TX1: FEC Enable
++ *   bit[6]=1: Reed-Solomon FEC enabled
++ */
++#define MAX96717_TX1_ADDR		0x29
++
++/* [MAX96724 Users Guide, I2C Broadcasting section, p44-46]
++ * MAX96717 I2C address translation registers (GMSL2 standard):
++ *   SRC_A / DST_A (0x42/0x43): Translation pair A (SER broadcast addr)
++ *   SRC_B / DST_B (0x44/0x45): Translation pair B (sensor passthrough)
++ *
++ * When host writes to SRC_B address, the MAX96717 translates it to
++ * DST_B and forwards via GMSL back-channel to the remote sensor.
++ *
++ */
++#define MAX96717_SRC_A_ADDR		0x42
++#define MAX96717_DST_A_ADDR		0x43
++#define MAX96717_I2C4_ADDR		0x44	/* SRC_B: sensor proxy addr */
++#define MAX96717_I2C5_ADDR		0x45	/* DST_B: sensor default addr */
++
++/* [PPTX slide 14] TX_STR_SEL: Stream ID select
++ *   bits[1:0]: stream ID for DES pipe routing
++ */
++#define MAX96717_TX_STR_SEL_ADDR	0x5B
++
++/* [PPTX slide 7 / XML 0x0110-0x0111] VIDEO_TX0/TX1: Video TX path config
++ *   [XML] 0x0110=0xE9, 0x0111=0x10 for tunnel mode data path
++ */
++#define MAX96717_VIDEO_TX0_ADDR		0x110
++#define MAX96717_VIDEO_TX1_ADDR		0x111
++
++/* [PPTX slide 7] FRONTTOP_0: Front-end topology
++ *   0x12 = single CSI-2 port A, all VCs pass through
++ */
++#define MAX96717_FRONTTOP0_ADDR		0x308
++
++/* [XML / PPTX slide 7] MIPI_RX0-RX3: CSI-2 receiver configuration
++ *   RX0 (0x330): CSI mode (0x00 = D-PHY controller A)
++ *   RX1 (0x331): Lane count - [PPTX slide 14] ctrl1_num_lanes bits[5:4]
++ *                 [XML] 0x30 = bits[5:4]=11 (4 lanes)
++ *   RX2 (0x332): Lane mapping - [XML] 0xE0 = default 1x4 map
++ *   RX3 (0x333): Lane mapping - [XML] 0x04 = default 1x4 map
++ */
++#define MAX96717_MIPI_RX0_ADDR		0x330
++#define MAX96717_MIPI_RX1_ADDR		0x331
++#define MAX96717_MIPI_RX2_ADDR		0x332
++#define MAX96717_MIPI_RX3_ADDR		0x333
++
++/* [PPTX slide 7 / slide 14] EXT11: TUNNEL MODE ENABLE
++ *   bit[7]=1: Tun_Mode = ON  *** CRITICAL REGISTER ***
++ *   [PPTX slide 7] 0x383 = 0x80
++ */
++#define MAX96717_EXT11_ADDR		0x383
++
++/* ===== Register Values ===== */
++
++/* [XML] Soft reset value for PIPE_EN register */
++#define MAX96717_SOFT_RESET		0x03
++
++/* [XML] Final enable: pipes enabled + video init */
++#define MAX96717_PIPE_EN_ALL		0x43
++
++/* [PPTX slide 7] CTRL0: GMSL2 mode + TX enable (Link A) */
++#define MAX96717_CTRL0_LINK_A		0x21
++/* CTRL0: GMSL2 mode + TX enable (Link B) */
++#define MAX96717_CTRL0_LINK_B		0x22
++
++/* [PPTX slide 7] CTRL0 reset all */
++#define MAX96717_RESET_ALL		0x80
++
++/* [PPTX slide 7] EXT11 tunnel mode enable value */
++#define MAX96717_TUN_MODE_EN		0x80
++
++/* [XML] VIDEO_TX0 tunnel mode data path enable */
++#define MAX96717_VIDEO_TX0_TUN		0xE9
++/* [XML] VIDEO_TX1 tunnel mode config */
++#define MAX96717_VIDEO_TX1_TUN		0x10
++
++/* [XML / PPTX slide 14] MIPI RX1: 4-lane CSI-2, bits[5:4]=11 */
++#define MAX96717_CSI_4_LANES		0x30
++/* 2-lane CSI-2, bits[5:4]=01 */
++#define MAX96717_CSI_2_LANES		0x10
++
++/* [XML] Lane mapping for 1x4 mode (matches MAX9295 1x4 values) */
++#define MAX96717_CSI_1X4_LANE_MAP1	0xE0
++#define MAX96717_CSI_1X4_LANE_MAP2	0x04
++
++/* [PPTX slide 7] FRONTTOP_0: single port A, all VCs */
++#define MAX96717_FRONTTOP0_PORT_A	0x12
++
++/* [XML] MIPI_RX0: CSI reset on + non-continuous clock */
++#define MAX96717_MIPI_RX0_RESET		0x08
++/* [PPTX slide 7] MIPI_RX0: Normal operation */
++#define MAX96717_MIPI_RX0_NORMAL	0x00
++
++/* [PPTX slide 9] REG1: 3 Gbps link speed, bit[3]=1 */
++#define MAX96717_LINK_SPEED_3GBPS	0x08
++/* [PPTX slide 9] REG1: 6 Gbps link speed, bit[4]=1 */
++#define MAX96717_LINK_SPEED_6GBPS	0x10
++
++/* [XML] EXT11 tunnel mode pre-config (0x0383=0x80) */
++#define MAX96717_EXT11_TUN_PRE		0x80
++
++#define MAX96717_MAX_PIPES		4
++
++/* ===== Data Structures ===== */
++
++struct max96717_client_ctx {
++	struct gmsl_link_ctx *g_ctx;
++	bool st_done;
++};
++
++struct max96717 {
++	struct i2c_client *i2c_client;
++	struct regmap *regmap;
++	struct max96717_client_ctx g_client;
++	struct mutex lock;
++	/* primary serializer properties */
++	__u32 def_addr;
++	__u32 pst2_ref;
++};
++
++static struct max96717 *prim_priv__;
++
++struct reg_pair {
++	u16 addr;
++	u8 val;
++};
++
++/* ===== Low-level I2C ===== */
++
++static int max96717_write_reg(struct device *dev, u16 addr, u8 val)
++{
++	struct max96717 *priv = dev_get_drvdata(dev);
++	int err;
++
++	err = regmap_write(priv->regmap, addr, val);
++	if (err)
++		dev_err(dev, "%s:i2c write failed, 0x%x = %x\n",
++			__func__, addr, val);
++
++	/* delay before next i2c command as required for SERDES link */
++	usleep_range(100, 110);
++
++	return err;
++}
++
++static int max96717_set_registers(struct device *dev, struct reg_pair *map,
++				  u32 count)
++{
++	int err = 0;
++	u32 j;
++
++	for (j = 0; j < count; j++) {
++		err = max96717_write_reg(dev, map[j].addr, map[j].val);
++		if (err)
++			break;
++	}
++
++	return err;
++}
++
++/* ===== Streaming Setup ===== */
++
++/*
++ * max96717_setup_streaming - Configure CSI-2 input and enable Tunnel Mode
++ *
++ * In Tunnel Mode (unlike MAX9295 Pixel Mode), the serializer encapsulates
++ * the entire CSI-2 byte stream verbatim into a single GMSL2 tunnel.
++ * All VCs (VC0-VC3) are preserved end-to-end.
++ */
++int max96717_setup_streaming(struct device *dev)
++{
++	struct max96717 *priv = dev_get_drvdata(dev);
++	int err = 0;
++	struct gmsl_link_ctx *g_ctx;
++	u32 lane_count;
++
++	/*
++	 * [XML] Full initialization sequence:
++	 *   0x0002 = 0x03  (soft reset)
++	 *   0x0383 = 0x80  (tunnel mode enable)
++	 *   0x0331 = 0x30  (4-lane CSI)
++	 *   0x0332 = 0xE0  (lane map1)
++	 *   0x0333 = 0x04  (lane map2)
++	 *   0x0110 = 0xE9  (video TX0 tunnel path)
++	 *   0x0111 = 0x10  (video TX1 tunnel config)
++	 *   0x0330 = 0x08  (CSI reset on)
++	 *   0x0330 = 0x00  (CSI reset off)
++	 *   0x0002 = 0x43  (final enable)
++	 */
++	struct reg_pair tunnel_init[] = {
++		/* [PPTX slide 7] EXT11: Tunnel Mode Enable */
++		{MAX96717_EXT11_ADDR, MAX96717_TUN_MODE_EN},
++		/* [XML] VIDEO_TX0/TX1: tunnel data path */
++		{MAX96717_VIDEO_TX0_ADDR, MAX96717_VIDEO_TX0_TUN},
++		{MAX96717_VIDEO_TX1_ADDR, MAX96717_VIDEO_TX1_TUN},
++	};
++
++	mutex_lock(&priv->lock);
++
++	if (!priv->g_client.g_ctx) {
++		dev_err(dev, "%s: no sdev client found\n", __func__);
++		err = -EINVAL;
++		goto error;
++	}
++
++	if (priv->g_client.st_done) {
++		dev_dbg(dev, "%s: stream setup is already done\n", __func__);
++		goto error;
++	}
++
++	g_ctx = priv->g_client.g_ctx;
++
++	/*
++	 * [Aardvark-verified] Soft reset before tunnel mode configuration
++	 * Clears stale pipe/CSI state for clean initialization.
++	 * Aardvark: 0x0002=0x03, sleep 30ms, then proceed with config.
++	 */
++	max96717_write_reg(dev, MAX96717_PIPE_EN_ADDR, MAX96717_SOFT_RESET);
++	msleep(30);
++
++	/*
++	 * [PPTX slide 14] ctrl1_num_lanes at 0x0331 bits[5:4]
++	 * [XML] 0x0331 = 0x30 for 4-lane
++	 * MAX96717 supports 1x4 mode only (single 4-lane D-PHY input)
++	 */
++	lane_count = (g_ctx->num_csi_lanes == 4) ?
++		MAX96717_CSI_4_LANES : MAX96717_CSI_2_LANES;
++
++	max96717_write_reg(dev, MAX96717_MIPI_RX1_ADDR, lane_count);
++
++	/* [XML] Lane mapping: 1x4 mode default */
++	max96717_write_reg(dev, MAX96717_MIPI_RX2_ADDR,
++			   MAX96717_CSI_1X4_LANE_MAP1);
++	max96717_write_reg(dev, MAX96717_MIPI_RX3_ADDR,
++			   MAX96717_CSI_1X4_LANE_MAP2);
++
++	/* Enable tunnel mode and configure video TX path */
++	err = max96717_set_registers(dev, tunnel_init,
++				     ARRAY_SIZE(tunnel_init));
++	if (err)
++		goto error;
++
++	/* [Aardvark-verified] CSI reset cycle with 2ms delay */
++	max96717_write_reg(dev, MAX96717_MIPI_RX0_ADDR,
++			   MAX96717_MIPI_RX0_RESET);
++	usleep_range(2000, 2100);
++	max96717_write_reg(dev, MAX96717_MIPI_RX0_ADDR,
++			   MAX96717_MIPI_RX0_NORMAL);
++
++	/* [XML] Final enable: pipes on + video init */
++	max96717_write_reg(dev, MAX96717_PIPE_EN_ADDR,
++			   MAX96717_PIPE_EN_ALL);
++
++	priv->g_client.st_done = true;
++
++error:
++	mutex_unlock(&priv->lock);
++	return err;
++}
++EXPORT_SYMBOL(max96717_setup_streaming);
++
++/* ===== Control Setup ===== */
++
++/*
++ * max96717_setup_control - Set up I2C address translation and link control
++ *
++ * Steps:
++ *   1. Reassign serializer I2C address via DEV_ADDR (reg 0x00)
++ *   2. Configure GMSL2 link mode via CTRL0 (reg 0x10)
++ *   3. Set I2C address translation for sensor passthrough:
++ *      I2C4/SRC_B (0x44) <- (sdev_reg << 1): proxy addr visible to host
++ *      I2C5/DST_B (0x45) <- (sdev_def << 1): real addr on back-channel
++ *
++ * This lets the Orin host access the D5xx sensor (def-addr 0x42) via
++ * the aliased proxy address (e.g. 0x1a) through the GMSL link.
++ *
++ */
++int max96717_setup_control(struct device *dev)
++{
++	struct max96717 *priv = dev_get_drvdata(dev);
++	int err = 0;
++	struct gmsl_link_ctx *g_ctx;
++
++	mutex_lock(&priv->lock);
++
++	if (!priv->g_client.g_ctx) {
++		dev_err(dev, "%s: no sensor dev client found\n", __func__);
++		err = -EINVAL;
++		goto error;
++	}
++
++	g_ctx = priv->g_client.g_ctx;
++
++	if (prim_priv__) {
++		/*
++		 * [HW note] The MAX96717 retains its I2C address across
++		 * reboots (PoC stays on).  If already at the aliased address,
++		 * the DEV_ADDR write to 0x40 NACKs.  Skip reassignment when
++		 * the primary and alias are the same physical device and the
++		 * serializer is already responsive at a non-default address.
++		 *
++		 * For cold-start (first power-on), this write is required.
++		 * We detect "already reassigned" by trying a read first:
++		 * if the primary address (0x40) NACKs, skip the reassign.
++		 */
++		unsigned int dev_id;
++		int probe_ret;
++
++		probe_ret = regmap_read(prim_priv__->regmap,
++					MAX96717_DEV_ADDR, &dev_id);
++		if (probe_ret == 0) {
++			/* Primary address (0x40) still responsive — do reassign */
++			max96717_write_reg(&prim_priv__->i2c_client->dev,
++					   MAX96717_DEV_ADDR,
++					   (g_ctx->ser_reg << 1));
++		} else {
++			dev_info(&prim_priv__->i2c_client->dev,
++				 "%s: SER already reassigned (addr 0x40 NACK), skipping DEV_ADDR write\n",
++				 __func__);
++		}
++	}
++
++	/* [PPTX slide 7] CTRL0: GMSL2 mode + TX enable */
++	if (g_ctx->serdes_csi_link == GMSL_SERDES_CSI_LINK_A)
++		err = max96717_write_reg(dev, MAX96717_CTRL0_ADDR,
++					 MAX96717_CTRL0_LINK_A);
++	else
++		err = max96717_write_reg(dev, MAX96717_CTRL0_ADDR,
++					 MAX96717_CTRL0_LINK_B);
++
++	if (err) {
++		dev_err(dev, "%s: ERROR: ser device not found\n", __func__);
++		goto error;
++	}
++
++	/* delay to settle link */
++	msleep(100);
++
++	/*
++	 * I2C address translation for sensor passthrough.
++	 * [MAX96724 Users Guide, I2C Broadcasting, p44-46]
++	 *
++	 * I2C4 / SRC_B (0x44): sensor proxy addr visible to Orin host
++	 * I2C5 / DST_B (0x45): sensor real addr on GMSL back-channel
++	 *
++	 * When host sends I2C to sdev_reg (e.g., 0x1a), the MAX96717
++	 * translates it to sdev_def (e.g., 0x42) and forwards via GMSL
++	 * back-channel to the HKR sensor.
++	 */
++	max96717_write_reg(dev, MAX96717_I2C4_ADDR,
++			   (g_ctx->sdev_reg << 1));
++	max96717_write_reg(dev, MAX96717_I2C5_ADDR,
++			   (g_ctx->sdev_def << 1));
++
++	/* dev addr pass-through ref */
++	if (prim_priv__)
++		prim_priv__->pst2_ref++;
++
++	g_ctx->serdev_found = true;
++
++error:
++	mutex_unlock(&priv->lock);
++	return err;
++}
++EXPORT_SYMBOL(max96717_setup_control);
++
++/* ===== GPIO Tunneling ===== */
++
++/*
++ * max96717_setup_gpio_tunneling - GPIO-over-GMSL no-op hook
++ *
++ * [PPTX slide 10] GPIO Signal Mapping:
++ *   MFP0 → GPIO0: FSIN (DES→SER, frame sync in)
++ *   MFP1 → GPIO1: FOUT/STROBE (SER→DES, frame sync out)
++ *   MFP4 → GPIO4: RESET_N (DES→SER, hard reset)
++ *   MFP5 → GPIO5: IRQ (SER→DES, interrupt request)
++ *   MFP6 → GPIO6: ZV_SYNC (DES→SER, IR stereo sync)
++ *
++ * The PPTX defines the signal mapping and MFP_CFG register range,
++ * but not the confirmed direction/function values. Keep this as
++ * an explicit no-op hook until the MAX96717 GPIO register values
++ * are available from ADI.
++ */
++int max96717_setup_gpio_tunneling(struct device *dev)
++{
++	struct max96717 *priv = dev_get_drvdata(dev);
++	int err = 0;
++
++	mutex_lock(&priv->lock);
++
++	dev_info(dev, "%s: GPIO tunneling hook is a no-op; MFP_CFG values are not defined yet\n",
++		 __func__);
++
++	mutex_unlock(&priv->lock);
++
++	return err;
++}
++EXPORT_SYMBOL(max96717_setup_gpio_tunneling);
++
++/* ===== Reset Control ===== */
++
++int max96717_reset_control(struct device *dev)
++{
++	struct max96717 *priv = dev_get_drvdata(dev);
++	int err = 0;
++
++	mutex_lock(&priv->lock);
++	if (!priv->g_client.g_ctx) {
++		dev_err(dev, "%s: no sdev client found\n", __func__);
++		err = -EINVAL;
++		goto error;
++	}
++
++	priv->g_client.st_done = false;
++
++	if (prim_priv__) {
++		prim_priv__->pst2_ref--;
++
++		max96717_write_reg(dev, MAX96717_DEV_ADDR,
++				   (prim_priv__->def_addr << 1));
++		if (prim_priv__->pst2_ref == 0)
++			max96717_write_reg(&prim_priv__->i2c_client->dev,
++					   MAX96717_CTRL0_ADDR,
++					   MAX96717_RESET_ALL);
++	}
++
++error:
++	mutex_unlock(&priv->lock);
++	return err;
++}
++EXPORT_SYMBOL(max96717_reset_control);
++
++/* ===== Device Pairing ===== */
++
++int max96717_sdev_pair(struct device *dev, struct gmsl_link_ctx *g_ctx)
++{
++	struct max96717 *priv;
++	int err = 0;
++
++	if (!dev || !g_ctx || !g_ctx->s_dev) {
++		dev_err(dev, "%s: invalid input params\n", __func__);
++		return -EINVAL;
++	}
++
++	priv = dev_get_drvdata(dev);
++	mutex_lock(&priv->lock);
++	if (priv->g_client.g_ctx) {
++		/* Already paired — tolerate if this is a re-probe of
++		 * the same camera after a failed first attempt.
++		 * Simply overwrite with the new g_ctx.
++		 */
++		dev_warn(dev, "%s: re-pairing (previous probe may have failed)\n",
++			 __func__);
++	}
++
++	priv->g_client.st_done = false;
++	priv->g_client.g_ctx = g_ctx;
++
++	/* mutex_unlock in error path, but we have none — inline the unlock */
++	mutex_unlock(&priv->lock);
++	return err;
++}
++EXPORT_SYMBOL(max96717_sdev_pair);
++
++int max96717_sdev_unpair(struct device *dev, struct device *s_dev)
++{
++	struct max96717 *priv = NULL;
++	int err = 0;
++
++	if (!dev || !s_dev) {
++		dev_err(dev, "%s: invalid input params\n", __func__);
++		return -EINVAL;
++	}
++
++	priv = dev_get_drvdata(dev);
++
++	mutex_lock(&priv->lock);
++
++	if (!priv->g_client.g_ctx) {
++		dev_dbg(dev, "%s: device is not paired\n", __func__);
++		err = 0; /* Not an error — already unpaired */
++		goto error;
++	}
++
++	if (priv->g_client.g_ctx->s_dev != s_dev) {
++		dev_warn(dev, "%s: s_dev mismatch, clearing anyway\n", __func__);
++	}
++
++	priv->g_client.g_ctx = NULL;
++	priv->g_client.st_done = false;
++
++error:
++	mutex_unlock(&priv->lock);
++	return err;
++}
++EXPORT_SYMBOL(max96717_sdev_unpair);
++
++/* ===== Pipe Configuration ===== */
++
++/*
++ * __max96717_set_pipe - Configure a single pipe's DT/VC mapping
++ *
++ * In Tunnel Mode, per-pipe DT/VC filtering is bypassed on the serializer。
++ * However, we still write the registers for d4xx framework compatibility.
++ *
++ */
++static int __max96717_set_pipe(struct device *dev, int pipe_id, u8 data_type1,
++			       u8 data_type2, u32 vc_id)
++{
++	int err = 0;
++	u8 bpp = 0x30;
++
++	struct reg_pair map_pipe_control[] = {
++		/* Pipe X DT addr + 0x2*pipe_id */
++		{0x0314, 0x5E},  /* data_type1 */
++		{0x0315, 0x52},  /* data_type2 */
++		{0x0309, 0x01},  /* VC select */
++		{0x030A, 0x00},
++		{0x031C, 0x30},  /* BPP */
++		{0x0102, 0x0E},  /* LIM_HEART: Disabled */
++	};
++
++	if (data_type1 == GMSL_CSI_DT_RGB_888)
++		bpp = 0x18;
++
++	map_pipe_control[0].addr += 0x2 * pipe_id;
++	map_pipe_control[1].addr += 0x2 * pipe_id;
++	map_pipe_control[2].addr += 0x2 * pipe_id;
++	map_pipe_control[3].addr += 0x2 * pipe_id;
++	map_pipe_control[4].addr += 0x1 * pipe_id;
++	map_pipe_control[5].addr += 0x8 * pipe_id;
++
++	map_pipe_control[0].val = 0x40 | data_type1;
++	map_pipe_control[1].val = 0x40 | data_type2;
++	if (pipe_id == 0)
++		map_pipe_control[1].val |= 0x80;
++	map_pipe_control[2].val = 1 << vc_id;
++	map_pipe_control[3].val = 0x00;
++	map_pipe_control[4].val = bpp;
++	map_pipe_control[5].val = 0x0E;
++
++	err = max96717_set_registers(dev, map_pipe_control,
++				     ARRAY_SIZE(map_pipe_control));
++
++	return err;
++}
++
++/*
++ * max96717_init_settings - Initialize default pipe/streaming settings
++ *
++ * In Tunnel Mode, per-pipe DT config is not functionally needed
++ * but we configure pipes for d4xx compatibility.
++ * Default: 4 pipes with YUV422_8 + EMBED, VC0-3.
++ */
++int max96717_init_settings(struct device *dev)
++{
++	int err = 0;
++	int i;
++	struct max96717 *priv = dev_get_drvdata(dev);
++
++	struct reg_pair map_init[] = {
++		/* [XML seq] PIPE_EN soft reset first, then enable tunnel mode.
++		 * Note: FRONTTOP0 is bypassed in tunnel mode (per UG) —
++		 * CSI-2 input goes directly into the tunnel, no port config needed.
++		 */
++		{MAX96717_PIPE_EN_ADDR, MAX96717_SOFT_RESET},
++		{MAX96717_EXT11_ADDR, MAX96717_TUN_MODE_EN},
++		{MAX96717_PIPE_EN_ADDR, 0xF3},
++		{MAX96717_MIPI_RX1_ADDR, MAX96717_CSI_4_LANES},
++	};
++
++	mutex_lock(&priv->lock);
++
++	/*
++	 * [HW requirement] After CTRL0 + I2C translation writes in
++	 * setup_control, the MAX96717 needs settling time before
++	 * accepting writes to PIPE_EN (0x02) and FRONTTOP registers.
++	 */
++	usleep_range(5000, 6000);
++
++	err = max96717_set_registers(dev, map_init, ARRAY_SIZE(map_init));
++
++	for (i = 0; i < MAX96717_MAX_PIPES; i++)
++		err |= __max96717_set_pipe(dev, i, GMSL_CSI_DT_YUV422_8,
++					   GMSL_CSI_DT_EMBED, i);
++
++	mutex_unlock(&priv->lock);
++
++	return err;
++}
++EXPORT_SYMBOL(max96717_init_settings);
++
++int max96717_set_pipe(struct device *dev, int pipe_id,
++		      u8 data_type1, u8 data_type2, u32 vc_id)
++{
++	struct max96717 *priv = dev_get_drvdata(dev);
++	int err = 0;
++
++	if (pipe_id > (MAX96717_MAX_PIPES - 1)) {
++		dev_info(dev, "%s: input pipe_id: %d exceeds max96717 max pipes\n",
++			 __func__, pipe_id);
++		return -EINVAL;
++	}
++
++	dev_dbg(dev, "%s pipe_id %d, data_type1 %u, data_type2 %u, vc_id %u\n",
++		__func__, pipe_id, data_type1, data_type2, vc_id);
++
++	mutex_lock(&priv->lock);
++
++	err = __max96717_set_pipe(dev, pipe_id, data_type1, data_type2, vc_id);
++
++	mutex_unlock(&priv->lock);
++
++	return err;
++}
++EXPORT_SYMBOL(max96717_set_pipe);
++
++/**
++ * max96717_retrigger_tx - Toggle SER TX to restore tunnel detection after
++ * a DES ONESHOT.  DES ONESHOT resets the data path; the SER must cycle
++ * its TX enable for the DES to re-acquire the tunnel stream.
++ */
++void max96717_retrigger_tx(struct device *dev)
++{
++	max96717_write_reg(dev, MAX96717_PIPE_EN_ADDR, MAX96717_SOFT_RESET);
++	msleep(30);
++	max96717_write_reg(dev, MAX96717_PIPE_EN_ADDR, MAX96717_PIPE_EN_ALL);
++}
++EXPORT_SYMBOL(max96717_retrigger_tx);
++
++/* ===== Probe / Remove ===== */
++
++static struct regmap_config max96717_regmap_config = {
++	.reg_bits = 16,
++	.val_bits = 8,
++	.cache_type = REGCACHE_RBTREE,
++};
++
++static int max96717_probe(struct i2c_client *client,
++			   const struct i2c_device_id *id)
++{
++	struct max96717 *priv;
++	int err = 0;
++	struct device_node *node = client->dev.of_node;
++
++	dev_info(&client->dev, "[MAX96717]: probing GMSL2 Serializer (Tunnel Mode)\n");
++
++	priv = devm_kzalloc(&client->dev, sizeof(*priv), GFP_KERNEL);
++	if (!priv)
++		return -ENOMEM;
++
++	priv->i2c_client = client;
++	priv->regmap = devm_regmap_init_i2c(priv->i2c_client,
++					     &max96717_regmap_config);
++	if (IS_ERR(priv->regmap)) {
++		dev_err(&client->dev,
++			"regmap init failed: %ld\n", PTR_ERR(priv->regmap));
++		return -ENODEV;
++	}
++
++	mutex_init(&priv->lock);
++
++	if (of_get_property(node, "is-prim-ser", NULL)) {
++		if (prim_priv__) {
++			dev_err(&client->dev,
++				"prim-ser already exists\n");
++			return -EEXIST;
++		}
++
++		err = of_property_read_u32(node, "reg", &priv->def_addr);
++		if (err < 0) {
++			dev_err(&client->dev, "reg not found\n");
++			return -EINVAL;
++		}
++
++		prim_priv__ = priv;
++	}
++
++	dev_set_drvdata(&client->dev, priv);
++
++	dev_info(&client->dev, "%s: success\n", __func__);
++
++	return err;
++}
++
++static int max96717_remove(struct i2c_client *client)
++{
++	struct max96717 *priv;
++
++	if (client != NULL) {
++		priv = dev_get_drvdata(&client->dev);
++		mutex_destroy(&priv->lock);
++		i2c_unregister_device(client);
++		client = NULL;
++	}
++
++	return 0;
++}
++
++static const struct i2c_device_id max96717_id[] = {
++	{ "max96717", 0 },
++	{ },
++};
++
++static const struct of_device_id max96717_of_match[] = {
++	{ .compatible = "adi,max96717", },
++	{ .compatible = "maxim,max96717", },
++	{ },
++};
++MODULE_DEVICE_TABLE(of, max96717_of_match);
++MODULE_DEVICE_TABLE(i2c, max96717_id);
++
++static struct i2c_driver max96717_i2c_driver = {
++	.driver = {
++		.name = "max96717",
++		.owner = THIS_MODULE,
++		.of_match_table = of_match_ptr(max96717_of_match),
++	},
++	.probe = max96717_probe,
++	.remove = max96717_remove,
++	.id_table = max96717_id,
++};
++
++static int __init max96717_init(void)
++{
++	return i2c_add_driver(&max96717_i2c_driver);
++}
++
++static void __exit max96717_exit(void)
++{
++	i2c_del_driver(&max96717_i2c_driver);
++}
++
++module_init(max96717_init);
++module_exit(max96717_exit);
++
++MODULE_DESCRIPTION("GMSL2 Serializer driver max96717 (Tunnel Mode)");
++MODULE_AUTHOR("RealSense AI");
++MODULE_LICENSE("GPL v2");
+diff --git a/drivers/media/i2c/max96724.c b/drivers/media/i2c/max96724.c
+new file mode 100644
+index 0000000..7286ff4
+--- /dev/null
++++ b/drivers/media/i2c/max96724.c
+@@ -0,0 +1,1690 @@
++/*
++ * max96724.c - MAX96724 GMSL2 Quad Deserializer driver (Tunnel Mode)
++ *
++ * Copyright (c) 2026, RealSense, Inc.  All rights reserved.
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms and conditions of the GNU General Public License,
++ * version 2, as published by the Free Software Foundation.
++ *
++ * This program is distributed in the hope it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
++ * more details.
++ *
++ * You should have received a copy of the GNU General Public License
++ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
++ */
++
++
++#include <linux/gpio.h>
++#include <linux/module.h>
++#include <linux/of.h>
++#include <linux/of_device.h>
++#include <linux/of_gpio.h>
++#include <media/camera_common.h>
++#include <linux/module.h>
++#include <media/max96724.h>
++
++/* ================================================================
++ * Register Addresses
++ * ================================================================ */
++
++/* --- Device ID / Configuration --- */
++
++/* [UG p.3] REG0: Device ID (read-only, returns 0xA2) */
++#define MAX96724_DEV_ID_ADDR		0x00
++
++/* [Errata §5] ERRB master reset register */
++#define MAX96724_ERRB_MST_RST_ADDR	0x05
++
++/* [UG Table 3, p.11] 0x0006: GMSL Link/PHY Enable and Mode Select
++ *   bits[7:4]: PHY mode (0=GMSL1, 1=GMSL2) per link D/C/B/A
++ *   bits[3:0]: Link Enable per link D/C/B/A
++ */
++#define MAX96724_LINK_EN_ADDR		0x0006
++
++/* [UG Table 3, p.11] 0x0010: GMSL Link/PHY Rate Select (Links A&B)
++ *   bits[7:6]: Tx Rate Link B, bits[5:4]: Rx Rate Link B
++ *   bits[3:2]: Tx Rate Link A, bits[1:0]: Rx Rate Link A
++ *   Tx: 00=187.5Mbps, Rx: 01=3Gbps, 10=6Gbps
++ */
++#define MAX96724_LINK_RATE_AB_ADDR	0x0010
++
++/* [UG Table 3, p.12] 0x0011: GMSL Link/PHY Rate Select (Links C&D) */
++#define MAX96724_LINK_RATE_CD_ADDR	0x0011
++
++/* [UG p.13] 0x001A: Link A lock status (bit[3]=LOCK) */
++#define MAX96724_LINK_A_LOCK_ADDR	0x001A
++
++/* [UG Table 3, p.12] 0x0018: GMSL Link Reset
++ *   bits[7:4]: Link reset D/C/B/A, bits[3:0]: One-shot reset D/C/B/A
++ */
++#define MAX96724_ONESHOT_ADDR		0x0018
++
++/* [UG p.11] REG13: Soft Reset (write 0x40, wait 5ms) */
++#define MAX96724_REG13_ADDR		0x000D
++
++/* [Errata §5] Error Channel Power Up registers (required for 6Gbps)
++ *   Write 0x75 immediately after power-up for robust 6Gbps operation
++ */
++#define MAX96724_ERRCH_A_ADDR		0x1449
++#define MAX96724_ERRCH_B_ADDR		0x1549
++#define MAX96724_ERRCH_C_ADDR		0x1649
++#define MAX96724_ERRCH_D_ADDR		0x1749
++#define MAX96724_ERRCH_FORCE_ON		0x75
++
++/* --- I2C Control Channel / Errata --- */
++
++/* [Errata #2] Tunnel Mode SRAM LCRC error suppression
++ *   Set 0x458[7:4] = 0x0 to suppress spurious ERRB in tunnel mode
++ */
++#define MAX96724_SRAM_LCRC_ERR_ADDR	0x0458
++
++/* --- Video Pipe Selection --- */
++
++/*
++ *   bits[3:0] = Pipe 0 source (0x0=SIOA)
++ *   bits[7:4] = Pipe 1 source (0x1=SIOB)
++ */
++#define MAX96724_PIPE_SEL0_ADDR		0xF0
++
++/*
++ *   bits[3:0] = Pipe 2 source (0x2=SIOC)
++ *   bits[7:4] = Pipe 3 source (0x3=SIOD)
++ */
++#define MAX96724_PIPE_SEL1_ADDR		0xF1
++
++/*
++ *   bit[0]=Pipe 0, bit[1]=Pipe 1, bit[2]=Pipe 2, bit[3]=Pipe 3
++ */
++#define MAX96724_PIPE_EN_ADDR		0xF4
++
++/* --- Pipe Receiver / Tunnel Mode --- */
++
++/*
++ *   bit[5]=1: Tunnel Mode, bits[1:0]=11: 4-lane MIPI out
++ *   Stride: 0x12 per pipe (P0=0x100, P1=0x112, P2=0x124, P3=0x136)
++ */
++#define MAX96724_VID_RX0_P0_ADDR	0x100
++#define MAX96724_VID_RX6_P0_ADDR	0x106
++#define MAX96724_VID_RX_STRIDE		0x12
++
++#define MAX96724_VID_RX1_P0_ADDR	0x101
++
++/* --- CSI-2 Output (BACKTOP) --- */
++
++/* [UG p.19] BACKTOP: CSI-2 output port enable
++ *   0x040B bit[1]=CSIB_EN, bit[0]=CSIA_EN
++ */
++#define MAX96724_BACKTOP_EN_ADDR	0x040B
++
++/* --- MIPI DPLL (Data Rate) --- */
++
++/* [UG Table 12, p.27] MIPI PHY DPLL Freq registers
++ *   bits[4:0] = frequency in multiples of 100MHz
++ *   bit[5]    = DPLL enable (must be set for DPLL to lock)
++ *   E.g., 0x27 = 700MHz + enable = 700Mbps/lane D-PHY
++ *   E.g., 0x2F = 1500MHz + enable = 1.5Gbps/lane
++ */
++#define MAX96724_DPLL_FREQ0_ADDR	0x0415
++#define MAX96724_DPLL_FREQ1_ADDR	0x0418
++#define MAX96724_DPLL_FREQ2_ADDR	0x041B
++#define MAX96724_DPLL_FREQ3_ADDR	0x041E
++
++/* [UG] DPLL PHY reset control
++ *   0x1D00 = DPLL CSI PHY1 control
++ *   Write 0xF4 to disable/reset, 0xF5 to enable
++ */
++#define MAX96724_DPLL_CSI2_ADDR		0x1D00
++#define MAX96724_DPLL_DISABLE		0xF4
++#define MAX96724_DPLL_ENABLE		0xF5
++
++/* --- CSI-2 Output PHY Configuration --- */
++
++/* [UG Table 12, p.25] MIPI PHY Mode Select register
++ *   bit[0]: 4x2 mode, bit[2]: 2x4 mode (Port A=PHY0+1, Port B=PHY2+3)
++ *   bit[3]: 2x4 alt mode (Port B=PHY0+1, Port A=PHY2+3)
++ */
++#define MAX96724_CSI_OUT_CFG_ADDR	0x08A0
++
++/* [UG Table 12, p.25] MIPI PHY Enable register
++ *   bits[7:4]: Enable PHY 3/2/1/0 (1=enabled, 0=standby)
++ */
++#define MAX96724_CSI_PHY_EN_ADDR	0x08A2
++
++/* [UG Table 12, p.25] MIPI PHY 0 and 1 Lane Mapping */
++#define MAX96724_CSI_LANE_MAP1_ADDR	0x08A3
++
++/* [UG Table 12, p.26] MIPI PHY 2 and 3 Lane Mapping */
++#define MAX96724_CSI_LANE_MAP2_ADDR	0x08A4
++
++/* [UG p.22] Pipe-to-controller mapping (Method 1) */
++#define MAX96724_MIPI_CTRL_SEL_ADDR	0x08CA
++
++/* --- Lane Control per pipe (stride 0x40) --- */
++
++/*
++ *   0xC0 = 4-lane enabled
++ */
++#define MAX96724_LANE_CTRL0_ADDR	0x090A
++#define MAX96724_LANE_CTRL1_ADDR	0x094A
++#define MAX96724_LANE_CTRL2_ADDR	0x098A
++#define MAX96724_LANE_CTRL3_ADDR	0x09CA
++
++/* --- Pipe Mapping Registers (stride 0x40 per pipe) --- */
++
++/*
++ *   Base addresses for Pipe X (Pipe 0)
++ *   Stride: 0x40 per pipe
++ */
++#define MAX96724_TX11_PIPE_X_EN_ADDR		0x090B
++#define MAX96724_TX45_PIPE_X_DST_CTRL_ADDR	0x092D
++#define MAX96724_PIPE_X_SRC_0_MAP_ADDR		0x090D
++#define MAX96724_PIPE_X_DST_0_MAP_ADDR		0x090E
++#define MAX96724_PIPE_X_SRC_1_MAP_ADDR		0x090F
++#define MAX96724_PIPE_X_DST_1_MAP_ADDR		0x0910
++#define MAX96724_PIPE_X_SRC_2_MAP_ADDR		0x0911
++#define MAX96724_PIPE_X_DST_2_MAP_ADDR		0x0912
++#define MAX96724_PIPE_X_SRC_3_MAP_ADDR		0x0913
++#define MAX96724_PIPE_X_DST_3_MAP_ADDR		0x0914
++
++/* --- Stream Select --- */
++
++/*
++ *   Pipe X=0x0933, stride 0x40 per pipe
++ */
++#define MAX96724_PIPE_X_ST_SEL_ADDR	0x0933
++
++/* --- Extended Pipe Mapping (DST_CTRL2-4 / TX49) --- */
++
++/* [Excel: MIPI_TX46-48] Extended DST_CTRL for additional mapping pairs
++ *   All to PHY1 (0x55), same as TX45
++ *   Stride: 0x40 per pipe (base = Pipe X)
++ */
++#define MAX96724_TX46_PIPE_X_ADDR	0x092E
++#define MAX96724_TX47_PIPE_X_ADDR	0x092F
++#define MAX96724_TX48_PIPE_X_ADDR	0x0930
++
++/* [UG p.30 + Aardvark-verified] MIPI_TX49 synchronous concatenation control
++ *   In tunnel mode, this register MUST be 0x87 for MIPI TX output to function.
++ *   Verified: setting to 0x00 disables tunnel output entirely (0x8D0 all zeros).
++ *   Stride: 0x40 per pipe (base = Pipe X)
++ */
++#define MAX96724_TX49_PIPE_X_ADDR	0x0931
++#define MAX96724_TX49_CONCAT_4W		0x87
++
++/* --- Tunnel Mode per-pipe --- */
++
++/*
++ *   bit[0] = TUN_EN, Default=0x08, write 0x09 to enable
++ */
++#define MAX96724_PIPE0_TUN_EN_ADDR	0x0936
++#define MAX96724_PIPE1_TUN_EN_ADDR	0x0976
++#define MAX96724_PIPE2_TUN_EN_ADDR	0x09B6
++#define MAX96724_PIPE3_TUN_EN_ADDR	0x09F6
++
++/*
++ *   bit[6]: disable auto-tunnel-detect
++ *   bits[5:4]: TUN_DEST (00=PHY0, 01=PHY1, 10=PHY2, 11=PHY3)
++ */
++#define MAX96724_PIPE0_TUN_DEST_ADDR	0x0939
++#define MAX96724_PIPE1_TUN_DEST_ADDR	0x0979
++#define MAX96724_PIPE2_TUN_DEST_ADDR	0x09B9
++#define MAX96724_PIPE3_TUN_DEST_ADDR	0x09F9
++
++/* ================================================================
++ * Register Values
++ * ================================================================ */
++
++/* [UG p.12] Soft reset value (write to 0x000D) */
++#define MAX96724_SOFT_RESET		0x40
++
++/* [UG Table 3, p.11-12] Link Rate values for 0x0010/0x0011
++ *   Per link pair: bits[1:0]=RxA, [3:2]=TxA, [5:4]=RxB, [7:6]=TxB
++ *   Tx = 00 (187.5Mbps), Rx = 01 (3Gbps) or 10 (6Gbps)
++ *   3Gbps: Tx=00, Rx=01 → per pair 0x01, both pairs = 0x01 in low nibble
++ */
++#define MAX96724_LINK_RATE_3GBPS	0x01  /* Rx=3G, Tx=187.5M for one link pair */
++#define MAX96724_LINK_RATE_6GBPS	0x02  /* Rx=6G, Tx=187.5M for one link pair */
++
++/* [UG Table 3, p.11] 0x0006: Link enable / mode values
++ *   bits[7:4] = PHY mode (1=GMSL2 per link)
++ *   bits[3:0] = Link enable per link
++ *   0xF1 = all GMSL2-mode, only Link A enabled
++ *   0xFF = all GMSL2-mode, all 4 links enabled
++ */
++#define MAX96724_LINK_EN_SIOA		0xF1  /* GMSL2 all, enable Link A only */
++#define MAX96724_LINK_EN_ALL		0xFF  /* GMSL2 all, enable all links */
++
++/* [UG p.19] BACKTOP_EN (0x040B): CSI output port enable */
++#define MAX96724_BACKTOP_CSIB_EN	0x02
++#define MAX96724_BACKTOP_CSIA_EN	0x01
++
++/* [XML] VIDEO_RX0: DIS_PKT_DET=1 (bit0) required for tunnel mode.
++ *   Without it, DES rejects tunnel data as invalid GMSL2 video packets.
++ *   SEQ_MISS_EN=1 (bit4), LINE_CRC_EN=1 (bit1).  XML value: 0x33.
++ */
++#define MAX96724_VID_RX0_CFG_VAL	0x33
++#define MAX96724_VID_RX6_CFG_VAL	0x0A
++
++/* [gmsl_ser_des_guide §4.9] Tunnel mode enable (MIPI_TX54, 0x0936):
++ *   bit[0] = TUN_EN = 1
++ *   bit[3] = TUN_CONT (continuous tunnel mode, required per verified XML)
++ *   XML/Guide value: 0x09
++ */
++#define MAX96724_TUN_EN			0x09
++
++/* [gmsl_ser_des_guide §7.5] Tunnel controller destination (MIPI_TX57, 0x0939):
++ *   bit[7]: DIS_AUTO_SER_LANE_DET (1=manual)
++ *   bit[6]: DIS_AUTO_TUN_DET (1=manual)
++ *   bits[5:4]: TUN_DEST (00=PHY0, 01=PHY1, 10=PHY2, 11=PHY3)
++ *   Verified XML: 0x50 = manual detect + PHY1 destination
++ */
++#define MAX96724_TUN_DEST_CTRL0		0x40  /* Manual detect + PHY0 */
++#define MAX96724_TUN_DEST_CTRL1		0x50  /* Manual detect + PHY1 (Port A master) */
++
++/* [UG Table 12, p.25] CSI output mode values */
++#define MAX96724_CSI_MODE_2X4_VAL	0x08  /* bit[3] = 2x4 alt: Ctrl1→PHY0+1→PortA (Aardvark-verified) */
++#define MAX96724_CSI_MODE_4X2_VAL	0x01  /* bit[0] = 4x2 mode */
++
++#define MAX96724_CSI_PHY_EN_ALL		0xF0
++#define MAX96724_CSI_PHY_EN_01		0x30  /* PHY0+PHY1 only */
++#define MAX96724_CSI_PHY_EN_23		0xC0  /* PHY2+PHY3 only (Port A in 2x4 alt mode) */
++
++/* [UG Table 12, p.25-26] Lane mapping default */
++#define MAX96724_CSI_LANE_MAP_DEFAULT	0xE4
++
++/* [UG Table 12, p.26-27] Lane control: 4-lane enabled */
++#define MAX96724_LANE_CTRL_4LANE	0xC0
++
++/* [UG Table 12, p.26-27] Lane control: 2-lane enabled.
++ *   bits[7:6] = (num_lanes - 1): 01=2-lane(0x40), 11=4-lane(0xC0)
++ *   Ref: gmsl_ser_des_guide §8.2, E2E_enable_guide §5.6.4 */
++#define MAX96724_LANE_CTRL_2LANE	0x40
++
++/* [SC20190112 2-lane] CSI PHY enable: all PHYs powered for DPLL lock
++ *   stability.  Even though only PHY0 data lanes reach Orin, the MAX96724
++ *   DPLL requires all PHYs to be powered.  Tested: single PHY → PLL never locks. */
++#define MAX96724_CSI_PHY_EN_2LANE	0xF0
++
++/* [SC20190112 2-lane] DPLL for Controller 0 (drives PHY0, 2 lanes).
++ *   bits[4:0] = data-rate / 100 MHz.  1400 Mbps / 100 = 14 = 0x0E.
++ *   bit[5]    = DPLL enable = 1.
++ *   Result: 0x2E = 1400 Mbps/lane D-PHY. */
++#define MAX96724_DPLL_1400MBPS_CTRL0	0x2E
++
++/* [SC20190112 2-lane] TX49 pipeline concatenation for 2-wide mode.
++ *   In 4x2 mode each controller drives only 2 lanes.
++ *   UG p.30: synchronous concatenation control, 0x83 for 2W. */
++#define MAX96724_TX49_CONCAT_2W		0x83
++
++/* [UG Table 3, p.12] One-shot reset: all links */
++#define MAX96724_ONESHOT_ALL		0x0F
++
++/* [UG Table 4, p.15] Pipe source selection values
++ *   Encoding per pipe nibble in tunnel mode (Aardvark-verified):
++ *   0x22 routes all pipes from Link A in tunnel mode.
++ */
++#define MAX96724_PIPE_SEL0_SINGLE	0x22  /* All pipes from Link A (Aardvark-verified) */
++#define MAX96724_PIPE_SEL1_SINGLE	0x22  /* All pipes from Link A (Aardvark-verified) */
++#define MAX96724_PIPE_SEL0_DUAL		0x40  /* Pipe 0 ← A/X, Pipe 1 ← B/X */
++#define MAX96724_PIPE_SEL0_QUAD_LO	0x40  /* Pipe 0 ← A/X, Pipe 1 ← B/X */
++#define MAX96724_PIPE_SEL1_QUAD_HI	0xC8  /* Pipe 2 ← C/X, Pipe 3 ← D/X */
++
++/* Pipe enable values */
++#define MAX96724_PIPE_EN_1		0x01
++#define MAX96724_PIPE_EN_2		0x03
++#define MAX96724_PIPE_EN_4		0x0F
++
++/* Lane control map: bits[7:6] = (num_lanes - 1) */
++#define MAX96724_LANE_CTRL_MAP(num_lanes) \
++	((((num_lanes) - 1) << 6) & 0xC0)
++
++/* Reset all */
++#define MAX96724_RESET_ALL		0x80
++
++/* Stream ID invalid */
++#define MAX96724_INVAL_ST_ID		0xFF
++#define MAX96724_RESET_ST_ID		0x00
++#define MAX96724_ST_ID_SEL_INVALID	0xF
++
++/* Controller mapping: all mappings → Controller 0 (not working in tunnel mode) */
++#define MAX96724_ALL_MAP_CTRL0		0x00
++/* Controller mapping: all mappings → Controller 1 (Aardvark-verified working) */
++#define MAX96724_ALL_MAP_CTRL1		0x55
++
++/* ================================================================
++ * Data Structures
++ * ================================================================ */
++
++/* Quad GMSL: up to 4 sources */
++#define MAX96724_MAX_SOURCES		4
++#define MAX96724_MAX_PIPES		4
++
++#define MAX96724_PIPE_X			0
++#define MAX96724_PIPE_Y			1
++#define MAX96724_PIPE_Z			2
++#define MAX96724_PIPE_U			3
++#define MAX96724_PIPE_INVALID		0xF
++
++#define MAX96724_CSI_CTRL_0		0
++#define MAX96724_CSI_CTRL_1		1
++#define MAX96724_CSI_CTRL_2		2
++#define MAX96724_CSI_CTRL_3		3
++
++/* CSI mode values */
++#define MAX96724_CSI_MODE_4X2		0x01
++#define MAX96724_CSI_MODE_2X4		0x08  /* 2x4 alt: Ctrl1→PHY0+1→PortA (Aardvark-verified working) */
++#define MAX96724_CSI_MODE_2X4_ALT	0x04  /* 2x4 standard (Ctrl0→PHY0+1, not working in tunnel) */
++
++/* Lane map presets */
++#define MAX96724_LANE_MAP1_4X2		0x44
++#define MAX96724_LANE_MAP2_4X2		0x44
++#define MAX96724_LANE_MAP1_2X4		0xE4  /* PHY0+PHY1 lane map (Aardvark-verified) */
++#define MAX96724_LANE_MAP2_2X4		0xE4
++
++struct max96724_source_ctx {
++	struct gmsl_link_ctx *g_ctx;
++	bool st_enabled;
++};
++
++struct pipe_ctx {
++	u32 id;
++	u32 dt_type;
++	u32 dst_csi_ctrl;
++	u32 st_count;
++	u32 st_id_sel;
++};
++
++struct max96724 {
++	struct i2c_client *i2c_client;
++	struct regmap *regmap;
++	u32 num_src;
++	u32 max_src;
++	u32 num_src_found;
++	u32 src_link;
++	bool splitter_enabled;
++	struct max96724_source_ctx sources[MAX96724_MAX_SOURCES];
++	struct mutex lock;
++	u32 sdev_ref;
++	bool lane_setup;
++	bool link_setup;
++	struct pipe_ctx pipe[MAX96724_MAX_PIPES];
++	u8 csi_mode;
++	u8 lane_mp1;
++	u8 lane_mp2;
++	int reset_gpio;
++	int pw_ref;
++	struct regulator *vdd_cam_1v2;
++	u8 link_speed;  /* DT-configurable: 3 or 6 Gbps */
++};
++
++struct reg_pair {
++	u16 addr;
++	u8 val;
++};
++
++/* ================================================================
++ * Low-level I2C
++ * ================================================================ */
++
++static int max96724_write_reg(struct device *dev, u16 addr, u8 val)
++{
++	struct max96724 *priv;
++	int err;
++
++	priv = dev_get_drvdata(dev);
++
++	err = regmap_write(priv->regmap, addr, val);
++	if (err)
++		dev_err(dev, "%s:i2c write failed, 0x%x = %x\n",
++			__func__, addr, val);
++
++	/* delay before next i2c command as required for SERDES link */
++	usleep_range(100, 110);
++
++	return err;
++}
++
++static int max96724_set_registers(struct device *dev, struct reg_pair *map,
++				  u32 count)
++{
++	int err = 0;
++	u32 j;
++
++	for (j = 0; j < count; j++) {
++		err = max96724_write_reg(dev, map[j].addr, map[j].val);
++		if (err)
++			break;
++	}
++
++	return err;
++}
++
++/* ================================================================
++ * Internal Helpers
++ * ================================================================ */
++
++static int max96724_get_sdev_idx(struct device *dev,
++				 struct device *s_dev, unsigned int *idx)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++	unsigned int i;
++	int err = 0;
++
++	mutex_lock(&priv->lock);
++	for (i = 0; i < priv->max_src; i++) {
++		if (priv->sources[i].g_ctx->s_dev == s_dev)
++			break;
++	}
++	if (i == priv->max_src) {
++		dev_err(dev, "no sdev found\n");
++		err = -EINVAL;
++		goto ret;
++	}
++
++	if (idx)
++		*idx = i;
++
++ret:
++	mutex_unlock(&priv->lock);
++	return err;
++}
++
++static void max96724_pipes_reset(struct max96724 *priv)
++{
++	/*
++	 * Default pipe configuration for D5xx/SC1.2:
++	 * In tunnel mode, DT types are not used for filtering
++	 * but we initialize them for d4xx framework compatibility.
++	 */
++	struct pipe_ctx pipe_defaults[] = {
++		{MAX96724_PIPE_X, GMSL_CSI_DT_RAW_12,
++			MAX96724_CSI_CTRL_1, 0, MAX96724_INVAL_ST_ID},
++		{MAX96724_PIPE_Y, GMSL_CSI_DT_RAW_12,
++			MAX96724_CSI_CTRL_1, 0, MAX96724_INVAL_ST_ID},
++		{MAX96724_PIPE_Z, GMSL_CSI_DT_EMBED,
++			MAX96724_CSI_CTRL_1, 0, MAX96724_INVAL_ST_ID},
++		{MAX96724_PIPE_U, GMSL_CSI_DT_EMBED,
++			MAX96724_CSI_CTRL_1, 0, MAX96724_INVAL_ST_ID}
++	};
++
++	memcpy(priv->pipe, pipe_defaults, sizeof(pipe_defaults));
++}
++
++static void max96724_reset_ctx(struct max96724 *priv)
++{
++	unsigned int i;
++
++	priv->link_setup = false;
++	priv->lane_setup = false;
++	priv->num_src_found = 0;
++	priv->src_link = 0;
++	priv->splitter_enabled = false;
++	max96724_pipes_reset(priv);
++	for (i = 0; i < priv->num_src; i++)
++		priv->sources[i].st_enabled = false;
++}
++
++/* ================================================================
++ * Power Management
++ * ================================================================ */
++
++/*
++ * max96724_power_on - Power on the MAX96724 deserializer
++ */
++int max96724_power_on(struct device *dev)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++	int err = 0;
++
++	mutex_lock(&priv->lock);
++	if (priv->pw_ref == 0) {
++		usleep_range(1, 2);
++		if (priv->reset_gpio)
++			gpio_set_value(priv->reset_gpio, 0);
++
++		usleep_range(30, 50);
++
++		if (priv->vdd_cam_1v2) {
++			err = regulator_enable(priv->vdd_cam_1v2);
++			if (unlikely(err))
++				goto ret;
++		}
++
++		usleep_range(30, 50);
++
++		/* exit reset mode: XCLR */
++		if (priv->reset_gpio) {
++			gpio_set_value(priv->reset_gpio, 0);
++			usleep_range(30, 50);
++			gpio_set_value(priv->reset_gpio, 1);
++			usleep_range(30, 50);
++		}
++
++		msleep(20);
++	}
++
++	priv->pw_ref++;
++
++ret:
++	mutex_unlock(&priv->lock);
++	return err;
++}
++EXPORT_SYMBOL(max96724_power_on);
++
++void max96724_power_off(struct device *dev)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++
++	mutex_lock(&priv->lock);
++	priv->pw_ref--;
++
++	if (priv->pw_ref < 0)
++		priv->pw_ref = 0;
++
++	if (priv->pw_ref == 0) {
++		usleep_range(1, 2);
++		if (priv->reset_gpio)
++			gpio_set_value(priv->reset_gpio, 0);
++
++		if (priv->vdd_cam_1v2)
++			regulator_disable(priv->vdd_cam_1v2);
++	}
++
++	mutex_unlock(&priv->lock);
++}
++EXPORT_SYMBOL(max96724_power_off);
++
++/* ================================================================
++ * Link Setup
++ * ================================================================ */
++
++/*
++ * max96724_write_link - Configure a specific GMSL link
++ *
++ * [Users Guide, Link Initialization, p11-12]
++ *   Register 0x0006: Link Enable and Mode Select
++ *   Register 0x0010: Link Rate (Links A/B)
++ *
++ * The link speed is DT-configurable via the "gmsl-link-speed" property.
++ */
++static int max96724_write_link(struct device *dev, u32 link)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++	u8 link_rate_ab, link_rate_cd;
++	u8 link_en_val;
++
++	/*
++	 * [Aardvark-verified] Disable CSI output before link configuration
++	 * This prevents glitches on CSI bus during GMSL link setup.
++	 * Re-enabled in max96724_setup_streaming() after full pipeline config.
++	 */
++	max96724_write_reg(dev, MAX96724_BACKTOP_EN_ADDR, 0x00);
++
++	/* [UG Table 3 + Tech Overview REG26]
++	 * Register 0x0010:
++	 *   bits[7:2] = Link rate configuration
++	 *   bits[1:0] = I2C CC pass-through link select
++	 *     10 = route CC via SIOA (Link A)  [tech overview: 0x02 → SIOA]
++	 *     01 = route CC via SIOB (Link B)
++	 *
++	 * For 6G + Link A: bits[7:2]=001000, bits[1:0]=10 → 0x22
++	 * For 6G + Link B: bits[7:2]=001000, bits[1:0]=01 → 0x21
++	 * For 3G + Link A: bits[7:2]=000100, bits[1:0]=10 → 0x12 (? or 0x11)
++	 * For 3G + Link B: bits[7:2]=000100, bits[1:0]=01 → 0x11 (? or 0x09)
++	 */
++	if (priv->link_speed == 6) {
++		if (link == GMSL_SERDES_CSI_LINK_B) {
++			link_rate_ab = 0x21; /* 6G rate + CC via Link B */
++		} else {
++			link_rate_ab = 0x22; /* 6G rate + CC via Link A */
++		}
++		link_rate_cd = 0x22; /* C/D: 6G rate (CC routing don't care) */
++	} else {
++		if (link == GMSL_SERDES_CSI_LINK_B) {
++			link_rate_ab = 0x09; /* 3G rate + CC via Link B */
++		} else {
++			link_rate_ab = 0x12; /* 3G rate + CC via Link A */
++		}
++		link_rate_cd = 0x11; /* C/D: 3G rate */
++	}
++
++	if (link == GMSL_SERDES_CSI_LINK_A) {
++		link_en_val = MAX96724_LINK_EN_SIOA;
++	} else if (link == GMSL_SERDES_CSI_LINK_B) {
++		link_en_val = 0xF2; /* GMSL2 all, enable Link B only */
++	} else {
++		dev_err(dev, "%s: invalid gmsl link\n", __func__);
++		return -EINVAL;
++	}
++
++	/* [UG Table 3] Set link rates + CC routing */
++	max96724_write_reg(dev, MAX96724_LINK_RATE_AB_ADDR, link_rate_ab);
++	max96724_write_reg(dev, MAX96724_LINK_RATE_CD_ADDR, link_rate_cd);
++
++	/*
++	 * [XML-verified sequence] One-shot reset applies rate configuration
++	 * to the link state machine, then link enable starts training.
++	 * XML order: rate → ONE-SHOT → LINK_EN → wait 1000ms.
++	 * Note: Error channel registers omitted (not in reference XML).
++	 */
++	max96724_write_reg(dev, MAX96724_ONESHOT_ADDR,
++			   MAX96724_ONESHOT_ALL);
++	max96724_write_reg(dev, MAX96724_LINK_EN_ADDR, link_en_val);
++
++	/*
++	 * Wait for link lock.
++	 * [XML] Uses 1000ms regardless of link speed.
++	 * I2C pass-through CC requires fully trained link, not just PHY lock.
++	 */
++	msleep(1000);
++
++	/* Check link lock status on ALL ports for diagnostics */
++	{
++		unsigned int lock_a = 0, lock_b = 0, lock_c = 0, lock_d = 0;
++		unsigned int link_en = 0;
++		unsigned int reg10 = 0, reg11 = 0;
++
++		regmap_read(priv->regmap, 0x001A, &lock_a);
++		regmap_read(priv->regmap, 0x001B, &lock_b);
++		regmap_read(priv->regmap, 0x001C, &lock_c);
++		regmap_read(priv->regmap, 0x001D, &lock_d);
++		regmap_read(priv->regmap, MAX96724_LINK_EN_ADDR, &link_en);
++		regmap_read(priv->regmap, 0x0010, &reg10);
++		regmap_read(priv->regmap, 0x0011, &reg11);
++		dev_info(dev,
++			 "GMSL link status: EN=0x%02x A=0x%02x(%s) B=0x%02x(%s) C=0x%02x(%s) D=0x%02x(%s) REG10=0x%02x REG11=0x%02x\n",
++			 link_en,
++			 lock_a, (lock_a & 0x08) ? "LOCK" : "noLk",
++			 lock_b, (lock_b & 0x08) ? "LOCK" : "noLk",
++			 lock_c, (lock_c & 0x08) ? "LOCK" : "noLk",
++			 lock_d, (lock_d & 0x08) ? "LOCK" : "noLk",
++			 reg10, reg11);
++	}
++
++	return 0;
++}
++
++int max96724_setup_link(struct device *dev, struct device *s_dev)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++	int err = 0;
++	unsigned int i = 0;
++
++	err = max96724_get_sdev_idx(dev, s_dev, &i);
++	if (err)
++		return err;
++
++	mutex_lock(&priv->lock);
++
++	if (!priv->splitter_enabled) {
++		err = max96724_write_link(dev,
++					  priv->sources[i].g_ctx->serdes_csi_link);
++		if (err)
++			goto ret;
++
++		priv->link_setup = true;
++	}
++
++ret:
++	mutex_unlock(&priv->lock);
++	return err;
++}
++EXPORT_SYMBOL(max96724_setup_link);
++
++/* ================================================================
++ * Control Setup
++ * ================================================================ */
++
++/*
++ * max96724_setup_control - Configure deserializer control pipeline
++ *
++ * Enables splitter mode when multiple sources are present,
++ * configures tunnel mode on all active pipes, and sets up
++ * the MIPI CSI-2 output.
++ */
++int max96724_setup_control(struct device *dev, struct device *s_dev)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++	int err = 0;
++	unsigned int i = 0;
++
++	static const u16 tun_en_addrs[] = {
++		MAX96724_PIPE0_TUN_EN_ADDR,
++		MAX96724_PIPE1_TUN_EN_ADDR,
++		MAX96724_PIPE2_TUN_EN_ADDR,
++		MAX96724_PIPE3_TUN_EN_ADDR,
++	};
++
++	static const u16 tun_dest_addrs[] = {
++		MAX96724_PIPE0_TUN_DEST_ADDR,
++		MAX96724_PIPE1_TUN_DEST_ADDR,
++		MAX96724_PIPE2_TUN_DEST_ADDR,
++		MAX96724_PIPE3_TUN_DEST_ADDR,
++	};
++
++	err = max96724_get_sdev_idx(dev, s_dev, &i);
++	if (err)
++		return err;
++
++	mutex_lock(&priv->lock);
++
++	if (!priv->link_setup) {
++		dev_err(dev, "%s: invalid state\n", __func__);
++		err = -EINVAL;
++		goto error;
++	}
++
++	if (priv->sources[i].g_ctx->serdev_found) {
++		priv->num_src_found++;
++		priv->src_link = priv->sources[i].g_ctx->serdes_csi_link;
++	}
++
++	/* Enable splitter mode for multi-camera configurations */
++	if ((priv->max_src > 1U) &&
++	    (priv->num_src_found > 0U) &&
++	    (priv->splitter_enabled == false)) {
++		/*
++		 * [UG Table 3] Multi-camera: set link rates and enable all links
++		 */
++		u8 link_rate = (priv->link_speed == 6) ? 0x22 : 0x11;
++
++		max96724_write_reg(dev, MAX96724_LINK_RATE_AB_ADDR,
++				   link_rate);
++		max96724_write_reg(dev, MAX96724_LINK_RATE_CD_ADDR,
++				   link_rate);
++		max96724_write_reg(dev, MAX96724_LINK_EN_ADDR,
++				   MAX96724_LINK_EN_ALL);
++
++		/* [Errata #5] For 6Gbps: force Error Channel power-up */
++		if (priv->link_speed == 6) {
++			max96724_write_reg(dev, MAX96724_ERRCH_A_ADDR,
++					   MAX96724_ERRCH_FORCE_ON);
++			max96724_write_reg(dev, MAX96724_ERRCH_B_ADDR,
++					   MAX96724_ERRCH_FORCE_ON);
++			max96724_write_reg(dev, MAX96724_ERRCH_C_ADDR,
++					   MAX96724_ERRCH_FORCE_ON);
++			max96724_write_reg(dev, MAX96724_ERRCH_D_ADDR,
++					   MAX96724_ERRCH_FORCE_ON);
++		}
++
++		priv->splitter_enabled = true;
++
++		msleep(100);
++	}
++
++	/*
++	 * [SC20190112] Enable tunnel mode and route to Controller 1.
++	 *   - TUN_EN   (0x0936): 0x01 (TUN_EN=1)
++	 *   - TUN_DEST (0x0939): 0x10 = Controller 1
++	 *   CSI_OUT_CFG=0x08 (2x4 alt): Controller 1 → PHY0+1 → Port A → Orin
++	 */
++	{
++		for (i = 0; i < MAX96724_MAX_PIPES; i++) {
++			max96724_write_reg(dev, tun_en_addrs[i],
++					   MAX96724_TUN_EN);
++			max96724_write_reg(dev, tun_dest_addrs[i],
++					   MAX96724_TUN_DEST_CTRL1);
++		}
++	}
++
++	/*
++	 * [Errata #2] Tunnel Mode SRAM LCRC: disable ERRB for SRAM LCRC
++	 * errors in tunnel mode when frame/line counters are non-zero.
++	 * This prevents spurious ERRB assertions (no video corruption).
++	 */
++	max96724_write_reg(dev, MAX96724_SRAM_LCRC_ERR_ADDR, 0x00);
++
++	max96724_write_reg(dev, MAX96724_ONESHOT_ADDR,
++			   MAX96724_ONESHOT_ALL);
++
++	priv->sdev_ref++;
++
++	/* Reset splitter mode if not all devices found */
++	if ((priv->sdev_ref == priv->max_src) &&
++	    (priv->splitter_enabled == true) &&
++	    (priv->num_src_found > 0U) &&
++	    (priv->num_src_found < priv->max_src)) {
++		err = max96724_write_link(dev, priv->src_link);
++		if (err)
++			goto error;
++
++		priv->splitter_enabled = false;
++	}
++
++error:
++	mutex_unlock(&priv->lock);
++	return err;
++}
++EXPORT_SYMBOL(max96724_setup_control);
++
++int max96724_reset_control(struct device *dev, struct device *s_dev)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++	int err = 0;
++
++	mutex_lock(&priv->lock);
++	if (!priv->sdev_ref) {
++		dev_info(dev, "%s: dev is already in reset state\n", __func__);
++		goto ret;
++	}
++
++	priv->sdev_ref--;
++	if (priv->sdev_ref == 0) {
++		max96724_reset_ctx(priv);
++		max96724_write_reg(dev, MAX96724_REG13_ADDR,
++				   MAX96724_SOFT_RESET);
++
++		msleep(100);
++	}
++
++ret:
++	mutex_unlock(&priv->lock);
++	return err;
++}
++EXPORT_SYMBOL(max96724_reset_control);
++
++/* ================================================================
++ * Device Registration
++ * ================================================================ */
++
++int max96724_sdev_register(struct device *dev, struct gmsl_link_ctx *g_ctx)
++{
++	struct max96724 *priv = NULL;
++	unsigned int i;
++	int err = 0;
++
++	if (!dev || !g_ctx || !g_ctx->s_dev) {
++		dev_err(dev, "%s: invalid input params\n", __func__);
++		return -EINVAL;
++	}
++
++	priv = dev_get_drvdata(dev);
++
++	mutex_lock(&priv->lock);
++
++	if (priv->num_src > priv->max_src) {
++		dev_err(dev,
++			"%s: MAX96724 inputs size exhausted\n", __func__);
++		err = -ENOMEM;
++		goto error;
++	}
++
++	/* Check csi mode compatibility.
++	 * 2x4 DES → gmsl-link: 1x4 or 2x4.
++	 * 4x2 DES → gmsl-link: 1x4, 2x2, or 4x2.
++	 */
++	if (priv->csi_mode == MAX96724_CSI_MODE_2X4) {
++		if (!((g_ctx->csi_mode == GMSL_CSI_1X4_MODE) ||
++		      (g_ctx->csi_mode == GMSL_CSI_2X4_MODE))) {
++			dev_err(dev, "%s: csi mode not supported\n", __func__);
++			err = -EINVAL;
++			goto error;
++		}
++	} else {
++		/* 4x2 DES mode: accept 1x4, 2x2, or 4x2 gmsl-link mode */
++		if (!((g_ctx->csi_mode == GMSL_CSI_1X4_MODE) ||
++		      (g_ctx->csi_mode == GMSL_CSI_2X2_MODE) ||
++		      (g_ctx->csi_mode == GMSL_CSI_4X2_MODE))) {
++			dev_err(dev, "%s: csi mode not supported\n", __func__);
++			err = -EINVAL;
++			goto error;
++		}
++	}
++
++	for (i = 0; i < priv->num_src; i++) {
++		if (g_ctx->serdes_csi_link ==
++		    priv->sources[i].g_ctx->serdes_csi_link) {
++			dev_err(dev,
++				"%s: serdes csi link is in use\n", __func__);
++			err = -EINVAL;
++			goto error;
++		}
++		if (g_ctx->num_csi_lanes !=
++		    priv->sources[i].g_ctx->num_csi_lanes) {
++			dev_err(dev,
++				"%s: csi num lanes mismatch\n", __func__);
++			err = -EINVAL;
++			goto error;
++		}
++	}
++
++	priv->sources[priv->num_src].g_ctx = g_ctx;
++	priv->sources[priv->num_src].st_enabled = false;
++
++	priv->num_src++;
++
++error:
++	mutex_unlock(&priv->lock);
++	return err;
++}
++EXPORT_SYMBOL(max96724_sdev_register);
++
++int max96724_sdev_unregister(struct device *dev, struct device *s_dev)
++{
++	struct max96724 *priv = NULL;
++	int err = 0;
++	unsigned int i = 0;
++
++	if (!dev || !s_dev) {
++		dev_err(dev, "%s: invalid input params\n", __func__);
++		return -EINVAL;
++	}
++
++	priv = dev_get_drvdata(dev);
++	mutex_lock(&priv->lock);
++
++	if (priv->num_src == 0) {
++		dev_err(dev, "%s: no source found\n", __func__);
++		err = -ENODATA;
++		goto error;
++	}
++
++	for (i = 0; i < priv->num_src; i++) {
++		if (s_dev == priv->sources[i].g_ctx->s_dev) {
++			priv->sources[i].g_ctx = NULL;
++			break;
++		}
++	}
++
++	if (i == priv->num_src) {
++		dev_err(dev,
++			"%s: requested device not found\n", __func__);
++		err = -EINVAL;
++		goto error;
++	}
++	priv->num_src--;
++
++error:
++	mutex_unlock(&priv->lock);
++	return err;
++}
++EXPORT_SYMBOL(max96724_sdev_unregister);
++
++/* ================================================================
++ * Streaming Setup
++ * ================================================================ */
++
++/*
++ * max96724_setup_streaming - Configure CSI-2 output pipeline
++ *
++ * In Tunnel Mode, the MAX96724 outputs the reconstructed CSI-2 stream
++ * with all VCs and DTs preserved from the serializer.
++ *
++ * The pipeline configuration:
++ *   1. Configure pipe-to-link routing (which GMSL input → which pipe)
++ *   2. Enable tunnel mode on active pipes
++ *   3. Configure MIPI CSI-2 output lanes and PHY
++ *   4. Enable BACKTOP output port
++ *
++ */
++int max96724_setup_streaming(struct device *dev, struct device *s_dev)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++	struct gmsl_link_ctx *g_ctx;
++	int err = 0;
++	unsigned int i = 0;
++	unsigned int src_idx;
++
++	err = max96724_get_sdev_idx(dev, s_dev, &i);
++	if (err)
++		return err;
++
++	mutex_lock(&priv->lock);
++	if (priv->sources[i].st_enabled)
++		goto ret;
++
++	src_idx = i;
++	g_ctx = priv->sources[src_idx].g_ctx;
++
++	/*
++	 * [Aardvark-verified] Pipe source routing
++	 *   Single cam: all pipes from Link A (0x22/0x22)
++	 *   Disable pipes before configuration, enable at the end
++	 */
++	if (priv->max_src >= 4) {
++		max96724_write_reg(dev, MAX96724_PIPE_SEL0_ADDR,
++				   MAX96724_PIPE_SEL0_QUAD_LO);
++		max96724_write_reg(dev, MAX96724_PIPE_SEL1_ADDR,
++				   MAX96724_PIPE_SEL1_QUAD_HI);
++	} else if (priv->max_src >= 2) {
++		max96724_write_reg(dev, MAX96724_PIPE_SEL0_ADDR,
++				   MAX96724_PIPE_SEL0_DUAL);
++	} else {
++		max96724_write_reg(dev, MAX96724_PIPE_SEL0_ADDR,
++				   MAX96724_PIPE_SEL0_SINGLE);
++		max96724_write_reg(dev, MAX96724_PIPE_SEL1_ADDR,
++				   MAX96724_PIPE_SEL1_SINGLE);
++	}
++	/* Disable all pipes during configuration */
++	max96724_write_reg(dev, MAX96724_PIPE_EN_ADDR, 0x00);
++
++	/*
++	 * [SC20190112] CSI output: 2x4 alt mode (0x08) for Port A.
++	 * In 2x4 alt: Controller 1 is master for Port A.
++	 *   PHY0 (slave) → DA0/DA1 (data lanes to Orin)
++	 *   PHY1 (master) → CLKA (clock to Orin)
++	 * Both PHY0 and PHY1 must be enabled for Port A output.
++	 * TUN_DEST=0x10 routes tunnel pipes to Controller 1.
++	 */
++	max96724_write_reg(dev, MAX96724_CSI_OUT_CFG_ADDR,
++			   MAX96724_CSI_MODE_2X4_VAL);
++	max96724_write_reg(dev, MAX96724_CSI_PHY_EN_ADDR,
++			   MAX96724_CSI_PHY_EN_01);
++
++	max96724_write_reg(dev, MAX96724_CSI_LANE_MAP1_ADDR,
++			   priv->lane_mp1);
++	max96724_write_reg(dev, MAX96724_CSI_LANE_MAP2_ADDR,
++			   priv->lane_mp2);
++
++	/* [gmsl_ser_des_guide §6.1] MIPI_CTRL_SEL: all pipes → Controller 1.
++	 * Guide: "in tunneling mode the MIPI_CTRL_SEL_x bits must match TUN_DEST"
++	 * 0x55 = Pipe0→Ctrl1, Pipe1→Ctrl1, Pipe2→Ctrl1, Pipe3→Ctrl1 */
++	max96724_write_reg(dev, MAX96724_MIPI_CTRL_SEL_ADDR, 0x55);
++
++	/* [gmsl_ser_des_guide §8.2] LANE_CTRL on Controller 1 register (0x094A).
++	 * 0x40 = 2-lane. Also set Ctrl0 for completeness. */
++	max96724_write_reg(dev, MAX96724_LANE_CTRL0_ADDR,
++			   MAX96724_LANE_CTRL_2LANE);
++	max96724_write_reg(dev, MAX96724_LANE_CTRL1_ADDR,
++			   MAX96724_LANE_CTRL_2LANE);
++	max96724_write_reg(dev, MAX96724_LANE_CTRL2_ADDR,
++			   MAX96724_LANE_CTRL_2LANE);
++	max96724_write_reg(dev, MAX96724_LANE_CTRL3_ADDR,
++			   MAX96724_LANE_CTRL_2LANE);
++
++	/*
++	 * [SC20190112 2-lane] DPLL for Controller 1 (drives Port A via PHY1 clock).
++	 * FREQ1 (0x0418) = 0x2E = 1400 Mbps/lane + DPLL enable.
++	 * 2 lanes × 1400 Mbps = 2800 Mbps total ≥ camera 2L × 700M input.
++	 */
++	if (!priv->lane_setup) {
++		max96724_write_reg(dev, MAX96724_DPLL_CSI2_ADDR,
++				   MAX96724_DPLL_DISABLE);
++		max96724_write_reg(dev, MAX96724_DPLL_FREQ1_ADDR,
++				   MAX96724_DPLL_1400MBPS_CTRL0);
++		max96724_write_reg(dev, MAX96724_DPLL_CSI2_ADDR,
++				   MAX96724_DPLL_ENABLE);
++
++		priv->lane_setup = true;
++	}
++
++	/*
++	 * [Aardvark-verified] Stream ID select for all pipes
++	 * 0x0933 + 0x40*pipe = stream select register
++	 * Value 0x10 selects the appropriate stream for tunnel mode
++	 */
++	for (i = 0; i < MAX96724_MAX_PIPES; i++) {
++		max96724_write_reg(dev,
++				   MAX96724_PIPE_X_ST_SEL_ADDR + (0x40 * i),
++				   0x10);
++	}
++
++	/* BACKTOP: enable Controller 1 / CSI-B (0x02).
++	 * In 2x4 alt mode, Controller 1 is master for Port A → Orin CSI.
++	 */
++	max96724_write_reg(dev, MAX96724_BACKTOP_EN_ADDR,
++			   MAX96724_BACKTOP_CSIB_EN);
++
++	/* Keep all video receivers aligned with serializer heartbeat mode. */
++	for (i = 0; i < MAX96724_MAX_PIPES; i++) {
++		max96724_write_reg(dev,
++				   MAX96724_VID_RX0_P0_ADDR +
++				   (MAX96724_VID_RX_STRIDE * i),
++				   MAX96724_VID_RX0_CFG_VAL);
++		max96724_write_reg(dev,
++				   MAX96724_VID_RX6_P0_ADDR +
++				   (MAX96724_VID_RX_STRIDE * i),
++				   MAX96724_VID_RX6_CFG_VAL);
++	}
++
++	max96724_write_reg(dev, MAX96724_ONESHOT_ADDR,
++			   MAX96724_ONESHOT_ALL);
++
++	/* Enable all 4 pipes (Aardvark-verified: 0x0F at end) */
++	max96724_write_reg(dev, MAX96724_PIPE_EN_ADDR, MAX96724_PIPE_EN_4);
++
++	priv->sources[src_idx].st_enabled = true;
++
++ret:
++	mutex_unlock(&priv->lock);
++	return err;
++}
++EXPORT_SYMBOL(max96724_setup_streaming);
++
++/* ================================================================
++ * Start / Stop Streaming
++ * ================================================================ */
++
++int max96724_start_streaming(struct device *dev, struct device *s_dev)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++	struct gmsl_link_ctx *g_ctx;
++	struct gmsl_stream *g_stream;
++	int err = 0;
++	unsigned int i = 0;
++
++	err = max96724_get_sdev_idx(dev, s_dev, &i);
++	if (err)
++		return err;
++
++	mutex_lock(&priv->lock);
++	g_ctx = priv->sources[i].g_ctx;
++
++	for (i = 0; i < g_ctx->num_streams; i++) {
++		g_stream = &g_ctx->streams[i];
++
++		if (g_stream->des_pipe != MAX96724_PIPE_INVALID)
++			max96724_write_reg(dev, g_stream->des_pipe,
++					   g_stream->st_id_sel);
++	}
++	mutex_unlock(&priv->lock);
++
++	return 0;
++}
++EXPORT_SYMBOL(max96724_start_streaming);
++
++int max96724_stop_streaming(struct device *dev, struct device *s_dev)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++	struct gmsl_link_ctx *g_ctx;
++	struct gmsl_stream *g_stream;
++	int err = 0;
++	unsigned int i = 0;
++
++	err = max96724_get_sdev_idx(dev, s_dev, &i);
++	if (err)
++		return err;
++
++	mutex_lock(&priv->lock);
++	g_ctx = priv->sources[i].g_ctx;
++
++	for (i = 0; i < g_ctx->num_streams; i++) {
++		g_stream = &g_ctx->streams[i];
++
++		if (g_stream->des_pipe != MAX96724_PIPE_INVALID)
++			max96724_write_reg(dev, g_stream->des_pipe,
++					   MAX96724_RESET_ST_ID);
++	}
++
++	mutex_unlock(&priv->lock);
++
++	return 0;
++}
++EXPORT_SYMBOL(max96724_stop_streaming);
++
++/* ================================================================
++ * Pipe Management
++ * ================================================================ */
++
++int max96724_get_available_pipe_id(struct device *dev, int vc_id)
++{
++	int i;
++	int pipe_id = -ENOMEM;
++	struct max96724 *priv = dev_get_drvdata(dev);
++
++	mutex_lock(&priv->lock);
++	for (i = 0; i < MAX96724_MAX_PIPES; i++) {
++		if (i == vc_id && !priv->pipe[i].st_count) {
++			priv->pipe[i].st_count++;
++			pipe_id = i;
++			break;
++		}
++	}
++	mutex_unlock(&priv->lock);
++
++	return pipe_id;
++}
++EXPORT_SYMBOL(max96724_get_available_pipe_id);
++
++int max96724_release_pipe(struct device *dev, int pipe_id)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++
++	if (pipe_id < 0 || pipe_id >= MAX96724_MAX_PIPES)
++		return -EINVAL;
++
++	mutex_lock(&priv->lock);
++	priv->pipe[pipe_id].st_count = 0;
++	mutex_unlock(&priv->lock);
++
++	return 0;
++}
++EXPORT_SYMBOL(max96724_release_pipe);
++
++int max96724_get_ser_pipe_id(struct device *dev, int dser_pipe_id, int vc_id)
++{
++	/*
++	 * In Tunnel Mode with MAX96717, all VCs are carried in a single
++	 * tunnel pipe. The pipe mapping is 1:1 for d4xx compatibility.
++	 */
++	return dser_pipe_id;
++}
++EXPORT_SYMBOL(max96724_get_ser_pipe_id);
++
++void max96724_reset_oneshot(struct device *dev)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++
++	mutex_lock(&priv->lock);
++	if (priv->splitter_enabled) {
++		/* [UG] Multi-camera: reset all links */
++		u8 link_rate = (priv->link_speed == 6) ? 0x22 : 0x11;
++
++		max96724_write_reg(dev, MAX96724_LINK_RATE_AB_ADDR,
++				   link_rate);
++		max96724_write_reg(dev, MAX96724_LINK_RATE_CD_ADDR,
++				   link_rate);
++		max96724_write_reg(dev, MAX96724_LINK_EN_ADDR,
++				   MAX96724_LINK_EN_ALL);
++	} else {
++		max96724_write_reg(dev, MAX96724_ONESHOT_ADDR,
++				   MAX96724_ONESHOT_ALL);
++	}
++	msleep(100);
++
++	/* ONESHOT resets CSI config to defaults.
++	 * Restore 1x4a+2x2 2-lane config after every ONESHOT (per guide §7):
++	 *   CSI_OUT_CFG=0x08  1x4a+2x2: Controller 1 → PHY0+1 → Port A
++	 *   PHY_EN=0x30       PHY0+PHY1 (both needed for Port A)
++	 *   MIPI_CTRL_SEL=0x55 all pipes → Controller 1 (must match TUN_DEST)
++	 *   BACKTOP=0x02      CSIB_EN (Controller 1)
++	 *   TUN_EN=0x09       tunnel enable (per verified XML)
++	 *   TUN_DEST=0x50     manual detect + PHY1 (per verified XML)
++	 *   DPLL_FREQ1=0x2E   1400Mbps (Controller 1's DPLL)
++	 *   LANE_CTRL1=0x40   2-lane on Controller 1
++	 *   VID_RX0=0x33      disable pkt detect for tunnel mode
++	 */
++	max96724_write_reg(dev, MAX96724_CSI_OUT_CFG_ADDR,
++			   MAX96724_CSI_MODE_2X4_VAL);
++	max96724_write_reg(dev, MAX96724_CSI_PHY_EN_ADDR,
++			   MAX96724_CSI_PHY_EN_01);
++	max96724_write_reg(dev, MAX96724_MIPI_CTRL_SEL_ADDR, 0x55);
++	max96724_write_reg(dev, MAX96724_BACKTOP_EN_ADDR,
++			   MAX96724_BACKTOP_CSIB_EN);
++	/* Restore 2-lane count on all controllers (ONESHOT resets to default) */
++	max96724_write_reg(dev, MAX96724_LANE_CTRL0_ADDR,
++			   MAX96724_LANE_CTRL_2LANE);
++	max96724_write_reg(dev, MAX96724_LANE_CTRL1_ADDR,
++			   MAX96724_LANE_CTRL_2LANE);
++	max96724_write_reg(dev, MAX96724_LANE_CTRL2_ADDR,
++			   MAX96724_LANE_CTRL_2LANE);
++	max96724_write_reg(dev, MAX96724_LANE_CTRL3_ADDR,
++			   MAX96724_LANE_CTRL_2LANE);
++	max96724_write_reg(dev, MAX96724_DPLL_FREQ1_ADDR,
++			   MAX96724_DPLL_1400MBPS_CTRL0);
++	max96724_write_reg(dev, MAX96724_VID_RX0_P0_ADDR,
++			   MAX96724_VID_RX0_CFG_VAL);
++	/* Re-enable tunnel on all pipes (ONESHOT resets TUN_EN to 0x08=disabled) */
++	max96724_write_reg(dev, MAX96724_PIPE0_TUN_EN_ADDR, MAX96724_TUN_EN);
++	max96724_write_reg(dev, MAX96724_PIPE1_TUN_EN_ADDR, MAX96724_TUN_EN);
++	max96724_write_reg(dev, MAX96724_PIPE2_TUN_EN_ADDR, MAX96724_TUN_EN);
++	max96724_write_reg(dev, MAX96724_PIPE3_TUN_EN_ADDR, MAX96724_TUN_EN);
++	/* TUN_DEST: set to Controller 1 (0x10) for 2x4 alt / Port A */
++	max96724_write_reg(dev, MAX96724_PIPE0_TUN_DEST_ADDR,
++			   MAX96724_TUN_DEST_CTRL1);
++	max96724_write_reg(dev, MAX96724_PIPE1_TUN_DEST_ADDR,
++			   MAX96724_TUN_DEST_CTRL1);
++	max96724_write_reg(dev, MAX96724_PIPE2_TUN_DEST_ADDR,
++			   MAX96724_TUN_DEST_CTRL1);
++	max96724_write_reg(dev, MAX96724_PIPE3_TUN_DEST_ADDR,
++			   MAX96724_TUN_DEST_CTRL1);
++
++	msleep(200);
++	mutex_unlock(&priv->lock);
++}
++EXPORT_SYMBOL(max96724_reset_oneshot);
++
++/* ================================================================
++ * Init Settings / Set Pipe
++ * ================================================================ */
++
++/*
++ * __max96724_set_pipe - Configure per-pipe mapping registers
++ */
++static int __max96724_set_pipe(struct device *dev, int pipe_id,
++			       u8 data_type1, u8 data_type2, u32 vc_id)
++{
++	int err = 0;
++	int i;
++	u8 en_mapping_num = 0x0F;
++	u8 all_mapping_phy = MAX96724_ALL_MAP_CTRL1;  /* Controller 1 for 2x4 alt Port A mode */
++
++	struct reg_pair map_pipe_control[] = {
++		/* Enable 4 mappings for Pipe X */
++		{MAX96724_TX11_PIPE_X_EN_ADDR, 0x0F},
++		/* Map data_type1 on vc_id */
++		{MAX96724_PIPE_X_SRC_0_MAP_ADDR, 0x1E},
++		{MAX96724_PIPE_X_DST_0_MAP_ADDR, 0x1E},
++		/* Map frame start on vc_id */
++		{MAX96724_PIPE_X_SRC_1_MAP_ADDR, 0x00},
++		{MAX96724_PIPE_X_DST_1_MAP_ADDR, 0x00},
++		/* Map frame end on vc_id */
++		{MAX96724_PIPE_X_SRC_2_MAP_ADDR, 0x01},
++		{MAX96724_PIPE_X_DST_2_MAP_ADDR, 0x01},
++		/* Map data_type2 on vc_id */
++		{MAX96724_PIPE_X_SRC_3_MAP_ADDR, 0x12},
++		{MAX96724_PIPE_X_DST_3_MAP_ADDR, 0x12},
++		/* All mappings to Controller 1 (2x4 alt: Ctrl1 drives Port A) */
++		{MAX96724_TX45_PIPE_X_DST_CTRL_ADDR, MAX96724_ALL_MAP_CTRL1},
++		{MAX96724_TX46_PIPE_X_ADDR, MAX96724_ALL_MAP_CTRL1},
++		{MAX96724_TX47_PIPE_X_ADDR, MAX96724_ALL_MAP_CTRL1},
++		{MAX96724_TX48_PIPE_X_ADDR, MAX96724_ALL_MAP_CTRL1},
++		/* [SC20190112 2-lane] TX49: Pipeline concatenation 2W (2-lane output) */
++		{MAX96724_TX49_PIPE_X_ADDR, MAX96724_TX49_CONCAT_2W},
++		/*
++		 * Keep DES heartbeat handling aligned with the serializer's
++		 * LIM_HEART-disabled tunnel mode to avoid persistent VID_SEQ_ERR.
++		 */
++		{0x0100, MAX96724_VID_RX0_CFG_VAL},
++		{0x0106, MAX96724_VID_RX6_CFG_VAL},
++		/*
++		 * Pipe stream control (offset 0x36 per pipe block).
++		 * [gmsl_ser_des_guide §4.9] TUN_EN = 0x09 per verified XML.
++		 */
++		{0x0936, MAX96724_TUN_EN},
++	};
++
++	/* Adjust addresses for pipe offset (stride 0x40 per pipe)
++	 * Entries 0-13: TX11, SRC/DST maps, TX45-TX49 (all stride 0x40)
++	 * Entries 14-15: VID_RX0/6 (stride 0x12)
++	 * Entry 16: Pipe stream control (stride 0x40)
++	 */
++	for (i = 0; i < 14; i++)
++		map_pipe_control[i].addr += 0x40 * pipe_id;
++
++	/* [max9296.c pattern] VID_RX offset: 0x12 per pipe */
++	map_pipe_control[14].addr += 0x12 * pipe_id;
++	map_pipe_control[15].addr += 0x12 * pipe_id;
++
++	/* Pipe stream control: stride 0x40 */
++	map_pipe_control[16].addr += 0x40 * pipe_id;
++
++	if (data_type2 == 0x0) {
++		en_mapping_num = 0x07;
++		all_mapping_phy = 0x15;  /* 3 mappings to Controller 1 */
++	}
++
++	map_pipe_control[0].val = en_mapping_num;
++	/* SRC: match incoming VC from camera (vc_id) */
++	map_pipe_control[1].val = (vc_id << 6) | data_type1;
++	/* DST: preserve VC — NVCSI/VI endpoints expect matching vc-id */
++	map_pipe_control[2].val = (vc_id << 6) | data_type1;
++	map_pipe_control[3].val = (vc_id << 6) | 0x00;
++	map_pipe_control[4].val = (vc_id << 6) | 0x00;
++	map_pipe_control[5].val = (vc_id << 6) | 0x01;
++	map_pipe_control[6].val = (vc_id << 6) | 0x01;
++	map_pipe_control[7].val = (vc_id << 6) | data_type2;
++	map_pipe_control[8].val = (vc_id << 6) | data_type2;
++	map_pipe_control[9].val = all_mapping_phy;
++	/* TX46-TX48 keep 0x55 (Ctrl1) from initializer */
++	/* TX49 keeps 0x83 (2W concat) from initializer */
++	/* VID_RX (entry 14) and pipe stream ctrl (entry 15) keep init values */
++
++	err = max96724_set_registers(dev, map_pipe_control,
++				     ARRAY_SIZE(map_pipe_control));
++
++	return err;
++}
++
++/*
++ * max96724_init_settings - Initialize default pipe and tunnel configuration
++ *
++ * Sets up all 4 pipes with default YUV422_8 + EMBED for VC0-3,
++ * matching the d4xx framework expectations.
++ *
++ */
++int max96724_init_settings(struct device *dev)
++{
++	int err = 0;
++	int i;
++	struct max96724 *priv = dev_get_drvdata(dev);
++
++	mutex_lock(&priv->lock);
++
++	for (i = 0; i < MAX96724_MAX_PIPES; i++)
++		err |= __max96724_set_pipe(dev, i, GMSL_CSI_DT_YUV422_8,
++					   GMSL_CSI_DT_EMBED, i);
++
++	mutex_unlock(&priv->lock);
++
++	return err;
++}
++EXPORT_SYMBOL(max96724_init_settings);
++
++int max96724_bind_ser_to_dser_pipe(struct device *dev, int dser_pipe_id,
++				   int ser_pipe_id, u32 vc_id)
++{
++	/* In Tunnel Mode, pipe mapping is 1:1 (each camera → one pipe) */
++	return 0;
++}
++EXPORT_SYMBOL(max96724_bind_ser_to_dser_pipe);
++
++int max96724_set_pipe(struct device *dev, int pipe_id,
++		      u8 data_type1, u8 data_type2, u32 vc_id)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++	int err = 0;
++
++	if (pipe_id > (MAX96724_MAX_PIPES - 1)) {
++		dev_info(dev, "%s: input pipe_id: %d exceeds max96724 max pipes\n",
++			 __func__, pipe_id);
++		return -EINVAL;
++	}
++
++	dev_dbg(dev, "%s pipe_id %d, data_type1 %u, data_type2 %u, vc_id %u\n",
++		__func__, pipe_id, data_type1, data_type2, vc_id);
++
++	mutex_lock(&priv->lock);
++
++	err = __max96724_set_pipe(dev, pipe_id, data_type1, data_type2, vc_id);
++
++	mutex_unlock(&priv->lock);
++
++	return err;
++}
++EXPORT_SYMBOL(max96724_set_pipe);
++
++/* ================================================================
++ * Device Tree Parsing
++ * ================================================================ */
++
++static const struct of_device_id max96724_of_match[] = {
++	{ .compatible = "adi,max96724", },
++	{ },
++};
++MODULE_DEVICE_TABLE(of, max96724_of_match);
++
++static int max96724_parse_dt(struct max96724 *priv,
++			     struct i2c_client *client)
++{
++	struct device_node *node = client->dev.of_node;
++	int err = 0;
++	const char *str_value;
++	int value;
++	const struct of_device_id *match;
++
++	if (!node)
++		return -EINVAL;
++
++	match = of_match_device(max96724_of_match, &client->dev);
++	if (!match) {
++		dev_err(&client->dev, "Failed to find matching dt id\n");
++		return -EFAULT;
++	}
++
++	/* CSI mode: "2x4" or "4x2" */
++	err = of_property_read_string(node, "csi-mode", &str_value);
++	if (err < 0) {
++		dev_err(&client->dev, "csi-mode property not found\n");
++		return err;
++	}
++
++	if (!strcmp(str_value, "2x4")) {
++		priv->csi_mode = MAX96724_CSI_MODE_2X4;
++		priv->lane_mp1 = MAX96724_LANE_MAP1_2X4;
++		priv->lane_mp2 = MAX96724_LANE_MAP2_2X4;
++	} else if (!strcmp(str_value, "4x2")) {
++		priv->csi_mode = MAX96724_CSI_MODE_4X2;
++		priv->lane_mp1 = MAX96724_LANE_MAP1_4X2;
++		priv->lane_mp2 = MAX96724_LANE_MAP2_4X2;
++	} else {
++		dev_err(&client->dev, "invalid csi mode\n");
++		return -EINVAL;
++	}
++
++	/* Max sources */
++	err = of_property_read_u32(node, "max-src", &value);
++	if (err < 0) {
++		dev_err(&client->dev, "No max-src info\n");
++		return err;
++	}
++	priv->max_src = value;
++
++	/* Reset GPIO */
++	priv->reset_gpio = of_get_named_gpio(node, "reset-gpios", 0);
++	if (priv->reset_gpio < 0) {
++		dev_err(&client->dev, "reset-gpios not found %d\n", err);
++		return err;
++	}
++
++	/* [User requirement] GMSL link speed from DT: 3 or 6 (Gbps) */
++	err = of_property_read_u32(node, "gmsl-link-speed", &value);
++	if (err < 0) {
++		/* Default to 3 Gbps if not specified */
++		priv->link_speed = 3;
++		dev_info(&client->dev,
++			 "gmsl-link-speed not specified, defaulting to 3 Gbps\n");
++	} else {
++		if (value != 3 && value != 6) {
++			dev_err(&client->dev,
++				"invalid gmsl-link-speed %d (must be 3 or 6)\n",
++				value);
++			return -EINVAL;
++		}
++		priv->link_speed = value;
++	}
++
++	/* 1.2V regulator (optional) */
++	if (of_get_property(node, "vdd_cam_1v2-supply", NULL)) {
++		priv->vdd_cam_1v2 = regulator_get(&client->dev, "vdd_cam_1v2");
++		if (IS_ERR(priv->vdd_cam_1v2)) {
++			dev_err(&client->dev,
++				"vdd_cam_1v2 regulator get failed\n");
++			err = PTR_ERR(priv->vdd_cam_1v2);
++			priv->vdd_cam_1v2 = NULL;
++			return err;
++		}
++	} else {
++		priv->vdd_cam_1v2 = NULL;
++	}
++
++	return 0;
++}
++
++/* ================================================================
++ * Probe / Remove
++ * ================================================================ */
++
++static struct regmap_config max96724_regmap_config = {
++	.reg_bits = 16,
++	.val_bits = 8,
++	.cache_type = REGCACHE_RBTREE,
++};
++
++static int max96724_probe(struct i2c_client *client,
++			   const struct i2c_device_id *id)
++{
++	struct max96724 *priv;
++	int err = 0;
++
++	dev_info(&client->dev,
++		 "[MAX96724]: probing Quad GMSL2 Deserializer (Tunnel Mode)\n");
++
++	priv = devm_kzalloc(&client->dev, sizeof(*priv), GFP_KERNEL);
++	if (!priv)
++		return -ENOMEM;
++
++	priv->i2c_client = client;
++	priv->regmap = devm_regmap_init_i2c(priv->i2c_client,
++					     &max96724_regmap_config);
++	if (IS_ERR(priv->regmap)) {
++		dev_err(&client->dev,
++			"regmap init failed: %ld\n", PTR_ERR(priv->regmap));
++		return -ENODEV;
++	}
++
++	err = max96724_parse_dt(priv, client);
++	if (err) {
++		dev_err(&client->dev, "unable to parse dt\n");
++		return -EFAULT;
++	}
++
++	max96724_pipes_reset(priv);
++
++	if (priv->max_src > MAX96724_MAX_SOURCES) {
++		dev_err(&client->dev,
++			"max sources more than currently supported\n");
++		return -EINVAL;
++	}
++
++	mutex_init(&priv->lock);
++
++	dev_set_drvdata(&client->dev, priv);
++
++	dev_info(&client->dev, "%s: success (link_speed=%d Gbps, max_src=%d)\n",
++		 __func__, priv->link_speed, priv->max_src);
++
++	return err;
++}
++
++static int max96724_remove(struct i2c_client *client)
++{
++	struct max96724 *priv;
++
++	if (client != NULL) {
++		priv = dev_get_drvdata(&client->dev);
++		mutex_destroy(&priv->lock);
++		i2c_unregister_device(client);
++		client = NULL;
++	}
++
++	return 0;
++}
++
++static const struct i2c_device_id max96724_id[] = {
++	{ "max96724", 0 },
++	{ },
++};
++
++MODULE_DEVICE_TABLE(i2c, max96724_id);
++
++static struct i2c_driver max96724_i2c_driver = {
++	.driver = {
++		.name = "max96724",
++		.owner = THIS_MODULE,
++		.of_match_table = of_match_ptr(max96724_of_match),
++	},
++	.probe = max96724_probe,
++	.remove = max96724_remove,
++	.id_table = max96724_id,
++};
++
++static int __init max96724_init(void)
++{
++	return i2c_add_driver(&max96724_i2c_driver);
++}
++
++static void __exit max96724_exit(void)
++{
++	i2c_del_driver(&max96724_i2c_driver);
++}
++
++module_init(max96724_init);
++module_exit(max96724_exit);
++
++MODULE_DESCRIPTION("Quad GMSL2 Deserializer driver max96724 (Tunnel Mode)");
++MODULE_AUTHOR("RealSense AI");
++MODULE_LICENSE("GPL v2");
+diff --git a/include/media/max96717.h b/include/media/max96717.h
+new file mode 100644
+index 0000000..65bf930
+--- /dev/null
++++ b/include/media/max96717.h
+@@ -0,0 +1,151 @@
++/*
++ * max96717.c - MAX96717 GMSL2 Serializer driver (Tunnel Mode)
++ *
++ * Copyright (c) 2026, RealSense, Inc.  All rights reserved.
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms and conditions of the GNU General Public License,
++ * version 2, as published by the Free Software Foundation.
++ *
++ * This program is distributed in the hope it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
++ * more details.
++ *
++ * You should have received a copy of the GNU General Public License
++ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
++ */
++
++/**
++ * @file
++ * <b>MAX96717 API: For Analog Devices MAX96717 GMSL2 serializer</b>
++ *
++ * @b Description: Defines elements used to set up and use an
++ *  Analog Devices MAX96717 GMSL2 serializer in Tunnel Mode.
++ */
++
++#ifndef __MAX96717_H__
++#define __MAX96717_H__
++
++#include <linux/types.h>
++#include <media/gmsl-link.h>
++
++/**
++ * \defgroup max96717 MAX96717 serializer driver
++ *
++ * Controls the MAX96717 GMSL2 serializer module (Tunnel Mode).
++ *
++ * @ingroup serdes_group
++ * @{
++ */
++
++/**
++ * @brief  Configures a single pipe on the serializer.
++ *
++ * In Tunnel Mode, per-pipe DT/VC filtering is not active on the serializer
++ * side (all VCs are tunneled transparently). This function maintains API
++ * compatibility with the d4xx sensor driver framework.
++ *
++ * @param  [in]  dev          The serializer device handle.
++ * @param  [in]  pipe_id      Pipe index (0..3).
++ * @param  [in]  data_type1   Primary CSI-2 data type.
++ * @param  [in]  data_type2   Secondary CSI-2 data type (e.g. embedded).
++ * @param  [in]  vc_id        Virtual channel ID.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96717_set_pipe(struct device *dev, int pipe_id, u8 data_type1,
++		      u8 data_type2, u32 vc_id);
++
++/**
++ * @brief  Toggle SER TX to restore tunnel detection after DES ONESHOT.
++ *
++ * A DES ONESHOT resets the video data path. The serializer must cycle
++ * its TX enable (REG2 0x03→0x43) for the deserializer to re-acquire
++ * the tunnel stream.
++ *
++ * @param  [in]  dev          The serializer device handle.
++ */
++void max96717_retrigger_tx(struct device *dev);
++
++/**
++ * @brief  Powers on the serializer and performs I2C overrides
++ * for sensor and serializer devices.
++ *
++ * Must be called after the deserializer's max96724_setup_link().
++ *
++ * @param  [in]  dev          The serializer device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96717_setup_control(struct device *dev);
++
++/**
++ * @brief  Reverts I2C overrides and resets the serializer.
++ *
++ * @param  [in]  dev          The serializer device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96717_reset_control(struct device *dev);
++
++/**
++ * @brief  Pairs a sensor device with the serializer.
++ *
++ * To be called by the sensor client driver.
++ *
++ * @param  [in]  dev          The serializer device handle.
++ * @param  [in]  g_ctx        The gmsl_link_ctx structure handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96717_sdev_pair(struct device *dev, struct gmsl_link_ctx *g_ctx);
++
++/**
++ * @brief  Unpairs a sensor device from the serializer.
++ *
++ * @param  [in]  dev          The serializer device handle.
++ * @param  [in]  s_dev        The sensor device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96717_sdev_unpair(struct device *dev, struct device *s_dev);
++
++/**
++ * @brief  Sets up the serializer's internal streaming pipeline.
++ *
++ * Configures CSI-2 input mode, lane mapping, and enables Tunnel Mode
++ * (EXT11[7]=1 at register 0x0383).
++ *
++ * @param  [in]  dev          The serializer device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96717_setup_streaming(struct device *dev);
++
++/**
++ * @brief  Applies initial register settings for the serializer.
++ *
++ * Configures default pipe settings and Tunnel Mode registers.
++ *
++ * @param  [in]  dev          The serializer device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96717_init_settings(struct device *dev);
++
++/**
++ * @brief  No-op hook for GPIO-over-GMSL tunneling for FSIN/FOUT signals.
++ *
++ * The signal map is documented, but the concrete MFP_CFG values are
++ * not available yet. This hook currently logs and returns success.
++ *
++ * @param  [in]  dev          The serializer device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96717_setup_gpio_tunneling(struct device *dev);
++
++/** @} */
++
++#endif  /* __MAX96717_H__ */
+diff --git a/include/media/max96724.h b/include/media/max96724.h
+new file mode 100644
+index 0000000..dc5a8ea
+--- /dev/null
++++ b/include/media/max96724.h
+@@ -0,0 +1,183 @@
++/*
++ * max96717.c - MAX96717 GMSL2 Serializer driver (Tunnel Mode)
++ *
++ * Copyright (c) 2026, RealSense, Inc.  All rights reserved.
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms and conditions of the GNU General Public License,
++ * version 2, as published by the Free Software Foundation.
++ *
++ * This program is distributed in the hope it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
++ * more details.
++ *
++ * You should have received a copy of the GNU General Public License
++ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
++ */
++
++/**
++ * @file
++ * <b>MAX96724 API: For Analog Devices MAX96724 GMSL2 quad deserializer</b>
++ *
++ * @b Description: Defines elements used to set up and use an
++ *  Analog Devices MAX96724 quad GMSL2 deserializer in Tunnel Mode.
++ */
++
++#ifndef __MAX96724_H__
++#define __MAX96724_H__
++
++#include <linux/types.h>
++#include <media/gmsl-link.h>
++
++/**
++ * \defgroup max96724 MAX96724 deserializer driver
++ *
++ * Controls the MAX96724 quad GMSL2 deserializer module (Tunnel Mode).
++ *
++ * @ingroup serdes_group
++ * @{
++ */
++
++int max96724_get_available_pipe_id(struct device *dev, int vc_id);
++int max96724_get_ser_pipe_id(struct device *dev, int dser_pipe_id, int vc_id);
++int max96724_set_pipe(struct device *dev, int pipe_id, u8 data_type1,
++		      u8 data_type2, u32 vc_id);
++int max96724_release_pipe(struct device *dev, int pipe_id);
++void max96724_reset_oneshot(struct device *dev);
++
++/**
++ * @brief  Puts the deserializer in single exclusive link mode.
++ *
++ * @param  [in]  dev          The deserializer device handle.
++ * @param  [in]  s_dev        The sensor device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96724_setup_link(struct device *dev, struct device *s_dev);
++
++/**
++ * @brief  Sets up the deserializer link's control pipeline.
++ *
++ * Configures I2C pass-through, splitter mode if needed, and
++ * enables the tunnel mode pipe routing for the source.
++ *
++ * @param  [in]  dev          The deserializer device handle.
++ * @param  [in]  s_dev        The sensor device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96724_setup_control(struct device *dev, struct device *s_dev);
++
++/**
++ * @brief  Resets the deserializer link control pipeline.
++ *
++ * @param  [in]  dev          The deserializer device handle.
++ * @param  [in]  s_dev        The sensor device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96724_reset_control(struct device *dev, struct device *s_dev);
++
++/**
++ * @brief  Registers a source sensor device with the deserializer.
++ *
++ * @param  [in]  dev          The deserializer device handle.
++ * @param  [in]  g_ctx        The gmsl_link_ctx structure handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96724_sdev_register(struct device *dev, struct gmsl_link_ctx *g_ctx);
++
++/**
++ * @brief  Unregisters a source sensor device from the deserializer.
++ *
++ * @param  [in]  dev          The deserializer device handle.
++ * @param  [in]  s_dev        The sensor device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96724_sdev_unregister(struct device *dev, struct device *s_dev);
++
++/**
++ * @brief  Configures the internal streaming pipeline.
++ *
++ * Sets up tunnel mode pipe routing, CSI-2 output lane configuration,
++ * and MIPI PHY settings.
++ *
++ * @param  [in]  dev          The deserializer device handle.
++ * @param  [in]  s_dev        The sensor device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96724_setup_streaming(struct device *dev, struct device *s_dev);
++
++/**
++ * @brief  Enables streaming for a source sensor.
++ *
++ * @param  [in]  dev          The deserializer device handle.
++ * @param  [in]  s_dev        The sensor device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96724_start_streaming(struct device *dev, struct device *s_dev);
++
++/**
++ * @brief  Disables streaming for a source sensor.
++ *
++ * @param  [in]  dev          The deserializer device handle.
++ * @param  [in]  s_dev        The sensor device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96724_stop_streaming(struct device *dev, struct device *s_dev);
++
++/**
++ * @brief  Powers on the MAX96724 deserializer module.
++ *
++ * Asserts shared reset GPIO and powers on the regulator.
++ *
++ * @param  [in]  dev          The deserializer device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96724_power_on(struct device *dev);
++
++/**
++ * @brief  Powers off the MAX96724 deserializer module.
++ *
++ * @param  [in]  dev          The deserializer device handle.
++ */
++void max96724_power_off(struct device *dev);
++
++/**
++ * @brief  Applies initial register settings for the deserializer.
++ *
++ * Configures default pipe mappings, tunnel mode, and CSI output for
++ * the D5xx/SC1.2 use case.
++ *
++ * @param  [in]  dev          The deserializer device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96724_init_settings(struct device *dev);
++
++/**
++ * @brief  Maps deserializer pipe ID to serializer pipe ID.
++ *
++ * In tunnel mode with MAX96717, all data flows through a single pipe
++ * per camera, so the mapping is 1:1.
++ *
++ * @param  [in]  dev             The deserializer device handle.
++ * @param  [in]  dser_pipe_id    Deserializer pipe ID.
++ * @param  [in]  ser_pipe_id     Serializer pipe ID.
++ * @param  [in]  vc_id           VC ID associated with this pipe.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96724_bind_ser_to_dser_pipe(struct device *dev, int dser_pipe_id,
++				   int ser_pipe_id, u32 vc_id);
++
++/** @} */
++
++#endif  /* __MAX96724_H__ */
+-- 
+2.25.1
+

--- a/nvidia-oot/7.0/0011-Add-MAX96717-serializer-and-MAX96724-deserializer-dr.patch
+++ b/nvidia-oot/7.0/0011-Add-MAX96717-serializer-and-MAX96724-deserializer-dr.patch
@@ -1,0 +1,2896 @@
+From 40fac9b67ddea60055961d32fa89fe8f608396ff Mon Sep 17 00:00:00 2001
+From: RealSense AI <realsense@realsenseai.com>
+Date: Tue, 12 May 2026 17:06:23 +0800
+Subject: [PATCH] Add MAX96717 serializer and MAX96724 deserializer drivers for
+ tunnel mode
+
+Add MAX96717 GMSL2 serializer and MAX96724 GMSL2 quad deserializer
+drivers for Tunnel Mode operation with D5xx cameras.
+
+MAX96717 serializer features:
+- CSI-2 input with 2/4 lane support
+- Tunnel Mode encapsulation of full CSI-2 byte stream
+- I2C address translation for sensor passthrough
+- GPIO-over-GMSL tunneling hook for FSIN/FOUT signals
+
+MAX96724 quad deserializer features:
+- Up to 4 GMSL2 links (quad camera support)
+- Configurable link speed (3 Gbps / 6 Gbps via DT)
+- Tunnel Mode pipe routing and CSI-2 output
+- 2x4 and 4x2 CSI output mode support
+- Power management with GPIO reset and regulator control
+
+Signed-off-by: RealSense AI <realsense@realsenseai.com>
+---
+ drivers/media/i2c/Makefile   |    2 +
+ drivers/media/i2c/max96717.c |  797 ++++++++++++++++
+ drivers/media/i2c/max96724.c | 1690 ++++++++++++++++++++++++++++++++++
+ include/media/max96717.h     |  151 +++
+ include/media/max96724.h     |  183 +++
+ 5 files changed, 2823 insertions(+)
+ create mode 100644 drivers/media/i2c/max96717.c
+ create mode 100644 drivers/media/i2c/max96724.c
+ create mode 100644 include/media/max96717.h
+ create mode 100644 include/media/max96724.h
+
+diff --git a/drivers/media/i2c/Makefile b/drivers/media/i2c/Makefile
+index b284938..947e6e9 100644
+--- a/drivers/media/i2c/Makefile
++++ b/drivers/media/i2c/Makefile
+@@ -8,6 +8,8 @@ obj-m += max9296.o
+ subdir-ccflags-y += -DCONFIG_VIDEO_D4XX_SERDES
+ subdir-ccflags-y += -DCONFIG_TEGRA_CAMERA_PLATFORM
+ obj-m += d4xx.o
++obj-m += max96717.o
++obj-m += max96724.o
+ ifeq ($(findstring ack_src,$(NV_BUILD_KERNEL_OPTIONS)),)
+ obj-m += max96712.o
+ 
+diff --git a/drivers/media/i2c/max96717.c b/drivers/media/i2c/max96717.c
+new file mode 100644
+index 0000000..78d8a01
+--- /dev/null
++++ b/drivers/media/i2c/max96717.c
+@@ -0,0 +1,797 @@
++/*
++ * max96717.c - MAX96717 GMSL2 Serializer driver (Tunnel Mode)
++ *
++ * Copyright (c) 2026, RealSense, Inc.  All rights reserved.
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms and conditions of the GNU General Public License,
++ * version 2, as published by the Free Software Foundation.
++ *
++ * This program is distributed in the hope it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
++ * more details.
++ *
++ * You should have received a copy of the GNU General Public License
++ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
++ */
++
++/*
++ * Register Reference Sources:
++ * [PPTX]  = GMSL_MAX96717_MAX96724_TechOverview - V1.pptx
++ * [XML]   = MAX96717_MAX96724_HKR_EVB_700mbps_tunnel_mode_basedonexcelsheet_D585.xml
++ *
++ * Every register address and value below is traceable to one of these sources.
++ */
++
++#include <media/camera_common.h>
++#include <linux/module.h>
++#include <media/max96717.h>
++
++/* ===== Register Addresses ===== */
++
++/* [PPTX slide 7] REG0: Device ID (read-only, returns 0x40) */
++#define MAX96717_DEV_ADDR		0x00
++
++/* [PPTX slide 7] REG1: Link Speed
++ *   bit[3]=1: 3 Gbps, bit[4]=1: 6 Gbps
++ */
++#define MAX96717_REG1_ADDR		0x01
++
++/* [PPTX slide 7 / XML 0x0002] PIPE_EN: Pipe enable / soft reset
++ *   [XML] 0x03 = soft reset, 0x43 = pipes enabled + video init
++ *   [PPTX slide 7] Matches MAX9295 PIPE_EN at 0x02
++ */
++#define MAX96717_PIPE_EN_ADDR		0x02
++
++/* [PPTX slide 7] CTRL0: GMSL2 TX Control
++ *   bit[5]=1: GMSL2 mode, bit[0]=1: enable transmitter
++ *   0x21 = GMSL2 mode + TX enable on Link A
++ */
++#define MAX96717_CTRL0_ADDR		0x10
++
++/* [PPTX slide 7] CTRL3: Start Video - final enable bit
++ *   bit[0]=1: activate video stream
++ */
++#define MAX96717_CTRL3_ADDR		0x13
++
++/* [PPTX slide 7] TX1: FEC Enable
++ *   bit[6]=1: Reed-Solomon FEC enabled
++ */
++#define MAX96717_TX1_ADDR		0x29
++
++/* [MAX96724 Users Guide, I2C Broadcasting section, p44-46]
++ * MAX96717 I2C address translation registers (GMSL2 standard):
++ *   SRC_A / DST_A (0x42/0x43): Translation pair A (SER broadcast addr)
++ *   SRC_B / DST_B (0x44/0x45): Translation pair B (sensor passthrough)
++ *
++ * When host writes to SRC_B address, the MAX96717 translates it to
++ * DST_B and forwards via GMSL back-channel to the remote sensor.
++ *
++ */
++#define MAX96717_SRC_A_ADDR		0x42
++#define MAX96717_DST_A_ADDR		0x43
++#define MAX96717_I2C4_ADDR		0x44	/* SRC_B: sensor proxy addr */
++#define MAX96717_I2C5_ADDR		0x45	/* DST_B: sensor default addr */
++
++/* [PPTX slide 14] TX_STR_SEL: Stream ID select
++ *   bits[1:0]: stream ID for DES pipe routing
++ */
++#define MAX96717_TX_STR_SEL_ADDR	0x5B
++
++/* [PPTX slide 7 / XML 0x0110-0x0111] VIDEO_TX0/TX1: Video TX path config
++ *   [XML] 0x0110=0xE9, 0x0111=0x10 for tunnel mode data path
++ */
++#define MAX96717_VIDEO_TX0_ADDR		0x110
++#define MAX96717_VIDEO_TX1_ADDR		0x111
++
++/* [PPTX slide 7] FRONTTOP_0: Front-end topology
++ *   0x12 = single CSI-2 port A, all VCs pass through
++ */
++#define MAX96717_FRONTTOP0_ADDR		0x308
++
++/* [XML / PPTX slide 7] MIPI_RX0-RX3: CSI-2 receiver configuration
++ *   RX0 (0x330): CSI mode (0x00 = D-PHY controller A)
++ *   RX1 (0x331): Lane count - [PPTX slide 14] ctrl1_num_lanes bits[5:4]
++ *                 [XML] 0x30 = bits[5:4]=11 (4 lanes)
++ *   RX2 (0x332): Lane mapping - [XML] 0xE0 = default 1x4 map
++ *   RX3 (0x333): Lane mapping - [XML] 0x04 = default 1x4 map
++ */
++#define MAX96717_MIPI_RX0_ADDR		0x330
++#define MAX96717_MIPI_RX1_ADDR		0x331
++#define MAX96717_MIPI_RX2_ADDR		0x332
++#define MAX96717_MIPI_RX3_ADDR		0x333
++
++/* [PPTX slide 7 / slide 14] EXT11: TUNNEL MODE ENABLE
++ *   bit[7]=1: Tun_Mode = ON  *** CRITICAL REGISTER ***
++ *   [PPTX slide 7] 0x383 = 0x80
++ */
++#define MAX96717_EXT11_ADDR		0x383
++
++/* ===== Register Values ===== */
++
++/* [XML] Soft reset value for PIPE_EN register */
++#define MAX96717_SOFT_RESET		0x03
++
++/* [XML] Final enable: pipes enabled + video init */
++#define MAX96717_PIPE_EN_ALL		0x43
++
++/* [PPTX slide 7] CTRL0: GMSL2 mode + TX enable (Link A) */
++#define MAX96717_CTRL0_LINK_A		0x21
++/* CTRL0: GMSL2 mode + TX enable (Link B) */
++#define MAX96717_CTRL0_LINK_B		0x22
++
++/* [PPTX slide 7] CTRL0 reset all */
++#define MAX96717_RESET_ALL		0x80
++
++/* [PPTX slide 7] EXT11 tunnel mode enable value */
++#define MAX96717_TUN_MODE_EN		0x80
++
++/* [XML] VIDEO_TX0 tunnel mode data path enable */
++#define MAX96717_VIDEO_TX0_TUN		0xE9
++/* [XML] VIDEO_TX1 tunnel mode config */
++#define MAX96717_VIDEO_TX1_TUN		0x10
++
++/* [XML / PPTX slide 14] MIPI RX1: 4-lane CSI-2, bits[5:4]=11 */
++#define MAX96717_CSI_4_LANES		0x30
++/* 2-lane CSI-2, bits[5:4]=01 */
++#define MAX96717_CSI_2_LANES		0x10
++
++/* [XML] Lane mapping for 1x4 mode (matches MAX9295 1x4 values) */
++#define MAX96717_CSI_1X4_LANE_MAP1	0xE0
++#define MAX96717_CSI_1X4_LANE_MAP2	0x04
++
++/* [PPTX slide 7] FRONTTOP_0: single port A, all VCs */
++#define MAX96717_FRONTTOP0_PORT_A	0x12
++
++/* [XML] MIPI_RX0: CSI reset on + non-continuous clock */
++#define MAX96717_MIPI_RX0_RESET		0x08
++/* [PPTX slide 7] MIPI_RX0: Normal operation */
++#define MAX96717_MIPI_RX0_NORMAL	0x00
++
++/* [PPTX slide 9] REG1: 3 Gbps link speed, bit[3]=1 */
++#define MAX96717_LINK_SPEED_3GBPS	0x08
++/* [PPTX slide 9] REG1: 6 Gbps link speed, bit[4]=1 */
++#define MAX96717_LINK_SPEED_6GBPS	0x10
++
++/* [XML] EXT11 tunnel mode pre-config (0x0383=0x80) */
++#define MAX96717_EXT11_TUN_PRE		0x80
++
++#define MAX96717_MAX_PIPES		4
++
++/* ===== Data Structures ===== */
++
++struct max96717_client_ctx {
++	struct gmsl_link_ctx *g_ctx;
++	bool st_done;
++};
++
++struct max96717 {
++	struct i2c_client *i2c_client;
++	struct regmap *regmap;
++	struct max96717_client_ctx g_client;
++	struct mutex lock;
++	/* primary serializer properties */
++	__u32 def_addr;
++	__u32 pst2_ref;
++};
++
++static struct max96717 *prim_priv__;
++
++struct reg_pair {
++	u16 addr;
++	u8 val;
++};
++
++/* ===== Low-level I2C ===== */
++
++static int max96717_write_reg(struct device *dev, u16 addr, u8 val)
++{
++	struct max96717 *priv = dev_get_drvdata(dev);
++	int err;
++
++	err = regmap_write(priv->regmap, addr, val);
++	if (err)
++		dev_err(dev, "%s:i2c write failed, 0x%x = %x\n",
++			__func__, addr, val);
++
++	/* delay before next i2c command as required for SERDES link */
++	usleep_range(100, 110);
++
++	return err;
++}
++
++static int max96717_set_registers(struct device *dev, struct reg_pair *map,
++				  u32 count)
++{
++	int err = 0;
++	u32 j;
++
++	for (j = 0; j < count; j++) {
++		err = max96717_write_reg(dev, map[j].addr, map[j].val);
++		if (err)
++			break;
++	}
++
++	return err;
++}
++
++/* ===== Streaming Setup ===== */
++
++/*
++ * max96717_setup_streaming - Configure CSI-2 input and enable Tunnel Mode
++ *
++ * In Tunnel Mode (unlike MAX9295 Pixel Mode), the serializer encapsulates
++ * the entire CSI-2 byte stream verbatim into a single GMSL2 tunnel.
++ * All VCs (VC0-VC3) are preserved end-to-end.
++ */
++int max96717_setup_streaming(struct device *dev)
++{
++	struct max96717 *priv = dev_get_drvdata(dev);
++	int err = 0;
++	struct gmsl_link_ctx *g_ctx;
++	u32 lane_count;
++
++	/*
++	 * [XML] Full initialization sequence:
++	 *   0x0002 = 0x03  (soft reset)
++	 *   0x0383 = 0x80  (tunnel mode enable)
++	 *   0x0331 = 0x30  (4-lane CSI)
++	 *   0x0332 = 0xE0  (lane map1)
++	 *   0x0333 = 0x04  (lane map2)
++	 *   0x0110 = 0xE9  (video TX0 tunnel path)
++	 *   0x0111 = 0x10  (video TX1 tunnel config)
++	 *   0x0330 = 0x08  (CSI reset on)
++	 *   0x0330 = 0x00  (CSI reset off)
++	 *   0x0002 = 0x43  (final enable)
++	 */
++	struct reg_pair tunnel_init[] = {
++		/* [PPTX slide 7] EXT11: Tunnel Mode Enable */
++		{MAX96717_EXT11_ADDR, MAX96717_TUN_MODE_EN},
++		/* [XML] VIDEO_TX0/TX1: tunnel data path */
++		{MAX96717_VIDEO_TX0_ADDR, MAX96717_VIDEO_TX0_TUN},
++		{MAX96717_VIDEO_TX1_ADDR, MAX96717_VIDEO_TX1_TUN},
++	};
++
++	mutex_lock(&priv->lock);
++
++	if (!priv->g_client.g_ctx) {
++		dev_err(dev, "%s: no sdev client found\n", __func__);
++		err = -EINVAL;
++		goto error;
++	}
++
++	if (priv->g_client.st_done) {
++		dev_dbg(dev, "%s: stream setup is already done\n", __func__);
++		goto error;
++	}
++
++	g_ctx = priv->g_client.g_ctx;
++
++	/*
++	 * [Aardvark-verified] Soft reset before tunnel mode configuration
++	 * Clears stale pipe/CSI state for clean initialization.
++	 * Aardvark: 0x0002=0x03, sleep 30ms, then proceed with config.
++	 */
++	max96717_write_reg(dev, MAX96717_PIPE_EN_ADDR, MAX96717_SOFT_RESET);
++	msleep(30);
++
++	/*
++	 * [PPTX slide 14] ctrl1_num_lanes at 0x0331 bits[5:4]
++	 * [XML] 0x0331 = 0x30 for 4-lane
++	 * MAX96717 supports 1x4 mode only (single 4-lane D-PHY input)
++	 */
++	lane_count = (g_ctx->num_csi_lanes == 4) ?
++		MAX96717_CSI_4_LANES : MAX96717_CSI_2_LANES;
++
++	max96717_write_reg(dev, MAX96717_MIPI_RX1_ADDR, lane_count);
++
++	/* [XML] Lane mapping: 1x4 mode default */
++	max96717_write_reg(dev, MAX96717_MIPI_RX2_ADDR,
++			   MAX96717_CSI_1X4_LANE_MAP1);
++	max96717_write_reg(dev, MAX96717_MIPI_RX3_ADDR,
++			   MAX96717_CSI_1X4_LANE_MAP2);
++
++	/* Enable tunnel mode and configure video TX path */
++	err = max96717_set_registers(dev, tunnel_init,
++				     ARRAY_SIZE(tunnel_init));
++	if (err)
++		goto error;
++
++	/* [Aardvark-verified] CSI reset cycle with 2ms delay */
++	max96717_write_reg(dev, MAX96717_MIPI_RX0_ADDR,
++			   MAX96717_MIPI_RX0_RESET);
++	usleep_range(2000, 2100);
++	max96717_write_reg(dev, MAX96717_MIPI_RX0_ADDR,
++			   MAX96717_MIPI_RX0_NORMAL);
++
++	/* [XML] Final enable: pipes on + video init */
++	max96717_write_reg(dev, MAX96717_PIPE_EN_ADDR,
++			   MAX96717_PIPE_EN_ALL);
++
++	priv->g_client.st_done = true;
++
++error:
++	mutex_unlock(&priv->lock);
++	return err;
++}
++EXPORT_SYMBOL(max96717_setup_streaming);
++
++/* ===== Control Setup ===== */
++
++/*
++ * max96717_setup_control - Set up I2C address translation and link control
++ *
++ * Steps:
++ *   1. Reassign serializer I2C address via DEV_ADDR (reg 0x00)
++ *   2. Configure GMSL2 link mode via CTRL0 (reg 0x10)
++ *   3. Set I2C address translation for sensor passthrough:
++ *      I2C4/SRC_B (0x44) <- (sdev_reg << 1): proxy addr visible to host
++ *      I2C5/DST_B (0x45) <- (sdev_def << 1): real addr on back-channel
++ *
++ * This lets the Orin host access the D5xx sensor (def-addr 0x42) via
++ * the aliased proxy address (e.g. 0x1a) through the GMSL link.
++ *
++ */
++int max96717_setup_control(struct device *dev)
++{
++	struct max96717 *priv = dev_get_drvdata(dev);
++	int err = 0;
++	struct gmsl_link_ctx *g_ctx;
++
++	mutex_lock(&priv->lock);
++
++	if (!priv->g_client.g_ctx) {
++		dev_err(dev, "%s: no sensor dev client found\n", __func__);
++		err = -EINVAL;
++		goto error;
++	}
++
++	g_ctx = priv->g_client.g_ctx;
++
++	if (prim_priv__) {
++		/*
++		 * [HW note] The MAX96717 retains its I2C address across
++		 * reboots (PoC stays on).  If already at the aliased address,
++		 * the DEV_ADDR write to 0x40 NACKs.  Skip reassignment when
++		 * the primary and alias are the same physical device and the
++		 * serializer is already responsive at a non-default address.
++		 *
++		 * For cold-start (first power-on), this write is required.
++		 * We detect "already reassigned" by trying a read first:
++		 * if the primary address (0x40) NACKs, skip the reassign.
++		 */
++		unsigned int dev_id;
++		int probe_ret;
++
++		probe_ret = regmap_read(prim_priv__->regmap,
++					MAX96717_DEV_ADDR, &dev_id);
++		if (probe_ret == 0) {
++			/* Primary address (0x40) still responsive — do reassign */
++			max96717_write_reg(&prim_priv__->i2c_client->dev,
++					   MAX96717_DEV_ADDR,
++					   (g_ctx->ser_reg << 1));
++		} else {
++			dev_info(&prim_priv__->i2c_client->dev,
++				 "%s: SER already reassigned (addr 0x40 NACK), skipping DEV_ADDR write\n",
++				 __func__);
++		}
++	}
++
++	/* [PPTX slide 7] CTRL0: GMSL2 mode + TX enable */
++	if (g_ctx->serdes_csi_link == GMSL_SERDES_CSI_LINK_A)
++		err = max96717_write_reg(dev, MAX96717_CTRL0_ADDR,
++					 MAX96717_CTRL0_LINK_A);
++	else
++		err = max96717_write_reg(dev, MAX96717_CTRL0_ADDR,
++					 MAX96717_CTRL0_LINK_B);
++
++	if (err) {
++		dev_err(dev, "%s: ERROR: ser device not found\n", __func__);
++		goto error;
++	}
++
++	/* delay to settle link */
++	msleep(100);
++
++	/*
++	 * I2C address translation for sensor passthrough.
++	 * [MAX96724 Users Guide, I2C Broadcasting, p44-46]
++	 *
++	 * I2C4 / SRC_B (0x44): sensor proxy addr visible to Orin host
++	 * I2C5 / DST_B (0x45): sensor real addr on GMSL back-channel
++	 *
++	 * When host sends I2C to sdev_reg (e.g., 0x1a), the MAX96717
++	 * translates it to sdev_def (e.g., 0x42) and forwards via GMSL
++	 * back-channel to the HKR sensor.
++	 */
++	max96717_write_reg(dev, MAX96717_I2C4_ADDR,
++			   (g_ctx->sdev_reg << 1));
++	max96717_write_reg(dev, MAX96717_I2C5_ADDR,
++			   (g_ctx->sdev_def << 1));
++
++	/* dev addr pass-through ref */
++	if (prim_priv__)
++		prim_priv__->pst2_ref++;
++
++	g_ctx->serdev_found = true;
++
++error:
++	mutex_unlock(&priv->lock);
++	return err;
++}
++EXPORT_SYMBOL(max96717_setup_control);
++
++/* ===== GPIO Tunneling ===== */
++
++/*
++ * max96717_setup_gpio_tunneling - GPIO-over-GMSL no-op hook
++ *
++ * [PPTX slide 10] GPIO Signal Mapping:
++ *   MFP0 → GPIO0: FSIN (DES→SER, frame sync in)
++ *   MFP1 → GPIO1: FOUT/STROBE (SER→DES, frame sync out)
++ *   MFP4 → GPIO4: RESET_N (DES→SER, hard reset)
++ *   MFP5 → GPIO5: IRQ (SER→DES, interrupt request)
++ *   MFP6 → GPIO6: ZV_SYNC (DES→SER, IR stereo sync)
++ *
++ * The PPTX defines the signal mapping and MFP_CFG register range,
++ * but not the confirmed direction/function values. Keep this as
++ * an explicit no-op hook until the MAX96717 GPIO register values
++ * are available from ADI.
++ */
++int max96717_setup_gpio_tunneling(struct device *dev)
++{
++	struct max96717 *priv = dev_get_drvdata(dev);
++	int err = 0;
++
++	mutex_lock(&priv->lock);
++
++	dev_info(dev, "%s: GPIO tunneling hook is a no-op; MFP_CFG values are not defined yet\n",
++		 __func__);
++
++	mutex_unlock(&priv->lock);
++
++	return err;
++}
++EXPORT_SYMBOL(max96717_setup_gpio_tunneling);
++
++/* ===== Reset Control ===== */
++
++int max96717_reset_control(struct device *dev)
++{
++	struct max96717 *priv = dev_get_drvdata(dev);
++	int err = 0;
++
++	mutex_lock(&priv->lock);
++	if (!priv->g_client.g_ctx) {
++		dev_err(dev, "%s: no sdev client found\n", __func__);
++		err = -EINVAL;
++		goto error;
++	}
++
++	priv->g_client.st_done = false;
++
++	if (prim_priv__) {
++		prim_priv__->pst2_ref--;
++
++		max96717_write_reg(dev, MAX96717_DEV_ADDR,
++				   (prim_priv__->def_addr << 1));
++		if (prim_priv__->pst2_ref == 0)
++			max96717_write_reg(&prim_priv__->i2c_client->dev,
++					   MAX96717_CTRL0_ADDR,
++					   MAX96717_RESET_ALL);
++	}
++
++error:
++	mutex_unlock(&priv->lock);
++	return err;
++}
++EXPORT_SYMBOL(max96717_reset_control);
++
++/* ===== Device Pairing ===== */
++
++int max96717_sdev_pair(struct device *dev, struct gmsl_link_ctx *g_ctx)
++{
++	struct max96717 *priv;
++	int err = 0;
++
++	if (!dev || !g_ctx || !g_ctx->s_dev) {
++		dev_err(dev, "%s: invalid input params\n", __func__);
++		return -EINVAL;
++	}
++
++	priv = dev_get_drvdata(dev);
++	mutex_lock(&priv->lock);
++	if (priv->g_client.g_ctx) {
++		/* Already paired — tolerate if this is a re-probe of
++		 * the same camera after a failed first attempt.
++		 * Simply overwrite with the new g_ctx.
++		 */
++		dev_warn(dev, "%s: re-pairing (previous probe may have failed)\n",
++			 __func__);
++	}
++
++	priv->g_client.st_done = false;
++	priv->g_client.g_ctx = g_ctx;
++
++	/* mutex_unlock in error path, but we have none — inline the unlock */
++	mutex_unlock(&priv->lock);
++	return err;
++}
++EXPORT_SYMBOL(max96717_sdev_pair);
++
++int max96717_sdev_unpair(struct device *dev, struct device *s_dev)
++{
++	struct max96717 *priv = NULL;
++	int err = 0;
++
++	if (!dev || !s_dev) {
++		dev_err(dev, "%s: invalid input params\n", __func__);
++		return -EINVAL;
++	}
++
++	priv = dev_get_drvdata(dev);
++
++	mutex_lock(&priv->lock);
++
++	if (!priv->g_client.g_ctx) {
++		dev_dbg(dev, "%s: device is not paired\n", __func__);
++		err = 0; /* Not an error — already unpaired */
++		goto error;
++	}
++
++	if (priv->g_client.g_ctx->s_dev != s_dev) {
++		dev_warn(dev, "%s: s_dev mismatch, clearing anyway\n", __func__);
++	}
++
++	priv->g_client.g_ctx = NULL;
++	priv->g_client.st_done = false;
++
++error:
++	mutex_unlock(&priv->lock);
++	return err;
++}
++EXPORT_SYMBOL(max96717_sdev_unpair);
++
++/* ===== Pipe Configuration ===== */
++
++/*
++ * __max96717_set_pipe - Configure a single pipe's DT/VC mapping
++ *
++ * In Tunnel Mode, per-pipe DT/VC filtering is bypassed on the serializer。
++ * However, we still write the registers for d4xx framework compatibility.
++ *
++ */
++static int __max96717_set_pipe(struct device *dev, int pipe_id, u8 data_type1,
++			       u8 data_type2, u32 vc_id)
++{
++	int err = 0;
++	u8 bpp = 0x30;
++
++	struct reg_pair map_pipe_control[] = {
++		/* Pipe X DT addr + 0x2*pipe_id */
++		{0x0314, 0x5E},  /* data_type1 */
++		{0x0315, 0x52},  /* data_type2 */
++		{0x0309, 0x01},  /* VC select */
++		{0x030A, 0x00},
++		{0x031C, 0x30},  /* BPP */
++		{0x0102, 0x0E},  /* LIM_HEART: Disabled */
++	};
++
++	if (data_type1 == GMSL_CSI_DT_RGB_888)
++		bpp = 0x18;
++
++	map_pipe_control[0].addr += 0x2 * pipe_id;
++	map_pipe_control[1].addr += 0x2 * pipe_id;
++	map_pipe_control[2].addr += 0x2 * pipe_id;
++	map_pipe_control[3].addr += 0x2 * pipe_id;
++	map_pipe_control[4].addr += 0x1 * pipe_id;
++	map_pipe_control[5].addr += 0x8 * pipe_id;
++
++	map_pipe_control[0].val = 0x40 | data_type1;
++	map_pipe_control[1].val = 0x40 | data_type2;
++	if (pipe_id == 0)
++		map_pipe_control[1].val |= 0x80;
++	map_pipe_control[2].val = 1 << vc_id;
++	map_pipe_control[3].val = 0x00;
++	map_pipe_control[4].val = bpp;
++	map_pipe_control[5].val = 0x0E;
++
++	err = max96717_set_registers(dev, map_pipe_control,
++				     ARRAY_SIZE(map_pipe_control));
++
++	return err;
++}
++
++/*
++ * max96717_init_settings - Initialize default pipe/streaming settings
++ *
++ * In Tunnel Mode, per-pipe DT config is not functionally needed
++ * but we configure pipes for d4xx compatibility.
++ * Default: 4 pipes with YUV422_8 + EMBED, VC0-3.
++ */
++int max96717_init_settings(struct device *dev)
++{
++	int err = 0;
++	int i;
++	struct max96717 *priv = dev_get_drvdata(dev);
++
++	struct reg_pair map_init[] = {
++		/* [XML seq] PIPE_EN soft reset first, then enable tunnel mode.
++		 * Note: FRONTTOP0 is bypassed in tunnel mode (per UG) —
++		 * CSI-2 input goes directly into the tunnel, no port config needed.
++		 */
++		{MAX96717_PIPE_EN_ADDR, MAX96717_SOFT_RESET},
++		{MAX96717_EXT11_ADDR, MAX96717_TUN_MODE_EN},
++		{MAX96717_PIPE_EN_ADDR, 0xF3},
++		{MAX96717_MIPI_RX1_ADDR, MAX96717_CSI_4_LANES},
++	};
++
++	mutex_lock(&priv->lock);
++
++	/*
++	 * [HW requirement] After CTRL0 + I2C translation writes in
++	 * setup_control, the MAX96717 needs settling time before
++	 * accepting writes to PIPE_EN (0x02) and FRONTTOP registers.
++	 */
++	usleep_range(5000, 6000);
++
++	err = max96717_set_registers(dev, map_init, ARRAY_SIZE(map_init));
++
++	for (i = 0; i < MAX96717_MAX_PIPES; i++)
++		err |= __max96717_set_pipe(dev, i, GMSL_CSI_DT_YUV422_8,
++					   GMSL_CSI_DT_EMBED, i);
++
++	mutex_unlock(&priv->lock);
++
++	return err;
++}
++EXPORT_SYMBOL(max96717_init_settings);
++
++int max96717_set_pipe(struct device *dev, int pipe_id,
++		      u8 data_type1, u8 data_type2, u32 vc_id)
++{
++	struct max96717 *priv = dev_get_drvdata(dev);
++	int err = 0;
++
++	if (pipe_id > (MAX96717_MAX_PIPES - 1)) {
++		dev_info(dev, "%s: input pipe_id: %d exceeds max96717 max pipes\n",
++			 __func__, pipe_id);
++		return -EINVAL;
++	}
++
++	dev_dbg(dev, "%s pipe_id %d, data_type1 %u, data_type2 %u, vc_id %u\n",
++		__func__, pipe_id, data_type1, data_type2, vc_id);
++
++	mutex_lock(&priv->lock);
++
++	err = __max96717_set_pipe(dev, pipe_id, data_type1, data_type2, vc_id);
++
++	mutex_unlock(&priv->lock);
++
++	return err;
++}
++EXPORT_SYMBOL(max96717_set_pipe);
++
++/**
++ * max96717_retrigger_tx - Toggle SER TX to restore tunnel detection after
++ * a DES ONESHOT.  DES ONESHOT resets the data path; the SER must cycle
++ * its TX enable for the DES to re-acquire the tunnel stream.
++ */
++void max96717_retrigger_tx(struct device *dev)
++{
++	max96717_write_reg(dev, MAX96717_PIPE_EN_ADDR, MAX96717_SOFT_RESET);
++	msleep(30);
++	max96717_write_reg(dev, MAX96717_PIPE_EN_ADDR, MAX96717_PIPE_EN_ALL);
++}
++EXPORT_SYMBOL(max96717_retrigger_tx);
++
++/* ===== Probe / Remove ===== */
++
++static struct regmap_config max96717_regmap_config = {
++	.reg_bits = 16,
++	.val_bits = 8,
++	.cache_type = REGCACHE_RBTREE,
++};
++
++static int max96717_probe(struct i2c_client *client,
++			   const struct i2c_device_id *id)
++{
++	struct max96717 *priv;
++	int err = 0;
++	struct device_node *node = client->dev.of_node;
++
++	dev_info(&client->dev, "[MAX96717]: probing GMSL2 Serializer (Tunnel Mode)\n");
++
++	priv = devm_kzalloc(&client->dev, sizeof(*priv), GFP_KERNEL);
++	if (!priv)
++		return -ENOMEM;
++
++	priv->i2c_client = client;
++	priv->regmap = devm_regmap_init_i2c(priv->i2c_client,
++					     &max96717_regmap_config);
++	if (IS_ERR(priv->regmap)) {
++		dev_err(&client->dev,
++			"regmap init failed: %ld\n", PTR_ERR(priv->regmap));
++		return -ENODEV;
++	}
++
++	mutex_init(&priv->lock);
++
++	if (of_get_property(node, "is-prim-ser", NULL)) {
++		if (prim_priv__) {
++			dev_err(&client->dev,
++				"prim-ser already exists\n");
++			return -EEXIST;
++		}
++
++		err = of_property_read_u32(node, "reg", &priv->def_addr);
++		if (err < 0) {
++			dev_err(&client->dev, "reg not found\n");
++			return -EINVAL;
++		}
++
++		prim_priv__ = priv;
++	}
++
++	dev_set_drvdata(&client->dev, priv);
++
++	dev_info(&client->dev, "%s: success\n", __func__);
++
++	return err;
++}
++
++static int max96717_remove(struct i2c_client *client)
++{
++	struct max96717 *priv;
++
++	if (client != NULL) {
++		priv = dev_get_drvdata(&client->dev);
++		mutex_destroy(&priv->lock);
++		i2c_unregister_device(client);
++		client = NULL;
++	}
++
++	return 0;
++}
++
++static const struct i2c_device_id max96717_id[] = {
++	{ "max96717", 0 },
++	{ },
++};
++
++static const struct of_device_id max96717_of_match[] = {
++	{ .compatible = "adi,max96717", },
++	{ .compatible = "maxim,max96717", },
++	{ },
++};
++MODULE_DEVICE_TABLE(of, max96717_of_match);
++MODULE_DEVICE_TABLE(i2c, max96717_id);
++
++static struct i2c_driver max96717_i2c_driver = {
++	.driver = {
++		.name = "max96717",
++		.owner = THIS_MODULE,
++		.of_match_table = of_match_ptr(max96717_of_match),
++	},
++	.probe = max96717_probe,
++	.remove = max96717_remove,
++	.id_table = max96717_id,
++};
++
++static int __init max96717_init(void)
++{
++	return i2c_add_driver(&max96717_i2c_driver);
++}
++
++static void __exit max96717_exit(void)
++{
++	i2c_del_driver(&max96717_i2c_driver);
++}
++
++module_init(max96717_init);
++module_exit(max96717_exit);
++
++MODULE_DESCRIPTION("GMSL2 Serializer driver max96717 (Tunnel Mode)");
++MODULE_AUTHOR("RealSense AI");
++MODULE_LICENSE("GPL v2");
+diff --git a/drivers/media/i2c/max96724.c b/drivers/media/i2c/max96724.c
+new file mode 100644
+index 0000000..7286ff4
+--- /dev/null
++++ b/drivers/media/i2c/max96724.c
+@@ -0,0 +1,1690 @@
++/*
++ * max96724.c - MAX96724 GMSL2 Quad Deserializer driver (Tunnel Mode)
++ *
++ * Copyright (c) 2026, RealSense, Inc.  All rights reserved.
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms and conditions of the GNU General Public License,
++ * version 2, as published by the Free Software Foundation.
++ *
++ * This program is distributed in the hope it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
++ * more details.
++ *
++ * You should have received a copy of the GNU General Public License
++ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
++ */
++
++
++#include <linux/gpio.h>
++#include <linux/module.h>
++#include <linux/of.h>
++#include <linux/of_device.h>
++#include <linux/of_gpio.h>
++#include <media/camera_common.h>
++#include <linux/module.h>
++#include <media/max96724.h>
++
++/* ================================================================
++ * Register Addresses
++ * ================================================================ */
++
++/* --- Device ID / Configuration --- */
++
++/* [UG p.3] REG0: Device ID (read-only, returns 0xA2) */
++#define MAX96724_DEV_ID_ADDR		0x00
++
++/* [Errata §5] ERRB master reset register */
++#define MAX96724_ERRB_MST_RST_ADDR	0x05
++
++/* [UG Table 3, p.11] 0x0006: GMSL Link/PHY Enable and Mode Select
++ *   bits[7:4]: PHY mode (0=GMSL1, 1=GMSL2) per link D/C/B/A
++ *   bits[3:0]: Link Enable per link D/C/B/A
++ */
++#define MAX96724_LINK_EN_ADDR		0x0006
++
++/* [UG Table 3, p.11] 0x0010: GMSL Link/PHY Rate Select (Links A&B)
++ *   bits[7:6]: Tx Rate Link B, bits[5:4]: Rx Rate Link B
++ *   bits[3:2]: Tx Rate Link A, bits[1:0]: Rx Rate Link A
++ *   Tx: 00=187.5Mbps, Rx: 01=3Gbps, 10=6Gbps
++ */
++#define MAX96724_LINK_RATE_AB_ADDR	0x0010
++
++/* [UG Table 3, p.12] 0x0011: GMSL Link/PHY Rate Select (Links C&D) */
++#define MAX96724_LINK_RATE_CD_ADDR	0x0011
++
++/* [UG p.13] 0x001A: Link A lock status (bit[3]=LOCK) */
++#define MAX96724_LINK_A_LOCK_ADDR	0x001A
++
++/* [UG Table 3, p.12] 0x0018: GMSL Link Reset
++ *   bits[7:4]: Link reset D/C/B/A, bits[3:0]: One-shot reset D/C/B/A
++ */
++#define MAX96724_ONESHOT_ADDR		0x0018
++
++/* [UG p.11] REG13: Soft Reset (write 0x40, wait 5ms) */
++#define MAX96724_REG13_ADDR		0x000D
++
++/* [Errata §5] Error Channel Power Up registers (required for 6Gbps)
++ *   Write 0x75 immediately after power-up for robust 6Gbps operation
++ */
++#define MAX96724_ERRCH_A_ADDR		0x1449
++#define MAX96724_ERRCH_B_ADDR		0x1549
++#define MAX96724_ERRCH_C_ADDR		0x1649
++#define MAX96724_ERRCH_D_ADDR		0x1749
++#define MAX96724_ERRCH_FORCE_ON		0x75
++
++/* --- I2C Control Channel / Errata --- */
++
++/* [Errata #2] Tunnel Mode SRAM LCRC error suppression
++ *   Set 0x458[7:4] = 0x0 to suppress spurious ERRB in tunnel mode
++ */
++#define MAX96724_SRAM_LCRC_ERR_ADDR	0x0458
++
++/* --- Video Pipe Selection --- */
++
++/*
++ *   bits[3:0] = Pipe 0 source (0x0=SIOA)
++ *   bits[7:4] = Pipe 1 source (0x1=SIOB)
++ */
++#define MAX96724_PIPE_SEL0_ADDR		0xF0
++
++/*
++ *   bits[3:0] = Pipe 2 source (0x2=SIOC)
++ *   bits[7:4] = Pipe 3 source (0x3=SIOD)
++ */
++#define MAX96724_PIPE_SEL1_ADDR		0xF1
++
++/*
++ *   bit[0]=Pipe 0, bit[1]=Pipe 1, bit[2]=Pipe 2, bit[3]=Pipe 3
++ */
++#define MAX96724_PIPE_EN_ADDR		0xF4
++
++/* --- Pipe Receiver / Tunnel Mode --- */
++
++/*
++ *   bit[5]=1: Tunnel Mode, bits[1:0]=11: 4-lane MIPI out
++ *   Stride: 0x12 per pipe (P0=0x100, P1=0x112, P2=0x124, P3=0x136)
++ */
++#define MAX96724_VID_RX0_P0_ADDR	0x100
++#define MAX96724_VID_RX6_P0_ADDR	0x106
++#define MAX96724_VID_RX_STRIDE		0x12
++
++#define MAX96724_VID_RX1_P0_ADDR	0x101
++
++/* --- CSI-2 Output (BACKTOP) --- */
++
++/* [UG p.19] BACKTOP: CSI-2 output port enable
++ *   0x040B bit[1]=CSIB_EN, bit[0]=CSIA_EN
++ */
++#define MAX96724_BACKTOP_EN_ADDR	0x040B
++
++/* --- MIPI DPLL (Data Rate) --- */
++
++/* [UG Table 12, p.27] MIPI PHY DPLL Freq registers
++ *   bits[4:0] = frequency in multiples of 100MHz
++ *   bit[5]    = DPLL enable (must be set for DPLL to lock)
++ *   E.g., 0x27 = 700MHz + enable = 700Mbps/lane D-PHY
++ *   E.g., 0x2F = 1500MHz + enable = 1.5Gbps/lane
++ */
++#define MAX96724_DPLL_FREQ0_ADDR	0x0415
++#define MAX96724_DPLL_FREQ1_ADDR	0x0418
++#define MAX96724_DPLL_FREQ2_ADDR	0x041B
++#define MAX96724_DPLL_FREQ3_ADDR	0x041E
++
++/* [UG] DPLL PHY reset control
++ *   0x1D00 = DPLL CSI PHY1 control
++ *   Write 0xF4 to disable/reset, 0xF5 to enable
++ */
++#define MAX96724_DPLL_CSI2_ADDR		0x1D00
++#define MAX96724_DPLL_DISABLE		0xF4
++#define MAX96724_DPLL_ENABLE		0xF5
++
++/* --- CSI-2 Output PHY Configuration --- */
++
++/* [UG Table 12, p.25] MIPI PHY Mode Select register
++ *   bit[0]: 4x2 mode, bit[2]: 2x4 mode (Port A=PHY0+1, Port B=PHY2+3)
++ *   bit[3]: 2x4 alt mode (Port B=PHY0+1, Port A=PHY2+3)
++ */
++#define MAX96724_CSI_OUT_CFG_ADDR	0x08A0
++
++/* [UG Table 12, p.25] MIPI PHY Enable register
++ *   bits[7:4]: Enable PHY 3/2/1/0 (1=enabled, 0=standby)
++ */
++#define MAX96724_CSI_PHY_EN_ADDR	0x08A2
++
++/* [UG Table 12, p.25] MIPI PHY 0 and 1 Lane Mapping */
++#define MAX96724_CSI_LANE_MAP1_ADDR	0x08A3
++
++/* [UG Table 12, p.26] MIPI PHY 2 and 3 Lane Mapping */
++#define MAX96724_CSI_LANE_MAP2_ADDR	0x08A4
++
++/* [UG p.22] Pipe-to-controller mapping (Method 1) */
++#define MAX96724_MIPI_CTRL_SEL_ADDR	0x08CA
++
++/* --- Lane Control per pipe (stride 0x40) --- */
++
++/*
++ *   0xC0 = 4-lane enabled
++ */
++#define MAX96724_LANE_CTRL0_ADDR	0x090A
++#define MAX96724_LANE_CTRL1_ADDR	0x094A
++#define MAX96724_LANE_CTRL2_ADDR	0x098A
++#define MAX96724_LANE_CTRL3_ADDR	0x09CA
++
++/* --- Pipe Mapping Registers (stride 0x40 per pipe) --- */
++
++/*
++ *   Base addresses for Pipe X (Pipe 0)
++ *   Stride: 0x40 per pipe
++ */
++#define MAX96724_TX11_PIPE_X_EN_ADDR		0x090B
++#define MAX96724_TX45_PIPE_X_DST_CTRL_ADDR	0x092D
++#define MAX96724_PIPE_X_SRC_0_MAP_ADDR		0x090D
++#define MAX96724_PIPE_X_DST_0_MAP_ADDR		0x090E
++#define MAX96724_PIPE_X_SRC_1_MAP_ADDR		0x090F
++#define MAX96724_PIPE_X_DST_1_MAP_ADDR		0x0910
++#define MAX96724_PIPE_X_SRC_2_MAP_ADDR		0x0911
++#define MAX96724_PIPE_X_DST_2_MAP_ADDR		0x0912
++#define MAX96724_PIPE_X_SRC_3_MAP_ADDR		0x0913
++#define MAX96724_PIPE_X_DST_3_MAP_ADDR		0x0914
++
++/* --- Stream Select --- */
++
++/*
++ *   Pipe X=0x0933, stride 0x40 per pipe
++ */
++#define MAX96724_PIPE_X_ST_SEL_ADDR	0x0933
++
++/* --- Extended Pipe Mapping (DST_CTRL2-4 / TX49) --- */
++
++/* [Excel: MIPI_TX46-48] Extended DST_CTRL for additional mapping pairs
++ *   All to PHY1 (0x55), same as TX45
++ *   Stride: 0x40 per pipe (base = Pipe X)
++ */
++#define MAX96724_TX46_PIPE_X_ADDR	0x092E
++#define MAX96724_TX47_PIPE_X_ADDR	0x092F
++#define MAX96724_TX48_PIPE_X_ADDR	0x0930
++
++/* [UG p.30 + Aardvark-verified] MIPI_TX49 synchronous concatenation control
++ *   In tunnel mode, this register MUST be 0x87 for MIPI TX output to function.
++ *   Verified: setting to 0x00 disables tunnel output entirely (0x8D0 all zeros).
++ *   Stride: 0x40 per pipe (base = Pipe X)
++ */
++#define MAX96724_TX49_PIPE_X_ADDR	0x0931
++#define MAX96724_TX49_CONCAT_4W		0x87
++
++/* --- Tunnel Mode per-pipe --- */
++
++/*
++ *   bit[0] = TUN_EN, Default=0x08, write 0x09 to enable
++ */
++#define MAX96724_PIPE0_TUN_EN_ADDR	0x0936
++#define MAX96724_PIPE1_TUN_EN_ADDR	0x0976
++#define MAX96724_PIPE2_TUN_EN_ADDR	0x09B6
++#define MAX96724_PIPE3_TUN_EN_ADDR	0x09F6
++
++/*
++ *   bit[6]: disable auto-tunnel-detect
++ *   bits[5:4]: TUN_DEST (00=PHY0, 01=PHY1, 10=PHY2, 11=PHY3)
++ */
++#define MAX96724_PIPE0_TUN_DEST_ADDR	0x0939
++#define MAX96724_PIPE1_TUN_DEST_ADDR	0x0979
++#define MAX96724_PIPE2_TUN_DEST_ADDR	0x09B9
++#define MAX96724_PIPE3_TUN_DEST_ADDR	0x09F9
++
++/* ================================================================
++ * Register Values
++ * ================================================================ */
++
++/* [UG p.12] Soft reset value (write to 0x000D) */
++#define MAX96724_SOFT_RESET		0x40
++
++/* [UG Table 3, p.11-12] Link Rate values for 0x0010/0x0011
++ *   Per link pair: bits[1:0]=RxA, [3:2]=TxA, [5:4]=RxB, [7:6]=TxB
++ *   Tx = 00 (187.5Mbps), Rx = 01 (3Gbps) or 10 (6Gbps)
++ *   3Gbps: Tx=00, Rx=01 → per pair 0x01, both pairs = 0x01 in low nibble
++ */
++#define MAX96724_LINK_RATE_3GBPS	0x01  /* Rx=3G, Tx=187.5M for one link pair */
++#define MAX96724_LINK_RATE_6GBPS	0x02  /* Rx=6G, Tx=187.5M for one link pair */
++
++/* [UG Table 3, p.11] 0x0006: Link enable / mode values
++ *   bits[7:4] = PHY mode (1=GMSL2 per link)
++ *   bits[3:0] = Link enable per link
++ *   0xF1 = all GMSL2-mode, only Link A enabled
++ *   0xFF = all GMSL2-mode, all 4 links enabled
++ */
++#define MAX96724_LINK_EN_SIOA		0xF1  /* GMSL2 all, enable Link A only */
++#define MAX96724_LINK_EN_ALL		0xFF  /* GMSL2 all, enable all links */
++
++/* [UG p.19] BACKTOP_EN (0x040B): CSI output port enable */
++#define MAX96724_BACKTOP_CSIB_EN	0x02
++#define MAX96724_BACKTOP_CSIA_EN	0x01
++
++/* [XML] VIDEO_RX0: DIS_PKT_DET=1 (bit0) required for tunnel mode.
++ *   Without it, DES rejects tunnel data as invalid GMSL2 video packets.
++ *   SEQ_MISS_EN=1 (bit4), LINE_CRC_EN=1 (bit1).  XML value: 0x33.
++ */
++#define MAX96724_VID_RX0_CFG_VAL	0x33
++#define MAX96724_VID_RX6_CFG_VAL	0x0A
++
++/* [gmsl_ser_des_guide §4.9] Tunnel mode enable (MIPI_TX54, 0x0936):
++ *   bit[0] = TUN_EN = 1
++ *   bit[3] = TUN_CONT (continuous tunnel mode, required per verified XML)
++ *   XML/Guide value: 0x09
++ */
++#define MAX96724_TUN_EN			0x09
++
++/* [gmsl_ser_des_guide §7.5] Tunnel controller destination (MIPI_TX57, 0x0939):
++ *   bit[7]: DIS_AUTO_SER_LANE_DET (1=manual)
++ *   bit[6]: DIS_AUTO_TUN_DET (1=manual)
++ *   bits[5:4]: TUN_DEST (00=PHY0, 01=PHY1, 10=PHY2, 11=PHY3)
++ *   Verified XML: 0x50 = manual detect + PHY1 destination
++ */
++#define MAX96724_TUN_DEST_CTRL0		0x40  /* Manual detect + PHY0 */
++#define MAX96724_TUN_DEST_CTRL1		0x50  /* Manual detect + PHY1 (Port A master) */
++
++/* [UG Table 12, p.25] CSI output mode values */
++#define MAX96724_CSI_MODE_2X4_VAL	0x08  /* bit[3] = 2x4 alt: Ctrl1→PHY0+1→PortA (Aardvark-verified) */
++#define MAX96724_CSI_MODE_4X2_VAL	0x01  /* bit[0] = 4x2 mode */
++
++#define MAX96724_CSI_PHY_EN_ALL		0xF0
++#define MAX96724_CSI_PHY_EN_01		0x30  /* PHY0+PHY1 only */
++#define MAX96724_CSI_PHY_EN_23		0xC0  /* PHY2+PHY3 only (Port A in 2x4 alt mode) */
++
++/* [UG Table 12, p.25-26] Lane mapping default */
++#define MAX96724_CSI_LANE_MAP_DEFAULT	0xE4
++
++/* [UG Table 12, p.26-27] Lane control: 4-lane enabled */
++#define MAX96724_LANE_CTRL_4LANE	0xC0
++
++/* [UG Table 12, p.26-27] Lane control: 2-lane enabled.
++ *   bits[7:6] = (num_lanes - 1): 01=2-lane(0x40), 11=4-lane(0xC0)
++ *   Ref: gmsl_ser_des_guide §8.2, E2E_enable_guide §5.6.4 */
++#define MAX96724_LANE_CTRL_2LANE	0x40
++
++/* [SC20190112 2-lane] CSI PHY enable: all PHYs powered for DPLL lock
++ *   stability.  Even though only PHY0 data lanes reach Orin, the MAX96724
++ *   DPLL requires all PHYs to be powered.  Tested: single PHY → PLL never locks. */
++#define MAX96724_CSI_PHY_EN_2LANE	0xF0
++
++/* [SC20190112 2-lane] DPLL for Controller 0 (drives PHY0, 2 lanes).
++ *   bits[4:0] = data-rate / 100 MHz.  1400 Mbps / 100 = 14 = 0x0E.
++ *   bit[5]    = DPLL enable = 1.
++ *   Result: 0x2E = 1400 Mbps/lane D-PHY. */
++#define MAX96724_DPLL_1400MBPS_CTRL0	0x2E
++
++/* [SC20190112 2-lane] TX49 pipeline concatenation for 2-wide mode.
++ *   In 4x2 mode each controller drives only 2 lanes.
++ *   UG p.30: synchronous concatenation control, 0x83 for 2W. */
++#define MAX96724_TX49_CONCAT_2W		0x83
++
++/* [UG Table 3, p.12] One-shot reset: all links */
++#define MAX96724_ONESHOT_ALL		0x0F
++
++/* [UG Table 4, p.15] Pipe source selection values
++ *   Encoding per pipe nibble in tunnel mode (Aardvark-verified):
++ *   0x22 routes all pipes from Link A in tunnel mode.
++ */
++#define MAX96724_PIPE_SEL0_SINGLE	0x22  /* All pipes from Link A (Aardvark-verified) */
++#define MAX96724_PIPE_SEL1_SINGLE	0x22  /* All pipes from Link A (Aardvark-verified) */
++#define MAX96724_PIPE_SEL0_DUAL		0x40  /* Pipe 0 ← A/X, Pipe 1 ← B/X */
++#define MAX96724_PIPE_SEL0_QUAD_LO	0x40  /* Pipe 0 ← A/X, Pipe 1 ← B/X */
++#define MAX96724_PIPE_SEL1_QUAD_HI	0xC8  /* Pipe 2 ← C/X, Pipe 3 ← D/X */
++
++/* Pipe enable values */
++#define MAX96724_PIPE_EN_1		0x01
++#define MAX96724_PIPE_EN_2		0x03
++#define MAX96724_PIPE_EN_4		0x0F
++
++/* Lane control map: bits[7:6] = (num_lanes - 1) */
++#define MAX96724_LANE_CTRL_MAP(num_lanes) \
++	((((num_lanes) - 1) << 6) & 0xC0)
++
++/* Reset all */
++#define MAX96724_RESET_ALL		0x80
++
++/* Stream ID invalid */
++#define MAX96724_INVAL_ST_ID		0xFF
++#define MAX96724_RESET_ST_ID		0x00
++#define MAX96724_ST_ID_SEL_INVALID	0xF
++
++/* Controller mapping: all mappings → Controller 0 (not working in tunnel mode) */
++#define MAX96724_ALL_MAP_CTRL0		0x00
++/* Controller mapping: all mappings → Controller 1 (Aardvark-verified working) */
++#define MAX96724_ALL_MAP_CTRL1		0x55
++
++/* ================================================================
++ * Data Structures
++ * ================================================================ */
++
++/* Quad GMSL: up to 4 sources */
++#define MAX96724_MAX_SOURCES		4
++#define MAX96724_MAX_PIPES		4
++
++#define MAX96724_PIPE_X			0
++#define MAX96724_PIPE_Y			1
++#define MAX96724_PIPE_Z			2
++#define MAX96724_PIPE_U			3
++#define MAX96724_PIPE_INVALID		0xF
++
++#define MAX96724_CSI_CTRL_0		0
++#define MAX96724_CSI_CTRL_1		1
++#define MAX96724_CSI_CTRL_2		2
++#define MAX96724_CSI_CTRL_3		3
++
++/* CSI mode values */
++#define MAX96724_CSI_MODE_4X2		0x01
++#define MAX96724_CSI_MODE_2X4		0x08  /* 2x4 alt: Ctrl1→PHY0+1→PortA (Aardvark-verified working) */
++#define MAX96724_CSI_MODE_2X4_ALT	0x04  /* 2x4 standard (Ctrl0→PHY0+1, not working in tunnel) */
++
++/* Lane map presets */
++#define MAX96724_LANE_MAP1_4X2		0x44
++#define MAX96724_LANE_MAP2_4X2		0x44
++#define MAX96724_LANE_MAP1_2X4		0xE4  /* PHY0+PHY1 lane map (Aardvark-verified) */
++#define MAX96724_LANE_MAP2_2X4		0xE4
++
++struct max96724_source_ctx {
++	struct gmsl_link_ctx *g_ctx;
++	bool st_enabled;
++};
++
++struct pipe_ctx {
++	u32 id;
++	u32 dt_type;
++	u32 dst_csi_ctrl;
++	u32 st_count;
++	u32 st_id_sel;
++};
++
++struct max96724 {
++	struct i2c_client *i2c_client;
++	struct regmap *regmap;
++	u32 num_src;
++	u32 max_src;
++	u32 num_src_found;
++	u32 src_link;
++	bool splitter_enabled;
++	struct max96724_source_ctx sources[MAX96724_MAX_SOURCES];
++	struct mutex lock;
++	u32 sdev_ref;
++	bool lane_setup;
++	bool link_setup;
++	struct pipe_ctx pipe[MAX96724_MAX_PIPES];
++	u8 csi_mode;
++	u8 lane_mp1;
++	u8 lane_mp2;
++	int reset_gpio;
++	int pw_ref;
++	struct regulator *vdd_cam_1v2;
++	u8 link_speed;  /* DT-configurable: 3 or 6 Gbps */
++};
++
++struct reg_pair {
++	u16 addr;
++	u8 val;
++};
++
++/* ================================================================
++ * Low-level I2C
++ * ================================================================ */
++
++static int max96724_write_reg(struct device *dev, u16 addr, u8 val)
++{
++	struct max96724 *priv;
++	int err;
++
++	priv = dev_get_drvdata(dev);
++
++	err = regmap_write(priv->regmap, addr, val);
++	if (err)
++		dev_err(dev, "%s:i2c write failed, 0x%x = %x\n",
++			__func__, addr, val);
++
++	/* delay before next i2c command as required for SERDES link */
++	usleep_range(100, 110);
++
++	return err;
++}
++
++static int max96724_set_registers(struct device *dev, struct reg_pair *map,
++				  u32 count)
++{
++	int err = 0;
++	u32 j;
++
++	for (j = 0; j < count; j++) {
++		err = max96724_write_reg(dev, map[j].addr, map[j].val);
++		if (err)
++			break;
++	}
++
++	return err;
++}
++
++/* ================================================================
++ * Internal Helpers
++ * ================================================================ */
++
++static int max96724_get_sdev_idx(struct device *dev,
++				 struct device *s_dev, unsigned int *idx)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++	unsigned int i;
++	int err = 0;
++
++	mutex_lock(&priv->lock);
++	for (i = 0; i < priv->max_src; i++) {
++		if (priv->sources[i].g_ctx->s_dev == s_dev)
++			break;
++	}
++	if (i == priv->max_src) {
++		dev_err(dev, "no sdev found\n");
++		err = -EINVAL;
++		goto ret;
++	}
++
++	if (idx)
++		*idx = i;
++
++ret:
++	mutex_unlock(&priv->lock);
++	return err;
++}
++
++static void max96724_pipes_reset(struct max96724 *priv)
++{
++	/*
++	 * Default pipe configuration for D5xx/SC1.2:
++	 * In tunnel mode, DT types are not used for filtering
++	 * but we initialize them for d4xx framework compatibility.
++	 */
++	struct pipe_ctx pipe_defaults[] = {
++		{MAX96724_PIPE_X, GMSL_CSI_DT_RAW_12,
++			MAX96724_CSI_CTRL_1, 0, MAX96724_INVAL_ST_ID},
++		{MAX96724_PIPE_Y, GMSL_CSI_DT_RAW_12,
++			MAX96724_CSI_CTRL_1, 0, MAX96724_INVAL_ST_ID},
++		{MAX96724_PIPE_Z, GMSL_CSI_DT_EMBED,
++			MAX96724_CSI_CTRL_1, 0, MAX96724_INVAL_ST_ID},
++		{MAX96724_PIPE_U, GMSL_CSI_DT_EMBED,
++			MAX96724_CSI_CTRL_1, 0, MAX96724_INVAL_ST_ID}
++	};
++
++	memcpy(priv->pipe, pipe_defaults, sizeof(pipe_defaults));
++}
++
++static void max96724_reset_ctx(struct max96724 *priv)
++{
++	unsigned int i;
++
++	priv->link_setup = false;
++	priv->lane_setup = false;
++	priv->num_src_found = 0;
++	priv->src_link = 0;
++	priv->splitter_enabled = false;
++	max96724_pipes_reset(priv);
++	for (i = 0; i < priv->num_src; i++)
++		priv->sources[i].st_enabled = false;
++}
++
++/* ================================================================
++ * Power Management
++ * ================================================================ */
++
++/*
++ * max96724_power_on - Power on the MAX96724 deserializer
++ */
++int max96724_power_on(struct device *dev)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++	int err = 0;
++
++	mutex_lock(&priv->lock);
++	if (priv->pw_ref == 0) {
++		usleep_range(1, 2);
++		if (priv->reset_gpio)
++			gpio_set_value(priv->reset_gpio, 0);
++
++		usleep_range(30, 50);
++
++		if (priv->vdd_cam_1v2) {
++			err = regulator_enable(priv->vdd_cam_1v2);
++			if (unlikely(err))
++				goto ret;
++		}
++
++		usleep_range(30, 50);
++
++		/* exit reset mode: XCLR */
++		if (priv->reset_gpio) {
++			gpio_set_value(priv->reset_gpio, 0);
++			usleep_range(30, 50);
++			gpio_set_value(priv->reset_gpio, 1);
++			usleep_range(30, 50);
++		}
++
++		msleep(20);
++	}
++
++	priv->pw_ref++;
++
++ret:
++	mutex_unlock(&priv->lock);
++	return err;
++}
++EXPORT_SYMBOL(max96724_power_on);
++
++void max96724_power_off(struct device *dev)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++
++	mutex_lock(&priv->lock);
++	priv->pw_ref--;
++
++	if (priv->pw_ref < 0)
++		priv->pw_ref = 0;
++
++	if (priv->pw_ref == 0) {
++		usleep_range(1, 2);
++		if (priv->reset_gpio)
++			gpio_set_value(priv->reset_gpio, 0);
++
++		if (priv->vdd_cam_1v2)
++			regulator_disable(priv->vdd_cam_1v2);
++	}
++
++	mutex_unlock(&priv->lock);
++}
++EXPORT_SYMBOL(max96724_power_off);
++
++/* ================================================================
++ * Link Setup
++ * ================================================================ */
++
++/*
++ * max96724_write_link - Configure a specific GMSL link
++ *
++ * [Users Guide, Link Initialization, p11-12]
++ *   Register 0x0006: Link Enable and Mode Select
++ *   Register 0x0010: Link Rate (Links A/B)
++ *
++ * The link speed is DT-configurable via the "gmsl-link-speed" property.
++ */
++static int max96724_write_link(struct device *dev, u32 link)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++	u8 link_rate_ab, link_rate_cd;
++	u8 link_en_val;
++
++	/*
++	 * [Aardvark-verified] Disable CSI output before link configuration
++	 * This prevents glitches on CSI bus during GMSL link setup.
++	 * Re-enabled in max96724_setup_streaming() after full pipeline config.
++	 */
++	max96724_write_reg(dev, MAX96724_BACKTOP_EN_ADDR, 0x00);
++
++	/* [UG Table 3 + Tech Overview REG26]
++	 * Register 0x0010:
++	 *   bits[7:2] = Link rate configuration
++	 *   bits[1:0] = I2C CC pass-through link select
++	 *     10 = route CC via SIOA (Link A)  [tech overview: 0x02 → SIOA]
++	 *     01 = route CC via SIOB (Link B)
++	 *
++	 * For 6G + Link A: bits[7:2]=001000, bits[1:0]=10 → 0x22
++	 * For 6G + Link B: bits[7:2]=001000, bits[1:0]=01 → 0x21
++	 * For 3G + Link A: bits[7:2]=000100, bits[1:0]=10 → 0x12 (? or 0x11)
++	 * For 3G + Link B: bits[7:2]=000100, bits[1:0]=01 → 0x11 (? or 0x09)
++	 */
++	if (priv->link_speed == 6) {
++		if (link == GMSL_SERDES_CSI_LINK_B) {
++			link_rate_ab = 0x21; /* 6G rate + CC via Link B */
++		} else {
++			link_rate_ab = 0x22; /* 6G rate + CC via Link A */
++		}
++		link_rate_cd = 0x22; /* C/D: 6G rate (CC routing don't care) */
++	} else {
++		if (link == GMSL_SERDES_CSI_LINK_B) {
++			link_rate_ab = 0x09; /* 3G rate + CC via Link B */
++		} else {
++			link_rate_ab = 0x12; /* 3G rate + CC via Link A */
++		}
++		link_rate_cd = 0x11; /* C/D: 3G rate */
++	}
++
++	if (link == GMSL_SERDES_CSI_LINK_A) {
++		link_en_val = MAX96724_LINK_EN_SIOA;
++	} else if (link == GMSL_SERDES_CSI_LINK_B) {
++		link_en_val = 0xF2; /* GMSL2 all, enable Link B only */
++	} else {
++		dev_err(dev, "%s: invalid gmsl link\n", __func__);
++		return -EINVAL;
++	}
++
++	/* [UG Table 3] Set link rates + CC routing */
++	max96724_write_reg(dev, MAX96724_LINK_RATE_AB_ADDR, link_rate_ab);
++	max96724_write_reg(dev, MAX96724_LINK_RATE_CD_ADDR, link_rate_cd);
++
++	/*
++	 * [XML-verified sequence] One-shot reset applies rate configuration
++	 * to the link state machine, then link enable starts training.
++	 * XML order: rate → ONE-SHOT → LINK_EN → wait 1000ms.
++	 * Note: Error channel registers omitted (not in reference XML).
++	 */
++	max96724_write_reg(dev, MAX96724_ONESHOT_ADDR,
++			   MAX96724_ONESHOT_ALL);
++	max96724_write_reg(dev, MAX96724_LINK_EN_ADDR, link_en_val);
++
++	/*
++	 * Wait for link lock.
++	 * [XML] Uses 1000ms regardless of link speed.
++	 * I2C pass-through CC requires fully trained link, not just PHY lock.
++	 */
++	msleep(1000);
++
++	/* Check link lock status on ALL ports for diagnostics */
++	{
++		unsigned int lock_a = 0, lock_b = 0, lock_c = 0, lock_d = 0;
++		unsigned int link_en = 0;
++		unsigned int reg10 = 0, reg11 = 0;
++
++		regmap_read(priv->regmap, 0x001A, &lock_a);
++		regmap_read(priv->regmap, 0x001B, &lock_b);
++		regmap_read(priv->regmap, 0x001C, &lock_c);
++		regmap_read(priv->regmap, 0x001D, &lock_d);
++		regmap_read(priv->regmap, MAX96724_LINK_EN_ADDR, &link_en);
++		regmap_read(priv->regmap, 0x0010, &reg10);
++		regmap_read(priv->regmap, 0x0011, &reg11);
++		dev_info(dev,
++			 "GMSL link status: EN=0x%02x A=0x%02x(%s) B=0x%02x(%s) C=0x%02x(%s) D=0x%02x(%s) REG10=0x%02x REG11=0x%02x\n",
++			 link_en,
++			 lock_a, (lock_a & 0x08) ? "LOCK" : "noLk",
++			 lock_b, (lock_b & 0x08) ? "LOCK" : "noLk",
++			 lock_c, (lock_c & 0x08) ? "LOCK" : "noLk",
++			 lock_d, (lock_d & 0x08) ? "LOCK" : "noLk",
++			 reg10, reg11);
++	}
++
++	return 0;
++}
++
++int max96724_setup_link(struct device *dev, struct device *s_dev)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++	int err = 0;
++	unsigned int i = 0;
++
++	err = max96724_get_sdev_idx(dev, s_dev, &i);
++	if (err)
++		return err;
++
++	mutex_lock(&priv->lock);
++
++	if (!priv->splitter_enabled) {
++		err = max96724_write_link(dev,
++					  priv->sources[i].g_ctx->serdes_csi_link);
++		if (err)
++			goto ret;
++
++		priv->link_setup = true;
++	}
++
++ret:
++	mutex_unlock(&priv->lock);
++	return err;
++}
++EXPORT_SYMBOL(max96724_setup_link);
++
++/* ================================================================
++ * Control Setup
++ * ================================================================ */
++
++/*
++ * max96724_setup_control - Configure deserializer control pipeline
++ *
++ * Enables splitter mode when multiple sources are present,
++ * configures tunnel mode on all active pipes, and sets up
++ * the MIPI CSI-2 output.
++ */
++int max96724_setup_control(struct device *dev, struct device *s_dev)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++	int err = 0;
++	unsigned int i = 0;
++
++	static const u16 tun_en_addrs[] = {
++		MAX96724_PIPE0_TUN_EN_ADDR,
++		MAX96724_PIPE1_TUN_EN_ADDR,
++		MAX96724_PIPE2_TUN_EN_ADDR,
++		MAX96724_PIPE3_TUN_EN_ADDR,
++	};
++
++	static const u16 tun_dest_addrs[] = {
++		MAX96724_PIPE0_TUN_DEST_ADDR,
++		MAX96724_PIPE1_TUN_DEST_ADDR,
++		MAX96724_PIPE2_TUN_DEST_ADDR,
++		MAX96724_PIPE3_TUN_DEST_ADDR,
++	};
++
++	err = max96724_get_sdev_idx(dev, s_dev, &i);
++	if (err)
++		return err;
++
++	mutex_lock(&priv->lock);
++
++	if (!priv->link_setup) {
++		dev_err(dev, "%s: invalid state\n", __func__);
++		err = -EINVAL;
++		goto error;
++	}
++
++	if (priv->sources[i].g_ctx->serdev_found) {
++		priv->num_src_found++;
++		priv->src_link = priv->sources[i].g_ctx->serdes_csi_link;
++	}
++
++	/* Enable splitter mode for multi-camera configurations */
++	if ((priv->max_src > 1U) &&
++	    (priv->num_src_found > 0U) &&
++	    (priv->splitter_enabled == false)) {
++		/*
++		 * [UG Table 3] Multi-camera: set link rates and enable all links
++		 */
++		u8 link_rate = (priv->link_speed == 6) ? 0x22 : 0x11;
++
++		max96724_write_reg(dev, MAX96724_LINK_RATE_AB_ADDR,
++				   link_rate);
++		max96724_write_reg(dev, MAX96724_LINK_RATE_CD_ADDR,
++				   link_rate);
++		max96724_write_reg(dev, MAX96724_LINK_EN_ADDR,
++				   MAX96724_LINK_EN_ALL);
++
++		/* [Errata #5] For 6Gbps: force Error Channel power-up */
++		if (priv->link_speed == 6) {
++			max96724_write_reg(dev, MAX96724_ERRCH_A_ADDR,
++					   MAX96724_ERRCH_FORCE_ON);
++			max96724_write_reg(dev, MAX96724_ERRCH_B_ADDR,
++					   MAX96724_ERRCH_FORCE_ON);
++			max96724_write_reg(dev, MAX96724_ERRCH_C_ADDR,
++					   MAX96724_ERRCH_FORCE_ON);
++			max96724_write_reg(dev, MAX96724_ERRCH_D_ADDR,
++					   MAX96724_ERRCH_FORCE_ON);
++		}
++
++		priv->splitter_enabled = true;
++
++		msleep(100);
++	}
++
++	/*
++	 * [SC20190112] Enable tunnel mode and route to Controller 1.
++	 *   - TUN_EN   (0x0936): 0x01 (TUN_EN=1)
++	 *   - TUN_DEST (0x0939): 0x10 = Controller 1
++	 *   CSI_OUT_CFG=0x08 (2x4 alt): Controller 1 → PHY0+1 → Port A → Orin
++	 */
++	{
++		for (i = 0; i < MAX96724_MAX_PIPES; i++) {
++			max96724_write_reg(dev, tun_en_addrs[i],
++					   MAX96724_TUN_EN);
++			max96724_write_reg(dev, tun_dest_addrs[i],
++					   MAX96724_TUN_DEST_CTRL1);
++		}
++	}
++
++	/*
++	 * [Errata #2] Tunnel Mode SRAM LCRC: disable ERRB for SRAM LCRC
++	 * errors in tunnel mode when frame/line counters are non-zero.
++	 * This prevents spurious ERRB assertions (no video corruption).
++	 */
++	max96724_write_reg(dev, MAX96724_SRAM_LCRC_ERR_ADDR, 0x00);
++
++	max96724_write_reg(dev, MAX96724_ONESHOT_ADDR,
++			   MAX96724_ONESHOT_ALL);
++
++	priv->sdev_ref++;
++
++	/* Reset splitter mode if not all devices found */
++	if ((priv->sdev_ref == priv->max_src) &&
++	    (priv->splitter_enabled == true) &&
++	    (priv->num_src_found > 0U) &&
++	    (priv->num_src_found < priv->max_src)) {
++		err = max96724_write_link(dev, priv->src_link);
++		if (err)
++			goto error;
++
++		priv->splitter_enabled = false;
++	}
++
++error:
++	mutex_unlock(&priv->lock);
++	return err;
++}
++EXPORT_SYMBOL(max96724_setup_control);
++
++int max96724_reset_control(struct device *dev, struct device *s_dev)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++	int err = 0;
++
++	mutex_lock(&priv->lock);
++	if (!priv->sdev_ref) {
++		dev_info(dev, "%s: dev is already in reset state\n", __func__);
++		goto ret;
++	}
++
++	priv->sdev_ref--;
++	if (priv->sdev_ref == 0) {
++		max96724_reset_ctx(priv);
++		max96724_write_reg(dev, MAX96724_REG13_ADDR,
++				   MAX96724_SOFT_RESET);
++
++		msleep(100);
++	}
++
++ret:
++	mutex_unlock(&priv->lock);
++	return err;
++}
++EXPORT_SYMBOL(max96724_reset_control);
++
++/* ================================================================
++ * Device Registration
++ * ================================================================ */
++
++int max96724_sdev_register(struct device *dev, struct gmsl_link_ctx *g_ctx)
++{
++	struct max96724 *priv = NULL;
++	unsigned int i;
++	int err = 0;
++
++	if (!dev || !g_ctx || !g_ctx->s_dev) {
++		dev_err(dev, "%s: invalid input params\n", __func__);
++		return -EINVAL;
++	}
++
++	priv = dev_get_drvdata(dev);
++
++	mutex_lock(&priv->lock);
++
++	if (priv->num_src > priv->max_src) {
++		dev_err(dev,
++			"%s: MAX96724 inputs size exhausted\n", __func__);
++		err = -ENOMEM;
++		goto error;
++	}
++
++	/* Check csi mode compatibility.
++	 * 2x4 DES → gmsl-link: 1x4 or 2x4.
++	 * 4x2 DES → gmsl-link: 1x4, 2x2, or 4x2.
++	 */
++	if (priv->csi_mode == MAX96724_CSI_MODE_2X4) {
++		if (!((g_ctx->csi_mode == GMSL_CSI_1X4_MODE) ||
++		      (g_ctx->csi_mode == GMSL_CSI_2X4_MODE))) {
++			dev_err(dev, "%s: csi mode not supported\n", __func__);
++			err = -EINVAL;
++			goto error;
++		}
++	} else {
++		/* 4x2 DES mode: accept 1x4, 2x2, or 4x2 gmsl-link mode */
++		if (!((g_ctx->csi_mode == GMSL_CSI_1X4_MODE) ||
++		      (g_ctx->csi_mode == GMSL_CSI_2X2_MODE) ||
++		      (g_ctx->csi_mode == GMSL_CSI_4X2_MODE))) {
++			dev_err(dev, "%s: csi mode not supported\n", __func__);
++			err = -EINVAL;
++			goto error;
++		}
++	}
++
++	for (i = 0; i < priv->num_src; i++) {
++		if (g_ctx->serdes_csi_link ==
++		    priv->sources[i].g_ctx->serdes_csi_link) {
++			dev_err(dev,
++				"%s: serdes csi link is in use\n", __func__);
++			err = -EINVAL;
++			goto error;
++		}
++		if (g_ctx->num_csi_lanes !=
++		    priv->sources[i].g_ctx->num_csi_lanes) {
++			dev_err(dev,
++				"%s: csi num lanes mismatch\n", __func__);
++			err = -EINVAL;
++			goto error;
++		}
++	}
++
++	priv->sources[priv->num_src].g_ctx = g_ctx;
++	priv->sources[priv->num_src].st_enabled = false;
++
++	priv->num_src++;
++
++error:
++	mutex_unlock(&priv->lock);
++	return err;
++}
++EXPORT_SYMBOL(max96724_sdev_register);
++
++int max96724_sdev_unregister(struct device *dev, struct device *s_dev)
++{
++	struct max96724 *priv = NULL;
++	int err = 0;
++	unsigned int i = 0;
++
++	if (!dev || !s_dev) {
++		dev_err(dev, "%s: invalid input params\n", __func__);
++		return -EINVAL;
++	}
++
++	priv = dev_get_drvdata(dev);
++	mutex_lock(&priv->lock);
++
++	if (priv->num_src == 0) {
++		dev_err(dev, "%s: no source found\n", __func__);
++		err = -ENODATA;
++		goto error;
++	}
++
++	for (i = 0; i < priv->num_src; i++) {
++		if (s_dev == priv->sources[i].g_ctx->s_dev) {
++			priv->sources[i].g_ctx = NULL;
++			break;
++		}
++	}
++
++	if (i == priv->num_src) {
++		dev_err(dev,
++			"%s: requested device not found\n", __func__);
++		err = -EINVAL;
++		goto error;
++	}
++	priv->num_src--;
++
++error:
++	mutex_unlock(&priv->lock);
++	return err;
++}
++EXPORT_SYMBOL(max96724_sdev_unregister);
++
++/* ================================================================
++ * Streaming Setup
++ * ================================================================ */
++
++/*
++ * max96724_setup_streaming - Configure CSI-2 output pipeline
++ *
++ * In Tunnel Mode, the MAX96724 outputs the reconstructed CSI-2 stream
++ * with all VCs and DTs preserved from the serializer.
++ *
++ * The pipeline configuration:
++ *   1. Configure pipe-to-link routing (which GMSL input → which pipe)
++ *   2. Enable tunnel mode on active pipes
++ *   3. Configure MIPI CSI-2 output lanes and PHY
++ *   4. Enable BACKTOP output port
++ *
++ */
++int max96724_setup_streaming(struct device *dev, struct device *s_dev)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++	struct gmsl_link_ctx *g_ctx;
++	int err = 0;
++	unsigned int i = 0;
++	unsigned int src_idx;
++
++	err = max96724_get_sdev_idx(dev, s_dev, &i);
++	if (err)
++		return err;
++
++	mutex_lock(&priv->lock);
++	if (priv->sources[i].st_enabled)
++		goto ret;
++
++	src_idx = i;
++	g_ctx = priv->sources[src_idx].g_ctx;
++
++	/*
++	 * [Aardvark-verified] Pipe source routing
++	 *   Single cam: all pipes from Link A (0x22/0x22)
++	 *   Disable pipes before configuration, enable at the end
++	 */
++	if (priv->max_src >= 4) {
++		max96724_write_reg(dev, MAX96724_PIPE_SEL0_ADDR,
++				   MAX96724_PIPE_SEL0_QUAD_LO);
++		max96724_write_reg(dev, MAX96724_PIPE_SEL1_ADDR,
++				   MAX96724_PIPE_SEL1_QUAD_HI);
++	} else if (priv->max_src >= 2) {
++		max96724_write_reg(dev, MAX96724_PIPE_SEL0_ADDR,
++				   MAX96724_PIPE_SEL0_DUAL);
++	} else {
++		max96724_write_reg(dev, MAX96724_PIPE_SEL0_ADDR,
++				   MAX96724_PIPE_SEL0_SINGLE);
++		max96724_write_reg(dev, MAX96724_PIPE_SEL1_ADDR,
++				   MAX96724_PIPE_SEL1_SINGLE);
++	}
++	/* Disable all pipes during configuration */
++	max96724_write_reg(dev, MAX96724_PIPE_EN_ADDR, 0x00);
++
++	/*
++	 * [SC20190112] CSI output: 2x4 alt mode (0x08) for Port A.
++	 * In 2x4 alt: Controller 1 is master for Port A.
++	 *   PHY0 (slave) → DA0/DA1 (data lanes to Orin)
++	 *   PHY1 (master) → CLKA (clock to Orin)
++	 * Both PHY0 and PHY1 must be enabled for Port A output.
++	 * TUN_DEST=0x10 routes tunnel pipes to Controller 1.
++	 */
++	max96724_write_reg(dev, MAX96724_CSI_OUT_CFG_ADDR,
++			   MAX96724_CSI_MODE_2X4_VAL);
++	max96724_write_reg(dev, MAX96724_CSI_PHY_EN_ADDR,
++			   MAX96724_CSI_PHY_EN_01);
++
++	max96724_write_reg(dev, MAX96724_CSI_LANE_MAP1_ADDR,
++			   priv->lane_mp1);
++	max96724_write_reg(dev, MAX96724_CSI_LANE_MAP2_ADDR,
++			   priv->lane_mp2);
++
++	/* [gmsl_ser_des_guide §6.1] MIPI_CTRL_SEL: all pipes → Controller 1.
++	 * Guide: "in tunneling mode the MIPI_CTRL_SEL_x bits must match TUN_DEST"
++	 * 0x55 = Pipe0→Ctrl1, Pipe1→Ctrl1, Pipe2→Ctrl1, Pipe3→Ctrl1 */
++	max96724_write_reg(dev, MAX96724_MIPI_CTRL_SEL_ADDR, 0x55);
++
++	/* [gmsl_ser_des_guide §8.2] LANE_CTRL on Controller 1 register (0x094A).
++	 * 0x40 = 2-lane. Also set Ctrl0 for completeness. */
++	max96724_write_reg(dev, MAX96724_LANE_CTRL0_ADDR,
++			   MAX96724_LANE_CTRL_2LANE);
++	max96724_write_reg(dev, MAX96724_LANE_CTRL1_ADDR,
++			   MAX96724_LANE_CTRL_2LANE);
++	max96724_write_reg(dev, MAX96724_LANE_CTRL2_ADDR,
++			   MAX96724_LANE_CTRL_2LANE);
++	max96724_write_reg(dev, MAX96724_LANE_CTRL3_ADDR,
++			   MAX96724_LANE_CTRL_2LANE);
++
++	/*
++	 * [SC20190112 2-lane] DPLL for Controller 1 (drives Port A via PHY1 clock).
++	 * FREQ1 (0x0418) = 0x2E = 1400 Mbps/lane + DPLL enable.
++	 * 2 lanes × 1400 Mbps = 2800 Mbps total ≥ camera 2L × 700M input.
++	 */
++	if (!priv->lane_setup) {
++		max96724_write_reg(dev, MAX96724_DPLL_CSI2_ADDR,
++				   MAX96724_DPLL_DISABLE);
++		max96724_write_reg(dev, MAX96724_DPLL_FREQ1_ADDR,
++				   MAX96724_DPLL_1400MBPS_CTRL0);
++		max96724_write_reg(dev, MAX96724_DPLL_CSI2_ADDR,
++				   MAX96724_DPLL_ENABLE);
++
++		priv->lane_setup = true;
++	}
++
++	/*
++	 * [Aardvark-verified] Stream ID select for all pipes
++	 * 0x0933 + 0x40*pipe = stream select register
++	 * Value 0x10 selects the appropriate stream for tunnel mode
++	 */
++	for (i = 0; i < MAX96724_MAX_PIPES; i++) {
++		max96724_write_reg(dev,
++				   MAX96724_PIPE_X_ST_SEL_ADDR + (0x40 * i),
++				   0x10);
++	}
++
++	/* BACKTOP: enable Controller 1 / CSI-B (0x02).
++	 * In 2x4 alt mode, Controller 1 is master for Port A → Orin CSI.
++	 */
++	max96724_write_reg(dev, MAX96724_BACKTOP_EN_ADDR,
++			   MAX96724_BACKTOP_CSIB_EN);
++
++	/* Keep all video receivers aligned with serializer heartbeat mode. */
++	for (i = 0; i < MAX96724_MAX_PIPES; i++) {
++		max96724_write_reg(dev,
++				   MAX96724_VID_RX0_P0_ADDR +
++				   (MAX96724_VID_RX_STRIDE * i),
++				   MAX96724_VID_RX0_CFG_VAL);
++		max96724_write_reg(dev,
++				   MAX96724_VID_RX6_P0_ADDR +
++				   (MAX96724_VID_RX_STRIDE * i),
++				   MAX96724_VID_RX6_CFG_VAL);
++	}
++
++	max96724_write_reg(dev, MAX96724_ONESHOT_ADDR,
++			   MAX96724_ONESHOT_ALL);
++
++	/* Enable all 4 pipes (Aardvark-verified: 0x0F at end) */
++	max96724_write_reg(dev, MAX96724_PIPE_EN_ADDR, MAX96724_PIPE_EN_4);
++
++	priv->sources[src_idx].st_enabled = true;
++
++ret:
++	mutex_unlock(&priv->lock);
++	return err;
++}
++EXPORT_SYMBOL(max96724_setup_streaming);
++
++/* ================================================================
++ * Start / Stop Streaming
++ * ================================================================ */
++
++int max96724_start_streaming(struct device *dev, struct device *s_dev)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++	struct gmsl_link_ctx *g_ctx;
++	struct gmsl_stream *g_stream;
++	int err = 0;
++	unsigned int i = 0;
++
++	err = max96724_get_sdev_idx(dev, s_dev, &i);
++	if (err)
++		return err;
++
++	mutex_lock(&priv->lock);
++	g_ctx = priv->sources[i].g_ctx;
++
++	for (i = 0; i < g_ctx->num_streams; i++) {
++		g_stream = &g_ctx->streams[i];
++
++		if (g_stream->des_pipe != MAX96724_PIPE_INVALID)
++			max96724_write_reg(dev, g_stream->des_pipe,
++					   g_stream->st_id_sel);
++	}
++	mutex_unlock(&priv->lock);
++
++	return 0;
++}
++EXPORT_SYMBOL(max96724_start_streaming);
++
++int max96724_stop_streaming(struct device *dev, struct device *s_dev)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++	struct gmsl_link_ctx *g_ctx;
++	struct gmsl_stream *g_stream;
++	int err = 0;
++	unsigned int i = 0;
++
++	err = max96724_get_sdev_idx(dev, s_dev, &i);
++	if (err)
++		return err;
++
++	mutex_lock(&priv->lock);
++	g_ctx = priv->sources[i].g_ctx;
++
++	for (i = 0; i < g_ctx->num_streams; i++) {
++		g_stream = &g_ctx->streams[i];
++
++		if (g_stream->des_pipe != MAX96724_PIPE_INVALID)
++			max96724_write_reg(dev, g_stream->des_pipe,
++					   MAX96724_RESET_ST_ID);
++	}
++
++	mutex_unlock(&priv->lock);
++
++	return 0;
++}
++EXPORT_SYMBOL(max96724_stop_streaming);
++
++/* ================================================================
++ * Pipe Management
++ * ================================================================ */
++
++int max96724_get_available_pipe_id(struct device *dev, int vc_id)
++{
++	int i;
++	int pipe_id = -ENOMEM;
++	struct max96724 *priv = dev_get_drvdata(dev);
++
++	mutex_lock(&priv->lock);
++	for (i = 0; i < MAX96724_MAX_PIPES; i++) {
++		if (i == vc_id && !priv->pipe[i].st_count) {
++			priv->pipe[i].st_count++;
++			pipe_id = i;
++			break;
++		}
++	}
++	mutex_unlock(&priv->lock);
++
++	return pipe_id;
++}
++EXPORT_SYMBOL(max96724_get_available_pipe_id);
++
++int max96724_release_pipe(struct device *dev, int pipe_id)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++
++	if (pipe_id < 0 || pipe_id >= MAX96724_MAX_PIPES)
++		return -EINVAL;
++
++	mutex_lock(&priv->lock);
++	priv->pipe[pipe_id].st_count = 0;
++	mutex_unlock(&priv->lock);
++
++	return 0;
++}
++EXPORT_SYMBOL(max96724_release_pipe);
++
++int max96724_get_ser_pipe_id(struct device *dev, int dser_pipe_id, int vc_id)
++{
++	/*
++	 * In Tunnel Mode with MAX96717, all VCs are carried in a single
++	 * tunnel pipe. The pipe mapping is 1:1 for d4xx compatibility.
++	 */
++	return dser_pipe_id;
++}
++EXPORT_SYMBOL(max96724_get_ser_pipe_id);
++
++void max96724_reset_oneshot(struct device *dev)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++
++	mutex_lock(&priv->lock);
++	if (priv->splitter_enabled) {
++		/* [UG] Multi-camera: reset all links */
++		u8 link_rate = (priv->link_speed == 6) ? 0x22 : 0x11;
++
++		max96724_write_reg(dev, MAX96724_LINK_RATE_AB_ADDR,
++				   link_rate);
++		max96724_write_reg(dev, MAX96724_LINK_RATE_CD_ADDR,
++				   link_rate);
++		max96724_write_reg(dev, MAX96724_LINK_EN_ADDR,
++				   MAX96724_LINK_EN_ALL);
++	} else {
++		max96724_write_reg(dev, MAX96724_ONESHOT_ADDR,
++				   MAX96724_ONESHOT_ALL);
++	}
++	msleep(100);
++
++	/* ONESHOT resets CSI config to defaults.
++	 * Restore 1x4a+2x2 2-lane config after every ONESHOT (per guide §7):
++	 *   CSI_OUT_CFG=0x08  1x4a+2x2: Controller 1 → PHY0+1 → Port A
++	 *   PHY_EN=0x30       PHY0+PHY1 (both needed for Port A)
++	 *   MIPI_CTRL_SEL=0x55 all pipes → Controller 1 (must match TUN_DEST)
++	 *   BACKTOP=0x02      CSIB_EN (Controller 1)
++	 *   TUN_EN=0x09       tunnel enable (per verified XML)
++	 *   TUN_DEST=0x50     manual detect + PHY1 (per verified XML)
++	 *   DPLL_FREQ1=0x2E   1400Mbps (Controller 1's DPLL)
++	 *   LANE_CTRL1=0x40   2-lane on Controller 1
++	 *   VID_RX0=0x33      disable pkt detect for tunnel mode
++	 */
++	max96724_write_reg(dev, MAX96724_CSI_OUT_CFG_ADDR,
++			   MAX96724_CSI_MODE_2X4_VAL);
++	max96724_write_reg(dev, MAX96724_CSI_PHY_EN_ADDR,
++			   MAX96724_CSI_PHY_EN_01);
++	max96724_write_reg(dev, MAX96724_MIPI_CTRL_SEL_ADDR, 0x55);
++	max96724_write_reg(dev, MAX96724_BACKTOP_EN_ADDR,
++			   MAX96724_BACKTOP_CSIB_EN);
++	/* Restore 2-lane count on all controllers (ONESHOT resets to default) */
++	max96724_write_reg(dev, MAX96724_LANE_CTRL0_ADDR,
++			   MAX96724_LANE_CTRL_2LANE);
++	max96724_write_reg(dev, MAX96724_LANE_CTRL1_ADDR,
++			   MAX96724_LANE_CTRL_2LANE);
++	max96724_write_reg(dev, MAX96724_LANE_CTRL2_ADDR,
++			   MAX96724_LANE_CTRL_2LANE);
++	max96724_write_reg(dev, MAX96724_LANE_CTRL3_ADDR,
++			   MAX96724_LANE_CTRL_2LANE);
++	max96724_write_reg(dev, MAX96724_DPLL_FREQ1_ADDR,
++			   MAX96724_DPLL_1400MBPS_CTRL0);
++	max96724_write_reg(dev, MAX96724_VID_RX0_P0_ADDR,
++			   MAX96724_VID_RX0_CFG_VAL);
++	/* Re-enable tunnel on all pipes (ONESHOT resets TUN_EN to 0x08=disabled) */
++	max96724_write_reg(dev, MAX96724_PIPE0_TUN_EN_ADDR, MAX96724_TUN_EN);
++	max96724_write_reg(dev, MAX96724_PIPE1_TUN_EN_ADDR, MAX96724_TUN_EN);
++	max96724_write_reg(dev, MAX96724_PIPE2_TUN_EN_ADDR, MAX96724_TUN_EN);
++	max96724_write_reg(dev, MAX96724_PIPE3_TUN_EN_ADDR, MAX96724_TUN_EN);
++	/* TUN_DEST: set to Controller 1 (0x10) for 2x4 alt / Port A */
++	max96724_write_reg(dev, MAX96724_PIPE0_TUN_DEST_ADDR,
++			   MAX96724_TUN_DEST_CTRL1);
++	max96724_write_reg(dev, MAX96724_PIPE1_TUN_DEST_ADDR,
++			   MAX96724_TUN_DEST_CTRL1);
++	max96724_write_reg(dev, MAX96724_PIPE2_TUN_DEST_ADDR,
++			   MAX96724_TUN_DEST_CTRL1);
++	max96724_write_reg(dev, MAX96724_PIPE3_TUN_DEST_ADDR,
++			   MAX96724_TUN_DEST_CTRL1);
++
++	msleep(200);
++	mutex_unlock(&priv->lock);
++}
++EXPORT_SYMBOL(max96724_reset_oneshot);
++
++/* ================================================================
++ * Init Settings / Set Pipe
++ * ================================================================ */
++
++/*
++ * __max96724_set_pipe - Configure per-pipe mapping registers
++ */
++static int __max96724_set_pipe(struct device *dev, int pipe_id,
++			       u8 data_type1, u8 data_type2, u32 vc_id)
++{
++	int err = 0;
++	int i;
++	u8 en_mapping_num = 0x0F;
++	u8 all_mapping_phy = MAX96724_ALL_MAP_CTRL1;  /* Controller 1 for 2x4 alt Port A mode */
++
++	struct reg_pair map_pipe_control[] = {
++		/* Enable 4 mappings for Pipe X */
++		{MAX96724_TX11_PIPE_X_EN_ADDR, 0x0F},
++		/* Map data_type1 on vc_id */
++		{MAX96724_PIPE_X_SRC_0_MAP_ADDR, 0x1E},
++		{MAX96724_PIPE_X_DST_0_MAP_ADDR, 0x1E},
++		/* Map frame start on vc_id */
++		{MAX96724_PIPE_X_SRC_1_MAP_ADDR, 0x00},
++		{MAX96724_PIPE_X_DST_1_MAP_ADDR, 0x00},
++		/* Map frame end on vc_id */
++		{MAX96724_PIPE_X_SRC_2_MAP_ADDR, 0x01},
++		{MAX96724_PIPE_X_DST_2_MAP_ADDR, 0x01},
++		/* Map data_type2 on vc_id */
++		{MAX96724_PIPE_X_SRC_3_MAP_ADDR, 0x12},
++		{MAX96724_PIPE_X_DST_3_MAP_ADDR, 0x12},
++		/* All mappings to Controller 1 (2x4 alt: Ctrl1 drives Port A) */
++		{MAX96724_TX45_PIPE_X_DST_CTRL_ADDR, MAX96724_ALL_MAP_CTRL1},
++		{MAX96724_TX46_PIPE_X_ADDR, MAX96724_ALL_MAP_CTRL1},
++		{MAX96724_TX47_PIPE_X_ADDR, MAX96724_ALL_MAP_CTRL1},
++		{MAX96724_TX48_PIPE_X_ADDR, MAX96724_ALL_MAP_CTRL1},
++		/* [SC20190112 2-lane] TX49: Pipeline concatenation 2W (2-lane output) */
++		{MAX96724_TX49_PIPE_X_ADDR, MAX96724_TX49_CONCAT_2W},
++		/*
++		 * Keep DES heartbeat handling aligned with the serializer's
++		 * LIM_HEART-disabled tunnel mode to avoid persistent VID_SEQ_ERR.
++		 */
++		{0x0100, MAX96724_VID_RX0_CFG_VAL},
++		{0x0106, MAX96724_VID_RX6_CFG_VAL},
++		/*
++		 * Pipe stream control (offset 0x36 per pipe block).
++		 * [gmsl_ser_des_guide §4.9] TUN_EN = 0x09 per verified XML.
++		 */
++		{0x0936, MAX96724_TUN_EN},
++	};
++
++	/* Adjust addresses for pipe offset (stride 0x40 per pipe)
++	 * Entries 0-13: TX11, SRC/DST maps, TX45-TX49 (all stride 0x40)
++	 * Entries 14-15: VID_RX0/6 (stride 0x12)
++	 * Entry 16: Pipe stream control (stride 0x40)
++	 */
++	for (i = 0; i < 14; i++)
++		map_pipe_control[i].addr += 0x40 * pipe_id;
++
++	/* [max9296.c pattern] VID_RX offset: 0x12 per pipe */
++	map_pipe_control[14].addr += 0x12 * pipe_id;
++	map_pipe_control[15].addr += 0x12 * pipe_id;
++
++	/* Pipe stream control: stride 0x40 */
++	map_pipe_control[16].addr += 0x40 * pipe_id;
++
++	if (data_type2 == 0x0) {
++		en_mapping_num = 0x07;
++		all_mapping_phy = 0x15;  /* 3 mappings to Controller 1 */
++	}
++
++	map_pipe_control[0].val = en_mapping_num;
++	/* SRC: match incoming VC from camera (vc_id) */
++	map_pipe_control[1].val = (vc_id << 6) | data_type1;
++	/* DST: preserve VC — NVCSI/VI endpoints expect matching vc-id */
++	map_pipe_control[2].val = (vc_id << 6) | data_type1;
++	map_pipe_control[3].val = (vc_id << 6) | 0x00;
++	map_pipe_control[4].val = (vc_id << 6) | 0x00;
++	map_pipe_control[5].val = (vc_id << 6) | 0x01;
++	map_pipe_control[6].val = (vc_id << 6) | 0x01;
++	map_pipe_control[7].val = (vc_id << 6) | data_type2;
++	map_pipe_control[8].val = (vc_id << 6) | data_type2;
++	map_pipe_control[9].val = all_mapping_phy;
++	/* TX46-TX48 keep 0x55 (Ctrl1) from initializer */
++	/* TX49 keeps 0x83 (2W concat) from initializer */
++	/* VID_RX (entry 14) and pipe stream ctrl (entry 15) keep init values */
++
++	err = max96724_set_registers(dev, map_pipe_control,
++				     ARRAY_SIZE(map_pipe_control));
++
++	return err;
++}
++
++/*
++ * max96724_init_settings - Initialize default pipe and tunnel configuration
++ *
++ * Sets up all 4 pipes with default YUV422_8 + EMBED for VC0-3,
++ * matching the d4xx framework expectations.
++ *
++ */
++int max96724_init_settings(struct device *dev)
++{
++	int err = 0;
++	int i;
++	struct max96724 *priv = dev_get_drvdata(dev);
++
++	mutex_lock(&priv->lock);
++
++	for (i = 0; i < MAX96724_MAX_PIPES; i++)
++		err |= __max96724_set_pipe(dev, i, GMSL_CSI_DT_YUV422_8,
++					   GMSL_CSI_DT_EMBED, i);
++
++	mutex_unlock(&priv->lock);
++
++	return err;
++}
++EXPORT_SYMBOL(max96724_init_settings);
++
++int max96724_bind_ser_to_dser_pipe(struct device *dev, int dser_pipe_id,
++				   int ser_pipe_id, u32 vc_id)
++{
++	/* In Tunnel Mode, pipe mapping is 1:1 (each camera → one pipe) */
++	return 0;
++}
++EXPORT_SYMBOL(max96724_bind_ser_to_dser_pipe);
++
++int max96724_set_pipe(struct device *dev, int pipe_id,
++		      u8 data_type1, u8 data_type2, u32 vc_id)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++	int err = 0;
++
++	if (pipe_id > (MAX96724_MAX_PIPES - 1)) {
++		dev_info(dev, "%s: input pipe_id: %d exceeds max96724 max pipes\n",
++			 __func__, pipe_id);
++		return -EINVAL;
++	}
++
++	dev_dbg(dev, "%s pipe_id %d, data_type1 %u, data_type2 %u, vc_id %u\n",
++		__func__, pipe_id, data_type1, data_type2, vc_id);
++
++	mutex_lock(&priv->lock);
++
++	err = __max96724_set_pipe(dev, pipe_id, data_type1, data_type2, vc_id);
++
++	mutex_unlock(&priv->lock);
++
++	return err;
++}
++EXPORT_SYMBOL(max96724_set_pipe);
++
++/* ================================================================
++ * Device Tree Parsing
++ * ================================================================ */
++
++static const struct of_device_id max96724_of_match[] = {
++	{ .compatible = "adi,max96724", },
++	{ },
++};
++MODULE_DEVICE_TABLE(of, max96724_of_match);
++
++static int max96724_parse_dt(struct max96724 *priv,
++			     struct i2c_client *client)
++{
++	struct device_node *node = client->dev.of_node;
++	int err = 0;
++	const char *str_value;
++	int value;
++	const struct of_device_id *match;
++
++	if (!node)
++		return -EINVAL;
++
++	match = of_match_device(max96724_of_match, &client->dev);
++	if (!match) {
++		dev_err(&client->dev, "Failed to find matching dt id\n");
++		return -EFAULT;
++	}
++
++	/* CSI mode: "2x4" or "4x2" */
++	err = of_property_read_string(node, "csi-mode", &str_value);
++	if (err < 0) {
++		dev_err(&client->dev, "csi-mode property not found\n");
++		return err;
++	}
++
++	if (!strcmp(str_value, "2x4")) {
++		priv->csi_mode = MAX96724_CSI_MODE_2X4;
++		priv->lane_mp1 = MAX96724_LANE_MAP1_2X4;
++		priv->lane_mp2 = MAX96724_LANE_MAP2_2X4;
++	} else if (!strcmp(str_value, "4x2")) {
++		priv->csi_mode = MAX96724_CSI_MODE_4X2;
++		priv->lane_mp1 = MAX96724_LANE_MAP1_4X2;
++		priv->lane_mp2 = MAX96724_LANE_MAP2_4X2;
++	} else {
++		dev_err(&client->dev, "invalid csi mode\n");
++		return -EINVAL;
++	}
++
++	/* Max sources */
++	err = of_property_read_u32(node, "max-src", &value);
++	if (err < 0) {
++		dev_err(&client->dev, "No max-src info\n");
++		return err;
++	}
++	priv->max_src = value;
++
++	/* Reset GPIO */
++	priv->reset_gpio = of_get_named_gpio(node, "reset-gpios", 0);
++	if (priv->reset_gpio < 0) {
++		dev_err(&client->dev, "reset-gpios not found %d\n", err);
++		return err;
++	}
++
++	/* [User requirement] GMSL link speed from DT: 3 or 6 (Gbps) */
++	err = of_property_read_u32(node, "gmsl-link-speed", &value);
++	if (err < 0) {
++		/* Default to 3 Gbps if not specified */
++		priv->link_speed = 3;
++		dev_info(&client->dev,
++			 "gmsl-link-speed not specified, defaulting to 3 Gbps\n");
++	} else {
++		if (value != 3 && value != 6) {
++			dev_err(&client->dev,
++				"invalid gmsl-link-speed %d (must be 3 or 6)\n",
++				value);
++			return -EINVAL;
++		}
++		priv->link_speed = value;
++	}
++
++	/* 1.2V regulator (optional) */
++	if (of_get_property(node, "vdd_cam_1v2-supply", NULL)) {
++		priv->vdd_cam_1v2 = regulator_get(&client->dev, "vdd_cam_1v2");
++		if (IS_ERR(priv->vdd_cam_1v2)) {
++			dev_err(&client->dev,
++				"vdd_cam_1v2 regulator get failed\n");
++			err = PTR_ERR(priv->vdd_cam_1v2);
++			priv->vdd_cam_1v2 = NULL;
++			return err;
++		}
++	} else {
++		priv->vdd_cam_1v2 = NULL;
++	}
++
++	return 0;
++}
++
++/* ================================================================
++ * Probe / Remove
++ * ================================================================ */
++
++static struct regmap_config max96724_regmap_config = {
++	.reg_bits = 16,
++	.val_bits = 8,
++	.cache_type = REGCACHE_RBTREE,
++};
++
++static int max96724_probe(struct i2c_client *client,
++			   const struct i2c_device_id *id)
++{
++	struct max96724 *priv;
++	int err = 0;
++
++	dev_info(&client->dev,
++		 "[MAX96724]: probing Quad GMSL2 Deserializer (Tunnel Mode)\n");
++
++	priv = devm_kzalloc(&client->dev, sizeof(*priv), GFP_KERNEL);
++	if (!priv)
++		return -ENOMEM;
++
++	priv->i2c_client = client;
++	priv->regmap = devm_regmap_init_i2c(priv->i2c_client,
++					     &max96724_regmap_config);
++	if (IS_ERR(priv->regmap)) {
++		dev_err(&client->dev,
++			"regmap init failed: %ld\n", PTR_ERR(priv->regmap));
++		return -ENODEV;
++	}
++
++	err = max96724_parse_dt(priv, client);
++	if (err) {
++		dev_err(&client->dev, "unable to parse dt\n");
++		return -EFAULT;
++	}
++
++	max96724_pipes_reset(priv);
++
++	if (priv->max_src > MAX96724_MAX_SOURCES) {
++		dev_err(&client->dev,
++			"max sources more than currently supported\n");
++		return -EINVAL;
++	}
++
++	mutex_init(&priv->lock);
++
++	dev_set_drvdata(&client->dev, priv);
++
++	dev_info(&client->dev, "%s: success (link_speed=%d Gbps, max_src=%d)\n",
++		 __func__, priv->link_speed, priv->max_src);
++
++	return err;
++}
++
++static int max96724_remove(struct i2c_client *client)
++{
++	struct max96724 *priv;
++
++	if (client != NULL) {
++		priv = dev_get_drvdata(&client->dev);
++		mutex_destroy(&priv->lock);
++		i2c_unregister_device(client);
++		client = NULL;
++	}
++
++	return 0;
++}
++
++static const struct i2c_device_id max96724_id[] = {
++	{ "max96724", 0 },
++	{ },
++};
++
++MODULE_DEVICE_TABLE(i2c, max96724_id);
++
++static struct i2c_driver max96724_i2c_driver = {
++	.driver = {
++		.name = "max96724",
++		.owner = THIS_MODULE,
++		.of_match_table = of_match_ptr(max96724_of_match),
++	},
++	.probe = max96724_probe,
++	.remove = max96724_remove,
++	.id_table = max96724_id,
++};
++
++static int __init max96724_init(void)
++{
++	return i2c_add_driver(&max96724_i2c_driver);
++}
++
++static void __exit max96724_exit(void)
++{
++	i2c_del_driver(&max96724_i2c_driver);
++}
++
++module_init(max96724_init);
++module_exit(max96724_exit);
++
++MODULE_DESCRIPTION("Quad GMSL2 Deserializer driver max96724 (Tunnel Mode)");
++MODULE_AUTHOR("RealSense AI");
++MODULE_LICENSE("GPL v2");
+diff --git a/include/media/max96717.h b/include/media/max96717.h
+new file mode 100644
+index 0000000..65bf930
+--- /dev/null
++++ b/include/media/max96717.h
+@@ -0,0 +1,151 @@
++/*
++ * max96717.c - MAX96717 GMSL2 Serializer driver (Tunnel Mode)
++ *
++ * Copyright (c) 2026, RealSense, Inc.  All rights reserved.
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms and conditions of the GNU General Public License,
++ * version 2, as published by the Free Software Foundation.
++ *
++ * This program is distributed in the hope it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
++ * more details.
++ *
++ * You should have received a copy of the GNU General Public License
++ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
++ */
++
++/**
++ * @file
++ * <b>MAX96717 API: For Analog Devices MAX96717 GMSL2 serializer</b>
++ *
++ * @b Description: Defines elements used to set up and use an
++ *  Analog Devices MAX96717 GMSL2 serializer in Tunnel Mode.
++ */
++
++#ifndef __MAX96717_H__
++#define __MAX96717_H__
++
++#include <linux/types.h>
++#include <media/gmsl-link.h>
++
++/**
++ * \defgroup max96717 MAX96717 serializer driver
++ *
++ * Controls the MAX96717 GMSL2 serializer module (Tunnel Mode).
++ *
++ * @ingroup serdes_group
++ * @{
++ */
++
++/**
++ * @brief  Configures a single pipe on the serializer.
++ *
++ * In Tunnel Mode, per-pipe DT/VC filtering is not active on the serializer
++ * side (all VCs are tunneled transparently). This function maintains API
++ * compatibility with the d4xx sensor driver framework.
++ *
++ * @param  [in]  dev          The serializer device handle.
++ * @param  [in]  pipe_id      Pipe index (0..3).
++ * @param  [in]  data_type1   Primary CSI-2 data type.
++ * @param  [in]  data_type2   Secondary CSI-2 data type (e.g. embedded).
++ * @param  [in]  vc_id        Virtual channel ID.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96717_set_pipe(struct device *dev, int pipe_id, u8 data_type1,
++		      u8 data_type2, u32 vc_id);
++
++/**
++ * @brief  Toggle SER TX to restore tunnel detection after DES ONESHOT.
++ *
++ * A DES ONESHOT resets the video data path. The serializer must cycle
++ * its TX enable (REG2 0x03→0x43) for the deserializer to re-acquire
++ * the tunnel stream.
++ *
++ * @param  [in]  dev          The serializer device handle.
++ */
++void max96717_retrigger_tx(struct device *dev);
++
++/**
++ * @brief  Powers on the serializer and performs I2C overrides
++ * for sensor and serializer devices.
++ *
++ * Must be called after the deserializer's max96724_setup_link().
++ *
++ * @param  [in]  dev          The serializer device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96717_setup_control(struct device *dev);
++
++/**
++ * @brief  Reverts I2C overrides and resets the serializer.
++ *
++ * @param  [in]  dev          The serializer device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96717_reset_control(struct device *dev);
++
++/**
++ * @brief  Pairs a sensor device with the serializer.
++ *
++ * To be called by the sensor client driver.
++ *
++ * @param  [in]  dev          The serializer device handle.
++ * @param  [in]  g_ctx        The gmsl_link_ctx structure handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96717_sdev_pair(struct device *dev, struct gmsl_link_ctx *g_ctx);
++
++/**
++ * @brief  Unpairs a sensor device from the serializer.
++ *
++ * @param  [in]  dev          The serializer device handle.
++ * @param  [in]  s_dev        The sensor device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96717_sdev_unpair(struct device *dev, struct device *s_dev);
++
++/**
++ * @brief  Sets up the serializer's internal streaming pipeline.
++ *
++ * Configures CSI-2 input mode, lane mapping, and enables Tunnel Mode
++ * (EXT11[7]=1 at register 0x0383).
++ *
++ * @param  [in]  dev          The serializer device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96717_setup_streaming(struct device *dev);
++
++/**
++ * @brief  Applies initial register settings for the serializer.
++ *
++ * Configures default pipe settings and Tunnel Mode registers.
++ *
++ * @param  [in]  dev          The serializer device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96717_init_settings(struct device *dev);
++
++/**
++ * @brief  No-op hook for GPIO-over-GMSL tunneling for FSIN/FOUT signals.
++ *
++ * The signal map is documented, but the concrete MFP_CFG values are
++ * not available yet. This hook currently logs and returns success.
++ *
++ * @param  [in]  dev          The serializer device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96717_setup_gpio_tunneling(struct device *dev);
++
++/** @} */
++
++#endif  /* __MAX96717_H__ */
+diff --git a/include/media/max96724.h b/include/media/max96724.h
+new file mode 100644
+index 0000000..dc5a8ea
+--- /dev/null
++++ b/include/media/max96724.h
+@@ -0,0 +1,183 @@
++/*
++ * max96717.c - MAX96717 GMSL2 Serializer driver (Tunnel Mode)
++ *
++ * Copyright (c) 2026, RealSense, Inc.  All rights reserved.
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms and conditions of the GNU General Public License,
++ * version 2, as published by the Free Software Foundation.
++ *
++ * This program is distributed in the hope it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
++ * more details.
++ *
++ * You should have received a copy of the GNU General Public License
++ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
++ */
++
++/**
++ * @file
++ * <b>MAX96724 API: For Analog Devices MAX96724 GMSL2 quad deserializer</b>
++ *
++ * @b Description: Defines elements used to set up and use an
++ *  Analog Devices MAX96724 quad GMSL2 deserializer in Tunnel Mode.
++ */
++
++#ifndef __MAX96724_H__
++#define __MAX96724_H__
++
++#include <linux/types.h>
++#include <media/gmsl-link.h>
++
++/**
++ * \defgroup max96724 MAX96724 deserializer driver
++ *
++ * Controls the MAX96724 quad GMSL2 deserializer module (Tunnel Mode).
++ *
++ * @ingroup serdes_group
++ * @{
++ */
++
++int max96724_get_available_pipe_id(struct device *dev, int vc_id);
++int max96724_get_ser_pipe_id(struct device *dev, int dser_pipe_id, int vc_id);
++int max96724_set_pipe(struct device *dev, int pipe_id, u8 data_type1,
++		      u8 data_type2, u32 vc_id);
++int max96724_release_pipe(struct device *dev, int pipe_id);
++void max96724_reset_oneshot(struct device *dev);
++
++/**
++ * @brief  Puts the deserializer in single exclusive link mode.
++ *
++ * @param  [in]  dev          The deserializer device handle.
++ * @param  [in]  s_dev        The sensor device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96724_setup_link(struct device *dev, struct device *s_dev);
++
++/**
++ * @brief  Sets up the deserializer link's control pipeline.
++ *
++ * Configures I2C pass-through, splitter mode if needed, and
++ * enables the tunnel mode pipe routing for the source.
++ *
++ * @param  [in]  dev          The deserializer device handle.
++ * @param  [in]  s_dev        The sensor device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96724_setup_control(struct device *dev, struct device *s_dev);
++
++/**
++ * @brief  Resets the deserializer link control pipeline.
++ *
++ * @param  [in]  dev          The deserializer device handle.
++ * @param  [in]  s_dev        The sensor device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96724_reset_control(struct device *dev, struct device *s_dev);
++
++/**
++ * @brief  Registers a source sensor device with the deserializer.
++ *
++ * @param  [in]  dev          The deserializer device handle.
++ * @param  [in]  g_ctx        The gmsl_link_ctx structure handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96724_sdev_register(struct device *dev, struct gmsl_link_ctx *g_ctx);
++
++/**
++ * @brief  Unregisters a source sensor device from the deserializer.
++ *
++ * @param  [in]  dev          The deserializer device handle.
++ * @param  [in]  s_dev        The sensor device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96724_sdev_unregister(struct device *dev, struct device *s_dev);
++
++/**
++ * @brief  Configures the internal streaming pipeline.
++ *
++ * Sets up tunnel mode pipe routing, CSI-2 output lane configuration,
++ * and MIPI PHY settings.
++ *
++ * @param  [in]  dev          The deserializer device handle.
++ * @param  [in]  s_dev        The sensor device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96724_setup_streaming(struct device *dev, struct device *s_dev);
++
++/**
++ * @brief  Enables streaming for a source sensor.
++ *
++ * @param  [in]  dev          The deserializer device handle.
++ * @param  [in]  s_dev        The sensor device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96724_start_streaming(struct device *dev, struct device *s_dev);
++
++/**
++ * @brief  Disables streaming for a source sensor.
++ *
++ * @param  [in]  dev          The deserializer device handle.
++ * @param  [in]  s_dev        The sensor device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96724_stop_streaming(struct device *dev, struct device *s_dev);
++
++/**
++ * @brief  Powers on the MAX96724 deserializer module.
++ *
++ * Asserts shared reset GPIO and powers on the regulator.
++ *
++ * @param  [in]  dev          The deserializer device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96724_power_on(struct device *dev);
++
++/**
++ * @brief  Powers off the MAX96724 deserializer module.
++ *
++ * @param  [in]  dev          The deserializer device handle.
++ */
++void max96724_power_off(struct device *dev);
++
++/**
++ * @brief  Applies initial register settings for the deserializer.
++ *
++ * Configures default pipe mappings, tunnel mode, and CSI output for
++ * the D5xx/SC1.2 use case.
++ *
++ * @param  [in]  dev          The deserializer device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96724_init_settings(struct device *dev);
++
++/**
++ * @brief  Maps deserializer pipe ID to serializer pipe ID.
++ *
++ * In tunnel mode with MAX96717, all data flows through a single pipe
++ * per camera, so the mapping is 1:1.
++ *
++ * @param  [in]  dev             The deserializer device handle.
++ * @param  [in]  dser_pipe_id    Deserializer pipe ID.
++ * @param  [in]  ser_pipe_id     Serializer pipe ID.
++ * @param  [in]  vc_id           VC ID associated with this pipe.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96724_bind_ser_to_dser_pipe(struct device *dev, int dser_pipe_id,
++				   int ser_pipe_id, u32 vc_id);
++
++/** @} */
++
++#endif  /* __MAX96724_H__ */
+-- 
+2.25.1
+

--- a/nvidia-oot/7.1/0011-Add-MAX96717-serializer-and-MAX96724-deserializer-dr.patch
+++ b/nvidia-oot/7.1/0011-Add-MAX96717-serializer-and-MAX96724-deserializer-dr.patch
@@ -1,0 +1,2896 @@
+From 40fac9b67ddea60055961d32fa89fe8f608396ff Mon Sep 17 00:00:00 2001
+From: RealSense AI <realsense@realsenseai.com>
+Date: Tue, 12 May 2026 17:06:23 +0800
+Subject: [PATCH] Add MAX96717 serializer and MAX96724 deserializer drivers for
+ tunnel mode
+
+Add MAX96717 GMSL2 serializer and MAX96724 GMSL2 quad deserializer
+drivers for Tunnel Mode operation with D5xx cameras.
+
+MAX96717 serializer features:
+- CSI-2 input with 2/4 lane support
+- Tunnel Mode encapsulation of full CSI-2 byte stream
+- I2C address translation for sensor passthrough
+- GPIO-over-GMSL tunneling hook for FSIN/FOUT signals
+
+MAX96724 quad deserializer features:
+- Up to 4 GMSL2 links (quad camera support)
+- Configurable link speed (3 Gbps / 6 Gbps via DT)
+- Tunnel Mode pipe routing and CSI-2 output
+- 2x4 and 4x2 CSI output mode support
+- Power management with GPIO reset and regulator control
+
+Signed-off-by: RealSense AI <realsense@realsenseai.com>
+---
+ drivers/media/i2c/Makefile   |    2 +
+ drivers/media/i2c/max96717.c |  797 ++++++++++++++++
+ drivers/media/i2c/max96724.c | 1690 ++++++++++++++++++++++++++++++++++
+ include/media/max96717.h     |  151 +++
+ include/media/max96724.h     |  183 +++
+ 5 files changed, 2823 insertions(+)
+ create mode 100644 drivers/media/i2c/max96717.c
+ create mode 100644 drivers/media/i2c/max96724.c
+ create mode 100644 include/media/max96717.h
+ create mode 100644 include/media/max96724.h
+
+diff --git a/drivers/media/i2c/Makefile b/drivers/media/i2c/Makefile
+index b284938..947e6e9 100644
+--- a/drivers/media/i2c/Makefile
++++ b/drivers/media/i2c/Makefile
+@@ -8,6 +8,8 @@ obj-m += max9296.o
+ subdir-ccflags-y += -DCONFIG_VIDEO_D4XX_SERDES
+ subdir-ccflags-y += -DCONFIG_TEGRA_CAMERA_PLATFORM
+ obj-m += d4xx.o
++obj-m += max96717.o
++obj-m += max96724.o
+ ifeq ($(findstring ack_src,$(NV_BUILD_KERNEL_OPTIONS)),)
+ obj-m += max96712.o
+ 
+diff --git a/drivers/media/i2c/max96717.c b/drivers/media/i2c/max96717.c
+new file mode 100644
+index 0000000..78d8a01
+--- /dev/null
++++ b/drivers/media/i2c/max96717.c
+@@ -0,0 +1,797 @@
++/*
++ * max96717.c - MAX96717 GMSL2 Serializer driver (Tunnel Mode)
++ *
++ * Copyright (c) 2026, RealSense, Inc.  All rights reserved.
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms and conditions of the GNU General Public License,
++ * version 2, as published by the Free Software Foundation.
++ *
++ * This program is distributed in the hope it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
++ * more details.
++ *
++ * You should have received a copy of the GNU General Public License
++ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
++ */
++
++/*
++ * Register Reference Sources:
++ * [PPTX]  = GMSL_MAX96717_MAX96724_TechOverview - V1.pptx
++ * [XML]   = MAX96717_MAX96724_HKR_EVB_700mbps_tunnel_mode_basedonexcelsheet_D585.xml
++ *
++ * Every register address and value below is traceable to one of these sources.
++ */
++
++#include <media/camera_common.h>
++#include <linux/module.h>
++#include <media/max96717.h>
++
++/* ===== Register Addresses ===== */
++
++/* [PPTX slide 7] REG0: Device ID (read-only, returns 0x40) */
++#define MAX96717_DEV_ADDR		0x00
++
++/* [PPTX slide 7] REG1: Link Speed
++ *   bit[3]=1: 3 Gbps, bit[4]=1: 6 Gbps
++ */
++#define MAX96717_REG1_ADDR		0x01
++
++/* [PPTX slide 7 / XML 0x0002] PIPE_EN: Pipe enable / soft reset
++ *   [XML] 0x03 = soft reset, 0x43 = pipes enabled + video init
++ *   [PPTX slide 7] Matches MAX9295 PIPE_EN at 0x02
++ */
++#define MAX96717_PIPE_EN_ADDR		0x02
++
++/* [PPTX slide 7] CTRL0: GMSL2 TX Control
++ *   bit[5]=1: GMSL2 mode, bit[0]=1: enable transmitter
++ *   0x21 = GMSL2 mode + TX enable on Link A
++ */
++#define MAX96717_CTRL0_ADDR		0x10
++
++/* [PPTX slide 7] CTRL3: Start Video - final enable bit
++ *   bit[0]=1: activate video stream
++ */
++#define MAX96717_CTRL3_ADDR		0x13
++
++/* [PPTX slide 7] TX1: FEC Enable
++ *   bit[6]=1: Reed-Solomon FEC enabled
++ */
++#define MAX96717_TX1_ADDR		0x29
++
++/* [MAX96724 Users Guide, I2C Broadcasting section, p44-46]
++ * MAX96717 I2C address translation registers (GMSL2 standard):
++ *   SRC_A / DST_A (0x42/0x43): Translation pair A (SER broadcast addr)
++ *   SRC_B / DST_B (0x44/0x45): Translation pair B (sensor passthrough)
++ *
++ * When host writes to SRC_B address, the MAX96717 translates it to
++ * DST_B and forwards via GMSL back-channel to the remote sensor.
++ *
++ */
++#define MAX96717_SRC_A_ADDR		0x42
++#define MAX96717_DST_A_ADDR		0x43
++#define MAX96717_I2C4_ADDR		0x44	/* SRC_B: sensor proxy addr */
++#define MAX96717_I2C5_ADDR		0x45	/* DST_B: sensor default addr */
++
++/* [PPTX slide 14] TX_STR_SEL: Stream ID select
++ *   bits[1:0]: stream ID for DES pipe routing
++ */
++#define MAX96717_TX_STR_SEL_ADDR	0x5B
++
++/* [PPTX slide 7 / XML 0x0110-0x0111] VIDEO_TX0/TX1: Video TX path config
++ *   [XML] 0x0110=0xE9, 0x0111=0x10 for tunnel mode data path
++ */
++#define MAX96717_VIDEO_TX0_ADDR		0x110
++#define MAX96717_VIDEO_TX1_ADDR		0x111
++
++/* [PPTX slide 7] FRONTTOP_0: Front-end topology
++ *   0x12 = single CSI-2 port A, all VCs pass through
++ */
++#define MAX96717_FRONTTOP0_ADDR		0x308
++
++/* [XML / PPTX slide 7] MIPI_RX0-RX3: CSI-2 receiver configuration
++ *   RX0 (0x330): CSI mode (0x00 = D-PHY controller A)
++ *   RX1 (0x331): Lane count - [PPTX slide 14] ctrl1_num_lanes bits[5:4]
++ *                 [XML] 0x30 = bits[5:4]=11 (4 lanes)
++ *   RX2 (0x332): Lane mapping - [XML] 0xE0 = default 1x4 map
++ *   RX3 (0x333): Lane mapping - [XML] 0x04 = default 1x4 map
++ */
++#define MAX96717_MIPI_RX0_ADDR		0x330
++#define MAX96717_MIPI_RX1_ADDR		0x331
++#define MAX96717_MIPI_RX2_ADDR		0x332
++#define MAX96717_MIPI_RX3_ADDR		0x333
++
++/* [PPTX slide 7 / slide 14] EXT11: TUNNEL MODE ENABLE
++ *   bit[7]=1: Tun_Mode = ON  *** CRITICAL REGISTER ***
++ *   [PPTX slide 7] 0x383 = 0x80
++ */
++#define MAX96717_EXT11_ADDR		0x383
++
++/* ===== Register Values ===== */
++
++/* [XML] Soft reset value for PIPE_EN register */
++#define MAX96717_SOFT_RESET		0x03
++
++/* [XML] Final enable: pipes enabled + video init */
++#define MAX96717_PIPE_EN_ALL		0x43
++
++/* [PPTX slide 7] CTRL0: GMSL2 mode + TX enable (Link A) */
++#define MAX96717_CTRL0_LINK_A		0x21
++/* CTRL0: GMSL2 mode + TX enable (Link B) */
++#define MAX96717_CTRL0_LINK_B		0x22
++
++/* [PPTX slide 7] CTRL0 reset all */
++#define MAX96717_RESET_ALL		0x80
++
++/* [PPTX slide 7] EXT11 tunnel mode enable value */
++#define MAX96717_TUN_MODE_EN		0x80
++
++/* [XML] VIDEO_TX0 tunnel mode data path enable */
++#define MAX96717_VIDEO_TX0_TUN		0xE9
++/* [XML] VIDEO_TX1 tunnel mode config */
++#define MAX96717_VIDEO_TX1_TUN		0x10
++
++/* [XML / PPTX slide 14] MIPI RX1: 4-lane CSI-2, bits[5:4]=11 */
++#define MAX96717_CSI_4_LANES		0x30
++/* 2-lane CSI-2, bits[5:4]=01 */
++#define MAX96717_CSI_2_LANES		0x10
++
++/* [XML] Lane mapping for 1x4 mode (matches MAX9295 1x4 values) */
++#define MAX96717_CSI_1X4_LANE_MAP1	0xE0
++#define MAX96717_CSI_1X4_LANE_MAP2	0x04
++
++/* [PPTX slide 7] FRONTTOP_0: single port A, all VCs */
++#define MAX96717_FRONTTOP0_PORT_A	0x12
++
++/* [XML] MIPI_RX0: CSI reset on + non-continuous clock */
++#define MAX96717_MIPI_RX0_RESET		0x08
++/* [PPTX slide 7] MIPI_RX0: Normal operation */
++#define MAX96717_MIPI_RX0_NORMAL	0x00
++
++/* [PPTX slide 9] REG1: 3 Gbps link speed, bit[3]=1 */
++#define MAX96717_LINK_SPEED_3GBPS	0x08
++/* [PPTX slide 9] REG1: 6 Gbps link speed, bit[4]=1 */
++#define MAX96717_LINK_SPEED_6GBPS	0x10
++
++/* [XML] EXT11 tunnel mode pre-config (0x0383=0x80) */
++#define MAX96717_EXT11_TUN_PRE		0x80
++
++#define MAX96717_MAX_PIPES		4
++
++/* ===== Data Structures ===== */
++
++struct max96717_client_ctx {
++	struct gmsl_link_ctx *g_ctx;
++	bool st_done;
++};
++
++struct max96717 {
++	struct i2c_client *i2c_client;
++	struct regmap *regmap;
++	struct max96717_client_ctx g_client;
++	struct mutex lock;
++	/* primary serializer properties */
++	__u32 def_addr;
++	__u32 pst2_ref;
++};
++
++static struct max96717 *prim_priv__;
++
++struct reg_pair {
++	u16 addr;
++	u8 val;
++};
++
++/* ===== Low-level I2C ===== */
++
++static int max96717_write_reg(struct device *dev, u16 addr, u8 val)
++{
++	struct max96717 *priv = dev_get_drvdata(dev);
++	int err;
++
++	err = regmap_write(priv->regmap, addr, val);
++	if (err)
++		dev_err(dev, "%s:i2c write failed, 0x%x = %x\n",
++			__func__, addr, val);
++
++	/* delay before next i2c command as required for SERDES link */
++	usleep_range(100, 110);
++
++	return err;
++}
++
++static int max96717_set_registers(struct device *dev, struct reg_pair *map,
++				  u32 count)
++{
++	int err = 0;
++	u32 j;
++
++	for (j = 0; j < count; j++) {
++		err = max96717_write_reg(dev, map[j].addr, map[j].val);
++		if (err)
++			break;
++	}
++
++	return err;
++}
++
++/* ===== Streaming Setup ===== */
++
++/*
++ * max96717_setup_streaming - Configure CSI-2 input and enable Tunnel Mode
++ *
++ * In Tunnel Mode (unlike MAX9295 Pixel Mode), the serializer encapsulates
++ * the entire CSI-2 byte stream verbatim into a single GMSL2 tunnel.
++ * All VCs (VC0-VC3) are preserved end-to-end.
++ */
++int max96717_setup_streaming(struct device *dev)
++{
++	struct max96717 *priv = dev_get_drvdata(dev);
++	int err = 0;
++	struct gmsl_link_ctx *g_ctx;
++	u32 lane_count;
++
++	/*
++	 * [XML] Full initialization sequence:
++	 *   0x0002 = 0x03  (soft reset)
++	 *   0x0383 = 0x80  (tunnel mode enable)
++	 *   0x0331 = 0x30  (4-lane CSI)
++	 *   0x0332 = 0xE0  (lane map1)
++	 *   0x0333 = 0x04  (lane map2)
++	 *   0x0110 = 0xE9  (video TX0 tunnel path)
++	 *   0x0111 = 0x10  (video TX1 tunnel config)
++	 *   0x0330 = 0x08  (CSI reset on)
++	 *   0x0330 = 0x00  (CSI reset off)
++	 *   0x0002 = 0x43  (final enable)
++	 */
++	struct reg_pair tunnel_init[] = {
++		/* [PPTX slide 7] EXT11: Tunnel Mode Enable */
++		{MAX96717_EXT11_ADDR, MAX96717_TUN_MODE_EN},
++		/* [XML] VIDEO_TX0/TX1: tunnel data path */
++		{MAX96717_VIDEO_TX0_ADDR, MAX96717_VIDEO_TX0_TUN},
++		{MAX96717_VIDEO_TX1_ADDR, MAX96717_VIDEO_TX1_TUN},
++	};
++
++	mutex_lock(&priv->lock);
++
++	if (!priv->g_client.g_ctx) {
++		dev_err(dev, "%s: no sdev client found\n", __func__);
++		err = -EINVAL;
++		goto error;
++	}
++
++	if (priv->g_client.st_done) {
++		dev_dbg(dev, "%s: stream setup is already done\n", __func__);
++		goto error;
++	}
++
++	g_ctx = priv->g_client.g_ctx;
++
++	/*
++	 * [Aardvark-verified] Soft reset before tunnel mode configuration
++	 * Clears stale pipe/CSI state for clean initialization.
++	 * Aardvark: 0x0002=0x03, sleep 30ms, then proceed with config.
++	 */
++	max96717_write_reg(dev, MAX96717_PIPE_EN_ADDR, MAX96717_SOFT_RESET);
++	msleep(30);
++
++	/*
++	 * [PPTX slide 14] ctrl1_num_lanes at 0x0331 bits[5:4]
++	 * [XML] 0x0331 = 0x30 for 4-lane
++	 * MAX96717 supports 1x4 mode only (single 4-lane D-PHY input)
++	 */
++	lane_count = (g_ctx->num_csi_lanes == 4) ?
++		MAX96717_CSI_4_LANES : MAX96717_CSI_2_LANES;
++
++	max96717_write_reg(dev, MAX96717_MIPI_RX1_ADDR, lane_count);
++
++	/* [XML] Lane mapping: 1x4 mode default */
++	max96717_write_reg(dev, MAX96717_MIPI_RX2_ADDR,
++			   MAX96717_CSI_1X4_LANE_MAP1);
++	max96717_write_reg(dev, MAX96717_MIPI_RX3_ADDR,
++			   MAX96717_CSI_1X4_LANE_MAP2);
++
++	/* Enable tunnel mode and configure video TX path */
++	err = max96717_set_registers(dev, tunnel_init,
++				     ARRAY_SIZE(tunnel_init));
++	if (err)
++		goto error;
++
++	/* [Aardvark-verified] CSI reset cycle with 2ms delay */
++	max96717_write_reg(dev, MAX96717_MIPI_RX0_ADDR,
++			   MAX96717_MIPI_RX0_RESET);
++	usleep_range(2000, 2100);
++	max96717_write_reg(dev, MAX96717_MIPI_RX0_ADDR,
++			   MAX96717_MIPI_RX0_NORMAL);
++
++	/* [XML] Final enable: pipes on + video init */
++	max96717_write_reg(dev, MAX96717_PIPE_EN_ADDR,
++			   MAX96717_PIPE_EN_ALL);
++
++	priv->g_client.st_done = true;
++
++error:
++	mutex_unlock(&priv->lock);
++	return err;
++}
++EXPORT_SYMBOL(max96717_setup_streaming);
++
++/* ===== Control Setup ===== */
++
++/*
++ * max96717_setup_control - Set up I2C address translation and link control
++ *
++ * Steps:
++ *   1. Reassign serializer I2C address via DEV_ADDR (reg 0x00)
++ *   2. Configure GMSL2 link mode via CTRL0 (reg 0x10)
++ *   3. Set I2C address translation for sensor passthrough:
++ *      I2C4/SRC_B (0x44) <- (sdev_reg << 1): proxy addr visible to host
++ *      I2C5/DST_B (0x45) <- (sdev_def << 1): real addr on back-channel
++ *
++ * This lets the Orin host access the D5xx sensor (def-addr 0x42) via
++ * the aliased proxy address (e.g. 0x1a) through the GMSL link.
++ *
++ */
++int max96717_setup_control(struct device *dev)
++{
++	struct max96717 *priv = dev_get_drvdata(dev);
++	int err = 0;
++	struct gmsl_link_ctx *g_ctx;
++
++	mutex_lock(&priv->lock);
++
++	if (!priv->g_client.g_ctx) {
++		dev_err(dev, "%s: no sensor dev client found\n", __func__);
++		err = -EINVAL;
++		goto error;
++	}
++
++	g_ctx = priv->g_client.g_ctx;
++
++	if (prim_priv__) {
++		/*
++		 * [HW note] The MAX96717 retains its I2C address across
++		 * reboots (PoC stays on).  If already at the aliased address,
++		 * the DEV_ADDR write to 0x40 NACKs.  Skip reassignment when
++		 * the primary and alias are the same physical device and the
++		 * serializer is already responsive at a non-default address.
++		 *
++		 * For cold-start (first power-on), this write is required.
++		 * We detect "already reassigned" by trying a read first:
++		 * if the primary address (0x40) NACKs, skip the reassign.
++		 */
++		unsigned int dev_id;
++		int probe_ret;
++
++		probe_ret = regmap_read(prim_priv__->regmap,
++					MAX96717_DEV_ADDR, &dev_id);
++		if (probe_ret == 0) {
++			/* Primary address (0x40) still responsive — do reassign */
++			max96717_write_reg(&prim_priv__->i2c_client->dev,
++					   MAX96717_DEV_ADDR,
++					   (g_ctx->ser_reg << 1));
++		} else {
++			dev_info(&prim_priv__->i2c_client->dev,
++				 "%s: SER already reassigned (addr 0x40 NACK), skipping DEV_ADDR write\n",
++				 __func__);
++		}
++	}
++
++	/* [PPTX slide 7] CTRL0: GMSL2 mode + TX enable */
++	if (g_ctx->serdes_csi_link == GMSL_SERDES_CSI_LINK_A)
++		err = max96717_write_reg(dev, MAX96717_CTRL0_ADDR,
++					 MAX96717_CTRL0_LINK_A);
++	else
++		err = max96717_write_reg(dev, MAX96717_CTRL0_ADDR,
++					 MAX96717_CTRL0_LINK_B);
++
++	if (err) {
++		dev_err(dev, "%s: ERROR: ser device not found\n", __func__);
++		goto error;
++	}
++
++	/* delay to settle link */
++	msleep(100);
++
++	/*
++	 * I2C address translation for sensor passthrough.
++	 * [MAX96724 Users Guide, I2C Broadcasting, p44-46]
++	 *
++	 * I2C4 / SRC_B (0x44): sensor proxy addr visible to Orin host
++	 * I2C5 / DST_B (0x45): sensor real addr on GMSL back-channel
++	 *
++	 * When host sends I2C to sdev_reg (e.g., 0x1a), the MAX96717
++	 * translates it to sdev_def (e.g., 0x42) and forwards via GMSL
++	 * back-channel to the HKR sensor.
++	 */
++	max96717_write_reg(dev, MAX96717_I2C4_ADDR,
++			   (g_ctx->sdev_reg << 1));
++	max96717_write_reg(dev, MAX96717_I2C5_ADDR,
++			   (g_ctx->sdev_def << 1));
++
++	/* dev addr pass-through ref */
++	if (prim_priv__)
++		prim_priv__->pst2_ref++;
++
++	g_ctx->serdev_found = true;
++
++error:
++	mutex_unlock(&priv->lock);
++	return err;
++}
++EXPORT_SYMBOL(max96717_setup_control);
++
++/* ===== GPIO Tunneling ===== */
++
++/*
++ * max96717_setup_gpio_tunneling - GPIO-over-GMSL no-op hook
++ *
++ * [PPTX slide 10] GPIO Signal Mapping:
++ *   MFP0 → GPIO0: FSIN (DES→SER, frame sync in)
++ *   MFP1 → GPIO1: FOUT/STROBE (SER→DES, frame sync out)
++ *   MFP4 → GPIO4: RESET_N (DES→SER, hard reset)
++ *   MFP5 → GPIO5: IRQ (SER→DES, interrupt request)
++ *   MFP6 → GPIO6: ZV_SYNC (DES→SER, IR stereo sync)
++ *
++ * The PPTX defines the signal mapping and MFP_CFG register range,
++ * but not the confirmed direction/function values. Keep this as
++ * an explicit no-op hook until the MAX96717 GPIO register values
++ * are available from ADI.
++ */
++int max96717_setup_gpio_tunneling(struct device *dev)
++{
++	struct max96717 *priv = dev_get_drvdata(dev);
++	int err = 0;
++
++	mutex_lock(&priv->lock);
++
++	dev_info(dev, "%s: GPIO tunneling hook is a no-op; MFP_CFG values are not defined yet\n",
++		 __func__);
++
++	mutex_unlock(&priv->lock);
++
++	return err;
++}
++EXPORT_SYMBOL(max96717_setup_gpio_tunneling);
++
++/* ===== Reset Control ===== */
++
++int max96717_reset_control(struct device *dev)
++{
++	struct max96717 *priv = dev_get_drvdata(dev);
++	int err = 0;
++
++	mutex_lock(&priv->lock);
++	if (!priv->g_client.g_ctx) {
++		dev_err(dev, "%s: no sdev client found\n", __func__);
++		err = -EINVAL;
++		goto error;
++	}
++
++	priv->g_client.st_done = false;
++
++	if (prim_priv__) {
++		prim_priv__->pst2_ref--;
++
++		max96717_write_reg(dev, MAX96717_DEV_ADDR,
++				   (prim_priv__->def_addr << 1));
++		if (prim_priv__->pst2_ref == 0)
++			max96717_write_reg(&prim_priv__->i2c_client->dev,
++					   MAX96717_CTRL0_ADDR,
++					   MAX96717_RESET_ALL);
++	}
++
++error:
++	mutex_unlock(&priv->lock);
++	return err;
++}
++EXPORT_SYMBOL(max96717_reset_control);
++
++/* ===== Device Pairing ===== */
++
++int max96717_sdev_pair(struct device *dev, struct gmsl_link_ctx *g_ctx)
++{
++	struct max96717 *priv;
++	int err = 0;
++
++	if (!dev || !g_ctx || !g_ctx->s_dev) {
++		dev_err(dev, "%s: invalid input params\n", __func__);
++		return -EINVAL;
++	}
++
++	priv = dev_get_drvdata(dev);
++	mutex_lock(&priv->lock);
++	if (priv->g_client.g_ctx) {
++		/* Already paired — tolerate if this is a re-probe of
++		 * the same camera after a failed first attempt.
++		 * Simply overwrite with the new g_ctx.
++		 */
++		dev_warn(dev, "%s: re-pairing (previous probe may have failed)\n",
++			 __func__);
++	}
++
++	priv->g_client.st_done = false;
++	priv->g_client.g_ctx = g_ctx;
++
++	/* mutex_unlock in error path, but we have none — inline the unlock */
++	mutex_unlock(&priv->lock);
++	return err;
++}
++EXPORT_SYMBOL(max96717_sdev_pair);
++
++int max96717_sdev_unpair(struct device *dev, struct device *s_dev)
++{
++	struct max96717 *priv = NULL;
++	int err = 0;
++
++	if (!dev || !s_dev) {
++		dev_err(dev, "%s: invalid input params\n", __func__);
++		return -EINVAL;
++	}
++
++	priv = dev_get_drvdata(dev);
++
++	mutex_lock(&priv->lock);
++
++	if (!priv->g_client.g_ctx) {
++		dev_dbg(dev, "%s: device is not paired\n", __func__);
++		err = 0; /* Not an error — already unpaired */
++		goto error;
++	}
++
++	if (priv->g_client.g_ctx->s_dev != s_dev) {
++		dev_warn(dev, "%s: s_dev mismatch, clearing anyway\n", __func__);
++	}
++
++	priv->g_client.g_ctx = NULL;
++	priv->g_client.st_done = false;
++
++error:
++	mutex_unlock(&priv->lock);
++	return err;
++}
++EXPORT_SYMBOL(max96717_sdev_unpair);
++
++/* ===== Pipe Configuration ===== */
++
++/*
++ * __max96717_set_pipe - Configure a single pipe's DT/VC mapping
++ *
++ * In Tunnel Mode, per-pipe DT/VC filtering is bypassed on the serializer。
++ * However, we still write the registers for d4xx framework compatibility.
++ *
++ */
++static int __max96717_set_pipe(struct device *dev, int pipe_id, u8 data_type1,
++			       u8 data_type2, u32 vc_id)
++{
++	int err = 0;
++	u8 bpp = 0x30;
++
++	struct reg_pair map_pipe_control[] = {
++		/* Pipe X DT addr + 0x2*pipe_id */
++		{0x0314, 0x5E},  /* data_type1 */
++		{0x0315, 0x52},  /* data_type2 */
++		{0x0309, 0x01},  /* VC select */
++		{0x030A, 0x00},
++		{0x031C, 0x30},  /* BPP */
++		{0x0102, 0x0E},  /* LIM_HEART: Disabled */
++	};
++
++	if (data_type1 == GMSL_CSI_DT_RGB_888)
++		bpp = 0x18;
++
++	map_pipe_control[0].addr += 0x2 * pipe_id;
++	map_pipe_control[1].addr += 0x2 * pipe_id;
++	map_pipe_control[2].addr += 0x2 * pipe_id;
++	map_pipe_control[3].addr += 0x2 * pipe_id;
++	map_pipe_control[4].addr += 0x1 * pipe_id;
++	map_pipe_control[5].addr += 0x8 * pipe_id;
++
++	map_pipe_control[0].val = 0x40 | data_type1;
++	map_pipe_control[1].val = 0x40 | data_type2;
++	if (pipe_id == 0)
++		map_pipe_control[1].val |= 0x80;
++	map_pipe_control[2].val = 1 << vc_id;
++	map_pipe_control[3].val = 0x00;
++	map_pipe_control[4].val = bpp;
++	map_pipe_control[5].val = 0x0E;
++
++	err = max96717_set_registers(dev, map_pipe_control,
++				     ARRAY_SIZE(map_pipe_control));
++
++	return err;
++}
++
++/*
++ * max96717_init_settings - Initialize default pipe/streaming settings
++ *
++ * In Tunnel Mode, per-pipe DT config is not functionally needed
++ * but we configure pipes for d4xx compatibility.
++ * Default: 4 pipes with YUV422_8 + EMBED, VC0-3.
++ */
++int max96717_init_settings(struct device *dev)
++{
++	int err = 0;
++	int i;
++	struct max96717 *priv = dev_get_drvdata(dev);
++
++	struct reg_pair map_init[] = {
++		/* [XML seq] PIPE_EN soft reset first, then enable tunnel mode.
++		 * Note: FRONTTOP0 is bypassed in tunnel mode (per UG) —
++		 * CSI-2 input goes directly into the tunnel, no port config needed.
++		 */
++		{MAX96717_PIPE_EN_ADDR, MAX96717_SOFT_RESET},
++		{MAX96717_EXT11_ADDR, MAX96717_TUN_MODE_EN},
++		{MAX96717_PIPE_EN_ADDR, 0xF3},
++		{MAX96717_MIPI_RX1_ADDR, MAX96717_CSI_4_LANES},
++	};
++
++	mutex_lock(&priv->lock);
++
++	/*
++	 * [HW requirement] After CTRL0 + I2C translation writes in
++	 * setup_control, the MAX96717 needs settling time before
++	 * accepting writes to PIPE_EN (0x02) and FRONTTOP registers.
++	 */
++	usleep_range(5000, 6000);
++
++	err = max96717_set_registers(dev, map_init, ARRAY_SIZE(map_init));
++
++	for (i = 0; i < MAX96717_MAX_PIPES; i++)
++		err |= __max96717_set_pipe(dev, i, GMSL_CSI_DT_YUV422_8,
++					   GMSL_CSI_DT_EMBED, i);
++
++	mutex_unlock(&priv->lock);
++
++	return err;
++}
++EXPORT_SYMBOL(max96717_init_settings);
++
++int max96717_set_pipe(struct device *dev, int pipe_id,
++		      u8 data_type1, u8 data_type2, u32 vc_id)
++{
++	struct max96717 *priv = dev_get_drvdata(dev);
++	int err = 0;
++
++	if (pipe_id > (MAX96717_MAX_PIPES - 1)) {
++		dev_info(dev, "%s: input pipe_id: %d exceeds max96717 max pipes\n",
++			 __func__, pipe_id);
++		return -EINVAL;
++	}
++
++	dev_dbg(dev, "%s pipe_id %d, data_type1 %u, data_type2 %u, vc_id %u\n",
++		__func__, pipe_id, data_type1, data_type2, vc_id);
++
++	mutex_lock(&priv->lock);
++
++	err = __max96717_set_pipe(dev, pipe_id, data_type1, data_type2, vc_id);
++
++	mutex_unlock(&priv->lock);
++
++	return err;
++}
++EXPORT_SYMBOL(max96717_set_pipe);
++
++/**
++ * max96717_retrigger_tx - Toggle SER TX to restore tunnel detection after
++ * a DES ONESHOT.  DES ONESHOT resets the data path; the SER must cycle
++ * its TX enable for the DES to re-acquire the tunnel stream.
++ */
++void max96717_retrigger_tx(struct device *dev)
++{
++	max96717_write_reg(dev, MAX96717_PIPE_EN_ADDR, MAX96717_SOFT_RESET);
++	msleep(30);
++	max96717_write_reg(dev, MAX96717_PIPE_EN_ADDR, MAX96717_PIPE_EN_ALL);
++}
++EXPORT_SYMBOL(max96717_retrigger_tx);
++
++/* ===== Probe / Remove ===== */
++
++static struct regmap_config max96717_regmap_config = {
++	.reg_bits = 16,
++	.val_bits = 8,
++	.cache_type = REGCACHE_RBTREE,
++};
++
++static int max96717_probe(struct i2c_client *client,
++			   const struct i2c_device_id *id)
++{
++	struct max96717 *priv;
++	int err = 0;
++	struct device_node *node = client->dev.of_node;
++
++	dev_info(&client->dev, "[MAX96717]: probing GMSL2 Serializer (Tunnel Mode)\n");
++
++	priv = devm_kzalloc(&client->dev, sizeof(*priv), GFP_KERNEL);
++	if (!priv)
++		return -ENOMEM;
++
++	priv->i2c_client = client;
++	priv->regmap = devm_regmap_init_i2c(priv->i2c_client,
++					     &max96717_regmap_config);
++	if (IS_ERR(priv->regmap)) {
++		dev_err(&client->dev,
++			"regmap init failed: %ld\n", PTR_ERR(priv->regmap));
++		return -ENODEV;
++	}
++
++	mutex_init(&priv->lock);
++
++	if (of_get_property(node, "is-prim-ser", NULL)) {
++		if (prim_priv__) {
++			dev_err(&client->dev,
++				"prim-ser already exists\n");
++			return -EEXIST;
++		}
++
++		err = of_property_read_u32(node, "reg", &priv->def_addr);
++		if (err < 0) {
++			dev_err(&client->dev, "reg not found\n");
++			return -EINVAL;
++		}
++
++		prim_priv__ = priv;
++	}
++
++	dev_set_drvdata(&client->dev, priv);
++
++	dev_info(&client->dev, "%s: success\n", __func__);
++
++	return err;
++}
++
++static int max96717_remove(struct i2c_client *client)
++{
++	struct max96717 *priv;
++
++	if (client != NULL) {
++		priv = dev_get_drvdata(&client->dev);
++		mutex_destroy(&priv->lock);
++		i2c_unregister_device(client);
++		client = NULL;
++	}
++
++	return 0;
++}
++
++static const struct i2c_device_id max96717_id[] = {
++	{ "max96717", 0 },
++	{ },
++};
++
++static const struct of_device_id max96717_of_match[] = {
++	{ .compatible = "adi,max96717", },
++	{ .compatible = "maxim,max96717", },
++	{ },
++};
++MODULE_DEVICE_TABLE(of, max96717_of_match);
++MODULE_DEVICE_TABLE(i2c, max96717_id);
++
++static struct i2c_driver max96717_i2c_driver = {
++	.driver = {
++		.name = "max96717",
++		.owner = THIS_MODULE,
++		.of_match_table = of_match_ptr(max96717_of_match),
++	},
++	.probe = max96717_probe,
++	.remove = max96717_remove,
++	.id_table = max96717_id,
++};
++
++static int __init max96717_init(void)
++{
++	return i2c_add_driver(&max96717_i2c_driver);
++}
++
++static void __exit max96717_exit(void)
++{
++	i2c_del_driver(&max96717_i2c_driver);
++}
++
++module_init(max96717_init);
++module_exit(max96717_exit);
++
++MODULE_DESCRIPTION("GMSL2 Serializer driver max96717 (Tunnel Mode)");
++MODULE_AUTHOR("RealSense AI");
++MODULE_LICENSE("GPL v2");
+diff --git a/drivers/media/i2c/max96724.c b/drivers/media/i2c/max96724.c
+new file mode 100644
+index 0000000..7286ff4
+--- /dev/null
++++ b/drivers/media/i2c/max96724.c
+@@ -0,0 +1,1690 @@
++/*
++ * max96724.c - MAX96724 GMSL2 Quad Deserializer driver (Tunnel Mode)
++ *
++ * Copyright (c) 2026, RealSense, Inc.  All rights reserved.
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms and conditions of the GNU General Public License,
++ * version 2, as published by the Free Software Foundation.
++ *
++ * This program is distributed in the hope it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
++ * more details.
++ *
++ * You should have received a copy of the GNU General Public License
++ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
++ */
++
++
++#include <linux/gpio.h>
++#include <linux/module.h>
++#include <linux/of.h>
++#include <linux/of_device.h>
++#include <linux/of_gpio.h>
++#include <media/camera_common.h>
++#include <linux/module.h>
++#include <media/max96724.h>
++
++/* ================================================================
++ * Register Addresses
++ * ================================================================ */
++
++/* --- Device ID / Configuration --- */
++
++/* [UG p.3] REG0: Device ID (read-only, returns 0xA2) */
++#define MAX96724_DEV_ID_ADDR		0x00
++
++/* [Errata §5] ERRB master reset register */
++#define MAX96724_ERRB_MST_RST_ADDR	0x05
++
++/* [UG Table 3, p.11] 0x0006: GMSL Link/PHY Enable and Mode Select
++ *   bits[7:4]: PHY mode (0=GMSL1, 1=GMSL2) per link D/C/B/A
++ *   bits[3:0]: Link Enable per link D/C/B/A
++ */
++#define MAX96724_LINK_EN_ADDR		0x0006
++
++/* [UG Table 3, p.11] 0x0010: GMSL Link/PHY Rate Select (Links A&B)
++ *   bits[7:6]: Tx Rate Link B, bits[5:4]: Rx Rate Link B
++ *   bits[3:2]: Tx Rate Link A, bits[1:0]: Rx Rate Link A
++ *   Tx: 00=187.5Mbps, Rx: 01=3Gbps, 10=6Gbps
++ */
++#define MAX96724_LINK_RATE_AB_ADDR	0x0010
++
++/* [UG Table 3, p.12] 0x0011: GMSL Link/PHY Rate Select (Links C&D) */
++#define MAX96724_LINK_RATE_CD_ADDR	0x0011
++
++/* [UG p.13] 0x001A: Link A lock status (bit[3]=LOCK) */
++#define MAX96724_LINK_A_LOCK_ADDR	0x001A
++
++/* [UG Table 3, p.12] 0x0018: GMSL Link Reset
++ *   bits[7:4]: Link reset D/C/B/A, bits[3:0]: One-shot reset D/C/B/A
++ */
++#define MAX96724_ONESHOT_ADDR		0x0018
++
++/* [UG p.11] REG13: Soft Reset (write 0x40, wait 5ms) */
++#define MAX96724_REG13_ADDR		0x000D
++
++/* [Errata §5] Error Channel Power Up registers (required for 6Gbps)
++ *   Write 0x75 immediately after power-up for robust 6Gbps operation
++ */
++#define MAX96724_ERRCH_A_ADDR		0x1449
++#define MAX96724_ERRCH_B_ADDR		0x1549
++#define MAX96724_ERRCH_C_ADDR		0x1649
++#define MAX96724_ERRCH_D_ADDR		0x1749
++#define MAX96724_ERRCH_FORCE_ON		0x75
++
++/* --- I2C Control Channel / Errata --- */
++
++/* [Errata #2] Tunnel Mode SRAM LCRC error suppression
++ *   Set 0x458[7:4] = 0x0 to suppress spurious ERRB in tunnel mode
++ */
++#define MAX96724_SRAM_LCRC_ERR_ADDR	0x0458
++
++/* --- Video Pipe Selection --- */
++
++/*
++ *   bits[3:0] = Pipe 0 source (0x0=SIOA)
++ *   bits[7:4] = Pipe 1 source (0x1=SIOB)
++ */
++#define MAX96724_PIPE_SEL0_ADDR		0xF0
++
++/*
++ *   bits[3:0] = Pipe 2 source (0x2=SIOC)
++ *   bits[7:4] = Pipe 3 source (0x3=SIOD)
++ */
++#define MAX96724_PIPE_SEL1_ADDR		0xF1
++
++/*
++ *   bit[0]=Pipe 0, bit[1]=Pipe 1, bit[2]=Pipe 2, bit[3]=Pipe 3
++ */
++#define MAX96724_PIPE_EN_ADDR		0xF4
++
++/* --- Pipe Receiver / Tunnel Mode --- */
++
++/*
++ *   bit[5]=1: Tunnel Mode, bits[1:0]=11: 4-lane MIPI out
++ *   Stride: 0x12 per pipe (P0=0x100, P1=0x112, P2=0x124, P3=0x136)
++ */
++#define MAX96724_VID_RX0_P0_ADDR	0x100
++#define MAX96724_VID_RX6_P0_ADDR	0x106
++#define MAX96724_VID_RX_STRIDE		0x12
++
++#define MAX96724_VID_RX1_P0_ADDR	0x101
++
++/* --- CSI-2 Output (BACKTOP) --- */
++
++/* [UG p.19] BACKTOP: CSI-2 output port enable
++ *   0x040B bit[1]=CSIB_EN, bit[0]=CSIA_EN
++ */
++#define MAX96724_BACKTOP_EN_ADDR	0x040B
++
++/* --- MIPI DPLL (Data Rate) --- */
++
++/* [UG Table 12, p.27] MIPI PHY DPLL Freq registers
++ *   bits[4:0] = frequency in multiples of 100MHz
++ *   bit[5]    = DPLL enable (must be set for DPLL to lock)
++ *   E.g., 0x27 = 700MHz + enable = 700Mbps/lane D-PHY
++ *   E.g., 0x2F = 1500MHz + enable = 1.5Gbps/lane
++ */
++#define MAX96724_DPLL_FREQ0_ADDR	0x0415
++#define MAX96724_DPLL_FREQ1_ADDR	0x0418
++#define MAX96724_DPLL_FREQ2_ADDR	0x041B
++#define MAX96724_DPLL_FREQ3_ADDR	0x041E
++
++/* [UG] DPLL PHY reset control
++ *   0x1D00 = DPLL CSI PHY1 control
++ *   Write 0xF4 to disable/reset, 0xF5 to enable
++ */
++#define MAX96724_DPLL_CSI2_ADDR		0x1D00
++#define MAX96724_DPLL_DISABLE		0xF4
++#define MAX96724_DPLL_ENABLE		0xF5
++
++/* --- CSI-2 Output PHY Configuration --- */
++
++/* [UG Table 12, p.25] MIPI PHY Mode Select register
++ *   bit[0]: 4x2 mode, bit[2]: 2x4 mode (Port A=PHY0+1, Port B=PHY2+3)
++ *   bit[3]: 2x4 alt mode (Port B=PHY0+1, Port A=PHY2+3)
++ */
++#define MAX96724_CSI_OUT_CFG_ADDR	0x08A0
++
++/* [UG Table 12, p.25] MIPI PHY Enable register
++ *   bits[7:4]: Enable PHY 3/2/1/0 (1=enabled, 0=standby)
++ */
++#define MAX96724_CSI_PHY_EN_ADDR	0x08A2
++
++/* [UG Table 12, p.25] MIPI PHY 0 and 1 Lane Mapping */
++#define MAX96724_CSI_LANE_MAP1_ADDR	0x08A3
++
++/* [UG Table 12, p.26] MIPI PHY 2 and 3 Lane Mapping */
++#define MAX96724_CSI_LANE_MAP2_ADDR	0x08A4
++
++/* [UG p.22] Pipe-to-controller mapping (Method 1) */
++#define MAX96724_MIPI_CTRL_SEL_ADDR	0x08CA
++
++/* --- Lane Control per pipe (stride 0x40) --- */
++
++/*
++ *   0xC0 = 4-lane enabled
++ */
++#define MAX96724_LANE_CTRL0_ADDR	0x090A
++#define MAX96724_LANE_CTRL1_ADDR	0x094A
++#define MAX96724_LANE_CTRL2_ADDR	0x098A
++#define MAX96724_LANE_CTRL3_ADDR	0x09CA
++
++/* --- Pipe Mapping Registers (stride 0x40 per pipe) --- */
++
++/*
++ *   Base addresses for Pipe X (Pipe 0)
++ *   Stride: 0x40 per pipe
++ */
++#define MAX96724_TX11_PIPE_X_EN_ADDR		0x090B
++#define MAX96724_TX45_PIPE_X_DST_CTRL_ADDR	0x092D
++#define MAX96724_PIPE_X_SRC_0_MAP_ADDR		0x090D
++#define MAX96724_PIPE_X_DST_0_MAP_ADDR		0x090E
++#define MAX96724_PIPE_X_SRC_1_MAP_ADDR		0x090F
++#define MAX96724_PIPE_X_DST_1_MAP_ADDR		0x0910
++#define MAX96724_PIPE_X_SRC_2_MAP_ADDR		0x0911
++#define MAX96724_PIPE_X_DST_2_MAP_ADDR		0x0912
++#define MAX96724_PIPE_X_SRC_3_MAP_ADDR		0x0913
++#define MAX96724_PIPE_X_DST_3_MAP_ADDR		0x0914
++
++/* --- Stream Select --- */
++
++/*
++ *   Pipe X=0x0933, stride 0x40 per pipe
++ */
++#define MAX96724_PIPE_X_ST_SEL_ADDR	0x0933
++
++/* --- Extended Pipe Mapping (DST_CTRL2-4 / TX49) --- */
++
++/* [Excel: MIPI_TX46-48] Extended DST_CTRL for additional mapping pairs
++ *   All to PHY1 (0x55), same as TX45
++ *   Stride: 0x40 per pipe (base = Pipe X)
++ */
++#define MAX96724_TX46_PIPE_X_ADDR	0x092E
++#define MAX96724_TX47_PIPE_X_ADDR	0x092F
++#define MAX96724_TX48_PIPE_X_ADDR	0x0930
++
++/* [UG p.30 + Aardvark-verified] MIPI_TX49 synchronous concatenation control
++ *   In tunnel mode, this register MUST be 0x87 for MIPI TX output to function.
++ *   Verified: setting to 0x00 disables tunnel output entirely (0x8D0 all zeros).
++ *   Stride: 0x40 per pipe (base = Pipe X)
++ */
++#define MAX96724_TX49_PIPE_X_ADDR	0x0931
++#define MAX96724_TX49_CONCAT_4W		0x87
++
++/* --- Tunnel Mode per-pipe --- */
++
++/*
++ *   bit[0] = TUN_EN, Default=0x08, write 0x09 to enable
++ */
++#define MAX96724_PIPE0_TUN_EN_ADDR	0x0936
++#define MAX96724_PIPE1_TUN_EN_ADDR	0x0976
++#define MAX96724_PIPE2_TUN_EN_ADDR	0x09B6
++#define MAX96724_PIPE3_TUN_EN_ADDR	0x09F6
++
++/*
++ *   bit[6]: disable auto-tunnel-detect
++ *   bits[5:4]: TUN_DEST (00=PHY0, 01=PHY1, 10=PHY2, 11=PHY3)
++ */
++#define MAX96724_PIPE0_TUN_DEST_ADDR	0x0939
++#define MAX96724_PIPE1_TUN_DEST_ADDR	0x0979
++#define MAX96724_PIPE2_TUN_DEST_ADDR	0x09B9
++#define MAX96724_PIPE3_TUN_DEST_ADDR	0x09F9
++
++/* ================================================================
++ * Register Values
++ * ================================================================ */
++
++/* [UG p.12] Soft reset value (write to 0x000D) */
++#define MAX96724_SOFT_RESET		0x40
++
++/* [UG Table 3, p.11-12] Link Rate values for 0x0010/0x0011
++ *   Per link pair: bits[1:0]=RxA, [3:2]=TxA, [5:4]=RxB, [7:6]=TxB
++ *   Tx = 00 (187.5Mbps), Rx = 01 (3Gbps) or 10 (6Gbps)
++ *   3Gbps: Tx=00, Rx=01 → per pair 0x01, both pairs = 0x01 in low nibble
++ */
++#define MAX96724_LINK_RATE_3GBPS	0x01  /* Rx=3G, Tx=187.5M for one link pair */
++#define MAX96724_LINK_RATE_6GBPS	0x02  /* Rx=6G, Tx=187.5M for one link pair */
++
++/* [UG Table 3, p.11] 0x0006: Link enable / mode values
++ *   bits[7:4] = PHY mode (1=GMSL2 per link)
++ *   bits[3:0] = Link enable per link
++ *   0xF1 = all GMSL2-mode, only Link A enabled
++ *   0xFF = all GMSL2-mode, all 4 links enabled
++ */
++#define MAX96724_LINK_EN_SIOA		0xF1  /* GMSL2 all, enable Link A only */
++#define MAX96724_LINK_EN_ALL		0xFF  /* GMSL2 all, enable all links */
++
++/* [UG p.19] BACKTOP_EN (0x040B): CSI output port enable */
++#define MAX96724_BACKTOP_CSIB_EN	0x02
++#define MAX96724_BACKTOP_CSIA_EN	0x01
++
++/* [XML] VIDEO_RX0: DIS_PKT_DET=1 (bit0) required for tunnel mode.
++ *   Without it, DES rejects tunnel data as invalid GMSL2 video packets.
++ *   SEQ_MISS_EN=1 (bit4), LINE_CRC_EN=1 (bit1).  XML value: 0x33.
++ */
++#define MAX96724_VID_RX0_CFG_VAL	0x33
++#define MAX96724_VID_RX6_CFG_VAL	0x0A
++
++/* [gmsl_ser_des_guide §4.9] Tunnel mode enable (MIPI_TX54, 0x0936):
++ *   bit[0] = TUN_EN = 1
++ *   bit[3] = TUN_CONT (continuous tunnel mode, required per verified XML)
++ *   XML/Guide value: 0x09
++ */
++#define MAX96724_TUN_EN			0x09
++
++/* [gmsl_ser_des_guide §7.5] Tunnel controller destination (MIPI_TX57, 0x0939):
++ *   bit[7]: DIS_AUTO_SER_LANE_DET (1=manual)
++ *   bit[6]: DIS_AUTO_TUN_DET (1=manual)
++ *   bits[5:4]: TUN_DEST (00=PHY0, 01=PHY1, 10=PHY2, 11=PHY3)
++ *   Verified XML: 0x50 = manual detect + PHY1 destination
++ */
++#define MAX96724_TUN_DEST_CTRL0		0x40  /* Manual detect + PHY0 */
++#define MAX96724_TUN_DEST_CTRL1		0x50  /* Manual detect + PHY1 (Port A master) */
++
++/* [UG Table 12, p.25] CSI output mode values */
++#define MAX96724_CSI_MODE_2X4_VAL	0x08  /* bit[3] = 2x4 alt: Ctrl1→PHY0+1→PortA (Aardvark-verified) */
++#define MAX96724_CSI_MODE_4X2_VAL	0x01  /* bit[0] = 4x2 mode */
++
++#define MAX96724_CSI_PHY_EN_ALL		0xF0
++#define MAX96724_CSI_PHY_EN_01		0x30  /* PHY0+PHY1 only */
++#define MAX96724_CSI_PHY_EN_23		0xC0  /* PHY2+PHY3 only (Port A in 2x4 alt mode) */
++
++/* [UG Table 12, p.25-26] Lane mapping default */
++#define MAX96724_CSI_LANE_MAP_DEFAULT	0xE4
++
++/* [UG Table 12, p.26-27] Lane control: 4-lane enabled */
++#define MAX96724_LANE_CTRL_4LANE	0xC0
++
++/* [UG Table 12, p.26-27] Lane control: 2-lane enabled.
++ *   bits[7:6] = (num_lanes - 1): 01=2-lane(0x40), 11=4-lane(0xC0)
++ *   Ref: gmsl_ser_des_guide §8.2, E2E_enable_guide §5.6.4 */
++#define MAX96724_LANE_CTRL_2LANE	0x40
++
++/* [SC20190112 2-lane] CSI PHY enable: all PHYs powered for DPLL lock
++ *   stability.  Even though only PHY0 data lanes reach Orin, the MAX96724
++ *   DPLL requires all PHYs to be powered.  Tested: single PHY → PLL never locks. */
++#define MAX96724_CSI_PHY_EN_2LANE	0xF0
++
++/* [SC20190112 2-lane] DPLL for Controller 0 (drives PHY0, 2 lanes).
++ *   bits[4:0] = data-rate / 100 MHz.  1400 Mbps / 100 = 14 = 0x0E.
++ *   bit[5]    = DPLL enable = 1.
++ *   Result: 0x2E = 1400 Mbps/lane D-PHY. */
++#define MAX96724_DPLL_1400MBPS_CTRL0	0x2E
++
++/* [SC20190112 2-lane] TX49 pipeline concatenation for 2-wide mode.
++ *   In 4x2 mode each controller drives only 2 lanes.
++ *   UG p.30: synchronous concatenation control, 0x83 for 2W. */
++#define MAX96724_TX49_CONCAT_2W		0x83
++
++/* [UG Table 3, p.12] One-shot reset: all links */
++#define MAX96724_ONESHOT_ALL		0x0F
++
++/* [UG Table 4, p.15] Pipe source selection values
++ *   Encoding per pipe nibble in tunnel mode (Aardvark-verified):
++ *   0x22 routes all pipes from Link A in tunnel mode.
++ */
++#define MAX96724_PIPE_SEL0_SINGLE	0x22  /* All pipes from Link A (Aardvark-verified) */
++#define MAX96724_PIPE_SEL1_SINGLE	0x22  /* All pipes from Link A (Aardvark-verified) */
++#define MAX96724_PIPE_SEL0_DUAL		0x40  /* Pipe 0 ← A/X, Pipe 1 ← B/X */
++#define MAX96724_PIPE_SEL0_QUAD_LO	0x40  /* Pipe 0 ← A/X, Pipe 1 ← B/X */
++#define MAX96724_PIPE_SEL1_QUAD_HI	0xC8  /* Pipe 2 ← C/X, Pipe 3 ← D/X */
++
++/* Pipe enable values */
++#define MAX96724_PIPE_EN_1		0x01
++#define MAX96724_PIPE_EN_2		0x03
++#define MAX96724_PIPE_EN_4		0x0F
++
++/* Lane control map: bits[7:6] = (num_lanes - 1) */
++#define MAX96724_LANE_CTRL_MAP(num_lanes) \
++	((((num_lanes) - 1) << 6) & 0xC0)
++
++/* Reset all */
++#define MAX96724_RESET_ALL		0x80
++
++/* Stream ID invalid */
++#define MAX96724_INVAL_ST_ID		0xFF
++#define MAX96724_RESET_ST_ID		0x00
++#define MAX96724_ST_ID_SEL_INVALID	0xF
++
++/* Controller mapping: all mappings → Controller 0 (not working in tunnel mode) */
++#define MAX96724_ALL_MAP_CTRL0		0x00
++/* Controller mapping: all mappings → Controller 1 (Aardvark-verified working) */
++#define MAX96724_ALL_MAP_CTRL1		0x55
++
++/* ================================================================
++ * Data Structures
++ * ================================================================ */
++
++/* Quad GMSL: up to 4 sources */
++#define MAX96724_MAX_SOURCES		4
++#define MAX96724_MAX_PIPES		4
++
++#define MAX96724_PIPE_X			0
++#define MAX96724_PIPE_Y			1
++#define MAX96724_PIPE_Z			2
++#define MAX96724_PIPE_U			3
++#define MAX96724_PIPE_INVALID		0xF
++
++#define MAX96724_CSI_CTRL_0		0
++#define MAX96724_CSI_CTRL_1		1
++#define MAX96724_CSI_CTRL_2		2
++#define MAX96724_CSI_CTRL_3		3
++
++/* CSI mode values */
++#define MAX96724_CSI_MODE_4X2		0x01
++#define MAX96724_CSI_MODE_2X4		0x08  /* 2x4 alt: Ctrl1→PHY0+1→PortA (Aardvark-verified working) */
++#define MAX96724_CSI_MODE_2X4_ALT	0x04  /* 2x4 standard (Ctrl0→PHY0+1, not working in tunnel) */
++
++/* Lane map presets */
++#define MAX96724_LANE_MAP1_4X2		0x44
++#define MAX96724_LANE_MAP2_4X2		0x44
++#define MAX96724_LANE_MAP1_2X4		0xE4  /* PHY0+PHY1 lane map (Aardvark-verified) */
++#define MAX96724_LANE_MAP2_2X4		0xE4
++
++struct max96724_source_ctx {
++	struct gmsl_link_ctx *g_ctx;
++	bool st_enabled;
++};
++
++struct pipe_ctx {
++	u32 id;
++	u32 dt_type;
++	u32 dst_csi_ctrl;
++	u32 st_count;
++	u32 st_id_sel;
++};
++
++struct max96724 {
++	struct i2c_client *i2c_client;
++	struct regmap *regmap;
++	u32 num_src;
++	u32 max_src;
++	u32 num_src_found;
++	u32 src_link;
++	bool splitter_enabled;
++	struct max96724_source_ctx sources[MAX96724_MAX_SOURCES];
++	struct mutex lock;
++	u32 sdev_ref;
++	bool lane_setup;
++	bool link_setup;
++	struct pipe_ctx pipe[MAX96724_MAX_PIPES];
++	u8 csi_mode;
++	u8 lane_mp1;
++	u8 lane_mp2;
++	int reset_gpio;
++	int pw_ref;
++	struct regulator *vdd_cam_1v2;
++	u8 link_speed;  /* DT-configurable: 3 or 6 Gbps */
++};
++
++struct reg_pair {
++	u16 addr;
++	u8 val;
++};
++
++/* ================================================================
++ * Low-level I2C
++ * ================================================================ */
++
++static int max96724_write_reg(struct device *dev, u16 addr, u8 val)
++{
++	struct max96724 *priv;
++	int err;
++
++	priv = dev_get_drvdata(dev);
++
++	err = regmap_write(priv->regmap, addr, val);
++	if (err)
++		dev_err(dev, "%s:i2c write failed, 0x%x = %x\n",
++			__func__, addr, val);
++
++	/* delay before next i2c command as required for SERDES link */
++	usleep_range(100, 110);
++
++	return err;
++}
++
++static int max96724_set_registers(struct device *dev, struct reg_pair *map,
++				  u32 count)
++{
++	int err = 0;
++	u32 j;
++
++	for (j = 0; j < count; j++) {
++		err = max96724_write_reg(dev, map[j].addr, map[j].val);
++		if (err)
++			break;
++	}
++
++	return err;
++}
++
++/* ================================================================
++ * Internal Helpers
++ * ================================================================ */
++
++static int max96724_get_sdev_idx(struct device *dev,
++				 struct device *s_dev, unsigned int *idx)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++	unsigned int i;
++	int err = 0;
++
++	mutex_lock(&priv->lock);
++	for (i = 0; i < priv->max_src; i++) {
++		if (priv->sources[i].g_ctx->s_dev == s_dev)
++			break;
++	}
++	if (i == priv->max_src) {
++		dev_err(dev, "no sdev found\n");
++		err = -EINVAL;
++		goto ret;
++	}
++
++	if (idx)
++		*idx = i;
++
++ret:
++	mutex_unlock(&priv->lock);
++	return err;
++}
++
++static void max96724_pipes_reset(struct max96724 *priv)
++{
++	/*
++	 * Default pipe configuration for D5xx/SC1.2:
++	 * In tunnel mode, DT types are not used for filtering
++	 * but we initialize them for d4xx framework compatibility.
++	 */
++	struct pipe_ctx pipe_defaults[] = {
++		{MAX96724_PIPE_X, GMSL_CSI_DT_RAW_12,
++			MAX96724_CSI_CTRL_1, 0, MAX96724_INVAL_ST_ID},
++		{MAX96724_PIPE_Y, GMSL_CSI_DT_RAW_12,
++			MAX96724_CSI_CTRL_1, 0, MAX96724_INVAL_ST_ID},
++		{MAX96724_PIPE_Z, GMSL_CSI_DT_EMBED,
++			MAX96724_CSI_CTRL_1, 0, MAX96724_INVAL_ST_ID},
++		{MAX96724_PIPE_U, GMSL_CSI_DT_EMBED,
++			MAX96724_CSI_CTRL_1, 0, MAX96724_INVAL_ST_ID}
++	};
++
++	memcpy(priv->pipe, pipe_defaults, sizeof(pipe_defaults));
++}
++
++static void max96724_reset_ctx(struct max96724 *priv)
++{
++	unsigned int i;
++
++	priv->link_setup = false;
++	priv->lane_setup = false;
++	priv->num_src_found = 0;
++	priv->src_link = 0;
++	priv->splitter_enabled = false;
++	max96724_pipes_reset(priv);
++	for (i = 0; i < priv->num_src; i++)
++		priv->sources[i].st_enabled = false;
++}
++
++/* ================================================================
++ * Power Management
++ * ================================================================ */
++
++/*
++ * max96724_power_on - Power on the MAX96724 deserializer
++ */
++int max96724_power_on(struct device *dev)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++	int err = 0;
++
++	mutex_lock(&priv->lock);
++	if (priv->pw_ref == 0) {
++		usleep_range(1, 2);
++		if (priv->reset_gpio)
++			gpio_set_value(priv->reset_gpio, 0);
++
++		usleep_range(30, 50);
++
++		if (priv->vdd_cam_1v2) {
++			err = regulator_enable(priv->vdd_cam_1v2);
++			if (unlikely(err))
++				goto ret;
++		}
++
++		usleep_range(30, 50);
++
++		/* exit reset mode: XCLR */
++		if (priv->reset_gpio) {
++			gpio_set_value(priv->reset_gpio, 0);
++			usleep_range(30, 50);
++			gpio_set_value(priv->reset_gpio, 1);
++			usleep_range(30, 50);
++		}
++
++		msleep(20);
++	}
++
++	priv->pw_ref++;
++
++ret:
++	mutex_unlock(&priv->lock);
++	return err;
++}
++EXPORT_SYMBOL(max96724_power_on);
++
++void max96724_power_off(struct device *dev)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++
++	mutex_lock(&priv->lock);
++	priv->pw_ref--;
++
++	if (priv->pw_ref < 0)
++		priv->pw_ref = 0;
++
++	if (priv->pw_ref == 0) {
++		usleep_range(1, 2);
++		if (priv->reset_gpio)
++			gpio_set_value(priv->reset_gpio, 0);
++
++		if (priv->vdd_cam_1v2)
++			regulator_disable(priv->vdd_cam_1v2);
++	}
++
++	mutex_unlock(&priv->lock);
++}
++EXPORT_SYMBOL(max96724_power_off);
++
++/* ================================================================
++ * Link Setup
++ * ================================================================ */
++
++/*
++ * max96724_write_link - Configure a specific GMSL link
++ *
++ * [Users Guide, Link Initialization, p11-12]
++ *   Register 0x0006: Link Enable and Mode Select
++ *   Register 0x0010: Link Rate (Links A/B)
++ *
++ * The link speed is DT-configurable via the "gmsl-link-speed" property.
++ */
++static int max96724_write_link(struct device *dev, u32 link)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++	u8 link_rate_ab, link_rate_cd;
++	u8 link_en_val;
++
++	/*
++	 * [Aardvark-verified] Disable CSI output before link configuration
++	 * This prevents glitches on CSI bus during GMSL link setup.
++	 * Re-enabled in max96724_setup_streaming() after full pipeline config.
++	 */
++	max96724_write_reg(dev, MAX96724_BACKTOP_EN_ADDR, 0x00);
++
++	/* [UG Table 3 + Tech Overview REG26]
++	 * Register 0x0010:
++	 *   bits[7:2] = Link rate configuration
++	 *   bits[1:0] = I2C CC pass-through link select
++	 *     10 = route CC via SIOA (Link A)  [tech overview: 0x02 → SIOA]
++	 *     01 = route CC via SIOB (Link B)
++	 *
++	 * For 6G + Link A: bits[7:2]=001000, bits[1:0]=10 → 0x22
++	 * For 6G + Link B: bits[7:2]=001000, bits[1:0]=01 → 0x21
++	 * For 3G + Link A: bits[7:2]=000100, bits[1:0]=10 → 0x12 (? or 0x11)
++	 * For 3G + Link B: bits[7:2]=000100, bits[1:0]=01 → 0x11 (? or 0x09)
++	 */
++	if (priv->link_speed == 6) {
++		if (link == GMSL_SERDES_CSI_LINK_B) {
++			link_rate_ab = 0x21; /* 6G rate + CC via Link B */
++		} else {
++			link_rate_ab = 0x22; /* 6G rate + CC via Link A */
++		}
++		link_rate_cd = 0x22; /* C/D: 6G rate (CC routing don't care) */
++	} else {
++		if (link == GMSL_SERDES_CSI_LINK_B) {
++			link_rate_ab = 0x09; /* 3G rate + CC via Link B */
++		} else {
++			link_rate_ab = 0x12; /* 3G rate + CC via Link A */
++		}
++		link_rate_cd = 0x11; /* C/D: 3G rate */
++	}
++
++	if (link == GMSL_SERDES_CSI_LINK_A) {
++		link_en_val = MAX96724_LINK_EN_SIOA;
++	} else if (link == GMSL_SERDES_CSI_LINK_B) {
++		link_en_val = 0xF2; /* GMSL2 all, enable Link B only */
++	} else {
++		dev_err(dev, "%s: invalid gmsl link\n", __func__);
++		return -EINVAL;
++	}
++
++	/* [UG Table 3] Set link rates + CC routing */
++	max96724_write_reg(dev, MAX96724_LINK_RATE_AB_ADDR, link_rate_ab);
++	max96724_write_reg(dev, MAX96724_LINK_RATE_CD_ADDR, link_rate_cd);
++
++	/*
++	 * [XML-verified sequence] One-shot reset applies rate configuration
++	 * to the link state machine, then link enable starts training.
++	 * XML order: rate → ONE-SHOT → LINK_EN → wait 1000ms.
++	 * Note: Error channel registers omitted (not in reference XML).
++	 */
++	max96724_write_reg(dev, MAX96724_ONESHOT_ADDR,
++			   MAX96724_ONESHOT_ALL);
++	max96724_write_reg(dev, MAX96724_LINK_EN_ADDR, link_en_val);
++
++	/*
++	 * Wait for link lock.
++	 * [XML] Uses 1000ms regardless of link speed.
++	 * I2C pass-through CC requires fully trained link, not just PHY lock.
++	 */
++	msleep(1000);
++
++	/* Check link lock status on ALL ports for diagnostics */
++	{
++		unsigned int lock_a = 0, lock_b = 0, lock_c = 0, lock_d = 0;
++		unsigned int link_en = 0;
++		unsigned int reg10 = 0, reg11 = 0;
++
++		regmap_read(priv->regmap, 0x001A, &lock_a);
++		regmap_read(priv->regmap, 0x001B, &lock_b);
++		regmap_read(priv->regmap, 0x001C, &lock_c);
++		regmap_read(priv->regmap, 0x001D, &lock_d);
++		regmap_read(priv->regmap, MAX96724_LINK_EN_ADDR, &link_en);
++		regmap_read(priv->regmap, 0x0010, &reg10);
++		regmap_read(priv->regmap, 0x0011, &reg11);
++		dev_info(dev,
++			 "GMSL link status: EN=0x%02x A=0x%02x(%s) B=0x%02x(%s) C=0x%02x(%s) D=0x%02x(%s) REG10=0x%02x REG11=0x%02x\n",
++			 link_en,
++			 lock_a, (lock_a & 0x08) ? "LOCK" : "noLk",
++			 lock_b, (lock_b & 0x08) ? "LOCK" : "noLk",
++			 lock_c, (lock_c & 0x08) ? "LOCK" : "noLk",
++			 lock_d, (lock_d & 0x08) ? "LOCK" : "noLk",
++			 reg10, reg11);
++	}
++
++	return 0;
++}
++
++int max96724_setup_link(struct device *dev, struct device *s_dev)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++	int err = 0;
++	unsigned int i = 0;
++
++	err = max96724_get_sdev_idx(dev, s_dev, &i);
++	if (err)
++		return err;
++
++	mutex_lock(&priv->lock);
++
++	if (!priv->splitter_enabled) {
++		err = max96724_write_link(dev,
++					  priv->sources[i].g_ctx->serdes_csi_link);
++		if (err)
++			goto ret;
++
++		priv->link_setup = true;
++	}
++
++ret:
++	mutex_unlock(&priv->lock);
++	return err;
++}
++EXPORT_SYMBOL(max96724_setup_link);
++
++/* ================================================================
++ * Control Setup
++ * ================================================================ */
++
++/*
++ * max96724_setup_control - Configure deserializer control pipeline
++ *
++ * Enables splitter mode when multiple sources are present,
++ * configures tunnel mode on all active pipes, and sets up
++ * the MIPI CSI-2 output.
++ */
++int max96724_setup_control(struct device *dev, struct device *s_dev)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++	int err = 0;
++	unsigned int i = 0;
++
++	static const u16 tun_en_addrs[] = {
++		MAX96724_PIPE0_TUN_EN_ADDR,
++		MAX96724_PIPE1_TUN_EN_ADDR,
++		MAX96724_PIPE2_TUN_EN_ADDR,
++		MAX96724_PIPE3_TUN_EN_ADDR,
++	};
++
++	static const u16 tun_dest_addrs[] = {
++		MAX96724_PIPE0_TUN_DEST_ADDR,
++		MAX96724_PIPE1_TUN_DEST_ADDR,
++		MAX96724_PIPE2_TUN_DEST_ADDR,
++		MAX96724_PIPE3_TUN_DEST_ADDR,
++	};
++
++	err = max96724_get_sdev_idx(dev, s_dev, &i);
++	if (err)
++		return err;
++
++	mutex_lock(&priv->lock);
++
++	if (!priv->link_setup) {
++		dev_err(dev, "%s: invalid state\n", __func__);
++		err = -EINVAL;
++		goto error;
++	}
++
++	if (priv->sources[i].g_ctx->serdev_found) {
++		priv->num_src_found++;
++		priv->src_link = priv->sources[i].g_ctx->serdes_csi_link;
++	}
++
++	/* Enable splitter mode for multi-camera configurations */
++	if ((priv->max_src > 1U) &&
++	    (priv->num_src_found > 0U) &&
++	    (priv->splitter_enabled == false)) {
++		/*
++		 * [UG Table 3] Multi-camera: set link rates and enable all links
++		 */
++		u8 link_rate = (priv->link_speed == 6) ? 0x22 : 0x11;
++
++		max96724_write_reg(dev, MAX96724_LINK_RATE_AB_ADDR,
++				   link_rate);
++		max96724_write_reg(dev, MAX96724_LINK_RATE_CD_ADDR,
++				   link_rate);
++		max96724_write_reg(dev, MAX96724_LINK_EN_ADDR,
++				   MAX96724_LINK_EN_ALL);
++
++		/* [Errata #5] For 6Gbps: force Error Channel power-up */
++		if (priv->link_speed == 6) {
++			max96724_write_reg(dev, MAX96724_ERRCH_A_ADDR,
++					   MAX96724_ERRCH_FORCE_ON);
++			max96724_write_reg(dev, MAX96724_ERRCH_B_ADDR,
++					   MAX96724_ERRCH_FORCE_ON);
++			max96724_write_reg(dev, MAX96724_ERRCH_C_ADDR,
++					   MAX96724_ERRCH_FORCE_ON);
++			max96724_write_reg(dev, MAX96724_ERRCH_D_ADDR,
++					   MAX96724_ERRCH_FORCE_ON);
++		}
++
++		priv->splitter_enabled = true;
++
++		msleep(100);
++	}
++
++	/*
++	 * [SC20190112] Enable tunnel mode and route to Controller 1.
++	 *   - TUN_EN   (0x0936): 0x01 (TUN_EN=1)
++	 *   - TUN_DEST (0x0939): 0x10 = Controller 1
++	 *   CSI_OUT_CFG=0x08 (2x4 alt): Controller 1 → PHY0+1 → Port A → Orin
++	 */
++	{
++		for (i = 0; i < MAX96724_MAX_PIPES; i++) {
++			max96724_write_reg(dev, tun_en_addrs[i],
++					   MAX96724_TUN_EN);
++			max96724_write_reg(dev, tun_dest_addrs[i],
++					   MAX96724_TUN_DEST_CTRL1);
++		}
++	}
++
++	/*
++	 * [Errata #2] Tunnel Mode SRAM LCRC: disable ERRB for SRAM LCRC
++	 * errors in tunnel mode when frame/line counters are non-zero.
++	 * This prevents spurious ERRB assertions (no video corruption).
++	 */
++	max96724_write_reg(dev, MAX96724_SRAM_LCRC_ERR_ADDR, 0x00);
++
++	max96724_write_reg(dev, MAX96724_ONESHOT_ADDR,
++			   MAX96724_ONESHOT_ALL);
++
++	priv->sdev_ref++;
++
++	/* Reset splitter mode if not all devices found */
++	if ((priv->sdev_ref == priv->max_src) &&
++	    (priv->splitter_enabled == true) &&
++	    (priv->num_src_found > 0U) &&
++	    (priv->num_src_found < priv->max_src)) {
++		err = max96724_write_link(dev, priv->src_link);
++		if (err)
++			goto error;
++
++		priv->splitter_enabled = false;
++	}
++
++error:
++	mutex_unlock(&priv->lock);
++	return err;
++}
++EXPORT_SYMBOL(max96724_setup_control);
++
++int max96724_reset_control(struct device *dev, struct device *s_dev)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++	int err = 0;
++
++	mutex_lock(&priv->lock);
++	if (!priv->sdev_ref) {
++		dev_info(dev, "%s: dev is already in reset state\n", __func__);
++		goto ret;
++	}
++
++	priv->sdev_ref--;
++	if (priv->sdev_ref == 0) {
++		max96724_reset_ctx(priv);
++		max96724_write_reg(dev, MAX96724_REG13_ADDR,
++				   MAX96724_SOFT_RESET);
++
++		msleep(100);
++	}
++
++ret:
++	mutex_unlock(&priv->lock);
++	return err;
++}
++EXPORT_SYMBOL(max96724_reset_control);
++
++/* ================================================================
++ * Device Registration
++ * ================================================================ */
++
++int max96724_sdev_register(struct device *dev, struct gmsl_link_ctx *g_ctx)
++{
++	struct max96724 *priv = NULL;
++	unsigned int i;
++	int err = 0;
++
++	if (!dev || !g_ctx || !g_ctx->s_dev) {
++		dev_err(dev, "%s: invalid input params\n", __func__);
++		return -EINVAL;
++	}
++
++	priv = dev_get_drvdata(dev);
++
++	mutex_lock(&priv->lock);
++
++	if (priv->num_src > priv->max_src) {
++		dev_err(dev,
++			"%s: MAX96724 inputs size exhausted\n", __func__);
++		err = -ENOMEM;
++		goto error;
++	}
++
++	/* Check csi mode compatibility.
++	 * 2x4 DES → gmsl-link: 1x4 or 2x4.
++	 * 4x2 DES → gmsl-link: 1x4, 2x2, or 4x2.
++	 */
++	if (priv->csi_mode == MAX96724_CSI_MODE_2X4) {
++		if (!((g_ctx->csi_mode == GMSL_CSI_1X4_MODE) ||
++		      (g_ctx->csi_mode == GMSL_CSI_2X4_MODE))) {
++			dev_err(dev, "%s: csi mode not supported\n", __func__);
++			err = -EINVAL;
++			goto error;
++		}
++	} else {
++		/* 4x2 DES mode: accept 1x4, 2x2, or 4x2 gmsl-link mode */
++		if (!((g_ctx->csi_mode == GMSL_CSI_1X4_MODE) ||
++		      (g_ctx->csi_mode == GMSL_CSI_2X2_MODE) ||
++		      (g_ctx->csi_mode == GMSL_CSI_4X2_MODE))) {
++			dev_err(dev, "%s: csi mode not supported\n", __func__);
++			err = -EINVAL;
++			goto error;
++		}
++	}
++
++	for (i = 0; i < priv->num_src; i++) {
++		if (g_ctx->serdes_csi_link ==
++		    priv->sources[i].g_ctx->serdes_csi_link) {
++			dev_err(dev,
++				"%s: serdes csi link is in use\n", __func__);
++			err = -EINVAL;
++			goto error;
++		}
++		if (g_ctx->num_csi_lanes !=
++		    priv->sources[i].g_ctx->num_csi_lanes) {
++			dev_err(dev,
++				"%s: csi num lanes mismatch\n", __func__);
++			err = -EINVAL;
++			goto error;
++		}
++	}
++
++	priv->sources[priv->num_src].g_ctx = g_ctx;
++	priv->sources[priv->num_src].st_enabled = false;
++
++	priv->num_src++;
++
++error:
++	mutex_unlock(&priv->lock);
++	return err;
++}
++EXPORT_SYMBOL(max96724_sdev_register);
++
++int max96724_sdev_unregister(struct device *dev, struct device *s_dev)
++{
++	struct max96724 *priv = NULL;
++	int err = 0;
++	unsigned int i = 0;
++
++	if (!dev || !s_dev) {
++		dev_err(dev, "%s: invalid input params\n", __func__);
++		return -EINVAL;
++	}
++
++	priv = dev_get_drvdata(dev);
++	mutex_lock(&priv->lock);
++
++	if (priv->num_src == 0) {
++		dev_err(dev, "%s: no source found\n", __func__);
++		err = -ENODATA;
++		goto error;
++	}
++
++	for (i = 0; i < priv->num_src; i++) {
++		if (s_dev == priv->sources[i].g_ctx->s_dev) {
++			priv->sources[i].g_ctx = NULL;
++			break;
++		}
++	}
++
++	if (i == priv->num_src) {
++		dev_err(dev,
++			"%s: requested device not found\n", __func__);
++		err = -EINVAL;
++		goto error;
++	}
++	priv->num_src--;
++
++error:
++	mutex_unlock(&priv->lock);
++	return err;
++}
++EXPORT_SYMBOL(max96724_sdev_unregister);
++
++/* ================================================================
++ * Streaming Setup
++ * ================================================================ */
++
++/*
++ * max96724_setup_streaming - Configure CSI-2 output pipeline
++ *
++ * In Tunnel Mode, the MAX96724 outputs the reconstructed CSI-2 stream
++ * with all VCs and DTs preserved from the serializer.
++ *
++ * The pipeline configuration:
++ *   1. Configure pipe-to-link routing (which GMSL input → which pipe)
++ *   2. Enable tunnel mode on active pipes
++ *   3. Configure MIPI CSI-2 output lanes and PHY
++ *   4. Enable BACKTOP output port
++ *
++ */
++int max96724_setup_streaming(struct device *dev, struct device *s_dev)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++	struct gmsl_link_ctx *g_ctx;
++	int err = 0;
++	unsigned int i = 0;
++	unsigned int src_idx;
++
++	err = max96724_get_sdev_idx(dev, s_dev, &i);
++	if (err)
++		return err;
++
++	mutex_lock(&priv->lock);
++	if (priv->sources[i].st_enabled)
++		goto ret;
++
++	src_idx = i;
++	g_ctx = priv->sources[src_idx].g_ctx;
++
++	/*
++	 * [Aardvark-verified] Pipe source routing
++	 *   Single cam: all pipes from Link A (0x22/0x22)
++	 *   Disable pipes before configuration, enable at the end
++	 */
++	if (priv->max_src >= 4) {
++		max96724_write_reg(dev, MAX96724_PIPE_SEL0_ADDR,
++				   MAX96724_PIPE_SEL0_QUAD_LO);
++		max96724_write_reg(dev, MAX96724_PIPE_SEL1_ADDR,
++				   MAX96724_PIPE_SEL1_QUAD_HI);
++	} else if (priv->max_src >= 2) {
++		max96724_write_reg(dev, MAX96724_PIPE_SEL0_ADDR,
++				   MAX96724_PIPE_SEL0_DUAL);
++	} else {
++		max96724_write_reg(dev, MAX96724_PIPE_SEL0_ADDR,
++				   MAX96724_PIPE_SEL0_SINGLE);
++		max96724_write_reg(dev, MAX96724_PIPE_SEL1_ADDR,
++				   MAX96724_PIPE_SEL1_SINGLE);
++	}
++	/* Disable all pipes during configuration */
++	max96724_write_reg(dev, MAX96724_PIPE_EN_ADDR, 0x00);
++
++	/*
++	 * [SC20190112] CSI output: 2x4 alt mode (0x08) for Port A.
++	 * In 2x4 alt: Controller 1 is master for Port A.
++	 *   PHY0 (slave) → DA0/DA1 (data lanes to Orin)
++	 *   PHY1 (master) → CLKA (clock to Orin)
++	 * Both PHY0 and PHY1 must be enabled for Port A output.
++	 * TUN_DEST=0x10 routes tunnel pipes to Controller 1.
++	 */
++	max96724_write_reg(dev, MAX96724_CSI_OUT_CFG_ADDR,
++			   MAX96724_CSI_MODE_2X4_VAL);
++	max96724_write_reg(dev, MAX96724_CSI_PHY_EN_ADDR,
++			   MAX96724_CSI_PHY_EN_01);
++
++	max96724_write_reg(dev, MAX96724_CSI_LANE_MAP1_ADDR,
++			   priv->lane_mp1);
++	max96724_write_reg(dev, MAX96724_CSI_LANE_MAP2_ADDR,
++			   priv->lane_mp2);
++
++	/* [gmsl_ser_des_guide §6.1] MIPI_CTRL_SEL: all pipes → Controller 1.
++	 * Guide: "in tunneling mode the MIPI_CTRL_SEL_x bits must match TUN_DEST"
++	 * 0x55 = Pipe0→Ctrl1, Pipe1→Ctrl1, Pipe2→Ctrl1, Pipe3→Ctrl1 */
++	max96724_write_reg(dev, MAX96724_MIPI_CTRL_SEL_ADDR, 0x55);
++
++	/* [gmsl_ser_des_guide §8.2] LANE_CTRL on Controller 1 register (0x094A).
++	 * 0x40 = 2-lane. Also set Ctrl0 for completeness. */
++	max96724_write_reg(dev, MAX96724_LANE_CTRL0_ADDR,
++			   MAX96724_LANE_CTRL_2LANE);
++	max96724_write_reg(dev, MAX96724_LANE_CTRL1_ADDR,
++			   MAX96724_LANE_CTRL_2LANE);
++	max96724_write_reg(dev, MAX96724_LANE_CTRL2_ADDR,
++			   MAX96724_LANE_CTRL_2LANE);
++	max96724_write_reg(dev, MAX96724_LANE_CTRL3_ADDR,
++			   MAX96724_LANE_CTRL_2LANE);
++
++	/*
++	 * [SC20190112 2-lane] DPLL for Controller 1 (drives Port A via PHY1 clock).
++	 * FREQ1 (0x0418) = 0x2E = 1400 Mbps/lane + DPLL enable.
++	 * 2 lanes × 1400 Mbps = 2800 Mbps total ≥ camera 2L × 700M input.
++	 */
++	if (!priv->lane_setup) {
++		max96724_write_reg(dev, MAX96724_DPLL_CSI2_ADDR,
++				   MAX96724_DPLL_DISABLE);
++		max96724_write_reg(dev, MAX96724_DPLL_FREQ1_ADDR,
++				   MAX96724_DPLL_1400MBPS_CTRL0);
++		max96724_write_reg(dev, MAX96724_DPLL_CSI2_ADDR,
++				   MAX96724_DPLL_ENABLE);
++
++		priv->lane_setup = true;
++	}
++
++	/*
++	 * [Aardvark-verified] Stream ID select for all pipes
++	 * 0x0933 + 0x40*pipe = stream select register
++	 * Value 0x10 selects the appropriate stream for tunnel mode
++	 */
++	for (i = 0; i < MAX96724_MAX_PIPES; i++) {
++		max96724_write_reg(dev,
++				   MAX96724_PIPE_X_ST_SEL_ADDR + (0x40 * i),
++				   0x10);
++	}
++
++	/* BACKTOP: enable Controller 1 / CSI-B (0x02).
++	 * In 2x4 alt mode, Controller 1 is master for Port A → Orin CSI.
++	 */
++	max96724_write_reg(dev, MAX96724_BACKTOP_EN_ADDR,
++			   MAX96724_BACKTOP_CSIB_EN);
++
++	/* Keep all video receivers aligned with serializer heartbeat mode. */
++	for (i = 0; i < MAX96724_MAX_PIPES; i++) {
++		max96724_write_reg(dev,
++				   MAX96724_VID_RX0_P0_ADDR +
++				   (MAX96724_VID_RX_STRIDE * i),
++				   MAX96724_VID_RX0_CFG_VAL);
++		max96724_write_reg(dev,
++				   MAX96724_VID_RX6_P0_ADDR +
++				   (MAX96724_VID_RX_STRIDE * i),
++				   MAX96724_VID_RX6_CFG_VAL);
++	}
++
++	max96724_write_reg(dev, MAX96724_ONESHOT_ADDR,
++			   MAX96724_ONESHOT_ALL);
++
++	/* Enable all 4 pipes (Aardvark-verified: 0x0F at end) */
++	max96724_write_reg(dev, MAX96724_PIPE_EN_ADDR, MAX96724_PIPE_EN_4);
++
++	priv->sources[src_idx].st_enabled = true;
++
++ret:
++	mutex_unlock(&priv->lock);
++	return err;
++}
++EXPORT_SYMBOL(max96724_setup_streaming);
++
++/* ================================================================
++ * Start / Stop Streaming
++ * ================================================================ */
++
++int max96724_start_streaming(struct device *dev, struct device *s_dev)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++	struct gmsl_link_ctx *g_ctx;
++	struct gmsl_stream *g_stream;
++	int err = 0;
++	unsigned int i = 0;
++
++	err = max96724_get_sdev_idx(dev, s_dev, &i);
++	if (err)
++		return err;
++
++	mutex_lock(&priv->lock);
++	g_ctx = priv->sources[i].g_ctx;
++
++	for (i = 0; i < g_ctx->num_streams; i++) {
++		g_stream = &g_ctx->streams[i];
++
++		if (g_stream->des_pipe != MAX96724_PIPE_INVALID)
++			max96724_write_reg(dev, g_stream->des_pipe,
++					   g_stream->st_id_sel);
++	}
++	mutex_unlock(&priv->lock);
++
++	return 0;
++}
++EXPORT_SYMBOL(max96724_start_streaming);
++
++int max96724_stop_streaming(struct device *dev, struct device *s_dev)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++	struct gmsl_link_ctx *g_ctx;
++	struct gmsl_stream *g_stream;
++	int err = 0;
++	unsigned int i = 0;
++
++	err = max96724_get_sdev_idx(dev, s_dev, &i);
++	if (err)
++		return err;
++
++	mutex_lock(&priv->lock);
++	g_ctx = priv->sources[i].g_ctx;
++
++	for (i = 0; i < g_ctx->num_streams; i++) {
++		g_stream = &g_ctx->streams[i];
++
++		if (g_stream->des_pipe != MAX96724_PIPE_INVALID)
++			max96724_write_reg(dev, g_stream->des_pipe,
++					   MAX96724_RESET_ST_ID);
++	}
++
++	mutex_unlock(&priv->lock);
++
++	return 0;
++}
++EXPORT_SYMBOL(max96724_stop_streaming);
++
++/* ================================================================
++ * Pipe Management
++ * ================================================================ */
++
++int max96724_get_available_pipe_id(struct device *dev, int vc_id)
++{
++	int i;
++	int pipe_id = -ENOMEM;
++	struct max96724 *priv = dev_get_drvdata(dev);
++
++	mutex_lock(&priv->lock);
++	for (i = 0; i < MAX96724_MAX_PIPES; i++) {
++		if (i == vc_id && !priv->pipe[i].st_count) {
++			priv->pipe[i].st_count++;
++			pipe_id = i;
++			break;
++		}
++	}
++	mutex_unlock(&priv->lock);
++
++	return pipe_id;
++}
++EXPORT_SYMBOL(max96724_get_available_pipe_id);
++
++int max96724_release_pipe(struct device *dev, int pipe_id)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++
++	if (pipe_id < 0 || pipe_id >= MAX96724_MAX_PIPES)
++		return -EINVAL;
++
++	mutex_lock(&priv->lock);
++	priv->pipe[pipe_id].st_count = 0;
++	mutex_unlock(&priv->lock);
++
++	return 0;
++}
++EXPORT_SYMBOL(max96724_release_pipe);
++
++int max96724_get_ser_pipe_id(struct device *dev, int dser_pipe_id, int vc_id)
++{
++	/*
++	 * In Tunnel Mode with MAX96717, all VCs are carried in a single
++	 * tunnel pipe. The pipe mapping is 1:1 for d4xx compatibility.
++	 */
++	return dser_pipe_id;
++}
++EXPORT_SYMBOL(max96724_get_ser_pipe_id);
++
++void max96724_reset_oneshot(struct device *dev)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++
++	mutex_lock(&priv->lock);
++	if (priv->splitter_enabled) {
++		/* [UG] Multi-camera: reset all links */
++		u8 link_rate = (priv->link_speed == 6) ? 0x22 : 0x11;
++
++		max96724_write_reg(dev, MAX96724_LINK_RATE_AB_ADDR,
++				   link_rate);
++		max96724_write_reg(dev, MAX96724_LINK_RATE_CD_ADDR,
++				   link_rate);
++		max96724_write_reg(dev, MAX96724_LINK_EN_ADDR,
++				   MAX96724_LINK_EN_ALL);
++	} else {
++		max96724_write_reg(dev, MAX96724_ONESHOT_ADDR,
++				   MAX96724_ONESHOT_ALL);
++	}
++	msleep(100);
++
++	/* ONESHOT resets CSI config to defaults.
++	 * Restore 1x4a+2x2 2-lane config after every ONESHOT (per guide §7):
++	 *   CSI_OUT_CFG=0x08  1x4a+2x2: Controller 1 → PHY0+1 → Port A
++	 *   PHY_EN=0x30       PHY0+PHY1 (both needed for Port A)
++	 *   MIPI_CTRL_SEL=0x55 all pipes → Controller 1 (must match TUN_DEST)
++	 *   BACKTOP=0x02      CSIB_EN (Controller 1)
++	 *   TUN_EN=0x09       tunnel enable (per verified XML)
++	 *   TUN_DEST=0x50     manual detect + PHY1 (per verified XML)
++	 *   DPLL_FREQ1=0x2E   1400Mbps (Controller 1's DPLL)
++	 *   LANE_CTRL1=0x40   2-lane on Controller 1
++	 *   VID_RX0=0x33      disable pkt detect for tunnel mode
++	 */
++	max96724_write_reg(dev, MAX96724_CSI_OUT_CFG_ADDR,
++			   MAX96724_CSI_MODE_2X4_VAL);
++	max96724_write_reg(dev, MAX96724_CSI_PHY_EN_ADDR,
++			   MAX96724_CSI_PHY_EN_01);
++	max96724_write_reg(dev, MAX96724_MIPI_CTRL_SEL_ADDR, 0x55);
++	max96724_write_reg(dev, MAX96724_BACKTOP_EN_ADDR,
++			   MAX96724_BACKTOP_CSIB_EN);
++	/* Restore 2-lane count on all controllers (ONESHOT resets to default) */
++	max96724_write_reg(dev, MAX96724_LANE_CTRL0_ADDR,
++			   MAX96724_LANE_CTRL_2LANE);
++	max96724_write_reg(dev, MAX96724_LANE_CTRL1_ADDR,
++			   MAX96724_LANE_CTRL_2LANE);
++	max96724_write_reg(dev, MAX96724_LANE_CTRL2_ADDR,
++			   MAX96724_LANE_CTRL_2LANE);
++	max96724_write_reg(dev, MAX96724_LANE_CTRL3_ADDR,
++			   MAX96724_LANE_CTRL_2LANE);
++	max96724_write_reg(dev, MAX96724_DPLL_FREQ1_ADDR,
++			   MAX96724_DPLL_1400MBPS_CTRL0);
++	max96724_write_reg(dev, MAX96724_VID_RX0_P0_ADDR,
++			   MAX96724_VID_RX0_CFG_VAL);
++	/* Re-enable tunnel on all pipes (ONESHOT resets TUN_EN to 0x08=disabled) */
++	max96724_write_reg(dev, MAX96724_PIPE0_TUN_EN_ADDR, MAX96724_TUN_EN);
++	max96724_write_reg(dev, MAX96724_PIPE1_TUN_EN_ADDR, MAX96724_TUN_EN);
++	max96724_write_reg(dev, MAX96724_PIPE2_TUN_EN_ADDR, MAX96724_TUN_EN);
++	max96724_write_reg(dev, MAX96724_PIPE3_TUN_EN_ADDR, MAX96724_TUN_EN);
++	/* TUN_DEST: set to Controller 1 (0x10) for 2x4 alt / Port A */
++	max96724_write_reg(dev, MAX96724_PIPE0_TUN_DEST_ADDR,
++			   MAX96724_TUN_DEST_CTRL1);
++	max96724_write_reg(dev, MAX96724_PIPE1_TUN_DEST_ADDR,
++			   MAX96724_TUN_DEST_CTRL1);
++	max96724_write_reg(dev, MAX96724_PIPE2_TUN_DEST_ADDR,
++			   MAX96724_TUN_DEST_CTRL1);
++	max96724_write_reg(dev, MAX96724_PIPE3_TUN_DEST_ADDR,
++			   MAX96724_TUN_DEST_CTRL1);
++
++	msleep(200);
++	mutex_unlock(&priv->lock);
++}
++EXPORT_SYMBOL(max96724_reset_oneshot);
++
++/* ================================================================
++ * Init Settings / Set Pipe
++ * ================================================================ */
++
++/*
++ * __max96724_set_pipe - Configure per-pipe mapping registers
++ */
++static int __max96724_set_pipe(struct device *dev, int pipe_id,
++			       u8 data_type1, u8 data_type2, u32 vc_id)
++{
++	int err = 0;
++	int i;
++	u8 en_mapping_num = 0x0F;
++	u8 all_mapping_phy = MAX96724_ALL_MAP_CTRL1;  /* Controller 1 for 2x4 alt Port A mode */
++
++	struct reg_pair map_pipe_control[] = {
++		/* Enable 4 mappings for Pipe X */
++		{MAX96724_TX11_PIPE_X_EN_ADDR, 0x0F},
++		/* Map data_type1 on vc_id */
++		{MAX96724_PIPE_X_SRC_0_MAP_ADDR, 0x1E},
++		{MAX96724_PIPE_X_DST_0_MAP_ADDR, 0x1E},
++		/* Map frame start on vc_id */
++		{MAX96724_PIPE_X_SRC_1_MAP_ADDR, 0x00},
++		{MAX96724_PIPE_X_DST_1_MAP_ADDR, 0x00},
++		/* Map frame end on vc_id */
++		{MAX96724_PIPE_X_SRC_2_MAP_ADDR, 0x01},
++		{MAX96724_PIPE_X_DST_2_MAP_ADDR, 0x01},
++		/* Map data_type2 on vc_id */
++		{MAX96724_PIPE_X_SRC_3_MAP_ADDR, 0x12},
++		{MAX96724_PIPE_X_DST_3_MAP_ADDR, 0x12},
++		/* All mappings to Controller 1 (2x4 alt: Ctrl1 drives Port A) */
++		{MAX96724_TX45_PIPE_X_DST_CTRL_ADDR, MAX96724_ALL_MAP_CTRL1},
++		{MAX96724_TX46_PIPE_X_ADDR, MAX96724_ALL_MAP_CTRL1},
++		{MAX96724_TX47_PIPE_X_ADDR, MAX96724_ALL_MAP_CTRL1},
++		{MAX96724_TX48_PIPE_X_ADDR, MAX96724_ALL_MAP_CTRL1},
++		/* [SC20190112 2-lane] TX49: Pipeline concatenation 2W (2-lane output) */
++		{MAX96724_TX49_PIPE_X_ADDR, MAX96724_TX49_CONCAT_2W},
++		/*
++		 * Keep DES heartbeat handling aligned with the serializer's
++		 * LIM_HEART-disabled tunnel mode to avoid persistent VID_SEQ_ERR.
++		 */
++		{0x0100, MAX96724_VID_RX0_CFG_VAL},
++		{0x0106, MAX96724_VID_RX6_CFG_VAL},
++		/*
++		 * Pipe stream control (offset 0x36 per pipe block).
++		 * [gmsl_ser_des_guide §4.9] TUN_EN = 0x09 per verified XML.
++		 */
++		{0x0936, MAX96724_TUN_EN},
++	};
++
++	/* Adjust addresses for pipe offset (stride 0x40 per pipe)
++	 * Entries 0-13: TX11, SRC/DST maps, TX45-TX49 (all stride 0x40)
++	 * Entries 14-15: VID_RX0/6 (stride 0x12)
++	 * Entry 16: Pipe stream control (stride 0x40)
++	 */
++	for (i = 0; i < 14; i++)
++		map_pipe_control[i].addr += 0x40 * pipe_id;
++
++	/* [max9296.c pattern] VID_RX offset: 0x12 per pipe */
++	map_pipe_control[14].addr += 0x12 * pipe_id;
++	map_pipe_control[15].addr += 0x12 * pipe_id;
++
++	/* Pipe stream control: stride 0x40 */
++	map_pipe_control[16].addr += 0x40 * pipe_id;
++
++	if (data_type2 == 0x0) {
++		en_mapping_num = 0x07;
++		all_mapping_phy = 0x15;  /* 3 mappings to Controller 1 */
++	}
++
++	map_pipe_control[0].val = en_mapping_num;
++	/* SRC: match incoming VC from camera (vc_id) */
++	map_pipe_control[1].val = (vc_id << 6) | data_type1;
++	/* DST: preserve VC — NVCSI/VI endpoints expect matching vc-id */
++	map_pipe_control[2].val = (vc_id << 6) | data_type1;
++	map_pipe_control[3].val = (vc_id << 6) | 0x00;
++	map_pipe_control[4].val = (vc_id << 6) | 0x00;
++	map_pipe_control[5].val = (vc_id << 6) | 0x01;
++	map_pipe_control[6].val = (vc_id << 6) | 0x01;
++	map_pipe_control[7].val = (vc_id << 6) | data_type2;
++	map_pipe_control[8].val = (vc_id << 6) | data_type2;
++	map_pipe_control[9].val = all_mapping_phy;
++	/* TX46-TX48 keep 0x55 (Ctrl1) from initializer */
++	/* TX49 keeps 0x83 (2W concat) from initializer */
++	/* VID_RX (entry 14) and pipe stream ctrl (entry 15) keep init values */
++
++	err = max96724_set_registers(dev, map_pipe_control,
++				     ARRAY_SIZE(map_pipe_control));
++
++	return err;
++}
++
++/*
++ * max96724_init_settings - Initialize default pipe and tunnel configuration
++ *
++ * Sets up all 4 pipes with default YUV422_8 + EMBED for VC0-3,
++ * matching the d4xx framework expectations.
++ *
++ */
++int max96724_init_settings(struct device *dev)
++{
++	int err = 0;
++	int i;
++	struct max96724 *priv = dev_get_drvdata(dev);
++
++	mutex_lock(&priv->lock);
++
++	for (i = 0; i < MAX96724_MAX_PIPES; i++)
++		err |= __max96724_set_pipe(dev, i, GMSL_CSI_DT_YUV422_8,
++					   GMSL_CSI_DT_EMBED, i);
++
++	mutex_unlock(&priv->lock);
++
++	return err;
++}
++EXPORT_SYMBOL(max96724_init_settings);
++
++int max96724_bind_ser_to_dser_pipe(struct device *dev, int dser_pipe_id,
++				   int ser_pipe_id, u32 vc_id)
++{
++	/* In Tunnel Mode, pipe mapping is 1:1 (each camera → one pipe) */
++	return 0;
++}
++EXPORT_SYMBOL(max96724_bind_ser_to_dser_pipe);
++
++int max96724_set_pipe(struct device *dev, int pipe_id,
++		      u8 data_type1, u8 data_type2, u32 vc_id)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++	int err = 0;
++
++	if (pipe_id > (MAX96724_MAX_PIPES - 1)) {
++		dev_info(dev, "%s: input pipe_id: %d exceeds max96724 max pipes\n",
++			 __func__, pipe_id);
++		return -EINVAL;
++	}
++
++	dev_dbg(dev, "%s pipe_id %d, data_type1 %u, data_type2 %u, vc_id %u\n",
++		__func__, pipe_id, data_type1, data_type2, vc_id);
++
++	mutex_lock(&priv->lock);
++
++	err = __max96724_set_pipe(dev, pipe_id, data_type1, data_type2, vc_id);
++
++	mutex_unlock(&priv->lock);
++
++	return err;
++}
++EXPORT_SYMBOL(max96724_set_pipe);
++
++/* ================================================================
++ * Device Tree Parsing
++ * ================================================================ */
++
++static const struct of_device_id max96724_of_match[] = {
++	{ .compatible = "adi,max96724", },
++	{ },
++};
++MODULE_DEVICE_TABLE(of, max96724_of_match);
++
++static int max96724_parse_dt(struct max96724 *priv,
++			     struct i2c_client *client)
++{
++	struct device_node *node = client->dev.of_node;
++	int err = 0;
++	const char *str_value;
++	int value;
++	const struct of_device_id *match;
++
++	if (!node)
++		return -EINVAL;
++
++	match = of_match_device(max96724_of_match, &client->dev);
++	if (!match) {
++		dev_err(&client->dev, "Failed to find matching dt id\n");
++		return -EFAULT;
++	}
++
++	/* CSI mode: "2x4" or "4x2" */
++	err = of_property_read_string(node, "csi-mode", &str_value);
++	if (err < 0) {
++		dev_err(&client->dev, "csi-mode property not found\n");
++		return err;
++	}
++
++	if (!strcmp(str_value, "2x4")) {
++		priv->csi_mode = MAX96724_CSI_MODE_2X4;
++		priv->lane_mp1 = MAX96724_LANE_MAP1_2X4;
++		priv->lane_mp2 = MAX96724_LANE_MAP2_2X4;
++	} else if (!strcmp(str_value, "4x2")) {
++		priv->csi_mode = MAX96724_CSI_MODE_4X2;
++		priv->lane_mp1 = MAX96724_LANE_MAP1_4X2;
++		priv->lane_mp2 = MAX96724_LANE_MAP2_4X2;
++	} else {
++		dev_err(&client->dev, "invalid csi mode\n");
++		return -EINVAL;
++	}
++
++	/* Max sources */
++	err = of_property_read_u32(node, "max-src", &value);
++	if (err < 0) {
++		dev_err(&client->dev, "No max-src info\n");
++		return err;
++	}
++	priv->max_src = value;
++
++	/* Reset GPIO */
++	priv->reset_gpio = of_get_named_gpio(node, "reset-gpios", 0);
++	if (priv->reset_gpio < 0) {
++		dev_err(&client->dev, "reset-gpios not found %d\n", err);
++		return err;
++	}
++
++	/* [User requirement] GMSL link speed from DT: 3 or 6 (Gbps) */
++	err = of_property_read_u32(node, "gmsl-link-speed", &value);
++	if (err < 0) {
++		/* Default to 3 Gbps if not specified */
++		priv->link_speed = 3;
++		dev_info(&client->dev,
++			 "gmsl-link-speed not specified, defaulting to 3 Gbps\n");
++	} else {
++		if (value != 3 && value != 6) {
++			dev_err(&client->dev,
++				"invalid gmsl-link-speed %d (must be 3 or 6)\n",
++				value);
++			return -EINVAL;
++		}
++		priv->link_speed = value;
++	}
++
++	/* 1.2V regulator (optional) */
++	if (of_get_property(node, "vdd_cam_1v2-supply", NULL)) {
++		priv->vdd_cam_1v2 = regulator_get(&client->dev, "vdd_cam_1v2");
++		if (IS_ERR(priv->vdd_cam_1v2)) {
++			dev_err(&client->dev,
++				"vdd_cam_1v2 regulator get failed\n");
++			err = PTR_ERR(priv->vdd_cam_1v2);
++			priv->vdd_cam_1v2 = NULL;
++			return err;
++		}
++	} else {
++		priv->vdd_cam_1v2 = NULL;
++	}
++
++	return 0;
++}
++
++/* ================================================================
++ * Probe / Remove
++ * ================================================================ */
++
++static struct regmap_config max96724_regmap_config = {
++	.reg_bits = 16,
++	.val_bits = 8,
++	.cache_type = REGCACHE_RBTREE,
++};
++
++static int max96724_probe(struct i2c_client *client,
++			   const struct i2c_device_id *id)
++{
++	struct max96724 *priv;
++	int err = 0;
++
++	dev_info(&client->dev,
++		 "[MAX96724]: probing Quad GMSL2 Deserializer (Tunnel Mode)\n");
++
++	priv = devm_kzalloc(&client->dev, sizeof(*priv), GFP_KERNEL);
++	if (!priv)
++		return -ENOMEM;
++
++	priv->i2c_client = client;
++	priv->regmap = devm_regmap_init_i2c(priv->i2c_client,
++					     &max96724_regmap_config);
++	if (IS_ERR(priv->regmap)) {
++		dev_err(&client->dev,
++			"regmap init failed: %ld\n", PTR_ERR(priv->regmap));
++		return -ENODEV;
++	}
++
++	err = max96724_parse_dt(priv, client);
++	if (err) {
++		dev_err(&client->dev, "unable to parse dt\n");
++		return -EFAULT;
++	}
++
++	max96724_pipes_reset(priv);
++
++	if (priv->max_src > MAX96724_MAX_SOURCES) {
++		dev_err(&client->dev,
++			"max sources more than currently supported\n");
++		return -EINVAL;
++	}
++
++	mutex_init(&priv->lock);
++
++	dev_set_drvdata(&client->dev, priv);
++
++	dev_info(&client->dev, "%s: success (link_speed=%d Gbps, max_src=%d)\n",
++		 __func__, priv->link_speed, priv->max_src);
++
++	return err;
++}
++
++static int max96724_remove(struct i2c_client *client)
++{
++	struct max96724 *priv;
++
++	if (client != NULL) {
++		priv = dev_get_drvdata(&client->dev);
++		mutex_destroy(&priv->lock);
++		i2c_unregister_device(client);
++		client = NULL;
++	}
++
++	return 0;
++}
++
++static const struct i2c_device_id max96724_id[] = {
++	{ "max96724", 0 },
++	{ },
++};
++
++MODULE_DEVICE_TABLE(i2c, max96724_id);
++
++static struct i2c_driver max96724_i2c_driver = {
++	.driver = {
++		.name = "max96724",
++		.owner = THIS_MODULE,
++		.of_match_table = of_match_ptr(max96724_of_match),
++	},
++	.probe = max96724_probe,
++	.remove = max96724_remove,
++	.id_table = max96724_id,
++};
++
++static int __init max96724_init(void)
++{
++	return i2c_add_driver(&max96724_i2c_driver);
++}
++
++static void __exit max96724_exit(void)
++{
++	i2c_del_driver(&max96724_i2c_driver);
++}
++
++module_init(max96724_init);
++module_exit(max96724_exit);
++
++MODULE_DESCRIPTION("Quad GMSL2 Deserializer driver max96724 (Tunnel Mode)");
++MODULE_AUTHOR("RealSense AI");
++MODULE_LICENSE("GPL v2");
+diff --git a/include/media/max96717.h b/include/media/max96717.h
+new file mode 100644
+index 0000000..65bf930
+--- /dev/null
++++ b/include/media/max96717.h
+@@ -0,0 +1,151 @@
++/*
++ * max96717.c - MAX96717 GMSL2 Serializer driver (Tunnel Mode)
++ *
++ * Copyright (c) 2026, RealSense, Inc.  All rights reserved.
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms and conditions of the GNU General Public License,
++ * version 2, as published by the Free Software Foundation.
++ *
++ * This program is distributed in the hope it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
++ * more details.
++ *
++ * You should have received a copy of the GNU General Public License
++ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
++ */
++
++/**
++ * @file
++ * <b>MAX96717 API: For Analog Devices MAX96717 GMSL2 serializer</b>
++ *
++ * @b Description: Defines elements used to set up and use an
++ *  Analog Devices MAX96717 GMSL2 serializer in Tunnel Mode.
++ */
++
++#ifndef __MAX96717_H__
++#define __MAX96717_H__
++
++#include <linux/types.h>
++#include <media/gmsl-link.h>
++
++/**
++ * \defgroup max96717 MAX96717 serializer driver
++ *
++ * Controls the MAX96717 GMSL2 serializer module (Tunnel Mode).
++ *
++ * @ingroup serdes_group
++ * @{
++ */
++
++/**
++ * @brief  Configures a single pipe on the serializer.
++ *
++ * In Tunnel Mode, per-pipe DT/VC filtering is not active on the serializer
++ * side (all VCs are tunneled transparently). This function maintains API
++ * compatibility with the d4xx sensor driver framework.
++ *
++ * @param  [in]  dev          The serializer device handle.
++ * @param  [in]  pipe_id      Pipe index (0..3).
++ * @param  [in]  data_type1   Primary CSI-2 data type.
++ * @param  [in]  data_type2   Secondary CSI-2 data type (e.g. embedded).
++ * @param  [in]  vc_id        Virtual channel ID.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96717_set_pipe(struct device *dev, int pipe_id, u8 data_type1,
++		      u8 data_type2, u32 vc_id);
++
++/**
++ * @brief  Toggle SER TX to restore tunnel detection after DES ONESHOT.
++ *
++ * A DES ONESHOT resets the video data path. The serializer must cycle
++ * its TX enable (REG2 0x03→0x43) for the deserializer to re-acquire
++ * the tunnel stream.
++ *
++ * @param  [in]  dev          The serializer device handle.
++ */
++void max96717_retrigger_tx(struct device *dev);
++
++/**
++ * @brief  Powers on the serializer and performs I2C overrides
++ * for sensor and serializer devices.
++ *
++ * Must be called after the deserializer's max96724_setup_link().
++ *
++ * @param  [in]  dev          The serializer device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96717_setup_control(struct device *dev);
++
++/**
++ * @brief  Reverts I2C overrides and resets the serializer.
++ *
++ * @param  [in]  dev          The serializer device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96717_reset_control(struct device *dev);
++
++/**
++ * @brief  Pairs a sensor device with the serializer.
++ *
++ * To be called by the sensor client driver.
++ *
++ * @param  [in]  dev          The serializer device handle.
++ * @param  [in]  g_ctx        The gmsl_link_ctx structure handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96717_sdev_pair(struct device *dev, struct gmsl_link_ctx *g_ctx);
++
++/**
++ * @brief  Unpairs a sensor device from the serializer.
++ *
++ * @param  [in]  dev          The serializer device handle.
++ * @param  [in]  s_dev        The sensor device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96717_sdev_unpair(struct device *dev, struct device *s_dev);
++
++/**
++ * @brief  Sets up the serializer's internal streaming pipeline.
++ *
++ * Configures CSI-2 input mode, lane mapping, and enables Tunnel Mode
++ * (EXT11[7]=1 at register 0x0383).
++ *
++ * @param  [in]  dev          The serializer device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96717_setup_streaming(struct device *dev);
++
++/**
++ * @brief  Applies initial register settings for the serializer.
++ *
++ * Configures default pipe settings and Tunnel Mode registers.
++ *
++ * @param  [in]  dev          The serializer device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96717_init_settings(struct device *dev);
++
++/**
++ * @brief  No-op hook for GPIO-over-GMSL tunneling for FSIN/FOUT signals.
++ *
++ * The signal map is documented, but the concrete MFP_CFG values are
++ * not available yet. This hook currently logs and returns success.
++ *
++ * @param  [in]  dev          The serializer device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96717_setup_gpio_tunneling(struct device *dev);
++
++/** @} */
++
++#endif  /* __MAX96717_H__ */
+diff --git a/include/media/max96724.h b/include/media/max96724.h
+new file mode 100644
+index 0000000..dc5a8ea
+--- /dev/null
++++ b/include/media/max96724.h
+@@ -0,0 +1,183 @@
++/*
++ * max96717.c - MAX96717 GMSL2 Serializer driver (Tunnel Mode)
++ *
++ * Copyright (c) 2026, RealSense, Inc.  All rights reserved.
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms and conditions of the GNU General Public License,
++ * version 2, as published by the Free Software Foundation.
++ *
++ * This program is distributed in the hope it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
++ * more details.
++ *
++ * You should have received a copy of the GNU General Public License
++ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
++ */
++
++/**
++ * @file
++ * <b>MAX96724 API: For Analog Devices MAX96724 GMSL2 quad deserializer</b>
++ *
++ * @b Description: Defines elements used to set up and use an
++ *  Analog Devices MAX96724 quad GMSL2 deserializer in Tunnel Mode.
++ */
++
++#ifndef __MAX96724_H__
++#define __MAX96724_H__
++
++#include <linux/types.h>
++#include <media/gmsl-link.h>
++
++/**
++ * \defgroup max96724 MAX96724 deserializer driver
++ *
++ * Controls the MAX96724 quad GMSL2 deserializer module (Tunnel Mode).
++ *
++ * @ingroup serdes_group
++ * @{
++ */
++
++int max96724_get_available_pipe_id(struct device *dev, int vc_id);
++int max96724_get_ser_pipe_id(struct device *dev, int dser_pipe_id, int vc_id);
++int max96724_set_pipe(struct device *dev, int pipe_id, u8 data_type1,
++		      u8 data_type2, u32 vc_id);
++int max96724_release_pipe(struct device *dev, int pipe_id);
++void max96724_reset_oneshot(struct device *dev);
++
++/**
++ * @brief  Puts the deserializer in single exclusive link mode.
++ *
++ * @param  [in]  dev          The deserializer device handle.
++ * @param  [in]  s_dev        The sensor device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96724_setup_link(struct device *dev, struct device *s_dev);
++
++/**
++ * @brief  Sets up the deserializer link's control pipeline.
++ *
++ * Configures I2C pass-through, splitter mode if needed, and
++ * enables the tunnel mode pipe routing for the source.
++ *
++ * @param  [in]  dev          The deserializer device handle.
++ * @param  [in]  s_dev        The sensor device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96724_setup_control(struct device *dev, struct device *s_dev);
++
++/**
++ * @brief  Resets the deserializer link control pipeline.
++ *
++ * @param  [in]  dev          The deserializer device handle.
++ * @param  [in]  s_dev        The sensor device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96724_reset_control(struct device *dev, struct device *s_dev);
++
++/**
++ * @brief  Registers a source sensor device with the deserializer.
++ *
++ * @param  [in]  dev          The deserializer device handle.
++ * @param  [in]  g_ctx        The gmsl_link_ctx structure handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96724_sdev_register(struct device *dev, struct gmsl_link_ctx *g_ctx);
++
++/**
++ * @brief  Unregisters a source sensor device from the deserializer.
++ *
++ * @param  [in]  dev          The deserializer device handle.
++ * @param  [in]  s_dev        The sensor device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96724_sdev_unregister(struct device *dev, struct device *s_dev);
++
++/**
++ * @brief  Configures the internal streaming pipeline.
++ *
++ * Sets up tunnel mode pipe routing, CSI-2 output lane configuration,
++ * and MIPI PHY settings.
++ *
++ * @param  [in]  dev          The deserializer device handle.
++ * @param  [in]  s_dev        The sensor device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96724_setup_streaming(struct device *dev, struct device *s_dev);
++
++/**
++ * @brief  Enables streaming for a source sensor.
++ *
++ * @param  [in]  dev          The deserializer device handle.
++ * @param  [in]  s_dev        The sensor device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96724_start_streaming(struct device *dev, struct device *s_dev);
++
++/**
++ * @brief  Disables streaming for a source sensor.
++ *
++ * @param  [in]  dev          The deserializer device handle.
++ * @param  [in]  s_dev        The sensor device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96724_stop_streaming(struct device *dev, struct device *s_dev);
++
++/**
++ * @brief  Powers on the MAX96724 deserializer module.
++ *
++ * Asserts shared reset GPIO and powers on the regulator.
++ *
++ * @param  [in]  dev          The deserializer device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96724_power_on(struct device *dev);
++
++/**
++ * @brief  Powers off the MAX96724 deserializer module.
++ *
++ * @param  [in]  dev          The deserializer device handle.
++ */
++void max96724_power_off(struct device *dev);
++
++/**
++ * @brief  Applies initial register settings for the deserializer.
++ *
++ * Configures default pipe mappings, tunnel mode, and CSI output for
++ * the D5xx/SC1.2 use case.
++ *
++ * @param  [in]  dev          The deserializer device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96724_init_settings(struct device *dev);
++
++/**
++ * @brief  Maps deserializer pipe ID to serializer pipe ID.
++ *
++ * In tunnel mode with MAX96717, all data flows through a single pipe
++ * per camera, so the mapping is 1:1.
++ *
++ * @param  [in]  dev             The deserializer device handle.
++ * @param  [in]  dser_pipe_id    Deserializer pipe ID.
++ * @param  [in]  ser_pipe_id     Serializer pipe ID.
++ * @param  [in]  vc_id           VC ID associated with this pipe.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96724_bind_ser_to_dser_pipe(struct device *dev, int dser_pipe_id,
++				   int ser_pipe_id, u32 vc_id);
++
++/** @} */
++
++#endif  /* __MAX96724_H__ */
+-- 
+2.25.1
+


### PR DESCRIPTION
## Summary
- add a Tegra234 device-tree overlay for RealSense D5xx / D585 camera bring-up
- define 4 CSI virtual channels for depth, IR-left, IR-right, and RGB streams
- configure MAX96724, MAX96717, HKR, and sensor aliasing for the AGX Orin CSI path

## Validation
- build_all.sh 6.2 ./Linux_for_Tegra/source