### PR TITLE
ext_sync_gen.py - Allow enable after enable

### DIFF
--- a/scripts/ext_sync_gen.py
+++ b/scripts/ext_sync_gen.py
@@ -54,6 +54,10 @@ def main():
         fd = os.open(CDI_TSC_DEV, os.O_RDWR)
         try:
             if args.enable:
+                try:
+                    tsc_fsync(fd, 0)
+                except OSError:
+                    pass
                 if args.fps is not None or args.duty is not None:
                     fps = args.fps if args.fps is not None else 30
                     duty = args.duty if args.duty is not None else 25


### PR DESCRIPTION
Allow changing ext_sync_gen pwm without disabling in between so this input is now legal:
python ext_sync_gen.py --enable --fps 30
python ext_sync_gen.py --enable --fps 60
(Previously the second command would have failed on 'resource busy')