### PR TITLE
[RSDSO-21490] Enable external sync for D41X (D415) cameras

### DIFF
--- a/kernel/realsense/d4xx.c
+++ b/kernel/realsense/d4xx.c
@@ -6096,9 +6096,10 @@ static void ds5_adjust_sync_mode_control(struct i2c_client *client, struct ds5 *
 	dev_type = ds5_dev_type(state, dev_type);
 	switch (dev_type) {
 	case DS5_DEVICE_TYPE_D41X:
-		/* D41X does not support sync mode */
+		/* D41X does support all 6 sync modes (0-5) */
+		__v4l2_ctrl_modify_range(state->ctrls.sync_mode, 0, 5, 0, 0);
+		state->ctrls.sync_mode->qmenu = sync_mode_menu_full;
 		dev_dbg(&client->dev, "%s(): D41X does not support sync mode\n", __func__);
-		__v4l2_ctrl_modify_range(state->ctrls.sync_mode, 0, 0, 0, 0);
 		break;
 	case DS5_DEVICE_TYPE_D40X:
 		/* D401 only supports modes 0 (Default) and 2 (Slave) */


### PR DESCRIPTION
## Summary
- Enable all sync modes (0-5) for D41X (D415) device type
- Assign `sync_mode_menu_full` for D41X, replacing the previous restriction to mode 0 only

## Test plan
- [ ] Verify all 6 sync modes are enumerable via `v4l2-ctl` on a D415 GMSL camera
- [ ] Verify sync mode behavior for each mode (Default, Master, Slave, etc.)
- [ ] Verify no regression on other device types (D40X, D45X, etc.)
