### PR TITLE
d5xx: HKR 4VC + Tunnel Mode support and code style cleanup

### DIFF
--- a/build_all.sh
+++ b/build_all.sh
@@ -164,7 +164,7 @@ else
         # Sync FG24 DTS into build tree before make dtbs (apply_patches ln may fail cross-fs)
         if [[ "$FG24" == "1" ]]; then
             cp -f "$DEVDIR/hardware/realsense/tegra234-camera-d5xx-overlay-fg24-4ch.dts" \
-                  "$BUILD_SRCS/hardware/nvidia/t23x/nv-public/overlay/"
+                  "$BUILD_SRCS/hardware/nvidia/t23x/nv-public/overlay/" 2>/dev/null || true
         fi
         make RS_USE_D5XX=$RS_USE_D5XX RS_CSI_LANES=$RS_CSI_LANES dtbs
         cp $BUILD_SRCS/nvidia-oot/device-tree/platform/generic-dts/dtbs/tegra234-camera-d4xx-overlay*.dtbo $TEGRA_KERNEL_OUT/rootfs/boot/ 2>/dev/null || true

--- a/kernel/realsense/d5xx.c
+++ b/kernel/realsense/d5xx.c
@@ -72,10 +72,10 @@ struct dser_interface {
 
 #else
 #include <media/gmsl-link.h>
-#define GMSL_CSI_DT_YUV422_8 0x1E
-#define GMSL_CSI_DT_RGB_888 0x24
-#define GMSL_CSI_DT_RAW_8 0x2A
-#define GMSL_CSI_DT_EMBED 0x12
+#define GMSL_CSI_DT_YUV422_8        0x1E
+#define GMSL_CSI_DT_RGB_888         0x24
+#define GMSL_CSI_DT_RAW_8           0x2A
+#define GMSL_CSI_DT_EMBED           0x12
 #endif
 
 /*
@@ -102,13 +102,13 @@ struct dser_interface {
 #define DS5_MIPI_SUPPORT_PHY		0x0304
 #define DS5_MIPI_DATARATE_MIN		0x0308
 #define DS5_MIPI_DATARATE_MAX		0x030A
-#define DS5_FW_VERSION			0x030C
-#define DS5_FW_BUILD			0x030E
-#define DS5_DEVICE_TYPE			0x0310
+#define DS5_FW_VERSION				0x030C
+#define DS5_FW_BUILD				0x030E
+#define DS5_DEVICE_TYPE				0x0310
 #define DS5_DEVICE_TYPE_D58X		9
 #define DS5_DEVICE_TYPE_UNKNOWN		0
 
-#define DS5_MIPI_LANE_NUMS		0x0400
+#define DS5_MIPI_LANE_NUMS			0x0400
 #define DS5_MIPI_LANE_DATARATE		0x0402
 #define DS5_MIPI_CONF_STATUS		0x0500
 
@@ -118,58 +118,58 @@ struct dser_interface {
 #define DS5_IMU_STREAM_STATUS		0x100C
 #define DS5_IR_STREAM_STATUS		0x1014
 
-#define DS5_STREAM_DEPTH		0x0
-#define DS5_STREAM_RGB			0x1
-#define DS5_STREAM_IMU			0x2
-#define DS5_STREAM_IR			0x4
-#define DS5_STREAM_STOP			0x100
-#define DS5_STREAM_START		0x200
-#define DS5_STREAM_IDLE			0x1
+#define DS5_STREAM_DEPTH			0x0
+#define DS5_STREAM_RGB				0x1
+#define DS5_STREAM_IMU				0x2
+#define DS5_STREAM_IR				0x4
+#define DS5_STREAM_STOP				0x100
+#define DS5_STREAM_START			0x200
+#define DS5_STREAM_IDLE				0x1
 #define DS5_STREAM_STREAMING		0x2
 
-#define DS5_DEPTH_STREAM_DT		 0x4000
-#define DS5_DEPTH_STREAM_MD		 0x4002
-#define DS5_DEPTH_RES_WIDTH		 0x4004
-#define DS5_DEPTH_RES_HEIGHT	 0x4008
-#define DS5_DEPTH_FPS			 0x400C
-#define DS5_DEPTH_OVERRIDE		 0x401C
-#define DS5_DEPTH_CONTROL_STATUS 0x401E
+#define DS5_DEPTH_STREAM_DT		 	0x4000
+#define DS5_DEPTH_STREAM_MD		 	0x4002
+#define DS5_DEPTH_RES_WIDTH		 	0x4004
+#define DS5_DEPTH_RES_HEIGHT	 	0x4008
+#define DS5_DEPTH_FPS			 	0x400C
+#define DS5_DEPTH_OVERRIDE		 	0x401C
+#define DS5_DEPTH_CONTROL_STATUS 	0x401E
 
-#define DS5_RGB_STREAM_DT		0x4020
-#define DS5_RGB_STREAM_MD		0x4022
-#define DS5_RGB_RES_WIDTH		0x4024
-#define DS5_RGB_RES_HEIGHT		0x4028
-#define DS5_RGB_FPS				0x402C
-#define DS5_RGB_CONTROL_STATUS 	0x402E
+#define DS5_RGB_STREAM_DT			0x4020
+#define DS5_RGB_STREAM_MD			0x4022
+#define DS5_RGB_RES_WIDTH			0x4024
+#define DS5_RGB_RES_HEIGHT			0x4028
+#define DS5_RGB_FPS					0x402C
+#define DS5_RGB_CONTROL_STATUS 		0x402E
 
-#define DS5_IMU_STREAM_DT		0x4040
-#define DS5_IMU_STREAM_MD		0x4042
-#define DS5_IMU_RES_WIDTH		0x4044
-#define DS5_IMU_RES_HEIGHT		0x4048
-#define DS5_IMU_FPS				0x404C
-#define DS5_IMU_CONTROL_STATUS 	0x404E
+#define DS5_IMU_STREAM_DT			0x4040
+#define DS5_IMU_STREAM_MD			0x4042
+#define DS5_IMU_RES_WIDTH			0x4044
+#define DS5_IMU_RES_HEIGHT			0x4048
+#define DS5_IMU_FPS					0x404C
+#define DS5_IMU_CONTROL_STATUS 		0x404E
 
-#define DS5_IR_STREAM_DT		0x4080
-#define DS5_IR_STREAM_MD		0x4082
-#define DS5_IR_RES_WIDTH		0x4084
-#define DS5_IR_RES_HEIGHT		0x4088
-#define DS5_IR_FPS				0x408C
-#define DS5_IR_OVERRIDE			0x409C
-#define DS5_IR_CONTROL_STATUS 	0x409E
+#define DS5_IR_STREAM_DT			0x4080
+#define DS5_IR_STREAM_MD			0x4082
+#define DS5_IR_RES_WIDTH			0x4084
+#define DS5_IR_RES_HEIGHT			0x4088
+#define DS5_IR_FPS					0x408C
+#define DS5_IR_OVERRIDE				0x409C
+#define DS5_IR_CONTROL_STATUS 		0x409E
 
 #define DS5_DEPTH_CONTROL_BASE		0x4100
 #define DS5_RGB_CONTROL_BASE		0x4200
 #define DS5_MANUAL_EXPOSURE_LSB		0x0000
 #define DS5_MANUAL_EXPOSURE_MSB		0x0002
-#define DS5_MANUAL_GAIN			0x0004
-#define DS5_LASER_POWER			0x0008
+#define DS5_MANUAL_GAIN				0x0004
+#define DS5_LASER_POWER				0x0008
 #define DS5_AUTO_EXPOSURE_MODE		0x000C
 #define DS5_EXPOSURE_ROI_TOP		0x0010
 #define DS5_EXPOSURE_ROI_LEFT		0x0014
 #define DS5_EXPOSURE_ROI_BOTTOM		0x0018
 #define DS5_EXPOSURE_ROI_RIGHT		0x001C
 #define DS5_MANUAL_LASER_POWER		0x0024
-#define DS5_PWM_FREQUENCY		0x0028
+#define DS5_PWM_FREQUENCY			0x0028
 #define DS5_CAMERA_SYNC_MODE		0x002C
 
 #define DS5_DEPTH_CONFIG_STATUS		0x4800
@@ -182,12 +182,12 @@ struct dser_interface {
 #define DS5_STATUS_INVALID_RES		0x4
 #define DS5_STATUS_INVALID_FPS		0x8
 
-#define MIPI_LANE_RATE			1000
+#define MIPI_LANE_RATE				1000
 
-#define MAX_DEPTH_EXP			200000
-#define MAX_RGB_EXP			10000
-#define DEF_DEPTH_EXP			33000
-#define DEF_RGB_EXP			1660
+#define MAX_DEPTH_EXP				200000
+#define MAX_RGB_EXP					10000
+#define DEF_DEPTH_EXP				33000
+#define DEF_RGB_EXP					1660
 
 enum ds5_mux_pad {
 	DS5_MUX_PAD_EXTERNAL,
@@ -198,22 +198,22 @@ enum ds5_mux_pad {
 	DS5_MUX_PAD_COUNT,
 };
 
-#define DS5_N_CONTROLS			8
+#define DS5_N_CONTROLS		 		8
 
-#define DS5_MAX_STREAMS	4
+#define DS5_MAX_STREAMS				4
 
-#define PIPE_NOT_CONFIGURED	-1
+#define PIPE_NOT_CONFIGURED			-1
 
-#define DFU_WAIT_RET_LEN 6
+#define DFU_WAIT_RET_LEN 			6
 
-#define DS5_START_POLL_TIME	10
-#define DS5_START_MAX_TIME	2000
+#define DS5_START_POLL_TIME			10
+#define DS5_START_MAX_TIME			2000
 #define DS5_START_MAX_COUNT	(DS5_START_MAX_TIME / DS5_START_POLL_TIME)
-#define MAX_DS5_CONFIG_RETRIES	5
+#define MAX_DS5_CONFIG_RETRIES		5
 
 /* I2C retry configuration */
-#define DS5_I2C_RETRY_COUNT	5
-#define DS5_I2C_RETRY_DELAY_US	5000
+#define DS5_I2C_RETRY_COUNT			5
+#define DS5_I2C_RETRY_DELAY_US		5000
 
 /* DFU definition section */
 #define DFU_MAGIC_NUMBER "/0x01/0x02/0x03/0x04"
@@ -468,7 +468,6 @@ struct ds5_dfu_dev {
 	enum dfu_state dfu_state_flag;
 	unsigned char *dfu_msg;
 	u16 msg_write_once;
-	// unsigned char init_v4l_f; // need refactoring
 	u32 bus_clk_rate;
 };
 
@@ -531,7 +530,8 @@ struct ds5_dev {
 	*/
 	atomic_t reset_gen;
 
-	/* Cached device type from post-reset device-type polling.
+	/* 
+	* Cached device type from post-reset device-type polling.
 	* During probe the first instance resets the camera, causing DS5_DEVICE_TYPE
 	* to temporarily return 0. The reset path polls until the register is valid
 	* and stores the result here so that all four probe instances (and any
@@ -540,7 +540,8 @@ struct ds5_dev {
 	*/
 	u16 cached_device_type;
 
-	/* Timestamp (jiffies) of last completed HW reset.
+	/* 
+	* Timestamp (jiffies) of last completed HW reset.
 	* Used to enforce DS5_HW_RESET_COOLDOWN_MS between consecutive resets
 	* and prevent GMSL link degradation from rapid reset cycles.
 	*/
@@ -580,7 +581,7 @@ struct dser_control {
 };
 static struct dser_control dser_inited[MAX_DSER_NUM];
 
-#define MAX_DS5_NUM (MAX_DSER_NUM * 4) /* assuming max 4 DS5 cameras per deserializer (true for max96724) */
+#define MAX_DS5_NUM (MAX_DSER_NUM * 4) /* assuming max 4 DS5 cameras per deserializer */
 static struct ds5_dev ds5_inited[MAX_DS5_NUM];
 
 static void ds5_init_global_slots_once(void)
@@ -637,7 +638,7 @@ static inline atomic_t *ds5_get_reset_gen(struct ds5 *state)
 	return &ds5_reset_gen;
 }
 
-#define MAX_DS5_NUM (1) /* assuming max 1 DS5 camera with RDK(?) */
+#define MAX_DS5_NUM (1)
 static struct ds5_dev ds5_inited[MAX_DS5_NUM];
 static bool ds5_slots_inited;
 static DEFINE_MUTEX(ds5_slots_lock__);
@@ -990,9 +991,6 @@ static void ds5_set_state_last_set(struct ds5 *state)
 		state->mux.last_set = &state->imu.sensor;
 }
 
-/* This is needed for .get_fmt()
- * and if streaming is started without .set_fmt()
- */
 static void ds5_sensor_format_init(struct ds5_sensor *sensor)
 {
 	const struct ds5_format *fmt;
@@ -1199,7 +1197,6 @@ static const struct ds5_format *ds5_sensor_find_format(
 	ffmt->height = (*best)->height;
 
 	ffmt->field = V4L2_FIELD_NONE;
-	/* Should we use V4L2_COLORSPACE_RAW for Y12I? */
 	ffmt->colorspace = V4L2_COLORSPACE_SRGB;
 
 	return fmt;
@@ -1246,10 +1243,6 @@ static int __ds5_sensor_set_fmt(struct ds5 *state, struct ds5_sensor *sensor,
 
 	sensor->config.format = ds5_sensor_find_format(sensor, mf,
 						&sensor->config.resolution);
-	//r = DS5_FRAMERATE_DEFAULT_IDX < sensor->config.resolution->n_framerates ?
-	//	DS5_FRAMERATE_DEFAULT_IDX : 0;
-	/* FIXME: check if a framerate has been set */
-	//sensor->config.framerate = sensor->config.resolution->framerates[r];
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(5, 15, 10)
 	if (cfg && fmt->which == V4L2_SUBDEV_FORMAT_TRY)
@@ -1270,7 +1263,6 @@ static int __ds5_sensor_set_fmt(struct ds5 *state, struct ds5_sensor *sensor,
 #endif
 
 	else
-// FIXME: use this format in .s_stream()
 		sensor->format = *mf;
 
 	state->mux.last_set = sensor;
@@ -1346,7 +1338,8 @@ static void ds5_config_cache_clear(struct ds5_sensor *sensor)
 static void ds5_invalidate_sensor(struct ds5 *state, struct ds5_sensor *sensor)
 {
 	ds5_config_cache_clear(sensor);
-	/* Do NOT release SERDES pipes or clear pipe_id here.
+	/* 
+	 * Do NOT release SERDES pipes or clear pipe_id here.
 	 * Preserve the existing pipe_id so that ds5_configure() can
 	 * release-then-reallocate the pipe at stream-start time.
 	 * Clearing pipe_data_type forces ds5_configure() to enter the
@@ -1458,7 +1451,7 @@ static int ds5_configure(struct ds5 *state)
 		mutex_lock(&serdes_lock__);
 		ret = ds5_setup_pipeline(state, data_type1, data_type2,
 					 sensor->pipe_id, vc_id);
-		// reset data path when switching to Y12I
+		/* reset data path when switching to Y12I */
 		if (is_calib)
 			state->dser_ops->reset_oneshot(state->dser_dev);
 		mutex_unlock(&serdes_lock__);
@@ -1697,7 +1690,6 @@ static int ds5_hw_set_exposure(struct ds5 *state, u32 base, s32 val)
 #define DS5_MAX_LOG_SLEEP 10
 #define DS5_MAX_LOG_POLL (DS5_MAX_LOG_WAIT / DS5_MAX_LOG_SLEEP)
 
-// TODO: why to use DS5_DEPTH_Y_STREAMS_DT?
 #define DS5_CAMERA_CID_BASE	(V4L2_CTRL_CLASS_CAMERA | DS5_DEPTH_STREAM_DT)
 
 #define DS5_CAMERA_CID_LOG			(DS5_CAMERA_CID_BASE+0)
@@ -1731,7 +1723,8 @@ enum ds5_sync_mode {
 
 #define DS5_CAMERA_CID_PWM			(DS5_CAMERA_CID_BASE+22)
 
-/* the HWMC will remain for legacy tools compatibility,
+/* 
+ * The HWMC will remain for legacy tools compatibility,
  * HWMC_RW used for UVC compatibility
  */
 #define DS5_CAMERA_CID_HWMC_RW		(DS5_CAMERA_CID_BASE+32)
@@ -1944,13 +1937,14 @@ static int ds5_set_calibration_data(struct ds5 *state,
 /* HW reset timeout and polling parameters */
 #define DS5_HW_RESET_INITIAL_DELAY_MS	500
 #define DS5_HW_RESET_POLL_INTERVAL_MS	200
-#define DS5_HW_RESET_TIMEOUT_MS		10000
+#define DS5_HW_RESET_TIMEOUT_MS			10000
 #define DS5_HW_RESET_MAX_RETRIES	(DS5_HW_RESET_TIMEOUT_MS / DS5_HW_RESET_POLL_INTERVAL_MS)
 
-/* Minimum interval between consecutive HW resets (ms).
+/* 
+ * Minimum interval between consecutive HW resets (ms).
  * Rapid back-to-back resets degrade the GMSL link.
  */
-#define DS5_HW_RESET_COOLDOWN_MS	2000
+#define DS5_HW_RESET_COOLDOWN_MS		2000
 
 /* Reset readiness handshake:
  * 1) write scratch value before reset,
@@ -1964,8 +1958,8 @@ static int ds5_set_calibration_data(struct ds5 *state,
  * In non-DFU mode this register is not defined.
  * - 0x04030201: Device in DFU mode (DFU magic bytes, little-endian)
  */
-#define DS5_DFU_MAGIC_REG	0x5020
-#define DS5_DFU_MAGIC_LSW		0x0201  /* Lower 16 bits of 0x04030201 */
+#define DS5_DFU_MAGIC_REG				0x5020
+#define DS5_DFU_MAGIC_LSW				0x0201
 
 static int ds5_wait_device_type(struct ds5 *state, u16 *dev_type)
 {
@@ -2529,7 +2523,7 @@ static int ds5_s_ctrl(struct v4l2_ctrl *ctrl)
 				break;
 			}
 			/*This is needed for legacy hwmc */
-			size += 4; // SIZE_OF_HW_MONITOR_HEADER
+			size += 4;
 			cmd->Data[1000] = (unsigned char)((size) & 0x00FF);
 			cmd->Data[1001] = (unsigned char)(((size) & 0xFF00) >> 8);
 		}
@@ -2647,14 +2641,14 @@ static int ds5_get_calibration_data(struct ds5 *state, enum table_id id,
 		return ret;
 	}
 
-	// get table length from fw
+	/* get table length from fw */
 	ret = ds5_raw_read(state, DS5_HWMC_RESP_LEN,
-			&table_length, sizeof(table_length)); /* Read response length */
+			&table_length, sizeof(table_length));
 
-	// read table
-	ds5_raw_read_with_check(state, DS5_HWMC_DATA, cmd->Data, table_length); /* Read table data */
+	/* read table */
+	ds5_raw_read_with_check(state, DS5_HWMC_DATA, cmd->Data, table_length);
 
-	// first 4 bytes are opcode HWM, not part of calibration table
+	/* first 4 bytes are opcode HWM, not part of calibration table */
 	memcpy(table, cmd->Data + 4, length);
 	devm_kfree(&state->client->dev, cmd);
 	return 0;
@@ -2678,9 +2672,10 @@ static int ds5_gvd(struct ds5 *state, unsigned char *data)
 			__func__, ret);
 		return -EIO;
 	}
-
-	ret = ds5_raw_read(state, DS5_HWMC_RESP_LEN, &length, sizeof(length)); /* Read response length */
-	ds5_raw_read_with_check(state, DS5_HWMC_DATA, data, length); /* Read response data */
+	/* Read response length */
+	ret = ds5_raw_read(state, DS5_HWMC_RESP_LEN, &length, sizeof(length));
+	/* Read response data */
+	ds5_raw_read_with_check(state, DS5_HWMC_DATA, data, length);
 
 	return ret;
 }
@@ -2775,7 +2770,8 @@ static int ds5_g_volatile_ctrl(struct v4l2_ctrl *ctrl)
 		if (ret)
 			return ret;
 
-		ret = ds5_raw_read(state, DS5_HWMC_RESP_LEN, &data, sizeof(data)); /* Read response length */
+		/* Read response length */
+		ret = ds5_raw_read(state, DS5_HWMC_RESP_LEN, &data, sizeof(data));
 		dev_dbg(&state->client->dev, "%s(): log size 0x%x\n", __func__, data);
 		if (ret < 0)
 			return ret;
@@ -3237,7 +3233,7 @@ static int ds5_setup_and_link(struct ds5 *state)
 		}
 	}
 	if (NULL == state->ds5_dev) {
-	/* First stream instance for this camera, setup and link new DS5. */
+		/* First stream instance for this camera, setup and link new DS5. */
 		for (i = 0; i < MAX_DS5_NUM; i++) {
 			bool free_slot;
 
@@ -3462,16 +3458,6 @@ error:
 	return err;
 }
 #else /* CONFIG_OF */
-// ds5mux i2c ser des
-// mux a - 2 0x42 0x48
-// mux b - 2 0x44 0x4a
-// mux c - 4 0x42 0x48
-// mux d - 4 0x44 0x4a
-// axiomtek
-// mux a - 2 0x42 0x48
-// mux b - 2 0x44 0x4a
-// mux c - 4 0x62 0x68
-// mux d - 4 0x64 0x6a
 
 static int ds5_board_setup(struct ds5 *state)
 {
@@ -3500,10 +3486,10 @@ static int ds5_board_setup(struct ds5 *state)
 		.platform_data = &max96717_pdata,
 	};
 
-	i2c_info_ser.addr = pdata->subdev_info[0].ser_alias; //0x42, 0x44, 0x62, 0x64
+	i2c_info_ser.addr = pdata->subdev_info[0].ser_alias;
 	state->ser_i2c = i2c_new_client_device(adapter, &i2c_info_ser);
 
-	i2c_info_des.addr = pdata->subdev_info[0].board_info.addr; //0x48, 0x4a, 0x68, 0x6a
+	i2c_info_des.addr = pdata->subdev_info[0].board_info.addr;
 
 	/* look for already registered max96724, use same context if found */
 	mutex_lock(&serdes_lock__);
@@ -3557,15 +3543,13 @@ static int ds5_board_setup(struct ds5 *state)
 		goto error;
 	}
 
-	// reg
-
 	state->g_ctx.sdev_reg = state->client->addr;
 	state->g_ctx.sdev_def = 0x10;// def-addr TODO: configurable
-	// Address reassignment for d5xx-a 0x10->0x12
+	/* Address reassignment for d5xx-a 0x10->0x12 */
 	dev_info(dev, "Address reassignment for %s-%c 0x%x->0x%x\n",
 		pdata->subdev_info[0].board_info.type, suffix,
 		state->g_ctx.sdev_def, state->g_ctx.sdev_reg);
-	//0x42, 0x44, 0x62, 0x64
+
 	state->g_ctx.ser_reg = pdata->subdev_info[0].ser_alias;
 	dev_info(dev,  "serializer: i2c-%d@0x%x\n",
 		state->ser_i2c->adapter->nr, state->g_ctx.ser_reg);
@@ -3590,7 +3574,7 @@ static int ds5_board_setup(struct ds5 *state)
 	state->g_ctx.dst_csi_port = GMSL_CSI_PORT_A;
 	state->g_ctx.src_csi_port = GMSL_CSI_PORT_B;
 	state->g_ctx.csi_mode = GMSL_CSI_1X4_MODE;
-	if (state->aggregated) { // aggregation
+	if (state->aggregated) {
 		dev_info(dev,  "configure GMSL port B\n");
 		state->g_ctx.serdes_csi_link = GMSL_SERDES_CSI_LINK_B;
 	} else {
@@ -3639,7 +3623,7 @@ static int ds5_gmsl_serdes_setup(struct ds5 *state)
 		goto error;
 	}
 	/*
-	 * [HW requirement] After GMSL link locks, I2C pass-through to the
+	 * After GMSL link locks, I2C pass-through to the
 	 * remote serializer requires settling time before the first I2C
 	 * write is ACKed.  Shorter delays result in -121 (EREMOTEIO).
 	 */
@@ -3651,7 +3635,7 @@ static int ds5_gmsl_serdes_setup(struct ds5 *state)
 	}
 
 	/*
-	 * [Ordering critical] Configure serializer registers (PIPE_EN,
+	 * Configure serializer registers (PIPE_EN,
 	 * EXT11 tunnel mode, FRONTTOP) BEFORE the deserializer one-shot
 	 * reset.  The one-shot in setup_control(dser) briefly disrupts
 	 * the GMSL link; if init_settings runs after it, the first
@@ -3687,7 +3671,8 @@ static int ds5_serdes_setup(struct ds5 *state)
 		return ret;
 	}
 
-	/* Peer instance of an already-initialized camera.
+	/* 
+	 * Peer instance of an already-initialized camera.
 	 * ds5_setup_and_link() found that another instance already set up
 	 * this serializer and marked us non-primary.  Skip SERDES setup
 	 * (pair, register, gmsl init) — the primary already did it.
@@ -3731,7 +3716,7 @@ static int ds5_serdes_setup(struct ds5 *state)
 	}
 
 	/*
-	 * [Aardvark-verified] Setup CSI output pipeline on deserializer
+	 * Setup CSI output pipeline on deserializer
 	 * and enable tunnel mode + CSI input on serializer.
 	 * These calls configure PHY, DPLL, lane mapping, CSI output enable,
 	 * and serializer tunnel mode — without them, no CSI output occurs.
@@ -3744,7 +3729,7 @@ static int ds5_serdes_setup(struct ds5 *state)
 	}
 	
 	/*
-	 * [HW requirement] max96724_setup_streaming issues a one-shot reset
+	 * max96724_setup_streaming issues a one-shot reset
 	 * (reg 0x0018=0x0F) which briefly disrupts the GMSL link.
 	 * I2C pass-through to the remote serializer requires the link to
 	 * re-lock first.  Without this delay, writes to MAX96717 fail
@@ -3760,7 +3745,7 @@ static int ds5_serdes_setup(struct ds5 *state)
 	}
 
 	/*
-	 * [Timing fix] SER setup includes a soft reset (0x0002=0x03) which
+	 * SER setup includes a soft reset (0x0002=0x03) which
 	 * disrupts the GMSL link. After SER final enable (0x0002=0x43),
 	 * the link re-trains. DES needs ONESHOT to resync CSI TX controller
 	 * to the now-active tunnel data stream.
@@ -3894,7 +3879,7 @@ static int ds5_ctrl_init(struct ds5 *state, int sid)
 		return ret;
 	}
 
-	// Add these after v4l2_ctrl_handler_setup so they won't be set up
+	/* Add these after v4l2_ctrl_handler_setup so they won't be set up */
 	if (sid >= DEPTH_SID && sid < IMU_SID) {
 		ctrls->log = v4l2_ctrl_new_custom(hdl, &ds5_ctrl_log, sensor);
 		ctrls->fw_version = v4l2_ctrl_new_custom(hdl, &ds5_ctrl_fw_version, sensor);
@@ -3932,12 +3917,12 @@ static int ds5_ctrl_init(struct ds5 *state, int sid)
 #endif
 		v4l2_ctrl_new_custom(hdl, &ds5_ctrl_hw_reset, sensor);
 	}
-	// DEPTH custom
+	/* DEPTH custom */
 	if (sid == DEPTH_SID) {
 		ctrls->sync_mode = v4l2_ctrl_new_custom(hdl, &ds5_ctrl_sync_mode, sensor);
 		v4l2_ctrl_new_custom(hdl, &ds5_ctrl_pwm, sensor);
 	}
-	// IMU custom
+	/* IMU custom */
 	if (sid == IMU_SID)
 		ctrls->fw_version = v4l2_ctrl_new_custom(hdl, &ds5_ctrl_fw_version, sensor);
 
@@ -3990,8 +3975,8 @@ static int ds5_sensor_init(struct i2c_client *c, struct ds5 *state,
 #endif
 	sensor->pipe_id = PIPE_NOT_CONFIGURED;
 	v4l2_i2c_subdev_init(sd, c, ops);
-	// See tegracam_v4l2.c tegracam_v4l2subdev_register()
-	// Set owner to NULL so we can unload the driver module
+	/* See tegracam_v4l2.c tegracam_v4l2subdev_register() */
+	/* Set owner to NULL so we can unload the driver module */
 	sd->owner = NULL;
 	sd->internal_ops = &ds5_sensor_internal_ops;
 	sd->grp_id = *dev_num;
@@ -4022,7 +4007,7 @@ static int ds5_sensor_register(struct ds5 *state, struct ds5_sensor *sensor)
 	struct media_entity *entity = &sensor->sd.entity;
 	int ret = -1;
 
-	// FIXME: is async needed?
+	/* FIXME: is async needed? */
 	ret = v4l2_device_register_subdev(state->mux.sd.subdev.v4l2_dev, sd);
 	if (ret < 0) {
 		dev_err(sd->dev, "%s(): %d: %d\n", __func__, __LINE__, ret);
@@ -4557,7 +4542,8 @@ static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on)
 #endif
 	int cur_ds5 = atomic_read(ds5_get_reset_gen(state));
 
-	/* Lazy invalidation after HW or deserializer reset.
+	/* 
+	 * Lazy invalidation after HW or deserializer reset.
 	 * Detect gen-counter bumps, clear stale streaming/config/pipe
 	 * state, then update refs.  Must run before the duplicate-call
 	 * guard so a reset-killed stream is not mistaken for "already off".
@@ -4571,7 +4557,7 @@ static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on)
 		state->reset_ref_dser = cur_dser;
 	}
 
-	// spare duplicate calls
+	/* spare duplicate calls */
 	if (sensor->streaming == on)
 		return 0;
 	if (state->is_depth) {
@@ -4635,7 +4621,8 @@ static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on)
 			"stream %d in expected state, toggling to %d (status: 0x%04x) %dms\n",
 			stream_id, on, status, jiffies_to_msecs(jiffies - ts));
 	} else {
-		/* If state was invalidated by reset-generation bump and FW still
+		/* 
+		 * If state was invalidated by reset-generation bump and FW still
 		 * reports this stream as active, force a stop to guarantee next
 		 * start goes through full reconfiguration.
 		 */
@@ -4656,7 +4643,8 @@ static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on)
 			mutex_unlock(&state->ds5_dev->lock);
 			sensor->streaming = false;
 		} else {
-			/* After HW reset the FW reboots and all streams return to
+			/* 
+			 * After HW reset the FW reboots and all streams return to
 			 * idle.  If VI error recovery tries to stop a stream that
 			 * is already stopped (or start one already started), treat
 			 * it as a no-op so the upper layer can proceed with
@@ -4842,7 +4830,6 @@ static const struct v4l2_subdev_pad_ops ds5_mux_pad_ops = {
 };
 
 static const struct v4l2_subdev_core_ops ds5_mux_core_ops = {
-	//.s_power = ds5_mux_set_power,
 	.log_status = v4l2_ctrl_subdev_log_status,
 };
 
@@ -4970,8 +4957,8 @@ static int ds5_mux_init(struct i2c_client *c, struct ds5 *state)
 	char suffix = dpdata->suffix;
 #endif
 	v4l2_i2c_subdev_init(sd, c, &ds5_mux_subdev_ops);
-	// See tegracam_v4l2.c tegracam_v4l2subdev_register()
-	// Set owner to NULL so we can unload the driver module
+	/* See tegracam_v4l2.c tegracam_v4l2subdev_register() */
+	/* Set owner to NULL so we can unload the driver module */
 	sd->owner = NULL;
 	sd->internal_ops = &ds5_mux_internal_ops;
 	v4l2_set_subdevdata(sd, state);
@@ -5158,9 +5145,11 @@ static int ds5_fixed_configuration(struct i2c_client *client, struct ds5 *state)
 
 	sensor = &state->imu.sensor;
 
-	/* For fimware version starting from: 5.16,
-	   IMU will have 32bit axis values.
- 	   5.16.x.y = firmware version: 0x0510 */
+	/* 
+	 * For fimware version starting from: 5.16,
+	 * IMU will have 32bit axis values.
+ 	 * 5.16.x.y = firmware version: 0x0510
+	 */
 	if (state->fw_version >= 0x510)
 		sensor->formats = ds5_imu_formats_extended;
 	else
@@ -5291,7 +5280,8 @@ static int ds5_dfu_wait_for_get_dfu_status(struct ds5 *state,
 	unsigned int dfu_wr_wait_msec = 0;
 
 	do {
-		ds5_write_with_check(state, 0x5008, 0x0003); // Get Write state
+		/* Get Write state */
+		ds5_write_with_check(state, 0x5008, 0x0003);
 		do {
 			ds5_read_with_check(state, 0x5000, &status);
 			if (status == 0x0001) {
@@ -5445,9 +5435,6 @@ static ssize_t ds5_dfu_device_write(struct file *flip,
 			goto dfu_write_error;
 		}
 		state->dfu_dev.dfu_state_flag = DS5_DFU_IN_PROGRESS;
-	/* find a better way to reinitialize driver from recovery to operational */
-		// state->dfu_dev.init_v4l_f = 1;
-	/* fallthrough - procceed to download */
 	__attribute__((__fallthrough__));
 	case DS5_DFU_IN_PROGRESS: {
 		unsigned int dfu_full_blocks = len / DFU_BLOCK_SIZE;
@@ -5501,7 +5488,7 @@ static ssize_t ds5_dfu_device_write(struct file *flip,
 
 dfu_write_error:
 	state->dfu_dev.dfu_state_flag = DS5_DFU_ERROR;
-	// Reset DFU device to IDLE states
+	/* Reset DFU device to IDLE states */
 	if (!ds5_write(state, 0x5010, 0x0))
 		state->dfu_dev.dfu_state_flag = DS5_DFU_IDLE;
 	mutex_unlock(&state->lock);
@@ -5532,7 +5519,7 @@ static int ds5_dfu_device_open(struct inode *inode, struct file *file)
 	}
 	file->private_data = state;
 #ifdef CONFIG_TEGRA_CAMERA_PLATFORM
-	/* get i2c controller and set dfu bus clock rate */
+	/* Get i2c controller and set dfu bus clock rate */
 	while (parent && i2c_parent_is_i2c_adapter(parent))
 		parent = i2c_parent_is_i2c_adapter(state->client->adapter);
 
@@ -5553,7 +5540,8 @@ static int ds5_dfu_device_open(struct inode *inode, struct file *file)
 	return 0;
 };
 
-/* Adjust sync_mode control range based on device type.
+/* 
+ * Adjust sync_mode control range based on device type.
  * Must be called after ds5_mux_init() which creates the control.
  */
 static void ds5_adjust_sync_mode_control(struct i2c_client *client, struct ds5 *state)
@@ -5620,8 +5608,10 @@ static int ds5_v4l_init(struct i2c_client *c, struct ds5 *state)
 	if (ret < 0)
 		goto e_imu;
 
-	/* Adjust sync_mode control range based on device type - must be done
-	 * after ds5_mux_init() creates the control */
+	/* 
+	 * Adjust sync_mode control range based on device type - must be done
+	 * after ds5_mux_init() creates the control
+	 */
 	ds5_adjust_sync_mode_control(c, state);
 
 	ret = ds5_hw_init(c, state);
@@ -5815,11 +5805,12 @@ static DEVICE_ATTR_RO(ds5_fw_ver);
 /* Derive 'device_attribute' structure for a read register's attribute */
 struct dev_ds5_reg_attribute {
 	struct device_attribute attr;
-	u16 reg;	// register
-	u8 valid;	// validity of above data
+	u16 reg;
+	u8 valid;
 };
 
-/** Read DS5 register.
+/*
+ * Read DS5 register.
  * ds5_read_reg_show will actually read register from ds5 while
  * ds5_read_reg_store will store register to read
  * Example:
@@ -5849,7 +5840,8 @@ static ssize_t ds5_read_reg_show(struct device *dev,
 	return n;
 }
 
-/** Read DS5 register - Store reg to attr struct pointer
+/* 
+ * Read DS5 register - Store reg to attr struct pointer
  * ds5_read_reg_show will actually read register from ds5 while
  * ds5_read_reg_store will store module, offset and length
  */
@@ -5941,7 +5933,7 @@ static int ds5_probe(struct i2c_client *c
 #ifdef CONFIG_OF
 	ret = of_property_read_u32(c->dev.of_node, "override_reg", &override_addr);
 	if (!ret) {
-		// Override probed address
+		/* Override probed address */
 		dev_dbg(&c->dev, "Using override addr 0x%x\n", override_addr);
 		c->addr = override_addr;
 	}
@@ -5992,7 +5984,7 @@ static int ds5_probe(struct i2c_client *c
 	state->fw_version = 0x0516;
 	dev_info(&c->dev, "%s(): BYPASS - skip camera I2C verify, fake FW 5.22\n", __func__);
 #else
-	// Verify communication
+	/* Verify communication */
 	ret = ds5_read(state, DS5_FW_VERSION, &state->fw_version);
 	if (ret < 0) {
 		dev_err(&c->dev,
@@ -6065,7 +6057,8 @@ static int ds5_probe(struct i2c_client *c
 			goto e_regulator;
 	}
 
-	/* Verify format-discovery readiness.
+	/* 
+	 * Verify format-discovery readiness.
 	 * FW_VERSION becomes readable earlier than DS5_DEVICE_TYPE, while later
 	 * probe code depends on DEVICE_TYPE to pick the correct format tables.
 	 */
@@ -6249,9 +6242,15 @@ static struct i2c_driver ds5_i2c_driver = {
 module_i2c_driver(ds5_i2c_driver);
 
 MODULE_DESCRIPTION("RealSense D5XX Camera Driver");
-MODULE_AUTHOR("Pinquan Wang <pinquan.wang@realsenseai.com>,\n\
-				Gang Hu <gang.a.hu@realsenseai.com>,\n\
-				Shengyong Zhou <shengyong.zhou@realsenseai.com>,\n\
-				Shuai Liu <shuai2.liu@realsenseai.com>");
+MODULE_AUTHOR("Guennadi Liakhovetski <guennadi.liakhovetski@intel.com>,\n\
+				Nael Masalha <nael.masalha@intel.com>,\n\
+				Alexander Gantman <alexander.gantman@intel.com>,\n\
+				Emil Jahshan <emil.jahshan@intel.com>,\n\
+				Xin Zhang <xin.x.zhang@intel.com>,\n\
+				Qingwu Zhang <qingwu.zhang@intel.com>,\n\
+				Evgeni Raikhel <evgeni.raikhel@intel.com>,\n\
+				Shikun Ding <shikun.ding@intel.com>,\n\
+				Dmitry Perchanov <dmitry.perchanov@intel.com>,\n\
+				Pinquan Wang <pinquan.wang@realsenseai.com>");
 MODULE_LICENSE("GPL v2");
 MODULE_VERSION("1.0.3.9");

--- a/nvidia-oot/6.0/0011-Add-MAX96717-serializer-and-MAX96724-deserializer-dr.patch
+++ b/nvidia-oot/6.0/0011-Add-MAX96717-serializer-and-MAX96724-deserializer-dr.patch
@@ -22,36 +22,22 @@ MAX96724 quad deserializer features:
 
 Signed-off-by: RealSense AI <realsense@realsenseai.com>
 ---
- drivers/media/i2c/Makefile   |    2 +
- drivers/media/i2c/max96717.c |  917 ++++++++++++++++
- drivers/media/i2c/max96724.c | 1927 ++++++++++++++++++++++++++++++++++
+ drivers/media/i2c/max96717.c |  791 ++++++++++++++
+ drivers/media/i2c/max96724.c | 1905 ++++++++++++++++++++++++++++++++++
  include/media/max96717.h     |  151 ++
  include/media/max96724.h     |  183 +++
- 5 files changed, 3180 insertions(+)
+ 4 files changed, 3030 insertions(+)
  create mode 100644 drivers/media/i2c/max96717.c
  create mode 100644 drivers/media/i2c/max96724.c
  create mode 100644 include/media/max96717.h
  create mode 100644 include/media/max96724.h
 
-diff --git a/drivers/media/i2c/Makefile b/drivers/media/i2c/Makefile
-index b284938..947e6e9 100644
---- a/drivers/media/i2c/Makefile
-+++ b/drivers/media/i2c/Makefile
-@@ -8,6 +8,8 @@ obj-m += max9296.o
- subdir-ccflags-y += -DCONFIG_VIDEO_D4XX_SERDES
- subdir-ccflags-y += -DCONFIG_TEGRA_CAMERA_PLATFORM
- obj-m += d4xx.o
-+obj-m += max96717.o
-+obj-m += max96724.o
- ifeq ($(findstring ack_src,$(NV_BUILD_KERNEL_OPTIONS)),)
- obj-m += max96712.o
- 
 diff --git a/drivers/media/i2c/max96717.c b/drivers/media/i2c/max96717.c
 new file mode 100644
-index 0000000..1dd24d3
+index 0000000..c26c24b
 --- /dev/null
 +++ b/drivers/media/i2c/max96717.c
-@@ -0,0 +1,917 @@
+@@ -0,0 +1,791 @@
 +/*
 + * max96717.c - MAX96717 GMSL2 Serializer driver (Tunnel Mode)
 + *
@@ -70,14 +56,6 @@ index 0000000..1dd24d3
 + * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
-+/*
-+ * Register Reference Sources:
-+ * [PPTX]  = GMSL_MAX96717_MAX96724_TechOverview - V1.pptx
-+ * [XML]   = MAX96717_MAX96724_HKR_EVB_700mbps_tunnel_mode_basedonexcelsheet_D585.xml
-+ *
-+ * Every register address and value below is traceable to one of these sources.
-+ */
-+
 +#include <media/camera_common.h>
 +#include <linux/of.h>
 +#include <linux/module.h>
@@ -85,149 +63,146 @@ index 0000000..1dd24d3
 +
 +/* ===== Register Addresses ===== */
 +
-+/* [PPTX slide 7] REG0: Device ID (read-only, returns 0x40) */
++/* REG0: Device ID (read-only, returns 0x40) */
 +#define MAX96717_DEV_ADDR		0x00
 +
-+/* [PPTX slide 7] REG1: Link Speed
++/* 
++ *   REG1: Link Speed
 + *   bit[3]=1: 3 Gbps, bit[4]=1: 6 Gbps
 + */
 +#define MAX96717_REG1_ADDR		0x01
 +
-+/* [PPTX slide 7 / XML 0x0002] PIPE_EN: Pipe enable / soft reset
-+ *   [XML] 0x03 = soft reset, 0x43 = pipes enabled + video init
-+ *   [PPTX slide 7] Matches MAX9295 PIPE_EN at 0x02
++/* 
++ *   PIPE_EN: Pipe enable / soft reset
++ *   0x03 = soft reset, 0x43 = pipes enabled + video init
++ *   Matches MAX9295 PIPE_EN at 0x02
 + */
 +#define MAX96717_PIPE_EN_ADDR		0x02
 +
-+/* [PPTX slide 7] CTRL0: GMSL2 TX Control
++/* 
++ *   CTRL0: GMSL2 TX Control
 + *   bit[5]=1: GMSL2 mode, bit[0]=1: enable transmitter
 + *   0x21 = GMSL2 mode + TX enable on Link A
 + */
 +#define MAX96717_CTRL0_ADDR		0x10
 +
-+/* [PPTX slide 7] CTRL3: Start Video - final enable bit
++/* 
++ *   CTRL3: Start Video - final enable bit
 + *   bit[0]=1: activate video stream
 + */
 +#define MAX96717_CTRL3_ADDR		0x13
 +
-+/* [PPTX slide 7] TX1: FEC Enable
++/* 
++ *   TX1: FEC Enable
 + *   bit[6]=1: Reed-Solomon FEC enabled
 + */
 +#define MAX96717_TX1_ADDR		0x29
 +
-+/* [MAX96724 Users Guide, I2C Broadcasting section, p44-46]
-+ * MAX96717 I2C address translation registers (GMSL2 standard):
++/*
++ *   MAX96717 I2C address translation registers (GMSL2 standard):
 + *   SRC_A / DST_A (0x42/0x43): Translation pair A (SER broadcast addr)
 + *   SRC_B / DST_B (0x44/0x45): Translation pair B (sensor passthrough)
 + *
-+ * When host writes to SRC_B address, the MAX96717 translates it to
-+ * DST_B and forwards via GMSL back-channel to the remote sensor.
++ *   When host writes to SRC_B address, the MAX96717 translates it to
++ *   DST_B and forwards via GMSL back-channel to the remote sensor.
 + *
 + */
 +#define MAX96717_SRC_A_ADDR		0x42
 +#define MAX96717_DST_A_ADDR		0x43
-+#define MAX96717_I2C4_ADDR		0x44	/* SRC_B: sensor proxy addr */
-+#define MAX96717_I2C5_ADDR		0x45	/* DST_B: sensor default addr */
++#define MAX96717_I2C4_ADDR		0x44
++#define MAX96717_I2C5_ADDR		0x45
 +
-+/* [PPTX slide 14] TX_STR_SEL: Stream ID select
++/* 
++ *   TX_STR_SEL: Stream ID select
 + *   bits[1:0]: stream ID for DES pipe routing
 + */
 +#define MAX96717_TX_STR_SEL_ADDR	0x5B
 +
-+/* [PPTX slide 7 / XML 0x0110-0x0111] VIDEO_TX0/TX1: Video TX path config
-+ *   [XML] 0x0110=0xE9, 0x0111=0x10 for tunnel mode data path
++/* 
++ *   VIDEO_TX0/TX1: Video TX path config
++ *   0x0110=0xE9, 0x0111=0x10 for tunnel mode data path
 + */
 +#define MAX96717_VIDEO_TX0_ADDR		0x110
 +#define MAX96717_VIDEO_TX1_ADDR		0x111
 +
-+/* [PPTX slide 7] FRONTTOP_0: Front-end topology
++/* 
++ *   FRONTTOP_0: Front-end topology
 + *   0x12 = single CSI-2 port A, all VCs pass through
 + */
 +#define MAX96717_FRONTTOP0_ADDR		0x308
 +
-+/* [XML / PPTX slide 7] MIPI_RX0-RX3: CSI-2 receiver configuration
++/* 
++ *   MIPI_RX0-RX3: CSI-2 receiver configuration
 + *   RX0 (0x330): CSI mode (0x00 = D-PHY controller A)
-+ *   RX1 (0x331): Lane count - [PPTX slide 14] ctrl1_num_lanes bits[5:4]
-+ *                 [XML] 0x30 = bits[5:4]=11 (4 lanes)
-+ *   RX2 (0x332): Lane mapping - [XML] 0xE0 = default 1x4 map
-+ *   RX3 (0x333): Lane mapping - [XML] 0x04 = default 1x4 map
++ *   RX1 (0x331): Lane count - ctrl1_num_lanes bits[5:4]
++ *                0x30 = bits[5:4]=11 (4 lanes)
++ *   RX2 (0x332): Lane mapping - 0xE0 = default 1x4 map
++ *   RX3 (0x333): Lane mapping - 0x04 = default 1x4 map
 + */
 +#define MAX96717_MIPI_RX0_ADDR		0x330
 +#define MAX96717_MIPI_RX1_ADDR		0x331
 +#define MAX96717_MIPI_RX2_ADDR		0x332
 +#define MAX96717_MIPI_RX3_ADDR		0x333
 +
-+/* [PPTX slide 7 / slide 14] EXT11: TUNNEL MODE ENABLE
-+ *   bit[7]=1: Tun_Mode = ON  *** CRITICAL REGISTER ***
-+ *   [PPTX slide 7] 0x383 = 0x80
++/* 
++ *   EXT11: TUNNEL MODE ENABLE
++ *   bit[7]=1: Tun_Mode = ON
++ *   0x383 = 0x80
 + */
 +#define MAX96717_EXT11_ADDR		0x383
 +
-+/* [SG2 working config] SER PHY / DLL calibration registers.
-+ *   These are device-level (not sensor-specific) and appear in every
-+ *   SG2 sensor variant (OX03C, ISX031, etc.).  The staged write pattern
-+ *   (0x80 -> 0x90) on 0x2D6/0x2C7 is a PHY calibration ramp sequence.
-+ *   Without these writes the GMSL2 link trains but the DES cannot
-+ *   recover a clean CSI-2 clock from the tunnel-mode data stream.
-+ */
-+#define MAX96717_PHY_CAL_2D6_ADDR	0x2D6
-+#define MAX96717_PHY_CAL_2C7_ADDR	0x2C7
-+#define MAX96717_PHY_CAL_2BE_ADDR	0x2BE
-+#define MAX96717_PHY_CAL_2C1_ADDR	0x2C1
-+#define MAX96717_PHY_CAL_3F0_ADDR	0x3F0
-+#define MAX96717_PHY_CAL_3F1_ADDR	0x3F1
-+
-+/* [SG2 working config] PHY calibration stage-1 value */
++/* PHY calibration stage-1 value */
 +#define MAX96717_PHY_CAL_STAGE1		0x80
-+/* [SG2 working config] PHY calibration stage-2 value */
++/* PHY calibration stage-2 value */
 +#define MAX96717_PHY_CAL_STAGE2		0x90
-+/* [SG2 working config] CSI input timing / frequency config */
++/* CSI input timing / frequency config */
 +#define MAX96717_CSI_TIMING_3F0		0x59
 +#define MAX96717_CSI_TIMING_3F1		0x09
 +
 +/* ===== Register Values ===== */
 +
-+/* [XML] Soft reset value for PIPE_EN register */
++/* Soft reset value for PIPE_EN register */
 +#define MAX96717_SOFT_RESET		0x03
 +
-+/* [XML] Final enable: pipes enabled + video init */
++/* Final enable: pipes enabled + video init */
 +#define MAX96717_PIPE_EN_ALL		0x43
 +
-+/* [PPTX slide 7] CTRL0: GMSL2 mode + TX enable (Link A) */
++/* CTRL0: GMSL2 mode + TX enable (Link A) */
 +#define MAX96717_CTRL0_LINK_A		0x21
 +/* CTRL0: GMSL2 mode + TX enable (Link B) */
 +#define MAX96717_CTRL0_LINK_B		0x22
 +
-+/* [PPTX slide 7] CTRL0 reset all */
++/* CTRL0 reset all */
 +#define MAX96717_RESET_ALL		0x80
 +
-+/* [PPTX slide 7] EXT11 tunnel mode enable value */
++/* EXT11 tunnel mode enable value */
 +#define MAX96717_TUN_MODE_EN		0x80
 +#define MAX96717_TUN_MODE_DIS		0x00
 +
-+/* [XML] VIDEO_TX0 tunnel mode data path enable */
++/* VIDEO_TX0 tunnel mode data path enable */
 +#define MAX96717_VIDEO_TX0_TUN		0xE9
-+/* [XML] VIDEO_TX1 tunnel mode config */
++/* VIDEO_TX1 tunnel mode config */
 +#define MAX96717_VIDEO_TX1_TUN		0x10
 +#define MAX96717_VIDEO_TX0_BPP_MANUAL	0x60
 +#define MAX96717_VIDEO_TX1_BPP16	0x50
 +#define MAX96717_VIDEO_TX2_ADDR		0x112
 +#define MAX96717_VIDEO_TX2_DRIFT_DIS	0x08
 +
-+/* [SG2 working config] MIPI RX1: 4-lane CSI-2.
-+ *   bits[5:4]=11 (4 lanes).  bits[1:0]=11 (PHY mode / lane ordering
-+ *   matching SG2 working config; was 0x30, SG2 uses 0x33). */
++/* 
++ *   MIPI RX1: 4-lane CSI-2.
++ *   bits[5:4]=11 (4 lanes).  bits[1:0]=11
++ */
 +#define MAX96717_CSI_4_LANES		0x33
 +/* 2-lane CSI-2, bits[5:4]=01 */
 +#define MAX96717_CSI_2_LANES		0x10
 +
-+/* [XML] Lane mapping for 1x4 mode (matches MAX9295 1x4 values) */
++/* Lane mapping for 1x4 mode */
 +#define MAX96717_CSI_1X4_LANE_MAP1	0xE0
 +#define MAX96717_CSI_1X4_LANE_MAP2	0x04
 +
-+/* [PPTX slide 7] FRONTTOP_0: single port A, all VCs */
++/* FRONTTOP_0: single port A, all VCs */
 +#define MAX96717_FRONTTOP0_PORT_A	0x12
-+/* [UG Use Case Example 1] Pixel mode from Port B into Pipe Z */
++/* Pixel mode from Port B into Pipe Z */
 +#define MAX96717_FRONTTOP0_PIXEL_PORT_B	0x64
 +#define MAX96717_FRONTTOP5_ADDR		0x30D
 +#define MAX96717_FRONTTOP9_ADDR		0x311
@@ -235,17 +210,17 @@ index 0000000..1dd24d3
 +#define MAX96717_FRONTTOP17_ADDR	0x319
 +#define MAX96717_FRONTTOP9_START_VIDEO	0x40
 +
-+/* [XML] MIPI_RX0: CSI reset on + non-continuous clock */
++/* MIPI_RX0: CSI reset on + non-continuous clock */
 +#define MAX96717_MIPI_RX0_RESET		0x08
-+/* [PPTX slide 7] MIPI_RX0: Normal operation */
++/* MIPI_RX0: Normal operation */
 +#define MAX96717_MIPI_RX0_NORMAL	0x00
 +
-+/* [PPTX slide 9] REG1: 3 Gbps link speed, bit[3]=1 */
++/* REG1: 3 Gbps link speed, bit[3]=1 */
 +#define MAX96717_LINK_SPEED_3GBPS	0x08
-+/* [PPTX slide 9] REG1: 6 Gbps link speed, bit[4]=1 */
++/* REG1: 6 Gbps link speed, bit[4]=1 */
 +#define MAX96717_LINK_SPEED_6GBPS	0x10
 +
-+/* [XML] EXT11 tunnel mode pre-config (0x0383=0x80) */
++/* EXT11 tunnel mode pre-config (0x0383=0x80) */
 +#define MAX96717_EXT11_TUN_PRE		0x80
 +
 +#define MAX96717_MAX_PIPES		4
@@ -323,43 +298,6 @@ index 0000000..1dd24d3
 +	int err = 0;
 +	struct gmsl_link_ctx *g_ctx;
 +
-+	/*
-+	 * [XML] Full initialization sequence:
-+	 *   0x0002 = 0x03  (soft reset)
-+	 *   0x0383 = 0x80  (tunnel mode enable)
-+	 *   0x0331 = 0x30  (4-lane CSI)
-+	 *   0x0332 = 0xE0  (lane map1)
-+	 *   0x0333 = 0x04  (lane map2)
-+	 *   0x0110 = 0xE9  (video TX0 tunnel path)
-+	 *   0x0111 = 0x10  (video TX1 tunnel config)
-+	 *   0x0330 = 0x08  (CSI reset on)
-+	 *   0x0330 = 0x00  (CSI reset off)
-+	 *   0x0002 = 0x43  (final enable)
-+	 */
-+	struct reg_pair tunnel_init[] = {
-+		/* [PPTX slide 7] EXT11: Tunnel Mode Enable */
-+		{MAX96717_EXT11_ADDR, MAX96717_TUN_MODE_EN},
-+		/* [XML] MIPI_RX1: 4-lane CSI-2 (CTRL1_NUM_LANES[5:4]=11) */
-+		{MAX96717_MIPI_RX1_ADDR, MAX96717_CSI_4_LANES},
-+		/* [XML] MIPI_RX2/RX3: 1x4 lane mapping */
-+		{MAX96717_MIPI_RX2_ADDR, MAX96717_CSI_1X4_LANE_MAP1},
-+		{MAX96717_MIPI_RX3_ADDR, MAX96717_CSI_1X4_LANE_MAP2},
-+		/* [XML] VIDEO_TX0/TX1: tunnel data path */
-+		{MAX96717_VIDEO_TX0_ADDR, MAX96717_VIDEO_TX0_TUN},
-+		{MAX96717_VIDEO_TX1_ADDR, MAX96717_VIDEO_TX1_TUN},
-+	};
-+	struct reg_pair pixel_init[] = {
-+		{MAX96717_EXT11_ADDR, MAX96717_TUN_MODE_DIS},
-+		{MAX96717_MIPI_RX1_ADDR, MAX96717_CSI_4_LANES},
-+		{MAX96717_MIPI_RX2_ADDR, MAX96717_CSI_1X4_LANE_MAP1},
-+		{MAX96717_MIPI_RX3_ADDR, MAX96717_CSI_1X4_LANE_MAP2},
-+		{MAX96717_FRONTTOP0_ADDR, MAX96717_FRONTTOP0_PIXEL_PORT_B},
-+		{MAX96717_FRONTTOP9_ADDR, MAX96717_FRONTTOP9_START_VIDEO},
-+		{MAX96717_VIDEO_TX0_ADDR, MAX96717_VIDEO_TX0_BPP_MANUAL},
-+		{MAX96717_VIDEO_TX1_ADDR, MAX96717_VIDEO_TX1_BPP16},
-+		{MAX96717_VIDEO_TX2_ADDR, MAX96717_VIDEO_TX2_DRIFT_DIS},
-+	};
-+
 +	mutex_lock(&priv->lock);
 +
 +	if (!priv->g_client.g_ctx) {
@@ -375,80 +313,19 @@ index 0000000..1dd24d3
 +
 +	g_ctx = priv->g_client.g_ctx;
 +
-+	/*
-+	 * [SG2 working config] SER PHY/DLL pre-calibration.
-+	 * These device-level registers calibrate the serializer's
-+	 * differential output pairs and clock recovery.  The staged
-+	 * write pattern (0x80 stage-1 now, 0x90 stage-2 after tunnel
-+	 * init) matches every SG2 sensor variant's init table.
-+	 * Applied BEFORE soft reset + tunnel config.
-+	 */
-+	max96717_write_reg(dev, MAX96717_PHY_CAL_2D6_ADDR,
-+			   MAX96717_PHY_CAL_STAGE1);
-+	max96717_write_reg(dev, MAX96717_PHY_CAL_2C7_ADDR,
-+			   MAX96717_PHY_CAL_STAGE1);
-+	max96717_write_reg(dev, MAX96717_PHY_CAL_2BE_ADDR,
-+			   MAX96717_PHY_CAL_STAGE1);
-+	max96717_write_reg(dev, MAX96717_PHY_CAL_2C1_ADDR,
-+			   MAX96717_PHY_CAL_STAGE1);
-+	max96717_write_reg(dev, MAX96717_PHY_CAL_3F0_ADDR,
-+			   MAX96717_CSI_TIMING_3F0);
-+	max96717_write_reg(dev, MAX96717_PHY_CAL_3F1_ADDR,
-+			   MAX96717_CSI_TIMING_3F1);
-+	msleep(100);
++	max96717_write_reg(dev, MAX96717_EXT11_ADDR, MAX96717_TUN_MODE_EN);
++	max96717_write_reg(dev, MAX96717_MIPI_RX1_ADDR, MAX96717_CSI_4_LANES);
++	max96717_write_reg(dev, MAX96717_MIPI_RX2_ADDR, MAX96717_CSI_1X4_LANE_MAP1);
++	max96717_write_reg(dev, MAX96717_MIPI_RX3_ADDR, MAX96717_CSI_1X4_LANE_MAP2);
++	max96717_write_reg(dev, MAX96717_VIDEO_TX0_ADDR, MAX96717_VIDEO_TX0_TUN);
++	max96717_write_reg(dev, MAX96717_VIDEO_TX1_ADDR, MAX96717_VIDEO_TX1_TUN);
 +
-+	/*
-+	 * [Aardvark-verified] Soft reset before tunnel mode configuration
-+	 * Clears stale pipe/CSI state for clean initialization.
-+	 * Aardvark: 0x0002=0x03, sleep 30ms, then proceed with config.
-+	 */
-+	max96717_write_reg(dev, MAX96717_PIPE_EN_ADDR, MAX96717_SOFT_RESET);
-+	msleep(30);
-+
-+	if (priv->pixel_mode)
-+		err = max96717_set_registers(dev, pixel_init,
-+					 ARRAY_SIZE(pixel_init));
-+	else
-+		err = max96717_set_registers(dev, tunnel_init,
-+					 ARRAY_SIZE(tunnel_init));
-+	if (err)
-+		goto error;
-+
-+	/*
-+	 * [FIX] Re-enable GMSL2 mode + TX after soft reset.
-+	 * setup_control() previously set CTRL0=0x21 (GMSL2+TX), but the
-+	 * PIPE_EN=0x03 soft reset above clears it back to the power-on
-+	 * default 0x01 (TX only, GMSL2 mode disabled).  Without this
-+	 * re-write the SER operates in GMSL1 mode while the DES expects
-+	 * GMSL2 — the link trains but the video data path silently breaks.
-+	 */
-+	if (g_ctx->serdes_csi_link == GMSL_SERDES_CSI_LINK_A)
-+		max96717_write_reg(dev, MAX96717_CTRL0_ADDR,
-+				   MAX96717_CTRL0_LINK_A);
-+	else
-+		max96717_write_reg(dev, MAX96717_CTRL0_ADDR,
-+				   MAX96717_CTRL0_LINK_B);
-+
-+	/*
-+	 * [SG2 working config] PHY calibration stage-2: ramp 0x80 -> 0x90.
-+	 * Applied AFTER tunnel mode + lane config, BEFORE CSI reset.
-+	 */
-+	max96717_write_reg(dev, MAX96717_PHY_CAL_2D6_ADDR,
-+			   MAX96717_PHY_CAL_STAGE2);
-+	max96717_write_reg(dev, MAX96717_PHY_CAL_2C7_ADDR,
-+			   MAX96717_PHY_CAL_STAGE2);
-+	msleep(20);
-+
-+	/* [Aardvark-verified] CSI reset cycle with 2ms delay */
-+	max96717_write_reg(dev, MAX96717_MIPI_RX0_ADDR,
-+			   MAX96717_MIPI_RX0_RESET);
++	max96717_write_reg(dev, MAX96717_MIPI_RX0_ADDR, MAX96717_MIPI_RX0_RESET);
 +	usleep_range(2000, 2100);
-+	max96717_write_reg(dev, MAX96717_MIPI_RX0_ADDR,
-+			   MAX96717_MIPI_RX0_NORMAL);
++	max96717_write_reg(dev, MAX96717_MIPI_RX0_ADDR, MAX96717_MIPI_RX0_NORMAL);
 +
-+	/* [XML] Final enable: pipes on + video init */
-+	max96717_write_reg(dev, MAX96717_PIPE_EN_ADDR,
-+			   MAX96717_PIPE_EN_ALL);
++	/* pipes on + video init */
++	max96717_write_reg(dev, MAX96717_PIPE_EN_ADDR, MAX96717_PIPE_EN_ALL);
 +
 +	priv->g_client.st_done = true;
 +
@@ -470,9 +347,6 @@ index 0000000..1dd24d3
 + *      I2C4/SRC_B (0x44) <- (sdev_reg << 1): proxy addr visible to host
 + *      I2C5/DST_B (0x45) <- (sdev_def << 1): real addr on back-channel
 + *
-+ * This lets the Orin host access the D5xx sensor (def-addr 0x42) via
-+ * the aliased proxy address (e.g. 0x1a) through the GMSL link.
-+ *
 + */
 +int max96717_setup_control(struct device *dev)
 +{
@@ -491,17 +365,6 @@ index 0000000..1dd24d3
 +	g_ctx = priv->g_client.g_ctx;
 +
 +	if (prim_priv__) {
-+		/*
-+		 * [HW note] The MAX96717 retains its I2C address across
-+		 * reboots (PoC stays on).  If already at the aliased address,
-+		 * the DEV_ADDR write to 0x40 NACKs.  Skip reassignment when
-+		 * the primary and alias are the same physical device and the
-+		 * serializer is already responsive at a non-default address.
-+		 *
-+		 * For cold-start (first power-on), this write is required.
-+		 * We detect "already reassigned" by trying a read first:
-+		 * if the primary address (0x40) NACKs, skip the reassign.
-+		 */
 +		unsigned int dev_id;
 +		int probe_ret;
 +
@@ -519,7 +382,7 @@ index 0000000..1dd24d3
 +		}
 +	}
 +
-+	/* [PPTX slide 7] CTRL0: GMSL2 mode + TX enable */
++	/* CTRL0: GMSL2 mode + TX enable */
 +	if (g_ctx->serdes_csi_link == GMSL_SERDES_CSI_LINK_A)
 +		err = max96717_write_reg(dev, MAX96717_CTRL0_ADDR,
 +					 MAX96717_CTRL0_LINK_A);
@@ -537,7 +400,6 @@ index 0000000..1dd24d3
 +
 +	/*
 +	 * I2C address translation for sensor passthrough.
-+	 * [MAX96724 Users Guide, I2C Broadcasting, p44-46]
 +	 *
 +	 * I2C4 / SRC_B (0x44): sensor proxy addr visible to Orin host
 +	 * I2C5 / DST_B (0x45): sensor real addr on GMSL back-channel
@@ -568,17 +430,13 @@ index 0000000..1dd24d3
 +/*
 + * max96717_setup_gpio_tunneling - GPIO-over-GMSL no-op hook
 + *
-+ * [PPTX slide 10] GPIO Signal Mapping:
++ *   GPIO Signal Mapping:
 + *   MFP0 → GPIO0: FSIN (DES→SER, frame sync in)
 + *   MFP1 → GPIO1: FOUT/STROBE (SER→DES, frame sync out)
 + *   MFP4 → GPIO4: RESET_N (DES→SER, hard reset)
 + *   MFP5 → GPIO5: IRQ (SER→DES, interrupt request)
 + *   MFP6 → GPIO6: ZV_SYNC (DES→SER, IR stereo sync)
 + *
-+ * The PPTX defines the signal mapping and MFP_CFG register range,
-+ * but not the confirmed direction/function values. Keep this as
-+ * an explicit no-op hook until the MAX96717 GPIO register values
-+ * are available from ADI.
 + */
 +int max96717_setup_gpio_tunneling(struct device *dev)
 +{
@@ -644,7 +502,8 @@ index 0000000..1dd24d3
 +	priv = dev_get_drvdata(dev);
 +	mutex_lock(&priv->lock);
 +	if (priv->g_client.g_ctx) {
-+		/* Already paired — tolerate if this is a re-probe of
++		/* 
++		 * Already paired — tolerate if this is a re-probe of
 +		 * the same camera after a failed first attempt.
 +		 * Simply overwrite with the new g_ctx.
 +		 */
@@ -774,7 +633,8 @@ index 0000000..1dd24d3
 +	struct max96717 *priv = dev_get_drvdata(dev);
 +
 +	struct reg_pair map_init[] = {
-+		/* [XML seq] PIPE_EN soft reset first, then enable tunnel mode.
++		/* 
++		 * PIPE_EN soft reset first, then enable tunnel mode.
 +		 * Note: FRONTTOP0 is bypassed in tunnel mode (per UG) —
 +		 * CSI-2 input goes directly into the tunnel, no port config needed.
 +		 */
@@ -796,7 +656,7 @@ index 0000000..1dd24d3
 +	mutex_lock(&priv->lock);
 +
 +	/*
-+	 * [HW requirement] After CTRL0 + I2C translation writes in
++	 * After CTRL0 + I2C translation writes in
 +	 * setup_control, the MAX96717 needs settling time before
 +	 * accepting writes to PIPE_EN (0x02) and FRONTTOP registers.
 +	 */
@@ -846,7 +706,7 @@ index 0000000..1dd24d3
 +}
 +EXPORT_SYMBOL(max96717_set_pipe);
 +
-+/**
++/*
 + * max96717_retrigger_tx - Toggle SER TX to restore tunnel detection after
 + * a DES ONESHOT.  DES ONESHOT resets the data path; the SER must cycle
 + * its TX enable for the DES to re-acquire the tunnel stream.
@@ -971,10 +831,10 @@ index 0000000..1dd24d3
 +MODULE_LICENSE("GPL v2");
 diff --git a/drivers/media/i2c/max96724.c b/drivers/media/i2c/max96724.c
 new file mode 100644
-index 0000000..4a1708c
+index 0000000..4e73c60
 --- /dev/null
 +++ b/drivers/media/i2c/max96724.c
-@@ -0,0 +1,1927 @@
+@@ -0,0 +1,1905 @@
 +/*
 + * max96724.c - MAX96724 GMSL2 Quad Deserializer driver (Tunnel Mode)
 + *
@@ -1010,40 +870,44 @@ index 0000000..4a1708c
 +
 +/* --- Device ID / Configuration --- */
 +
-+/* [UG p.3] REG0: Device ID (read-only, returns 0xA2) */
++/* REG0: Device ID (read-only, returns 0xA2) */
 +#define MAX96724_DEV_ID_ADDR		0x00
 +
-+/* [Errata §5] ERRB master reset register */
++/* ERRB master reset register */
 +#define MAX96724_ERRB_MST_RST_ADDR	0x05
 +
-+/* [UG Table 3, p.11] 0x0006: GMSL Link/PHY Enable and Mode Select
++/* 
++ *   GMSL Link/PHY Enable and Mode Select
 + *   bits[7:4]: PHY mode (0=GMSL1, 1=GMSL2) per link D/C/B/A
 + *   bits[3:0]: Link Enable per link D/C/B/A
 + */
 +#define MAX96724_LINK_EN_ADDR		0x0006
 +
-+/* [UG Table 3, p.11] 0x0010: GMSL Link/PHY Rate Select (Links A&B)
++/* 
++ *   GMSL Link/PHY Rate Select (Links A&B)
 + *   bits[7:6]: Tx Rate Link B, bits[5:4]: Rx Rate Link B
 + *   bits[3:2]: Tx Rate Link A, bits[1:0]: Rx Rate Link A
 + *   Tx: 00=187.5Mbps, Rx: 01=3Gbps, 10=6Gbps
 + */
 +#define MAX96724_LINK_RATE_AB_ADDR	0x0010
 +
-+/* [UG Table 3, p.12] 0x0011: GMSL Link/PHY Rate Select (Links C&D) */
++/* GMSL Link/PHY Rate Select (Links C&D) */
 +#define MAX96724_LINK_RATE_CD_ADDR	0x0011
 +
-+/* [UG p.13] 0x001A: Link A lock status (bit[3]=LOCK) */
++/* Link A lock status (bit[3]=LOCK) */
 +#define MAX96724_LINK_A_LOCK_ADDR	0x001A
 +
-+/* [UG Table 3, p.12] 0x0018: GMSL Link Reset
++/* 
++ *   GMSL Link Reset
 + *   bits[7:4]: Link reset D/C/B/A, bits[3:0]: One-shot reset D/C/B/A
 + */
 +#define MAX96724_ONESHOT_ADDR		0x0018
 +
-+/* [UG p.11] REG13: Soft Reset (write 0x40, wait 5ms) */
++/* Soft Reset (write 0x40, wait 5ms) */
 +#define MAX96724_REG13_ADDR		0x000D
 +
-+/* [Errata §5] Error Channel Power Up registers (required for 6Gbps)
++/* 
++ *   Error Channel Power Up registers (required for 6Gbps)
 + *   Write 0x75 immediately after power-up for robust 6Gbps operation
 + */
 +#define MAX96724_ERRCH_A_ADDR		0x1449
@@ -1054,7 +918,8 @@ index 0000000..4a1708c
 +
 +/* --- I2C Control Channel / Errata --- */
 +
-+/* [Errata #2] Tunnel Mode SRAM LCRC error suppression
++/* 
++ *   Tunnel Mode SRAM LCRC error suppression
 + *   Set 0x458[7:4] = 0x0 to suppress spurious ERRB in tunnel mode
 + */
 +#define MAX96724_SRAM_LCRC_ERR_ADDR	0x0458
@@ -1073,9 +938,6 @@ index 0000000..4a1708c
 + */
 +#define MAX96724_PIPE_SEL1_ADDR		0xF1
 +
-+/*
-+ *   bit[0]=Pipe 0, bit[1]=Pipe 1, bit[2]=Pipe 2, bit[3]=Pipe 3
-+ */
 +#define MAX96724_PIPE_EN_ADDR		0xF4
 +
 +/* --- Pipe Receiver / Tunnel Mode --- */
@@ -1092,14 +954,15 @@ index 0000000..4a1708c
 +
 +/* --- CSI-2 Output (BACKTOP) --- */
 +
-+/* [UG p.19] BACKTOP: CSI-2 output port enable
++/* BACKTOP: CSI-2 output port enable
 + *   0x040B bit[1]=CSIB_EN, bit[0]=CSIA_EN
 + */
 +#define MAX96724_BACKTOP_EN_ADDR	0x040B
 +
 +/* --- MIPI DPLL (Data Rate) --- */
 +
-+/* [UG Table 12, p.27] MIPI PHY DPLL Freq registers
++/* 
++ *   MIPI PHY DPLL Freq registers
 + *   bits[4:0] = frequency in multiples of 100MHz
 + *   bit[5]    = DPLL enable (must be set for DPLL to lock)
 + *   E.g., 0x27 = 700MHz + enable = 700Mbps/lane D-PHY
@@ -1110,7 +973,8 @@ index 0000000..4a1708c
 +#define MAX96724_DPLL_FREQ2_ADDR	0x041B
 +#define MAX96724_DPLL_FREQ3_ADDR	0x041E
 +
-+/* [UG] DPLL PHY reset control
++/* 
++ *   DPLL PHY reset control
 + *   0x1D00 = DPLL CSI PHY1 control
 + *   Write 0xF4 to disable/reset, 0xF5 to enable
 + */
@@ -1120,49 +984,47 @@ index 0000000..4a1708c
 +
 +/* --- CSI-2 Output PHY Configuration --- */
 +
-+/* [UG rev2 Table 12 + MIPI PHY section] CSI output mode/config register.
++/* 
++ * CSI output mode/config register.
 + * Mode bits (set exactly one of [4:0]):
 + *   bit[0]=0x01: 4x2 mode
 + *   bit[2]=0x04: 2x4 mode        (Ctrl 1 = master for Port A, Ctrl 2 = Port B)
 + *   bit[3]=0x08: 1x4a + 2x2 mode (Ctrl 1 = master for Port A)
 + *   bit[4]=0x10: 1x4b + 2x2 mode (Ctrl 2 = master for Port B)
-+ * In ALL x4 D-PHY modes Port A = PHY0+PHY1 and Port B = PHY2+PHY3 (UG:
-+ * "PHY 1 and PHY 2 are the master PHYs providing the MIPI clock for ports
-+ * A and B").  bit[2] vs bit[3] only differ in how the OTHER port is grouped,
-+ * not in which PHYs carry Port A.
-+ * Clock-force bits (high nibble):
++ *
++ * Clock-force bits:
 + *   bit[7]=0x80: force ALL MIPI clocks running (continuous HS clock)
 + *   bit[6]=0x40: force PHY 3 MIPI clock running
 + *   bit[5]=0x20: force PHY 0 MIPI clock running
 + */
 +#define MAX96724_CSI_OUT_CFG_ADDR	0x08A0
 +
-+/* [UG Table 12, p.25] MIPI PHY Enable register
++/* 
++ *   MIPI PHY Enable register
 + *   bits[7:4]: Enable PHY 3/2/1/0 (1=enabled, 0=standby)
 + */
 +#define MAX96724_CSI_PHY_EN_ADDR	0x08A2
 +
-+/* [UG Table 12, p.25] MIPI PHY 0 and 1 Lane Mapping */
++/* MIPI PHY 0 and 1 Lane Mapping */
 +#define MAX96724_CSI_LANE_MAP1_ADDR	0x08A3
 +
-+/* [UG Table 12, p.26] MIPI PHY 2 and 3 Lane Mapping */
++/* MIPI PHY 2 and 3 Lane Mapping */
 +#define MAX96724_CSI_LANE_MAP2_ADDR	0x08A4
 +
-+/* [FG24-4CH board] MIPI output lane polarity (P/N swap) registers.
++/* 
++ *   MIPI output lane polarity (P/N swap) registers.
 + *   0x08A5 = PHY0/PHY1 lane polarity, 0x08A6 = PHY2/PHY3 lane polarity.
 + *   The FangZhu FG24-4CH PCB swaps the differential P/N pairs on the
 + *   MAX96724 CSI output, so the deserializer must invert lane polarity
-+ *   or the Orin CIL never locks the HS clock (total silence/2500ms timeout).
-+ *   Per FangZhu MAX4CH_FG24_POC_Enable table: write 0x3F to both.
 + */
 +#define MAX96724_CSI_PHY_POL0_ADDR	0x08A5
 +#define MAX96724_CSI_PHY_POL1_ADDR	0x08A6
 +#define MAX96724_CSI_PHY_POL_SWAP	0x3F
 +
-+/* [UG p.22] Pipe-to-controller mapping (Method 1) */
++/* Pipe-to-controller mapping */
 +#define MAX96724_MIPI_CTRL_SEL_ADDR	0x08CA
 +
-+/* [OG03C reference dump] Method-1 controller mapping */
++/* Method-1 controller mapping */
 +#define MAX96724_MIPI_CTRL_SEL_PIXEL	0xE4
 +
 +/* --- Lane Control per pipe (stride 0x40) --- */
@@ -1201,7 +1063,8 @@ index 0000000..4a1708c
 +
 +/* --- Extended Pipe Mapping (DST_CTRL2-4 / TX49) --- */
 +
-+/* [Excel: MIPI_TX46-48] Extended DST_CTRL for additional mapping pairs
++/* 
++ *   Extended DST_CTRL for additional mapping pairs
 + *   All to PHY1 (0x55), same as TX45
 + *   Stride: 0x40 per pipe (base = Pipe X)
 + */
@@ -1209,7 +1072,8 @@ index 0000000..4a1708c
 +#define MAX96724_TX47_PIPE_X_ADDR	0x092F
 +#define MAX96724_TX48_PIPE_X_ADDR	0x0930
 +
-+/* [UG p.30] MIPI_TX49 synchronous concatenation control
++/* 
++ *   MIPI_TX49 synchronous concatenation control
 + *   Set to 0x00 (no concat) for single-camera tunnel mode.
 + *   For 4W concat use 0x87.
 + *   Stride: 0x40 per pipe (base = Pipe X)
@@ -1240,10 +1104,11 @@ index 0000000..4a1708c
 + * Register Values
 + * ================================================================ */
 +
-+/* [UG p.12] Soft reset value (write to 0x000D) */
++/* Soft reset value (write to 0x000D) */
 +#define MAX96724_SOFT_RESET		0x40
 +
-+/* [UG Table 3, p.11-12] Link Rate values for 0x0010/0x0011
++/* 
++ * Link Rate values for 0x0010/0x0011
 + *   Per link pair: bits[1:0]=RxA, [3:2]=TxA, [5:4]=RxB, [7:6]=TxB
 + *   Tx = 00 (187.5Mbps), Rx = 01 (3Gbps) or 10 (6Gbps)
 + *   3Gbps: Tx=00, Rx=01 → per pair 0x01, both pairs = 0x01 in low nibble
@@ -1251,7 +1116,8 @@ index 0000000..4a1708c
 +#define MAX96724_LINK_RATE_3GBPS	0x01  /* Rx=3G, Tx=187.5M for one link pair */
 +#define MAX96724_LINK_RATE_6GBPS	0x02  /* Rx=6G, Tx=187.5M for one link pair */
 +
-+/* [UG Table 3, p.11] 0x0006: Link enable / mode values
++/* 
++ * 0x0006: Link enable / mode values
 + *   bits[7:4] = PHY mode (1=GMSL2 per link)
 + *   bits[3:0] = Link enable per link
 + *   0xF1 = all GMSL2-mode, only Link A enabled
@@ -1260,98 +1126,97 @@ index 0000000..4a1708c
 +#define MAX96724_LINK_EN_SIOA		0xF1  /* GMSL2 all, enable Link A only */
 +#define MAX96724_LINK_EN_ALL		0xFF  /* GMSL2 all, enable all links */
 +
-+/* [UG p.19] BACKTOP_EN (0x040B): CSI output port enable */
++/* BACKTOP_EN (0x040B): CSI output port enable */
 +#define MAX96724_BACKTOP_CSIB_EN	0x02
 +#define MAX96724_BACKTOP_CSIA_EN	0x01
 +
-+/* [XML] VIDEO_RX0: DIS_PKT_DET=1 (bit0) required for tunnel mode.
++/* 
++ *   VIDEO_RX0: DIS_PKT_DET=1 (bit0) required for tunnel mode.
 + *   Without it, DES rejects tunnel data as invalid GMSL2 video packets.
 + *   SEQ_MISS_EN=1 (bit4), LINE_CRC_EN=1 (bit1).  XML value: 0x33.
 + */
 +#define MAX96724_VID_RX0_CFG_VAL	0x33
 +#define MAX96724_VID_RX6_CFG_VAL	0x0A
 +
-+/* [OG03C reference dump] Pixel-mode receiver settings */
++/* Pixel-mode receiver settings */
 +#define MAX96724_VID_RX0_PIXEL_VAL	0x32
 +#define MAX96724_VID_RX6_PIXEL_VAL	0x12
 +
-+/* [XML] Tunnel mode enable (MIPI_TX54, 0x0936):
++/* 
++ *   Tunnel mode enable (MIPI_TX54, 0x0936):
 + *   bit[0] = TUN_EN = 1
 + *   Verified value: 0x01
 + */
 +#define MAX96724_TUN_EN			0x01
 +
-+/* [OG03C reference dump] Default/reset state when tunnel is disabled */
++/* Default/reset state when tunnel is disabled */
 +#define MAX96724_TUN_DISABLED		0x08
 +
-+/* [XML] Tunnel controller destination (MIPI_TX57, 0x0939):
++/* 
++ *   Tunnel controller destination (MIPI_TX57, 0x0939):
 + *   bits[5:4]: TUN_DEST (00=PHY0, 01=PHY1, 10=PHY2, 11=PHY3)
 + *   Verified value: 0x10 = PHY1 destination with auto-detect enabled
 + */
 +#define MAX96724_TUN_DEST_CTRL0		0x00  /* Auto-detect + PHY0 */
 +#define MAX96724_TUN_DEST_CTRL1		0x10  /* Auto-detect + PHY1 (Port A master) */
 +
-+/* [UG rev2 Table 12] CSI output mode values written to 0x08A0.
-+ *   We use bit[2] = 0x04 = clean 2x4 mode (Port A = PHY0+PHY1, Ctrl 1 master).
-+ *   This matches the ADI reference "Lane Swap Programming Example"
-+ *   (0x4E,0x08A0,0x04) and the FangZhu working config.  Note bit[3]=0x08
-+ *   (1x4a+2x2) ALSO keeps Port A on PHY0+PHY1; for a single 4-lane Port A
-+ *   output either presents a valid Port A, so 0x04 is the spec-clean choice
-+ *   rather than a hard requirement.
-+ */
 +#define MAX96724_CSI_MODE_2X4_VAL	0x04  /* bit[2] = clean 2x4: Port A = PHY0+PHY1 */
-+/* 0x84 = 2x4 mode (bit2) + bit[7] "force ALL MIPI clocks running".  The bit[7]
-+ * clock-force is the key part: it keeps the D-PHY clock lane in continuous HS
-+ * mode so the Orin NVCSI/CIL can lock.  Asserted LAST in setup_streaming(),
-+ * matching the FangZhu End_Common 0x08A0=0x84 write. */
++
++/* 
++ *   0x84 = 2x4 mode (bit2) + bit[7] "force ALL MIPI clocks running".  The bit[7]
++ *   clock-force is the key part: it keeps the D-PHY clock lane in continuous HS
++ *   mode so the Orin NVCSI/CIL can lock.
++ */
 +#define MAX96724_CSI_OUT_EN_VAL		0x84  /* 2x4 + bit[7] force all MIPI clocks running */
-+#define MAX96724_CSI_MODE_4X2_VAL	0x01  /* bit[0] = 4x2 mode */
 +
 +#define MAX96724_CSI_PHY_EN_ALL		0xF0
 +#define MAX96724_CSI_PHY_EN_01		0x30  /* PHY0+PHY1 only (Port A) */
 +#define MAX96724_CSI_PHY_EN_23		0xC0  /* PHY2+PHY3 only (Port B) */
 +
-+/* [UG Table 12, p.25-26] Lane mapping default */
++/* Lane mapping default */
 +#define MAX96724_CSI_LANE_MAP_DEFAULT	0xE4
 +
-+/* [UG Table 12, p.26-27] Lane control: 4-lane enabled */
++/* Lane control: 4-lane enabled */
 +#define MAX96724_LANE_CTRL_4LANE	0xC0
 +
-+/* [UG Table 12, p.26-27] Lane control: 2-lane enabled.
++/*
++ *   Lane control: 2-lane enabled.
 + *   bits[7:6] = (num_lanes - 1): 01=2-lane(0x40), 11=4-lane(0xC0)
-+ *   Ref: gmsl_ser_des_guide §8.2, E2E_enable_guide §5.6.4 */
++ *   Ref: gmsl_ser_des_guide §8.2, E2E_enable_guide §5.6.4 
++ */
 +#define MAX96724_LANE_CTRL_2LANE	0x40
 +
-+/* [SC20190112 2-lane] CSI PHY enable: all PHYs powered for DPLL lock
-+ *   stability.  Even though only PHY0 data lanes reach Orin, the MAX96724
-+ *   DPLL requires all PHYs to be powered.  Tested: single PHY → PLL never locks. */
++/* 
++ *   CSI PHY enable: all PHYs powered for DPLL lock.
++ */
 +#define MAX96724_CSI_PHY_EN_2LANE	0xF0
 +
-+/* [SC20190112 2-lane] DPLL for Controller 0 (drives PHY0, 2 lanes).
++/* 
++ *   DPLL for Controller 0 (drives PHY0, 2 lanes).
 + *   bits[4:0] = data-rate / 100 MHz.  700 Mbps / 100 = 7 = 0x07.
 + *   bit[5]    = DPLL enable = 1.
-+ *   Result: 0x27 = 700 Mbps/lane D-PHY. */
++ *   Result: 0x27 = 700 Mbps/lane D-PHY.
++ */
 +#define MAX96724_DPLL_700MBPS_CTRL0	0x27
 +
-+/* [FG24-4CH working-config verified] CSI-output DPLL data rate = 1500 Mbps.
++/* 
++ *   CSI-output DPLL data rate = 1500 Mbps.
 + *   bits[4:0] = data-rate / 100 MHz -> 1500/100 = 15 = 0x0F. bit[5] = DPLL en.
-+ *   Result 0x2F.  The FangZhu MAX4CH config writes this to ALL FOUR controllers
-+ *   (0x0415/0x0418/0x041B/0x041E), matching DT max_lane_speed = 1500000.  The
-+ *   old 0x27 (700 Mbps, 2 controllers only) is a 2-lane-variant leftover that
-+ *   left the Orin CIL unable to lock the HS clock (empty rtcpu trace). */
++ */
 +#define MAX96724_DPLL_1500MBPS		0x2F
 +
-+/* [UG Table 3, p.12] One-shot reset: all links */
++/* One-shot reset: all links */
 +#define MAX96724_ONESHOT_ALL		0x0F
 +
-+/* [UG Table 4, p.15] Pipe source selection values
-+ *   Encoding per pipe nibble in tunnel mode (Aardvark-verified):
++/* 
++ *   Pipe source selection values
++ *   Encoding per pipe nibble in tunnel mode:
 + *   0x22 routes all pipes from Link A in tunnel mode.
 + */
-+#define MAX96724_PIPE_SEL0_SINGLE	0x22  /* All pipes from Link A (Aardvark-verified) */
-+#define MAX96724_PIPE_SEL1_SINGLE	0x22  /* All pipes from Link A (Aardvark-verified) */
-+#define MAX96724_PIPE_SEL0_PIXEL	0x62  /* OG03C pixel-mode reference */
-+#define MAX96724_PIPE_SEL1_PIXEL	0xEA  /* OG03C pixel-mode reference */
++#define MAX96724_PIPE_SEL0_SINGLE	0x22  /* All pipes from Link A */
++#define MAX96724_PIPE_SEL1_SINGLE	0x22  /* All pipes from Link A */
++#define MAX96724_PIPE_SEL0_PIXEL	0x62  /* pixel-mode reference */
++#define MAX96724_PIPE_SEL1_PIXEL	0xEA  /* pixel-mode reference */
 +#define MAX96724_PIPE_SEL0_DUAL		0x40  /* Pipe 0 ← A/X, Pipe 1 ← B/X */
 +#define MAX96724_PIPE_SEL0_QUAD_LO	0x40  /* Pipe 0 ← A/X, Pipe 1 ← B/X */
 +#define MAX96724_PIPE_SEL1_QUAD_HI	0xC8  /* Pipe 2 ← C/X, Pipe 3 ← D/X */
@@ -1373,12 +1238,12 @@ index 0000000..4a1708c
 +#define MAX96724_RESET_ST_ID		0x00
 +#define MAX96724_ST_ID_SEL_INVALID	0xF
 +
-+/* Controller mapping: all mappings → Controller 0 (not working in tunnel mode) */
++/* Controller mapping: all mappings → Controller 0 */
 +#define MAX96724_ALL_MAP_CTRL0		0x00
-+/* Controller mapping: all mappings → Controller 1 (Aardvark-verified working) */
++/* Controller mapping: all mappings → Controller 1 */
 +#define MAX96724_ALL_MAP_CTRL1		0x55
 +
-+/* [OG03C reference dump] Three mappings to controller 1 */
++/* Three mappings to controller 1 */
 +#define MAX96724_MAP3_CTRL1		0x15
 +
 +/* ================================================================
@@ -1400,16 +1265,9 @@ index 0000000..4a1708c
 +#define MAX96724_CSI_CTRL_2		2
 +#define MAX96724_CSI_CTRL_3		3
 +
-+/* Internal csi_mode enum flags (NOT the register value written to 0x08A0;
-+ * see MAX96724_CSI_MODE_2X4_VAL for the actual register value).  These are
-+ * only compared against priv->csi_mode to select a code path. */
-+#define MAX96724_CSI_MODE_4X2		0x01
 +#define MAX96724_CSI_MODE_2X4		0x08  /* enum tag for the 4-lane Port A (Ctrl1) path */
-+#define MAX96724_CSI_MODE_2X4_ALT	0x04  /* enum tag (unused alt path) */
 +
 +/* Lane map presets */
-+#define MAX96724_LANE_MAP1_4X2		0x44
-+#define MAX96724_LANE_MAP2_4X2		0x44
 +#define MAX96724_LANE_MAP1_2X4		0xE4  /* SC20190112 subset: PHY0 data + PHY1 clock */
 +#define MAX96724_LANE_MAP2_2X4		0x44  /* keep unused PHY2/3 straight in 0x08 mode */
 +
@@ -2042,10 +1900,6 @@ index 0000000..4a1708c
 +		goto error;
 +	}
 +
-+	/* Check csi mode compatibility.
-+	 * 2x4 DES → gmsl-link: 1x4 or 2x4.
-+	 * 4x2 DES → gmsl-link: 1x4, 2x2, or 4x2.
-+	 */
 +	if (priv->csi_mode == MAX96724_CSI_MODE_2X4) {
 +		if (!((g_ctx->csi_mode == GMSL_CSI_1X4_MODE) ||
 +		      (g_ctx->csi_mode == GMSL_CSI_2X4_MODE))) {
@@ -2054,14 +1908,9 @@ index 0000000..4a1708c
 +			goto error;
 +		}
 +	} else {
-+		/* 4x2 DES mode: accept 1x4, 2x2, or 4x2 gmsl-link mode */
-+		if (!((g_ctx->csi_mode == GMSL_CSI_1X4_MODE) ||
-+		      (g_ctx->csi_mode == GMSL_CSI_2X2_MODE) ||
-+		      (g_ctx->csi_mode == GMSL_CSI_4X2_MODE))) {
-+			dev_err(dev, "%s: csi mode not supported\n", __func__);
-+			err = -EINVAL;
-+			goto error;
-+		}
++		dev_err(dev, "%s: only csi 2x4 mode is supported\n", __func__);
++		err = -EINVAL;
++		goto error;
 +	}
 +
 +	for (i = 0; i < priv->num_src; i++) {
@@ -2144,7 +1993,7 @@ index 0000000..4a1708c
 + * with all VCs and DTs preserved from the serializer.
 + *
 + * The pipeline configuration:
-+ *   1. Configure pipe-to-link routing (which GMSL input → which pipe)
++ *   1. Configure pipe-to-link routing
 + *   2. Enable tunnel mode on active pipes
 + *   3. Configure MIPI CSI-2 output lanes and PHY
 + *   4. Enable BACKTOP output port
@@ -2195,9 +2044,9 @@ index 0000000..4a1708c
 +	}
 +
 +	/*
-+	 * [Aardvark-verified] Pipe source routing
-+	 *   Single cam: all pipes from Link A (0x22/0x22)
-+	 *   Disable pipes before configuration, enable at the end
++	 * Pipe source routing
++	 * Single cam: all pipes from Link A (0x22/0x22)
++	 * Disable pipes before configuration, enable at the end
 +	 */
 +	max96724_write_reg(dev, MAX96724_PIPE_SEL0_ADDR, pipe_sel0);
 +	max96724_write_reg(dev, MAX96724_PIPE_SEL1_ADDR, pipe_sel1);
@@ -2205,16 +2054,14 @@ index 0000000..4a1708c
 +	max96724_write_reg(dev, MAX96724_PIPE_EN_ADDR, 0x00);
 +
 +	/*
-+	 * [SC20190112] Keep 0x08 mode so PHY1 remains the Port A clock master,
++	 * Keep 0x08 mode so PHY1 remains the Port A clock master,
 +	 * but restore the live 2-lane subset used by the bridge board.
 +	 */
 +	max96724_apply_porta_subset(dev, priv);
 +
 +	/*
-+	 * [D585 700Mbps fix] CSI-output DPLL data rate = 700 Mbps
-+	 * on ALL FOUR controller freq registers, matching D585 native
-+	 * MIPI rate (pix_clk_hz=175M, 16bpp, 4-lane).
-+	 * DT serdes_pix_clk_hz=175MHz drives correct THS_SETTLE for 700Mbps.
++	 * CSI-output DPLL data rate = 700 Mbps
++	 * on ALL FOUR controller freq registers
 +	 */
 +	if (!priv->lane_setup) {
 +		max96724_write_reg(dev, MAX96724_DPLL_FREQ0_ADDR,
@@ -2233,7 +2080,7 @@ index 0000000..4a1708c
 +			   MAX96724_MIPI_CTRL_SEL_PIXEL);
 +
 +	/*
-+	 * [Aardvark-verified] Stream ID select for all pipes
++	 * Stream ID select for all pipes
 +	 * 0x0933 + 0x40*pipe = stream select register
 +	 * Value 0x10 selects the appropriate stream for tunnel mode
 +	 */
@@ -2243,7 +2090,8 @@ index 0000000..4a1708c
 +				   st_sel_cfg);
 +	}
 +
-+	/* BACKTOP: enable Controller 1 / CSI-B (0x02).
++	/* 
++	 * BACKTOP: enable Controller 1 / CSI-B (0x02).
 +	 * In 2x4 mode, Controller 1 is master for Port A -> Orin CSI.
 +	 */
 +	max96724_write_reg(dev, MAX96724_BACKTOP_EN_ADDR,
@@ -2252,10 +2100,9 @@ index 0000000..4a1708c
 +	dev_info(dev, "=== setup_streaming: writing 0x84 (force all MIPI clocks) ===\n");
 +
 +	/*
-+	 * [FG24-4CH working-config verified] Assert 0x08A0=0x84 LAST: 2x4 mode +
-+	 * bit[7] "force all MIPI clocks running".  The clock-force keeps the
-+	 * D-PHY clock lane continuous so the Orin CIL can lock; written only
-+	 * after the full pipeline is configured, matching FangZhu End_Common.
++	 * Assert 0x08A0=0x84 LAST: 2x4 mode + bit[7] "force all MIPI clocks running".  
++	 * The clock-force keeps the D-PHY clock lane continuous so the Orin CIL can lock;
++	 * written only after the full pipeline is configured.
 +	 */
 +	max96724_write_reg(dev, MAX96724_CSI_OUT_CFG_ADDR,
 +			   MAX96724_CSI_OUT_EN_VAL);
@@ -2280,7 +2127,7 @@ index 0000000..4a1708c
 +	max96724_write_reg(dev, MAX96724_ONESHOT_ADDR,
 +			   MAX96724_ONESHOT_ALL);
 +
-+	/* Enable all 4 pipes (Aardvark-verified: 0x0F at end) */
++	/* Enable all 4 pipes */
 +	max96724_write_reg(dev, MAX96724_PIPE_EN_ADDR, MAX96724_PIPE_EN_4);
 +
 +	priv->sources[src_idx].st_enabled = true;
@@ -2393,10 +2240,7 @@ index 0000000..4a1708c
 +
 +int max96724_get_ser_pipe_id(struct device *dev, int dser_pipe_id, int vc_id)
 +{
-+	/*
-+	 * In Tunnel Mode with MAX96717, all VCs are carried in a single
-+	 * tunnel pipe. The pipe mapping is 1:1 for d4xx compatibility.
-+	 */
++	/* In Tunnel Mode with MAX96717, all VCs are carried in a single tunnel pipe. */
 +	return dser_pipe_id;
 +}
 +EXPORT_SYMBOL(max96724_get_ser_pipe_id);
@@ -2414,7 +2258,7 @@ index 0000000..4a1708c
 +
 +	mutex_lock(&priv->lock);
 +	if (priv->splitter_enabled) {
-+		/* [UG] Multi-camera: reset all links */
++		/* Multi-camera: reset all links */
 +		u8 link_rate = (priv->link_speed == 6) ? 0x22 : 0x11;
 +
 +		max96724_write_reg(dev, MAX96724_LINK_RATE_AB_ADDR,
@@ -2445,20 +2289,21 @@ index 0000000..4a1708c
 +		dpll_cfg = MAX96724_DPLL_1500MBPS;
 +	}
 +
-+	/* ONESHOT resets CSI/tunnel state. Restore the full pipeline config.
++	/* 
++	 * ONESHOT resets CSI/tunnel state. Restore the full pipeline config.
 +	 * Mirror setup_streaming() order: disable pipes -> restore everything ->
 +	 * BACKTOP/0x84 -> VID_RX -> final ONESHOT to latch -> enable pipes.
 +	 */
 +	max96724_write_reg(dev, MAX96724_PIPE_EN_ADDR, 0x00);
 +
-+	/* Pipe source routing (same as setup_streaming): all pipes from Link A */
++	/* Pipe source routing: all pipes from Link A */
 +	max96724_write_reg(dev, MAX96724_PIPE_SEL0_ADDR, pipe_sel0);
 +	max96724_write_reg(dev, MAX96724_PIPE_SEL1_ADDR, pipe_sel1);
 +
 +	max96724_apply_porta_subset(dev, priv);
 +
 +	/*
-+	 * [D585 700Mbps fix] CSI-output DPLL data rate = 700 Mbps on ALL
++	 * CSI-output DPLL data rate = 700 Mbps on ALL
 +	 * FOUR controllers, matching D585 native MIPI rate.
 +	 * reset_oneshot is called by the sensor after setup_streaming, so it must
 +	 * mirror the same DPLL values.
@@ -2518,7 +2363,7 @@ index 0000000..4a1708c
 +			   MAX96724_PIPE_EN_4);
 +
 +	/*
-+	 * [FG24-4CH working-config verified] Assert 0x08A0=0x84 LAST:
++	 * Assert 0x08A0=0x84 LAST:
 +	 * 2x4 mode + bit[7] force all MIPI clocks running.  Must mirror
 +	 * setup_streaming because the sensor's oneshot path overwrites it.
 +	 */
@@ -2566,7 +2411,7 @@ index 0000000..4a1708c
 +		{MAX96724_TX46_PIPE_X_ADDR, MAX96724_ALL_MAP_CTRL1},
 +		{MAX96724_TX47_PIPE_X_ADDR, MAX96724_ALL_MAP_CTRL1},
 +		{MAX96724_TX48_PIPE_X_ADDR, MAX96724_ALL_MAP_CTRL1},
-+		/* TX49: concat disabled (single-camera) */
++		/* TX49: concat disabled */
 +		{MAX96724_TX49_PIPE_X_ADDR, 0x00},
 +		/*
 +		 * Keep DES heartbeat handling aligned with the serializer's
@@ -2576,12 +2421,13 @@ index 0000000..4a1708c
 +		{0x0106, MAX96724_VID_RX6_CFG_VAL},
 +		/*
 +		 * Pipe stream control (offset 0x36 per pipe block).
-+		 * [XML] TUN_EN = 0x01.
++		 * TUN_EN = 0x01.
 +		 */
 +		{0x0936, MAX96724_TUN_EN},
 +	};
 +
-+	/* Adjust addresses for pipe offset (stride 0x40 per pipe)
++	/* 
++	 * Adjust addresses for pipe offset (stride 0x40 per pipe)
 +	 * Entries 0-13: TX11, SRC/DST maps, TX45-TX49 (all stride 0x40)
 +	 * Entries 14-15: VID_RX0/6 (stride 0x12)
 +	 * Entry 16: Pipe stream control (stride 0x40)
@@ -2589,7 +2435,7 @@ index 0000000..4a1708c
 +	for (i = 0; i < 14; i++)
 +		map_pipe_control[i].addr += 0x40 * pipe_id;
 +
-+	/* [max9296.c pattern] VID_RX offset: 0x12 per pipe */
++	/* VID_RX offset: 0x12 per pipe */
 +	map_pipe_control[14].addr += 0x12 * pipe_id;
 +	map_pipe_control[15].addr += 0x12 * pipe_id;
 +
@@ -2610,7 +2456,7 @@ index 0000000..4a1708c
 +		map_pipe_control[15].val = MAX96724_VID_RX6_PIXEL_VAL;
 +		map_pipe_control[16].val = MAX96724_TUN_DISABLED;
 +	} else {
-+		/* Single-RGB tunnel: no concatenation needed */
++		/* no concatenation needed */
 +		map_pipe_control[13].val = 0x00;
 +	}
 +
@@ -2628,7 +2474,7 @@ index 0000000..4a1708c
 +	map_pipe_control[9].val = all_mapping_phy;
 +	/* TX46-TX48 keep 0x55 (Ctrl1) from initializer */
 +	/* TX49 set to 0x00 above — overridden per mode in pixel/tunnel branch */
-+	/* VID_RX (entry 14) and pipe stream ctrl (entry 15) keep init values */
++	/* VID_RX and pipe stream ctrl keep init values */
 +
 +	err = max96724_set_registers(dev, map_pipe_control,
 +				     ARRAY_SIZE(map_pipe_control));
@@ -2731,16 +2577,8 @@ index 0000000..4a1708c
 +
 +	if (!strcmp(str_value, "2x4")) {
 +		priv->csi_mode = MAX96724_CSI_MODE_2X4;
-+		/*
-+		 * SC20190112 keeps the 0x08 Port-A clocking scheme but only brings
-+		 * PHY0 data lanes and the PHY1 clock lane to Orin.
-+		 */
 +		priv->lane_mp1 = MAX96724_LANE_MAP1_2X4;
 +		priv->lane_mp2 = MAX96724_LANE_MAP2_2X4;
-+	} else if (!strcmp(str_value, "4x2")) {
-+		priv->csi_mode = MAX96724_CSI_MODE_4X2;
-+		priv->lane_mp1 = MAX96724_LANE_MAP1_4X2;
-+		priv->lane_mp2 = MAX96724_LANE_MAP2_4X2;
 +	} else {
 +		dev_err(&client->dev, "invalid csi mode\n");
 +		return -EINVAL;
@@ -2762,7 +2600,7 @@ index 0000000..4a1708c
 +		priv->reset_gpio = -1;
 +	}
 +
-+	/* [User requirement] GMSL link speed from DT: 3 or 6 (Gbps) */
++	/* GMSL link speed from DT: 3 or 6 (Gbps) */
 +	err = of_property_read_u32(node, "gmsl-link-speed", &value);
 +	if (err < 0) {
 +		/* Default to 3 Gbps if not specified */

--- a/nvidia-oot/6.1/0011-Add-MAX96717-serializer-and-MAX96724-deserializer-dr.patch
+++ b/nvidia-oot/6.1/0011-Add-MAX96717-serializer-and-MAX96724-deserializer-dr.patch
@@ -22,36 +22,22 @@ MAX96724 quad deserializer features:
 
 Signed-off-by: RealSense AI <realsense@realsenseai.com>
 ---
- drivers/media/i2c/Makefile   |    2 +
- drivers/media/i2c/max96717.c |  917 ++++++++++++++++
- drivers/media/i2c/max96724.c | 1927 ++++++++++++++++++++++++++++++++++
+ drivers/media/i2c/max96717.c |  791 ++++++++++++++
+ drivers/media/i2c/max96724.c | 1905 ++++++++++++++++++++++++++++++++++
  include/media/max96717.h     |  151 ++
  include/media/max96724.h     |  183 +++
- 5 files changed, 3180 insertions(+)
+ 4 files changed, 3030 insertions(+)
  create mode 100644 drivers/media/i2c/max96717.c
  create mode 100644 drivers/media/i2c/max96724.c
  create mode 100644 include/media/max96717.h
  create mode 100644 include/media/max96724.h
 
-diff --git a/drivers/media/i2c/Makefile b/drivers/media/i2c/Makefile
-index b284938..947e6e9 100644
---- a/drivers/media/i2c/Makefile
-+++ b/drivers/media/i2c/Makefile
-@@ -8,6 +8,8 @@ obj-m += max9296.o
- subdir-ccflags-y += -DCONFIG_VIDEO_D4XX_SERDES
- subdir-ccflags-y += -DCONFIG_TEGRA_CAMERA_PLATFORM
- obj-m += d4xx.o
-+obj-m += max96717.o
-+obj-m += max96724.o
- ifeq ($(findstring ack_src,$(NV_BUILD_KERNEL_OPTIONS)),)
- obj-m += max96712.o
- 
 diff --git a/drivers/media/i2c/max96717.c b/drivers/media/i2c/max96717.c
 new file mode 100644
-index 0000000..1dd24d3
+index 0000000..c26c24b
 --- /dev/null
 +++ b/drivers/media/i2c/max96717.c
-@@ -0,0 +1,917 @@
+@@ -0,0 +1,791 @@
 +/*
 + * max96717.c - MAX96717 GMSL2 Serializer driver (Tunnel Mode)
 + *
@@ -70,14 +56,6 @@ index 0000000..1dd24d3
 + * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
-+/*
-+ * Register Reference Sources:
-+ * [PPTX]  = GMSL_MAX96717_MAX96724_TechOverview - V1.pptx
-+ * [XML]   = MAX96717_MAX96724_HKR_EVB_700mbps_tunnel_mode_basedonexcelsheet_D585.xml
-+ *
-+ * Every register address and value below is traceable to one of these sources.
-+ */
-+
 +#include <media/camera_common.h>
 +#include <linux/of.h>
 +#include <linux/module.h>
@@ -85,149 +63,146 @@ index 0000000..1dd24d3
 +
 +/* ===== Register Addresses ===== */
 +
-+/* [PPTX slide 7] REG0: Device ID (read-only, returns 0x40) */
++/* REG0: Device ID (read-only, returns 0x40) */
 +#define MAX96717_DEV_ADDR		0x00
 +
-+/* [PPTX slide 7] REG1: Link Speed
++/* 
++ *   REG1: Link Speed
 + *   bit[3]=1: 3 Gbps, bit[4]=1: 6 Gbps
 + */
 +#define MAX96717_REG1_ADDR		0x01
 +
-+/* [PPTX slide 7 / XML 0x0002] PIPE_EN: Pipe enable / soft reset
-+ *   [XML] 0x03 = soft reset, 0x43 = pipes enabled + video init
-+ *   [PPTX slide 7] Matches MAX9295 PIPE_EN at 0x02
++/* 
++ *   PIPE_EN: Pipe enable / soft reset
++ *   0x03 = soft reset, 0x43 = pipes enabled + video init
++ *   Matches MAX9295 PIPE_EN at 0x02
 + */
 +#define MAX96717_PIPE_EN_ADDR		0x02
 +
-+/* [PPTX slide 7] CTRL0: GMSL2 TX Control
++/* 
++ *   CTRL0: GMSL2 TX Control
 + *   bit[5]=1: GMSL2 mode, bit[0]=1: enable transmitter
 + *   0x21 = GMSL2 mode + TX enable on Link A
 + */
 +#define MAX96717_CTRL0_ADDR		0x10
 +
-+/* [PPTX slide 7] CTRL3: Start Video - final enable bit
++/* 
++ *   CTRL3: Start Video - final enable bit
 + *   bit[0]=1: activate video stream
 + */
 +#define MAX96717_CTRL3_ADDR		0x13
 +
-+/* [PPTX slide 7] TX1: FEC Enable
++/* 
++ *   TX1: FEC Enable
 + *   bit[6]=1: Reed-Solomon FEC enabled
 + */
 +#define MAX96717_TX1_ADDR		0x29
 +
-+/* [MAX96724 Users Guide, I2C Broadcasting section, p44-46]
-+ * MAX96717 I2C address translation registers (GMSL2 standard):
++/*
++ *   MAX96717 I2C address translation registers (GMSL2 standard):
 + *   SRC_A / DST_A (0x42/0x43): Translation pair A (SER broadcast addr)
 + *   SRC_B / DST_B (0x44/0x45): Translation pair B (sensor passthrough)
 + *
-+ * When host writes to SRC_B address, the MAX96717 translates it to
-+ * DST_B and forwards via GMSL back-channel to the remote sensor.
++ *   When host writes to SRC_B address, the MAX96717 translates it to
++ *   DST_B and forwards via GMSL back-channel to the remote sensor.
 + *
 + */
 +#define MAX96717_SRC_A_ADDR		0x42
 +#define MAX96717_DST_A_ADDR		0x43
-+#define MAX96717_I2C4_ADDR		0x44	/* SRC_B: sensor proxy addr */
-+#define MAX96717_I2C5_ADDR		0x45	/* DST_B: sensor default addr */
++#define MAX96717_I2C4_ADDR		0x44
++#define MAX96717_I2C5_ADDR		0x45
 +
-+/* [PPTX slide 14] TX_STR_SEL: Stream ID select
++/* 
++ *   TX_STR_SEL: Stream ID select
 + *   bits[1:0]: stream ID for DES pipe routing
 + */
 +#define MAX96717_TX_STR_SEL_ADDR	0x5B
 +
-+/* [PPTX slide 7 / XML 0x0110-0x0111] VIDEO_TX0/TX1: Video TX path config
-+ *   [XML] 0x0110=0xE9, 0x0111=0x10 for tunnel mode data path
++/* 
++ *   VIDEO_TX0/TX1: Video TX path config
++ *   0x0110=0xE9, 0x0111=0x10 for tunnel mode data path
 + */
 +#define MAX96717_VIDEO_TX0_ADDR		0x110
 +#define MAX96717_VIDEO_TX1_ADDR		0x111
 +
-+/* [PPTX slide 7] FRONTTOP_0: Front-end topology
++/* 
++ *   FRONTTOP_0: Front-end topology
 + *   0x12 = single CSI-2 port A, all VCs pass through
 + */
 +#define MAX96717_FRONTTOP0_ADDR		0x308
 +
-+/* [XML / PPTX slide 7] MIPI_RX0-RX3: CSI-2 receiver configuration
++/* 
++ *   MIPI_RX0-RX3: CSI-2 receiver configuration
 + *   RX0 (0x330): CSI mode (0x00 = D-PHY controller A)
-+ *   RX1 (0x331): Lane count - [PPTX slide 14] ctrl1_num_lanes bits[5:4]
-+ *                 [XML] 0x30 = bits[5:4]=11 (4 lanes)
-+ *   RX2 (0x332): Lane mapping - [XML] 0xE0 = default 1x4 map
-+ *   RX3 (0x333): Lane mapping - [XML] 0x04 = default 1x4 map
++ *   RX1 (0x331): Lane count - ctrl1_num_lanes bits[5:4]
++ *                0x30 = bits[5:4]=11 (4 lanes)
++ *   RX2 (0x332): Lane mapping - 0xE0 = default 1x4 map
++ *   RX3 (0x333): Lane mapping - 0x04 = default 1x4 map
 + */
 +#define MAX96717_MIPI_RX0_ADDR		0x330
 +#define MAX96717_MIPI_RX1_ADDR		0x331
 +#define MAX96717_MIPI_RX2_ADDR		0x332
 +#define MAX96717_MIPI_RX3_ADDR		0x333
 +
-+/* [PPTX slide 7 / slide 14] EXT11: TUNNEL MODE ENABLE
-+ *   bit[7]=1: Tun_Mode = ON  *** CRITICAL REGISTER ***
-+ *   [PPTX slide 7] 0x383 = 0x80
++/* 
++ *   EXT11: TUNNEL MODE ENABLE
++ *   bit[7]=1: Tun_Mode = ON
++ *   0x383 = 0x80
 + */
 +#define MAX96717_EXT11_ADDR		0x383
 +
-+/* [SG2 working config] SER PHY / DLL calibration registers.
-+ *   These are device-level (not sensor-specific) and appear in every
-+ *   SG2 sensor variant (OX03C, ISX031, etc.).  The staged write pattern
-+ *   (0x80 -> 0x90) on 0x2D6/0x2C7 is a PHY calibration ramp sequence.
-+ *   Without these writes the GMSL2 link trains but the DES cannot
-+ *   recover a clean CSI-2 clock from the tunnel-mode data stream.
-+ */
-+#define MAX96717_PHY_CAL_2D6_ADDR	0x2D6
-+#define MAX96717_PHY_CAL_2C7_ADDR	0x2C7
-+#define MAX96717_PHY_CAL_2BE_ADDR	0x2BE
-+#define MAX96717_PHY_CAL_2C1_ADDR	0x2C1
-+#define MAX96717_PHY_CAL_3F0_ADDR	0x3F0
-+#define MAX96717_PHY_CAL_3F1_ADDR	0x3F1
-+
-+/* [SG2 working config] PHY calibration stage-1 value */
++/* PHY calibration stage-1 value */
 +#define MAX96717_PHY_CAL_STAGE1		0x80
-+/* [SG2 working config] PHY calibration stage-2 value */
++/* PHY calibration stage-2 value */
 +#define MAX96717_PHY_CAL_STAGE2		0x90
-+/* [SG2 working config] CSI input timing / frequency config */
++/* CSI input timing / frequency config */
 +#define MAX96717_CSI_TIMING_3F0		0x59
 +#define MAX96717_CSI_TIMING_3F1		0x09
 +
 +/* ===== Register Values ===== */
 +
-+/* [XML] Soft reset value for PIPE_EN register */
++/* Soft reset value for PIPE_EN register */
 +#define MAX96717_SOFT_RESET		0x03
 +
-+/* [XML] Final enable: pipes enabled + video init */
++/* Final enable: pipes enabled + video init */
 +#define MAX96717_PIPE_EN_ALL		0x43
 +
-+/* [PPTX slide 7] CTRL0: GMSL2 mode + TX enable (Link A) */
++/* CTRL0: GMSL2 mode + TX enable (Link A) */
 +#define MAX96717_CTRL0_LINK_A		0x21
 +/* CTRL0: GMSL2 mode + TX enable (Link B) */
 +#define MAX96717_CTRL0_LINK_B		0x22
 +
-+/* [PPTX slide 7] CTRL0 reset all */
++/* CTRL0 reset all */
 +#define MAX96717_RESET_ALL		0x80
 +
-+/* [PPTX slide 7] EXT11 tunnel mode enable value */
++/* EXT11 tunnel mode enable value */
 +#define MAX96717_TUN_MODE_EN		0x80
 +#define MAX96717_TUN_MODE_DIS		0x00
 +
-+/* [XML] VIDEO_TX0 tunnel mode data path enable */
++/* VIDEO_TX0 tunnel mode data path enable */
 +#define MAX96717_VIDEO_TX0_TUN		0xE9
-+/* [XML] VIDEO_TX1 tunnel mode config */
++/* VIDEO_TX1 tunnel mode config */
 +#define MAX96717_VIDEO_TX1_TUN		0x10
 +#define MAX96717_VIDEO_TX0_BPP_MANUAL	0x60
 +#define MAX96717_VIDEO_TX1_BPP16	0x50
 +#define MAX96717_VIDEO_TX2_ADDR		0x112
 +#define MAX96717_VIDEO_TX2_DRIFT_DIS	0x08
 +
-+/* [SG2 working config] MIPI RX1: 4-lane CSI-2.
-+ *   bits[5:4]=11 (4 lanes).  bits[1:0]=11 (PHY mode / lane ordering
-+ *   matching SG2 working config; was 0x30, SG2 uses 0x33). */
++/* 
++ *   MIPI RX1: 4-lane CSI-2.
++ *   bits[5:4]=11 (4 lanes).  bits[1:0]=11
++ */
 +#define MAX96717_CSI_4_LANES		0x33
 +/* 2-lane CSI-2, bits[5:4]=01 */
 +#define MAX96717_CSI_2_LANES		0x10
 +
-+/* [XML] Lane mapping for 1x4 mode (matches MAX9295 1x4 values) */
++/* Lane mapping for 1x4 mode */
 +#define MAX96717_CSI_1X4_LANE_MAP1	0xE0
 +#define MAX96717_CSI_1X4_LANE_MAP2	0x04
 +
-+/* [PPTX slide 7] FRONTTOP_0: single port A, all VCs */
++/* FRONTTOP_0: single port A, all VCs */
 +#define MAX96717_FRONTTOP0_PORT_A	0x12
-+/* [UG Use Case Example 1] Pixel mode from Port B into Pipe Z */
++/* Pixel mode from Port B into Pipe Z */
 +#define MAX96717_FRONTTOP0_PIXEL_PORT_B	0x64
 +#define MAX96717_FRONTTOP5_ADDR		0x30D
 +#define MAX96717_FRONTTOP9_ADDR		0x311
@@ -235,17 +210,17 @@ index 0000000..1dd24d3
 +#define MAX96717_FRONTTOP17_ADDR	0x319
 +#define MAX96717_FRONTTOP9_START_VIDEO	0x40
 +
-+/* [XML] MIPI_RX0: CSI reset on + non-continuous clock */
++/* MIPI_RX0: CSI reset on + non-continuous clock */
 +#define MAX96717_MIPI_RX0_RESET		0x08
-+/* [PPTX slide 7] MIPI_RX0: Normal operation */
++/* MIPI_RX0: Normal operation */
 +#define MAX96717_MIPI_RX0_NORMAL	0x00
 +
-+/* [PPTX slide 9] REG1: 3 Gbps link speed, bit[3]=1 */
++/* REG1: 3 Gbps link speed, bit[3]=1 */
 +#define MAX96717_LINK_SPEED_3GBPS	0x08
-+/* [PPTX slide 9] REG1: 6 Gbps link speed, bit[4]=1 */
++/* REG1: 6 Gbps link speed, bit[4]=1 */
 +#define MAX96717_LINK_SPEED_6GBPS	0x10
 +
-+/* [XML] EXT11 tunnel mode pre-config (0x0383=0x80) */
++/* EXT11 tunnel mode pre-config (0x0383=0x80) */
 +#define MAX96717_EXT11_TUN_PRE		0x80
 +
 +#define MAX96717_MAX_PIPES		4
@@ -323,43 +298,6 @@ index 0000000..1dd24d3
 +	int err = 0;
 +	struct gmsl_link_ctx *g_ctx;
 +
-+	/*
-+	 * [XML] Full initialization sequence:
-+	 *   0x0002 = 0x03  (soft reset)
-+	 *   0x0383 = 0x80  (tunnel mode enable)
-+	 *   0x0331 = 0x30  (4-lane CSI)
-+	 *   0x0332 = 0xE0  (lane map1)
-+	 *   0x0333 = 0x04  (lane map2)
-+	 *   0x0110 = 0xE9  (video TX0 tunnel path)
-+	 *   0x0111 = 0x10  (video TX1 tunnel config)
-+	 *   0x0330 = 0x08  (CSI reset on)
-+	 *   0x0330 = 0x00  (CSI reset off)
-+	 *   0x0002 = 0x43  (final enable)
-+	 */
-+	struct reg_pair tunnel_init[] = {
-+		/* [PPTX slide 7] EXT11: Tunnel Mode Enable */
-+		{MAX96717_EXT11_ADDR, MAX96717_TUN_MODE_EN},
-+		/* [XML] MIPI_RX1: 4-lane CSI-2 (CTRL1_NUM_LANES[5:4]=11) */
-+		{MAX96717_MIPI_RX1_ADDR, MAX96717_CSI_4_LANES},
-+		/* [XML] MIPI_RX2/RX3: 1x4 lane mapping */
-+		{MAX96717_MIPI_RX2_ADDR, MAX96717_CSI_1X4_LANE_MAP1},
-+		{MAX96717_MIPI_RX3_ADDR, MAX96717_CSI_1X4_LANE_MAP2},
-+		/* [XML] VIDEO_TX0/TX1: tunnel data path */
-+		{MAX96717_VIDEO_TX0_ADDR, MAX96717_VIDEO_TX0_TUN},
-+		{MAX96717_VIDEO_TX1_ADDR, MAX96717_VIDEO_TX1_TUN},
-+	};
-+	struct reg_pair pixel_init[] = {
-+		{MAX96717_EXT11_ADDR, MAX96717_TUN_MODE_DIS},
-+		{MAX96717_MIPI_RX1_ADDR, MAX96717_CSI_4_LANES},
-+		{MAX96717_MIPI_RX2_ADDR, MAX96717_CSI_1X4_LANE_MAP1},
-+		{MAX96717_MIPI_RX3_ADDR, MAX96717_CSI_1X4_LANE_MAP2},
-+		{MAX96717_FRONTTOP0_ADDR, MAX96717_FRONTTOP0_PIXEL_PORT_B},
-+		{MAX96717_FRONTTOP9_ADDR, MAX96717_FRONTTOP9_START_VIDEO},
-+		{MAX96717_VIDEO_TX0_ADDR, MAX96717_VIDEO_TX0_BPP_MANUAL},
-+		{MAX96717_VIDEO_TX1_ADDR, MAX96717_VIDEO_TX1_BPP16},
-+		{MAX96717_VIDEO_TX2_ADDR, MAX96717_VIDEO_TX2_DRIFT_DIS},
-+	};
-+
 +	mutex_lock(&priv->lock);
 +
 +	if (!priv->g_client.g_ctx) {
@@ -375,80 +313,19 @@ index 0000000..1dd24d3
 +
 +	g_ctx = priv->g_client.g_ctx;
 +
-+	/*
-+	 * [SG2 working config] SER PHY/DLL pre-calibration.
-+	 * These device-level registers calibrate the serializer's
-+	 * differential output pairs and clock recovery.  The staged
-+	 * write pattern (0x80 stage-1 now, 0x90 stage-2 after tunnel
-+	 * init) matches every SG2 sensor variant's init table.
-+	 * Applied BEFORE soft reset + tunnel config.
-+	 */
-+	max96717_write_reg(dev, MAX96717_PHY_CAL_2D6_ADDR,
-+			   MAX96717_PHY_CAL_STAGE1);
-+	max96717_write_reg(dev, MAX96717_PHY_CAL_2C7_ADDR,
-+			   MAX96717_PHY_CAL_STAGE1);
-+	max96717_write_reg(dev, MAX96717_PHY_CAL_2BE_ADDR,
-+			   MAX96717_PHY_CAL_STAGE1);
-+	max96717_write_reg(dev, MAX96717_PHY_CAL_2C1_ADDR,
-+			   MAX96717_PHY_CAL_STAGE1);
-+	max96717_write_reg(dev, MAX96717_PHY_CAL_3F0_ADDR,
-+			   MAX96717_CSI_TIMING_3F0);
-+	max96717_write_reg(dev, MAX96717_PHY_CAL_3F1_ADDR,
-+			   MAX96717_CSI_TIMING_3F1);
-+	msleep(100);
++	max96717_write_reg(dev, MAX96717_EXT11_ADDR, MAX96717_TUN_MODE_EN);
++	max96717_write_reg(dev, MAX96717_MIPI_RX1_ADDR, MAX96717_CSI_4_LANES);
++	max96717_write_reg(dev, MAX96717_MIPI_RX2_ADDR, MAX96717_CSI_1X4_LANE_MAP1);
++	max96717_write_reg(dev, MAX96717_MIPI_RX3_ADDR, MAX96717_CSI_1X4_LANE_MAP2);
++	max96717_write_reg(dev, MAX96717_VIDEO_TX0_ADDR, MAX96717_VIDEO_TX0_TUN);
++	max96717_write_reg(dev, MAX96717_VIDEO_TX1_ADDR, MAX96717_VIDEO_TX1_TUN);
 +
-+	/*
-+	 * [Aardvark-verified] Soft reset before tunnel mode configuration
-+	 * Clears stale pipe/CSI state for clean initialization.
-+	 * Aardvark: 0x0002=0x03, sleep 30ms, then proceed with config.
-+	 */
-+	max96717_write_reg(dev, MAX96717_PIPE_EN_ADDR, MAX96717_SOFT_RESET);
-+	msleep(30);
-+
-+	if (priv->pixel_mode)
-+		err = max96717_set_registers(dev, pixel_init,
-+					 ARRAY_SIZE(pixel_init));
-+	else
-+		err = max96717_set_registers(dev, tunnel_init,
-+					 ARRAY_SIZE(tunnel_init));
-+	if (err)
-+		goto error;
-+
-+	/*
-+	 * [FIX] Re-enable GMSL2 mode + TX after soft reset.
-+	 * setup_control() previously set CTRL0=0x21 (GMSL2+TX), but the
-+	 * PIPE_EN=0x03 soft reset above clears it back to the power-on
-+	 * default 0x01 (TX only, GMSL2 mode disabled).  Without this
-+	 * re-write the SER operates in GMSL1 mode while the DES expects
-+	 * GMSL2 — the link trains but the video data path silently breaks.
-+	 */
-+	if (g_ctx->serdes_csi_link == GMSL_SERDES_CSI_LINK_A)
-+		max96717_write_reg(dev, MAX96717_CTRL0_ADDR,
-+				   MAX96717_CTRL0_LINK_A);
-+	else
-+		max96717_write_reg(dev, MAX96717_CTRL0_ADDR,
-+				   MAX96717_CTRL0_LINK_B);
-+
-+	/*
-+	 * [SG2 working config] PHY calibration stage-2: ramp 0x80 -> 0x90.
-+	 * Applied AFTER tunnel mode + lane config, BEFORE CSI reset.
-+	 */
-+	max96717_write_reg(dev, MAX96717_PHY_CAL_2D6_ADDR,
-+			   MAX96717_PHY_CAL_STAGE2);
-+	max96717_write_reg(dev, MAX96717_PHY_CAL_2C7_ADDR,
-+			   MAX96717_PHY_CAL_STAGE2);
-+	msleep(20);
-+
-+	/* [Aardvark-verified] CSI reset cycle with 2ms delay */
-+	max96717_write_reg(dev, MAX96717_MIPI_RX0_ADDR,
-+			   MAX96717_MIPI_RX0_RESET);
++	max96717_write_reg(dev, MAX96717_MIPI_RX0_ADDR, MAX96717_MIPI_RX0_RESET);
 +	usleep_range(2000, 2100);
-+	max96717_write_reg(dev, MAX96717_MIPI_RX0_ADDR,
-+			   MAX96717_MIPI_RX0_NORMAL);
++	max96717_write_reg(dev, MAX96717_MIPI_RX0_ADDR, MAX96717_MIPI_RX0_NORMAL);
 +
-+	/* [XML] Final enable: pipes on + video init */
-+	max96717_write_reg(dev, MAX96717_PIPE_EN_ADDR,
-+			   MAX96717_PIPE_EN_ALL);
++	/* pipes on + video init */
++	max96717_write_reg(dev, MAX96717_PIPE_EN_ADDR, MAX96717_PIPE_EN_ALL);
 +
 +	priv->g_client.st_done = true;
 +
@@ -470,9 +347,6 @@ index 0000000..1dd24d3
 + *      I2C4/SRC_B (0x44) <- (sdev_reg << 1): proxy addr visible to host
 + *      I2C5/DST_B (0x45) <- (sdev_def << 1): real addr on back-channel
 + *
-+ * This lets the Orin host access the D5xx sensor (def-addr 0x42) via
-+ * the aliased proxy address (e.g. 0x1a) through the GMSL link.
-+ *
 + */
 +int max96717_setup_control(struct device *dev)
 +{
@@ -491,17 +365,6 @@ index 0000000..1dd24d3
 +	g_ctx = priv->g_client.g_ctx;
 +
 +	if (prim_priv__) {
-+		/*
-+		 * [HW note] The MAX96717 retains its I2C address across
-+		 * reboots (PoC stays on).  If already at the aliased address,
-+		 * the DEV_ADDR write to 0x40 NACKs.  Skip reassignment when
-+		 * the primary and alias are the same physical device and the
-+		 * serializer is already responsive at a non-default address.
-+		 *
-+		 * For cold-start (first power-on), this write is required.
-+		 * We detect "already reassigned" by trying a read first:
-+		 * if the primary address (0x40) NACKs, skip the reassign.
-+		 */
 +		unsigned int dev_id;
 +		int probe_ret;
 +
@@ -519,7 +382,7 @@ index 0000000..1dd24d3
 +		}
 +	}
 +
-+	/* [PPTX slide 7] CTRL0: GMSL2 mode + TX enable */
++	/* CTRL0: GMSL2 mode + TX enable */
 +	if (g_ctx->serdes_csi_link == GMSL_SERDES_CSI_LINK_A)
 +		err = max96717_write_reg(dev, MAX96717_CTRL0_ADDR,
 +					 MAX96717_CTRL0_LINK_A);
@@ -537,7 +400,6 @@ index 0000000..1dd24d3
 +
 +	/*
 +	 * I2C address translation for sensor passthrough.
-+	 * [MAX96724 Users Guide, I2C Broadcasting, p44-46]
 +	 *
 +	 * I2C4 / SRC_B (0x44): sensor proxy addr visible to Orin host
 +	 * I2C5 / DST_B (0x45): sensor real addr on GMSL back-channel
@@ -568,17 +430,13 @@ index 0000000..1dd24d3
 +/*
 + * max96717_setup_gpio_tunneling - GPIO-over-GMSL no-op hook
 + *
-+ * [PPTX slide 10] GPIO Signal Mapping:
++ *   GPIO Signal Mapping:
 + *   MFP0 → GPIO0: FSIN (DES→SER, frame sync in)
 + *   MFP1 → GPIO1: FOUT/STROBE (SER→DES, frame sync out)
 + *   MFP4 → GPIO4: RESET_N (DES→SER, hard reset)
 + *   MFP5 → GPIO5: IRQ (SER→DES, interrupt request)
 + *   MFP6 → GPIO6: ZV_SYNC (DES→SER, IR stereo sync)
 + *
-+ * The PPTX defines the signal mapping and MFP_CFG register range,
-+ * but not the confirmed direction/function values. Keep this as
-+ * an explicit no-op hook until the MAX96717 GPIO register values
-+ * are available from ADI.
 + */
 +int max96717_setup_gpio_tunneling(struct device *dev)
 +{
@@ -644,7 +502,8 @@ index 0000000..1dd24d3
 +	priv = dev_get_drvdata(dev);
 +	mutex_lock(&priv->lock);
 +	if (priv->g_client.g_ctx) {
-+		/* Already paired — tolerate if this is a re-probe of
++		/* 
++		 * Already paired — tolerate if this is a re-probe of
 +		 * the same camera after a failed first attempt.
 +		 * Simply overwrite with the new g_ctx.
 +		 */
@@ -774,7 +633,8 @@ index 0000000..1dd24d3
 +	struct max96717 *priv = dev_get_drvdata(dev);
 +
 +	struct reg_pair map_init[] = {
-+		/* [XML seq] PIPE_EN soft reset first, then enable tunnel mode.
++		/* 
++		 * PIPE_EN soft reset first, then enable tunnel mode.
 +		 * Note: FRONTTOP0 is bypassed in tunnel mode (per UG) —
 +		 * CSI-2 input goes directly into the tunnel, no port config needed.
 +		 */
@@ -796,7 +656,7 @@ index 0000000..1dd24d3
 +	mutex_lock(&priv->lock);
 +
 +	/*
-+	 * [HW requirement] After CTRL0 + I2C translation writes in
++	 * After CTRL0 + I2C translation writes in
 +	 * setup_control, the MAX96717 needs settling time before
 +	 * accepting writes to PIPE_EN (0x02) and FRONTTOP registers.
 +	 */
@@ -846,7 +706,7 @@ index 0000000..1dd24d3
 +}
 +EXPORT_SYMBOL(max96717_set_pipe);
 +
-+/**
++/*
 + * max96717_retrigger_tx - Toggle SER TX to restore tunnel detection after
 + * a DES ONESHOT.  DES ONESHOT resets the data path; the SER must cycle
 + * its TX enable for the DES to re-acquire the tunnel stream.
@@ -971,10 +831,10 @@ index 0000000..1dd24d3
 +MODULE_LICENSE("GPL v2");
 diff --git a/drivers/media/i2c/max96724.c b/drivers/media/i2c/max96724.c
 new file mode 100644
-index 0000000..4a1708c
+index 0000000..4e73c60
 --- /dev/null
 +++ b/drivers/media/i2c/max96724.c
-@@ -0,0 +1,1927 @@
+@@ -0,0 +1,1905 @@
 +/*
 + * max96724.c - MAX96724 GMSL2 Quad Deserializer driver (Tunnel Mode)
 + *
@@ -1010,40 +870,44 @@ index 0000000..4a1708c
 +
 +/* --- Device ID / Configuration --- */
 +
-+/* [UG p.3] REG0: Device ID (read-only, returns 0xA2) */
++/* REG0: Device ID (read-only, returns 0xA2) */
 +#define MAX96724_DEV_ID_ADDR		0x00
 +
-+/* [Errata §5] ERRB master reset register */
++/* ERRB master reset register */
 +#define MAX96724_ERRB_MST_RST_ADDR	0x05
 +
-+/* [UG Table 3, p.11] 0x0006: GMSL Link/PHY Enable and Mode Select
++/* 
++ *   GMSL Link/PHY Enable and Mode Select
 + *   bits[7:4]: PHY mode (0=GMSL1, 1=GMSL2) per link D/C/B/A
 + *   bits[3:0]: Link Enable per link D/C/B/A
 + */
 +#define MAX96724_LINK_EN_ADDR		0x0006
 +
-+/* [UG Table 3, p.11] 0x0010: GMSL Link/PHY Rate Select (Links A&B)
++/* 
++ *   GMSL Link/PHY Rate Select (Links A&B)
 + *   bits[7:6]: Tx Rate Link B, bits[5:4]: Rx Rate Link B
 + *   bits[3:2]: Tx Rate Link A, bits[1:0]: Rx Rate Link A
 + *   Tx: 00=187.5Mbps, Rx: 01=3Gbps, 10=6Gbps
 + */
 +#define MAX96724_LINK_RATE_AB_ADDR	0x0010
 +
-+/* [UG Table 3, p.12] 0x0011: GMSL Link/PHY Rate Select (Links C&D) */
++/* GMSL Link/PHY Rate Select (Links C&D) */
 +#define MAX96724_LINK_RATE_CD_ADDR	0x0011
 +
-+/* [UG p.13] 0x001A: Link A lock status (bit[3]=LOCK) */
++/* Link A lock status (bit[3]=LOCK) */
 +#define MAX96724_LINK_A_LOCK_ADDR	0x001A
 +
-+/* [UG Table 3, p.12] 0x0018: GMSL Link Reset
++/* 
++ *   GMSL Link Reset
 + *   bits[7:4]: Link reset D/C/B/A, bits[3:0]: One-shot reset D/C/B/A
 + */
 +#define MAX96724_ONESHOT_ADDR		0x0018
 +
-+/* [UG p.11] REG13: Soft Reset (write 0x40, wait 5ms) */
++/* Soft Reset (write 0x40, wait 5ms) */
 +#define MAX96724_REG13_ADDR		0x000D
 +
-+/* [Errata §5] Error Channel Power Up registers (required for 6Gbps)
++/* 
++ *   Error Channel Power Up registers (required for 6Gbps)
 + *   Write 0x75 immediately after power-up for robust 6Gbps operation
 + */
 +#define MAX96724_ERRCH_A_ADDR		0x1449
@@ -1054,7 +918,8 @@ index 0000000..4a1708c
 +
 +/* --- I2C Control Channel / Errata --- */
 +
-+/* [Errata #2] Tunnel Mode SRAM LCRC error suppression
++/* 
++ *   Tunnel Mode SRAM LCRC error suppression
 + *   Set 0x458[7:4] = 0x0 to suppress spurious ERRB in tunnel mode
 + */
 +#define MAX96724_SRAM_LCRC_ERR_ADDR	0x0458
@@ -1073,9 +938,6 @@ index 0000000..4a1708c
 + */
 +#define MAX96724_PIPE_SEL1_ADDR		0xF1
 +
-+/*
-+ *   bit[0]=Pipe 0, bit[1]=Pipe 1, bit[2]=Pipe 2, bit[3]=Pipe 3
-+ */
 +#define MAX96724_PIPE_EN_ADDR		0xF4
 +
 +/* --- Pipe Receiver / Tunnel Mode --- */
@@ -1092,14 +954,15 @@ index 0000000..4a1708c
 +
 +/* --- CSI-2 Output (BACKTOP) --- */
 +
-+/* [UG p.19] BACKTOP: CSI-2 output port enable
++/* BACKTOP: CSI-2 output port enable
 + *   0x040B bit[1]=CSIB_EN, bit[0]=CSIA_EN
 + */
 +#define MAX96724_BACKTOP_EN_ADDR	0x040B
 +
 +/* --- MIPI DPLL (Data Rate) --- */
 +
-+/* [UG Table 12, p.27] MIPI PHY DPLL Freq registers
++/* 
++ *   MIPI PHY DPLL Freq registers
 + *   bits[4:0] = frequency in multiples of 100MHz
 + *   bit[5]    = DPLL enable (must be set for DPLL to lock)
 + *   E.g., 0x27 = 700MHz + enable = 700Mbps/lane D-PHY
@@ -1110,7 +973,8 @@ index 0000000..4a1708c
 +#define MAX96724_DPLL_FREQ2_ADDR	0x041B
 +#define MAX96724_DPLL_FREQ3_ADDR	0x041E
 +
-+/* [UG] DPLL PHY reset control
++/* 
++ *   DPLL PHY reset control
 + *   0x1D00 = DPLL CSI PHY1 control
 + *   Write 0xF4 to disable/reset, 0xF5 to enable
 + */
@@ -1120,49 +984,47 @@ index 0000000..4a1708c
 +
 +/* --- CSI-2 Output PHY Configuration --- */
 +
-+/* [UG rev2 Table 12 + MIPI PHY section] CSI output mode/config register.
++/* 
++ * CSI output mode/config register.
 + * Mode bits (set exactly one of [4:0]):
 + *   bit[0]=0x01: 4x2 mode
 + *   bit[2]=0x04: 2x4 mode        (Ctrl 1 = master for Port A, Ctrl 2 = Port B)
 + *   bit[3]=0x08: 1x4a + 2x2 mode (Ctrl 1 = master for Port A)
 + *   bit[4]=0x10: 1x4b + 2x2 mode (Ctrl 2 = master for Port B)
-+ * In ALL x4 D-PHY modes Port A = PHY0+PHY1 and Port B = PHY2+PHY3 (UG:
-+ * "PHY 1 and PHY 2 are the master PHYs providing the MIPI clock for ports
-+ * A and B").  bit[2] vs bit[3] only differ in how the OTHER port is grouped,
-+ * not in which PHYs carry Port A.
-+ * Clock-force bits (high nibble):
++ *
++ * Clock-force bits:
 + *   bit[7]=0x80: force ALL MIPI clocks running (continuous HS clock)
 + *   bit[6]=0x40: force PHY 3 MIPI clock running
 + *   bit[5]=0x20: force PHY 0 MIPI clock running
 + */
 +#define MAX96724_CSI_OUT_CFG_ADDR	0x08A0
 +
-+/* [UG Table 12, p.25] MIPI PHY Enable register
++/* 
++ *   MIPI PHY Enable register
 + *   bits[7:4]: Enable PHY 3/2/1/0 (1=enabled, 0=standby)
 + */
 +#define MAX96724_CSI_PHY_EN_ADDR	0x08A2
 +
-+/* [UG Table 12, p.25] MIPI PHY 0 and 1 Lane Mapping */
++/* MIPI PHY 0 and 1 Lane Mapping */
 +#define MAX96724_CSI_LANE_MAP1_ADDR	0x08A3
 +
-+/* [UG Table 12, p.26] MIPI PHY 2 and 3 Lane Mapping */
++/* MIPI PHY 2 and 3 Lane Mapping */
 +#define MAX96724_CSI_LANE_MAP2_ADDR	0x08A4
 +
-+/* [FG24-4CH board] MIPI output lane polarity (P/N swap) registers.
++/* 
++ *   MIPI output lane polarity (P/N swap) registers.
 + *   0x08A5 = PHY0/PHY1 lane polarity, 0x08A6 = PHY2/PHY3 lane polarity.
 + *   The FangZhu FG24-4CH PCB swaps the differential P/N pairs on the
 + *   MAX96724 CSI output, so the deserializer must invert lane polarity
-+ *   or the Orin CIL never locks the HS clock (total silence/2500ms timeout).
-+ *   Per FangZhu MAX4CH_FG24_POC_Enable table: write 0x3F to both.
 + */
 +#define MAX96724_CSI_PHY_POL0_ADDR	0x08A5
 +#define MAX96724_CSI_PHY_POL1_ADDR	0x08A6
 +#define MAX96724_CSI_PHY_POL_SWAP	0x3F
 +
-+/* [UG p.22] Pipe-to-controller mapping (Method 1) */
++/* Pipe-to-controller mapping */
 +#define MAX96724_MIPI_CTRL_SEL_ADDR	0x08CA
 +
-+/* [OG03C reference dump] Method-1 controller mapping */
++/* Method-1 controller mapping */
 +#define MAX96724_MIPI_CTRL_SEL_PIXEL	0xE4
 +
 +/* --- Lane Control per pipe (stride 0x40) --- */
@@ -1201,7 +1063,8 @@ index 0000000..4a1708c
 +
 +/* --- Extended Pipe Mapping (DST_CTRL2-4 / TX49) --- */
 +
-+/* [Excel: MIPI_TX46-48] Extended DST_CTRL for additional mapping pairs
++/* 
++ *   Extended DST_CTRL for additional mapping pairs
 + *   All to PHY1 (0x55), same as TX45
 + *   Stride: 0x40 per pipe (base = Pipe X)
 + */
@@ -1209,7 +1072,8 @@ index 0000000..4a1708c
 +#define MAX96724_TX47_PIPE_X_ADDR	0x092F
 +#define MAX96724_TX48_PIPE_X_ADDR	0x0930
 +
-+/* [UG p.30] MIPI_TX49 synchronous concatenation control
++/* 
++ *   MIPI_TX49 synchronous concatenation control
 + *   Set to 0x00 (no concat) for single-camera tunnel mode.
 + *   For 4W concat use 0x87.
 + *   Stride: 0x40 per pipe (base = Pipe X)
@@ -1240,10 +1104,11 @@ index 0000000..4a1708c
 + * Register Values
 + * ================================================================ */
 +
-+/* [UG p.12] Soft reset value (write to 0x000D) */
++/* Soft reset value (write to 0x000D) */
 +#define MAX96724_SOFT_RESET		0x40
 +
-+/* [UG Table 3, p.11-12] Link Rate values for 0x0010/0x0011
++/* 
++ * Link Rate values for 0x0010/0x0011
 + *   Per link pair: bits[1:0]=RxA, [3:2]=TxA, [5:4]=RxB, [7:6]=TxB
 + *   Tx = 00 (187.5Mbps), Rx = 01 (3Gbps) or 10 (6Gbps)
 + *   3Gbps: Tx=00, Rx=01 → per pair 0x01, both pairs = 0x01 in low nibble
@@ -1251,7 +1116,8 @@ index 0000000..4a1708c
 +#define MAX96724_LINK_RATE_3GBPS	0x01  /* Rx=3G, Tx=187.5M for one link pair */
 +#define MAX96724_LINK_RATE_6GBPS	0x02  /* Rx=6G, Tx=187.5M for one link pair */
 +
-+/* [UG Table 3, p.11] 0x0006: Link enable / mode values
++/* 
++ * 0x0006: Link enable / mode values
 + *   bits[7:4] = PHY mode (1=GMSL2 per link)
 + *   bits[3:0] = Link enable per link
 + *   0xF1 = all GMSL2-mode, only Link A enabled
@@ -1260,98 +1126,97 @@ index 0000000..4a1708c
 +#define MAX96724_LINK_EN_SIOA		0xF1  /* GMSL2 all, enable Link A only */
 +#define MAX96724_LINK_EN_ALL		0xFF  /* GMSL2 all, enable all links */
 +
-+/* [UG p.19] BACKTOP_EN (0x040B): CSI output port enable */
++/* BACKTOP_EN (0x040B): CSI output port enable */
 +#define MAX96724_BACKTOP_CSIB_EN	0x02
 +#define MAX96724_BACKTOP_CSIA_EN	0x01
 +
-+/* [XML] VIDEO_RX0: DIS_PKT_DET=1 (bit0) required for tunnel mode.
++/* 
++ *   VIDEO_RX0: DIS_PKT_DET=1 (bit0) required for tunnel mode.
 + *   Without it, DES rejects tunnel data as invalid GMSL2 video packets.
 + *   SEQ_MISS_EN=1 (bit4), LINE_CRC_EN=1 (bit1).  XML value: 0x33.
 + */
 +#define MAX96724_VID_RX0_CFG_VAL	0x33
 +#define MAX96724_VID_RX6_CFG_VAL	0x0A
 +
-+/* [OG03C reference dump] Pixel-mode receiver settings */
++/* Pixel-mode receiver settings */
 +#define MAX96724_VID_RX0_PIXEL_VAL	0x32
 +#define MAX96724_VID_RX6_PIXEL_VAL	0x12
 +
-+/* [XML] Tunnel mode enable (MIPI_TX54, 0x0936):
++/* 
++ *   Tunnel mode enable (MIPI_TX54, 0x0936):
 + *   bit[0] = TUN_EN = 1
 + *   Verified value: 0x01
 + */
 +#define MAX96724_TUN_EN			0x01
 +
-+/* [OG03C reference dump] Default/reset state when tunnel is disabled */
++/* Default/reset state when tunnel is disabled */
 +#define MAX96724_TUN_DISABLED		0x08
 +
-+/* [XML] Tunnel controller destination (MIPI_TX57, 0x0939):
++/* 
++ *   Tunnel controller destination (MIPI_TX57, 0x0939):
 + *   bits[5:4]: TUN_DEST (00=PHY0, 01=PHY1, 10=PHY2, 11=PHY3)
 + *   Verified value: 0x10 = PHY1 destination with auto-detect enabled
 + */
 +#define MAX96724_TUN_DEST_CTRL0		0x00  /* Auto-detect + PHY0 */
 +#define MAX96724_TUN_DEST_CTRL1		0x10  /* Auto-detect + PHY1 (Port A master) */
 +
-+/* [UG rev2 Table 12] CSI output mode values written to 0x08A0.
-+ *   We use bit[2] = 0x04 = clean 2x4 mode (Port A = PHY0+PHY1, Ctrl 1 master).
-+ *   This matches the ADI reference "Lane Swap Programming Example"
-+ *   (0x4E,0x08A0,0x04) and the FangZhu working config.  Note bit[3]=0x08
-+ *   (1x4a+2x2) ALSO keeps Port A on PHY0+PHY1; for a single 4-lane Port A
-+ *   output either presents a valid Port A, so 0x04 is the spec-clean choice
-+ *   rather than a hard requirement.
-+ */
 +#define MAX96724_CSI_MODE_2X4_VAL	0x04  /* bit[2] = clean 2x4: Port A = PHY0+PHY1 */
-+/* 0x84 = 2x4 mode (bit2) + bit[7] "force ALL MIPI clocks running".  The bit[7]
-+ * clock-force is the key part: it keeps the D-PHY clock lane in continuous HS
-+ * mode so the Orin NVCSI/CIL can lock.  Asserted LAST in setup_streaming(),
-+ * matching the FangZhu End_Common 0x08A0=0x84 write. */
++
++/* 
++ *   0x84 = 2x4 mode (bit2) + bit[7] "force ALL MIPI clocks running".  The bit[7]
++ *   clock-force is the key part: it keeps the D-PHY clock lane in continuous HS
++ *   mode so the Orin NVCSI/CIL can lock.
++ */
 +#define MAX96724_CSI_OUT_EN_VAL		0x84  /* 2x4 + bit[7] force all MIPI clocks running */
-+#define MAX96724_CSI_MODE_4X2_VAL	0x01  /* bit[0] = 4x2 mode */
 +
 +#define MAX96724_CSI_PHY_EN_ALL		0xF0
 +#define MAX96724_CSI_PHY_EN_01		0x30  /* PHY0+PHY1 only (Port A) */
 +#define MAX96724_CSI_PHY_EN_23		0xC0  /* PHY2+PHY3 only (Port B) */
 +
-+/* [UG Table 12, p.25-26] Lane mapping default */
++/* Lane mapping default */
 +#define MAX96724_CSI_LANE_MAP_DEFAULT	0xE4
 +
-+/* [UG Table 12, p.26-27] Lane control: 4-lane enabled */
++/* Lane control: 4-lane enabled */
 +#define MAX96724_LANE_CTRL_4LANE	0xC0
 +
-+/* [UG Table 12, p.26-27] Lane control: 2-lane enabled.
++/*
++ *   Lane control: 2-lane enabled.
 + *   bits[7:6] = (num_lanes - 1): 01=2-lane(0x40), 11=4-lane(0xC0)
-+ *   Ref: gmsl_ser_des_guide §8.2, E2E_enable_guide §5.6.4 */
++ *   Ref: gmsl_ser_des_guide §8.2, E2E_enable_guide §5.6.4 
++ */
 +#define MAX96724_LANE_CTRL_2LANE	0x40
 +
-+/* [SC20190112 2-lane] CSI PHY enable: all PHYs powered for DPLL lock
-+ *   stability.  Even though only PHY0 data lanes reach Orin, the MAX96724
-+ *   DPLL requires all PHYs to be powered.  Tested: single PHY → PLL never locks. */
++/* 
++ *   CSI PHY enable: all PHYs powered for DPLL lock.
++ */
 +#define MAX96724_CSI_PHY_EN_2LANE	0xF0
 +
-+/* [SC20190112 2-lane] DPLL for Controller 0 (drives PHY0, 2 lanes).
++/* 
++ *   DPLL for Controller 0 (drives PHY0, 2 lanes).
 + *   bits[4:0] = data-rate / 100 MHz.  700 Mbps / 100 = 7 = 0x07.
 + *   bit[5]    = DPLL enable = 1.
-+ *   Result: 0x27 = 700 Mbps/lane D-PHY. */
++ *   Result: 0x27 = 700 Mbps/lane D-PHY.
++ */
 +#define MAX96724_DPLL_700MBPS_CTRL0	0x27
 +
-+/* [FG24-4CH working-config verified] CSI-output DPLL data rate = 1500 Mbps.
++/* 
++ *   CSI-output DPLL data rate = 1500 Mbps.
 + *   bits[4:0] = data-rate / 100 MHz -> 1500/100 = 15 = 0x0F. bit[5] = DPLL en.
-+ *   Result 0x2F.  The FangZhu MAX4CH config writes this to ALL FOUR controllers
-+ *   (0x0415/0x0418/0x041B/0x041E), matching DT max_lane_speed = 1500000.  The
-+ *   old 0x27 (700 Mbps, 2 controllers only) is a 2-lane-variant leftover that
-+ *   left the Orin CIL unable to lock the HS clock (empty rtcpu trace). */
++ */
 +#define MAX96724_DPLL_1500MBPS		0x2F
 +
-+/* [UG Table 3, p.12] One-shot reset: all links */
++/* One-shot reset: all links */
 +#define MAX96724_ONESHOT_ALL		0x0F
 +
-+/* [UG Table 4, p.15] Pipe source selection values
-+ *   Encoding per pipe nibble in tunnel mode (Aardvark-verified):
++/* 
++ *   Pipe source selection values
++ *   Encoding per pipe nibble in tunnel mode:
 + *   0x22 routes all pipes from Link A in tunnel mode.
 + */
-+#define MAX96724_PIPE_SEL0_SINGLE	0x22  /* All pipes from Link A (Aardvark-verified) */
-+#define MAX96724_PIPE_SEL1_SINGLE	0x22  /* All pipes from Link A (Aardvark-verified) */
-+#define MAX96724_PIPE_SEL0_PIXEL	0x62  /* OG03C pixel-mode reference */
-+#define MAX96724_PIPE_SEL1_PIXEL	0xEA  /* OG03C pixel-mode reference */
++#define MAX96724_PIPE_SEL0_SINGLE	0x22  /* All pipes from Link A */
++#define MAX96724_PIPE_SEL1_SINGLE	0x22  /* All pipes from Link A */
++#define MAX96724_PIPE_SEL0_PIXEL	0x62  /* pixel-mode reference */
++#define MAX96724_PIPE_SEL1_PIXEL	0xEA  /* pixel-mode reference */
 +#define MAX96724_PIPE_SEL0_DUAL		0x40  /* Pipe 0 ← A/X, Pipe 1 ← B/X */
 +#define MAX96724_PIPE_SEL0_QUAD_LO	0x40  /* Pipe 0 ← A/X, Pipe 1 ← B/X */
 +#define MAX96724_PIPE_SEL1_QUAD_HI	0xC8  /* Pipe 2 ← C/X, Pipe 3 ← D/X */
@@ -1373,12 +1238,12 @@ index 0000000..4a1708c
 +#define MAX96724_RESET_ST_ID		0x00
 +#define MAX96724_ST_ID_SEL_INVALID	0xF
 +
-+/* Controller mapping: all mappings → Controller 0 (not working in tunnel mode) */
++/* Controller mapping: all mappings → Controller 0 */
 +#define MAX96724_ALL_MAP_CTRL0		0x00
-+/* Controller mapping: all mappings → Controller 1 (Aardvark-verified working) */
++/* Controller mapping: all mappings → Controller 1 */
 +#define MAX96724_ALL_MAP_CTRL1		0x55
 +
-+/* [OG03C reference dump] Three mappings to controller 1 */
++/* Three mappings to controller 1 */
 +#define MAX96724_MAP3_CTRL1		0x15
 +
 +/* ================================================================
@@ -1400,16 +1265,9 @@ index 0000000..4a1708c
 +#define MAX96724_CSI_CTRL_2		2
 +#define MAX96724_CSI_CTRL_3		3
 +
-+/* Internal csi_mode enum flags (NOT the register value written to 0x08A0;
-+ * see MAX96724_CSI_MODE_2X4_VAL for the actual register value).  These are
-+ * only compared against priv->csi_mode to select a code path. */
-+#define MAX96724_CSI_MODE_4X2		0x01
 +#define MAX96724_CSI_MODE_2X4		0x08  /* enum tag for the 4-lane Port A (Ctrl1) path */
-+#define MAX96724_CSI_MODE_2X4_ALT	0x04  /* enum tag (unused alt path) */
 +
 +/* Lane map presets */
-+#define MAX96724_LANE_MAP1_4X2		0x44
-+#define MAX96724_LANE_MAP2_4X2		0x44
 +#define MAX96724_LANE_MAP1_2X4		0xE4  /* SC20190112 subset: PHY0 data + PHY1 clock */
 +#define MAX96724_LANE_MAP2_2X4		0x44  /* keep unused PHY2/3 straight in 0x08 mode */
 +
@@ -2042,10 +1900,6 @@ index 0000000..4a1708c
 +		goto error;
 +	}
 +
-+	/* Check csi mode compatibility.
-+	 * 2x4 DES → gmsl-link: 1x4 or 2x4.
-+	 * 4x2 DES → gmsl-link: 1x4, 2x2, or 4x2.
-+	 */
 +	if (priv->csi_mode == MAX96724_CSI_MODE_2X4) {
 +		if (!((g_ctx->csi_mode == GMSL_CSI_1X4_MODE) ||
 +		      (g_ctx->csi_mode == GMSL_CSI_2X4_MODE))) {
@@ -2054,14 +1908,9 @@ index 0000000..4a1708c
 +			goto error;
 +		}
 +	} else {
-+		/* 4x2 DES mode: accept 1x4, 2x2, or 4x2 gmsl-link mode */
-+		if (!((g_ctx->csi_mode == GMSL_CSI_1X4_MODE) ||
-+		      (g_ctx->csi_mode == GMSL_CSI_2X2_MODE) ||
-+		      (g_ctx->csi_mode == GMSL_CSI_4X2_MODE))) {
-+			dev_err(dev, "%s: csi mode not supported\n", __func__);
-+			err = -EINVAL;
-+			goto error;
-+		}
++		dev_err(dev, "%s: only csi 2x4 mode is supported\n", __func__);
++		err = -EINVAL;
++		goto error;
 +	}
 +
 +	for (i = 0; i < priv->num_src; i++) {
@@ -2144,7 +1993,7 @@ index 0000000..4a1708c
 + * with all VCs and DTs preserved from the serializer.
 + *
 + * The pipeline configuration:
-+ *   1. Configure pipe-to-link routing (which GMSL input → which pipe)
++ *   1. Configure pipe-to-link routing
 + *   2. Enable tunnel mode on active pipes
 + *   3. Configure MIPI CSI-2 output lanes and PHY
 + *   4. Enable BACKTOP output port
@@ -2195,9 +2044,9 @@ index 0000000..4a1708c
 +	}
 +
 +	/*
-+	 * [Aardvark-verified] Pipe source routing
-+	 *   Single cam: all pipes from Link A (0x22/0x22)
-+	 *   Disable pipes before configuration, enable at the end
++	 * Pipe source routing
++	 * Single cam: all pipes from Link A (0x22/0x22)
++	 * Disable pipes before configuration, enable at the end
 +	 */
 +	max96724_write_reg(dev, MAX96724_PIPE_SEL0_ADDR, pipe_sel0);
 +	max96724_write_reg(dev, MAX96724_PIPE_SEL1_ADDR, pipe_sel1);
@@ -2205,16 +2054,14 @@ index 0000000..4a1708c
 +	max96724_write_reg(dev, MAX96724_PIPE_EN_ADDR, 0x00);
 +
 +	/*
-+	 * [SC20190112] Keep 0x08 mode so PHY1 remains the Port A clock master,
++	 * Keep 0x08 mode so PHY1 remains the Port A clock master,
 +	 * but restore the live 2-lane subset used by the bridge board.
 +	 */
 +	max96724_apply_porta_subset(dev, priv);
 +
 +	/*
-+	 * [D585 700Mbps fix] CSI-output DPLL data rate = 700 Mbps
-+	 * on ALL FOUR controller freq registers, matching D585 native
-+	 * MIPI rate (pix_clk_hz=175M, 16bpp, 4-lane).
-+	 * DT serdes_pix_clk_hz=175MHz drives correct THS_SETTLE for 700Mbps.
++	 * CSI-output DPLL data rate = 700 Mbps
++	 * on ALL FOUR controller freq registers
 +	 */
 +	if (!priv->lane_setup) {
 +		max96724_write_reg(dev, MAX96724_DPLL_FREQ0_ADDR,
@@ -2233,7 +2080,7 @@ index 0000000..4a1708c
 +			   MAX96724_MIPI_CTRL_SEL_PIXEL);
 +
 +	/*
-+	 * [Aardvark-verified] Stream ID select for all pipes
++	 * Stream ID select for all pipes
 +	 * 0x0933 + 0x40*pipe = stream select register
 +	 * Value 0x10 selects the appropriate stream for tunnel mode
 +	 */
@@ -2243,7 +2090,8 @@ index 0000000..4a1708c
 +				   st_sel_cfg);
 +	}
 +
-+	/* BACKTOP: enable Controller 1 / CSI-B (0x02).
++	/* 
++	 * BACKTOP: enable Controller 1 / CSI-B (0x02).
 +	 * In 2x4 mode, Controller 1 is master for Port A -> Orin CSI.
 +	 */
 +	max96724_write_reg(dev, MAX96724_BACKTOP_EN_ADDR,
@@ -2252,10 +2100,9 @@ index 0000000..4a1708c
 +	dev_info(dev, "=== setup_streaming: writing 0x84 (force all MIPI clocks) ===\n");
 +
 +	/*
-+	 * [FG24-4CH working-config verified] Assert 0x08A0=0x84 LAST: 2x4 mode +
-+	 * bit[7] "force all MIPI clocks running".  The clock-force keeps the
-+	 * D-PHY clock lane continuous so the Orin CIL can lock; written only
-+	 * after the full pipeline is configured, matching FangZhu End_Common.
++	 * Assert 0x08A0=0x84 LAST: 2x4 mode + bit[7] "force all MIPI clocks running".  
++	 * The clock-force keeps the D-PHY clock lane continuous so the Orin CIL can lock;
++	 * written only after the full pipeline is configured.
 +	 */
 +	max96724_write_reg(dev, MAX96724_CSI_OUT_CFG_ADDR,
 +			   MAX96724_CSI_OUT_EN_VAL);
@@ -2280,7 +2127,7 @@ index 0000000..4a1708c
 +	max96724_write_reg(dev, MAX96724_ONESHOT_ADDR,
 +			   MAX96724_ONESHOT_ALL);
 +
-+	/* Enable all 4 pipes (Aardvark-verified: 0x0F at end) */
++	/* Enable all 4 pipes */
 +	max96724_write_reg(dev, MAX96724_PIPE_EN_ADDR, MAX96724_PIPE_EN_4);
 +
 +	priv->sources[src_idx].st_enabled = true;
@@ -2393,10 +2240,7 @@ index 0000000..4a1708c
 +
 +int max96724_get_ser_pipe_id(struct device *dev, int dser_pipe_id, int vc_id)
 +{
-+	/*
-+	 * In Tunnel Mode with MAX96717, all VCs are carried in a single
-+	 * tunnel pipe. The pipe mapping is 1:1 for d4xx compatibility.
-+	 */
++	/* In Tunnel Mode with MAX96717, all VCs are carried in a single tunnel pipe. */
 +	return dser_pipe_id;
 +}
 +EXPORT_SYMBOL(max96724_get_ser_pipe_id);
@@ -2414,7 +2258,7 @@ index 0000000..4a1708c
 +
 +	mutex_lock(&priv->lock);
 +	if (priv->splitter_enabled) {
-+		/* [UG] Multi-camera: reset all links */
++		/* Multi-camera: reset all links */
 +		u8 link_rate = (priv->link_speed == 6) ? 0x22 : 0x11;
 +
 +		max96724_write_reg(dev, MAX96724_LINK_RATE_AB_ADDR,
@@ -2445,20 +2289,21 @@ index 0000000..4a1708c
 +		dpll_cfg = MAX96724_DPLL_1500MBPS;
 +	}
 +
-+	/* ONESHOT resets CSI/tunnel state. Restore the full pipeline config.
++	/* 
++	 * ONESHOT resets CSI/tunnel state. Restore the full pipeline config.
 +	 * Mirror setup_streaming() order: disable pipes -> restore everything ->
 +	 * BACKTOP/0x84 -> VID_RX -> final ONESHOT to latch -> enable pipes.
 +	 */
 +	max96724_write_reg(dev, MAX96724_PIPE_EN_ADDR, 0x00);
 +
-+	/* Pipe source routing (same as setup_streaming): all pipes from Link A */
++	/* Pipe source routing: all pipes from Link A */
 +	max96724_write_reg(dev, MAX96724_PIPE_SEL0_ADDR, pipe_sel0);
 +	max96724_write_reg(dev, MAX96724_PIPE_SEL1_ADDR, pipe_sel1);
 +
 +	max96724_apply_porta_subset(dev, priv);
 +
 +	/*
-+	 * [D585 700Mbps fix] CSI-output DPLL data rate = 700 Mbps on ALL
++	 * CSI-output DPLL data rate = 700 Mbps on ALL
 +	 * FOUR controllers, matching D585 native MIPI rate.
 +	 * reset_oneshot is called by the sensor after setup_streaming, so it must
 +	 * mirror the same DPLL values.
@@ -2518,7 +2363,7 @@ index 0000000..4a1708c
 +			   MAX96724_PIPE_EN_4);
 +
 +	/*
-+	 * [FG24-4CH working-config verified] Assert 0x08A0=0x84 LAST:
++	 * Assert 0x08A0=0x84 LAST:
 +	 * 2x4 mode + bit[7] force all MIPI clocks running.  Must mirror
 +	 * setup_streaming because the sensor's oneshot path overwrites it.
 +	 */
@@ -2566,7 +2411,7 @@ index 0000000..4a1708c
 +		{MAX96724_TX46_PIPE_X_ADDR, MAX96724_ALL_MAP_CTRL1},
 +		{MAX96724_TX47_PIPE_X_ADDR, MAX96724_ALL_MAP_CTRL1},
 +		{MAX96724_TX48_PIPE_X_ADDR, MAX96724_ALL_MAP_CTRL1},
-+		/* TX49: concat disabled (single-camera) */
++		/* TX49: concat disabled */
 +		{MAX96724_TX49_PIPE_X_ADDR, 0x00},
 +		/*
 +		 * Keep DES heartbeat handling aligned with the serializer's
@@ -2576,12 +2421,13 @@ index 0000000..4a1708c
 +		{0x0106, MAX96724_VID_RX6_CFG_VAL},
 +		/*
 +		 * Pipe stream control (offset 0x36 per pipe block).
-+		 * [XML] TUN_EN = 0x01.
++		 * TUN_EN = 0x01.
 +		 */
 +		{0x0936, MAX96724_TUN_EN},
 +	};
 +
-+	/* Adjust addresses for pipe offset (stride 0x40 per pipe)
++	/* 
++	 * Adjust addresses for pipe offset (stride 0x40 per pipe)
 +	 * Entries 0-13: TX11, SRC/DST maps, TX45-TX49 (all stride 0x40)
 +	 * Entries 14-15: VID_RX0/6 (stride 0x12)
 +	 * Entry 16: Pipe stream control (stride 0x40)
@@ -2589,7 +2435,7 @@ index 0000000..4a1708c
 +	for (i = 0; i < 14; i++)
 +		map_pipe_control[i].addr += 0x40 * pipe_id;
 +
-+	/* [max9296.c pattern] VID_RX offset: 0x12 per pipe */
++	/* VID_RX offset: 0x12 per pipe */
 +	map_pipe_control[14].addr += 0x12 * pipe_id;
 +	map_pipe_control[15].addr += 0x12 * pipe_id;
 +
@@ -2610,7 +2456,7 @@ index 0000000..4a1708c
 +		map_pipe_control[15].val = MAX96724_VID_RX6_PIXEL_VAL;
 +		map_pipe_control[16].val = MAX96724_TUN_DISABLED;
 +	} else {
-+		/* Single-RGB tunnel: no concatenation needed */
++		/* no concatenation needed */
 +		map_pipe_control[13].val = 0x00;
 +	}
 +
@@ -2628,7 +2474,7 @@ index 0000000..4a1708c
 +	map_pipe_control[9].val = all_mapping_phy;
 +	/* TX46-TX48 keep 0x55 (Ctrl1) from initializer */
 +	/* TX49 set to 0x00 above — overridden per mode in pixel/tunnel branch */
-+	/* VID_RX (entry 14) and pipe stream ctrl (entry 15) keep init values */
++	/* VID_RX and pipe stream ctrl keep init values */
 +
 +	err = max96724_set_registers(dev, map_pipe_control,
 +				     ARRAY_SIZE(map_pipe_control));
@@ -2731,16 +2577,8 @@ index 0000000..4a1708c
 +
 +	if (!strcmp(str_value, "2x4")) {
 +		priv->csi_mode = MAX96724_CSI_MODE_2X4;
-+		/*
-+		 * SC20190112 keeps the 0x08 Port-A clocking scheme but only brings
-+		 * PHY0 data lanes and the PHY1 clock lane to Orin.
-+		 */
 +		priv->lane_mp1 = MAX96724_LANE_MAP1_2X4;
 +		priv->lane_mp2 = MAX96724_LANE_MAP2_2X4;
-+	} else if (!strcmp(str_value, "4x2")) {
-+		priv->csi_mode = MAX96724_CSI_MODE_4X2;
-+		priv->lane_mp1 = MAX96724_LANE_MAP1_4X2;
-+		priv->lane_mp2 = MAX96724_LANE_MAP2_4X2;
 +	} else {
 +		dev_err(&client->dev, "invalid csi mode\n");
 +		return -EINVAL;
@@ -2762,7 +2600,7 @@ index 0000000..4a1708c
 +		priv->reset_gpio = -1;
 +	}
 +
-+	/* [User requirement] GMSL link speed from DT: 3 or 6 (Gbps) */
++	/* GMSL link speed from DT: 3 or 6 (Gbps) */
 +	err = of_property_read_u32(node, "gmsl-link-speed", &value);
 +	if (err < 0) {
 +		/* Default to 3 Gbps if not specified */

--- a/nvidia-oot/6.2/0011-Add-MAX96717-serializer-and-MAX96724-deserializer-dr.patch
+++ b/nvidia-oot/6.2/0011-Add-MAX96717-serializer-and-MAX96724-deserializer-dr.patch
@@ -22,36 +22,22 @@ MAX96724 quad deserializer features:
 
 Signed-off-by: RealSense AI <realsense@realsenseai.com>
 ---
- drivers/media/i2c/Makefile   |    2 +
- drivers/media/i2c/max96717.c |  917 ++++++++++++++++
- drivers/media/i2c/max96724.c | 1927 ++++++++++++++++++++++++++++++++++
+ drivers/media/i2c/max96717.c |  791 ++++++++++++++
+ drivers/media/i2c/max96724.c | 1905 ++++++++++++++++++++++++++++++++++
  include/media/max96717.h     |  151 ++
  include/media/max96724.h     |  183 +++
- 5 files changed, 3180 insertions(+)
+ 4 files changed, 3030 insertions(+)
  create mode 100644 drivers/media/i2c/max96717.c
  create mode 100644 drivers/media/i2c/max96724.c
  create mode 100644 include/media/max96717.h
  create mode 100644 include/media/max96724.h
 
-diff --git a/drivers/media/i2c/Makefile b/drivers/media/i2c/Makefile
-index b284938..947e6e9 100644
---- a/drivers/media/i2c/Makefile
-+++ b/drivers/media/i2c/Makefile
-@@ -8,6 +8,8 @@ obj-m += max9296.o
- subdir-ccflags-y += -DCONFIG_VIDEO_D4XX_SERDES
- subdir-ccflags-y += -DCONFIG_TEGRA_CAMERA_PLATFORM
- obj-m += d4xx.o
-+obj-m += max96717.o
-+obj-m += max96724.o
- ifeq ($(findstring ack_src,$(NV_BUILD_KERNEL_OPTIONS)),)
- obj-m += max96712.o
- 
 diff --git a/drivers/media/i2c/max96717.c b/drivers/media/i2c/max96717.c
 new file mode 100644
-index 0000000..1dd24d3
+index 0000000..c26c24b
 --- /dev/null
 +++ b/drivers/media/i2c/max96717.c
-@@ -0,0 +1,917 @@
+@@ -0,0 +1,791 @@
 +/*
 + * max96717.c - MAX96717 GMSL2 Serializer driver (Tunnel Mode)
 + *
@@ -70,14 +56,6 @@ index 0000000..1dd24d3
 + * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
-+/*
-+ * Register Reference Sources:
-+ * [PPTX]  = GMSL_MAX96717_MAX96724_TechOverview - V1.pptx
-+ * [XML]   = MAX96717_MAX96724_HKR_EVB_700mbps_tunnel_mode_basedonexcelsheet_D585.xml
-+ *
-+ * Every register address and value below is traceable to one of these sources.
-+ */
-+
 +#include <media/camera_common.h>
 +#include <linux/of.h>
 +#include <linux/module.h>
@@ -85,149 +63,146 @@ index 0000000..1dd24d3
 +
 +/* ===== Register Addresses ===== */
 +
-+/* [PPTX slide 7] REG0: Device ID (read-only, returns 0x40) */
++/* REG0: Device ID (read-only, returns 0x40) */
 +#define MAX96717_DEV_ADDR		0x00
 +
-+/* [PPTX slide 7] REG1: Link Speed
++/* 
++ *   REG1: Link Speed
 + *   bit[3]=1: 3 Gbps, bit[4]=1: 6 Gbps
 + */
 +#define MAX96717_REG1_ADDR		0x01
 +
-+/* [PPTX slide 7 / XML 0x0002] PIPE_EN: Pipe enable / soft reset
-+ *   [XML] 0x03 = soft reset, 0x43 = pipes enabled + video init
-+ *   [PPTX slide 7] Matches MAX9295 PIPE_EN at 0x02
++/* 
++ *   PIPE_EN: Pipe enable / soft reset
++ *   0x03 = soft reset, 0x43 = pipes enabled + video init
++ *   Matches MAX9295 PIPE_EN at 0x02
 + */
 +#define MAX96717_PIPE_EN_ADDR		0x02
 +
-+/* [PPTX slide 7] CTRL0: GMSL2 TX Control
++/* 
++ *   CTRL0: GMSL2 TX Control
 + *   bit[5]=1: GMSL2 mode, bit[0]=1: enable transmitter
 + *   0x21 = GMSL2 mode + TX enable on Link A
 + */
 +#define MAX96717_CTRL0_ADDR		0x10
 +
-+/* [PPTX slide 7] CTRL3: Start Video - final enable bit
++/* 
++ *   CTRL3: Start Video - final enable bit
 + *   bit[0]=1: activate video stream
 + */
 +#define MAX96717_CTRL3_ADDR		0x13
 +
-+/* [PPTX slide 7] TX1: FEC Enable
++/* 
++ *   TX1: FEC Enable
 + *   bit[6]=1: Reed-Solomon FEC enabled
 + */
 +#define MAX96717_TX1_ADDR		0x29
 +
-+/* [MAX96724 Users Guide, I2C Broadcasting section, p44-46]
-+ * MAX96717 I2C address translation registers (GMSL2 standard):
++/*
++ *   MAX96717 I2C address translation registers (GMSL2 standard):
 + *   SRC_A / DST_A (0x42/0x43): Translation pair A (SER broadcast addr)
 + *   SRC_B / DST_B (0x44/0x45): Translation pair B (sensor passthrough)
 + *
-+ * When host writes to SRC_B address, the MAX96717 translates it to
-+ * DST_B and forwards via GMSL back-channel to the remote sensor.
++ *   When host writes to SRC_B address, the MAX96717 translates it to
++ *   DST_B and forwards via GMSL back-channel to the remote sensor.
 + *
 + */
 +#define MAX96717_SRC_A_ADDR		0x42
 +#define MAX96717_DST_A_ADDR		0x43
-+#define MAX96717_I2C4_ADDR		0x44	/* SRC_B: sensor proxy addr */
-+#define MAX96717_I2C5_ADDR		0x45	/* DST_B: sensor default addr */
++#define MAX96717_I2C4_ADDR		0x44
++#define MAX96717_I2C5_ADDR		0x45
 +
-+/* [PPTX slide 14] TX_STR_SEL: Stream ID select
++/* 
++ *   TX_STR_SEL: Stream ID select
 + *   bits[1:0]: stream ID for DES pipe routing
 + */
 +#define MAX96717_TX_STR_SEL_ADDR	0x5B
 +
-+/* [PPTX slide 7 / XML 0x0110-0x0111] VIDEO_TX0/TX1: Video TX path config
-+ *   [XML] 0x0110=0xE9, 0x0111=0x10 for tunnel mode data path
++/* 
++ *   VIDEO_TX0/TX1: Video TX path config
++ *   0x0110=0xE9, 0x0111=0x10 for tunnel mode data path
 + */
 +#define MAX96717_VIDEO_TX0_ADDR		0x110
 +#define MAX96717_VIDEO_TX1_ADDR		0x111
 +
-+/* [PPTX slide 7] FRONTTOP_0: Front-end topology
++/* 
++ *   FRONTTOP_0: Front-end topology
 + *   0x12 = single CSI-2 port A, all VCs pass through
 + */
 +#define MAX96717_FRONTTOP0_ADDR		0x308
 +
-+/* [XML / PPTX slide 7] MIPI_RX0-RX3: CSI-2 receiver configuration
++/* 
++ *   MIPI_RX0-RX3: CSI-2 receiver configuration
 + *   RX0 (0x330): CSI mode (0x00 = D-PHY controller A)
-+ *   RX1 (0x331): Lane count - [PPTX slide 14] ctrl1_num_lanes bits[5:4]
-+ *                 [XML] 0x30 = bits[5:4]=11 (4 lanes)
-+ *   RX2 (0x332): Lane mapping - [XML] 0xE0 = default 1x4 map
-+ *   RX3 (0x333): Lane mapping - [XML] 0x04 = default 1x4 map
++ *   RX1 (0x331): Lane count - ctrl1_num_lanes bits[5:4]
++ *                0x30 = bits[5:4]=11 (4 lanes)
++ *   RX2 (0x332): Lane mapping - 0xE0 = default 1x4 map
++ *   RX3 (0x333): Lane mapping - 0x04 = default 1x4 map
 + */
 +#define MAX96717_MIPI_RX0_ADDR		0x330
 +#define MAX96717_MIPI_RX1_ADDR		0x331
 +#define MAX96717_MIPI_RX2_ADDR		0x332
 +#define MAX96717_MIPI_RX3_ADDR		0x333
 +
-+/* [PPTX slide 7 / slide 14] EXT11: TUNNEL MODE ENABLE
-+ *   bit[7]=1: Tun_Mode = ON  *** CRITICAL REGISTER ***
-+ *   [PPTX slide 7] 0x383 = 0x80
++/* 
++ *   EXT11: TUNNEL MODE ENABLE
++ *   bit[7]=1: Tun_Mode = ON
++ *   0x383 = 0x80
 + */
 +#define MAX96717_EXT11_ADDR		0x383
 +
-+/* [SG2 working config] SER PHY / DLL calibration registers.
-+ *   These are device-level (not sensor-specific) and appear in every
-+ *   SG2 sensor variant (OX03C, ISX031, etc.).  The staged write pattern
-+ *   (0x80 -> 0x90) on 0x2D6/0x2C7 is a PHY calibration ramp sequence.
-+ *   Without these writes the GMSL2 link trains but the DES cannot
-+ *   recover a clean CSI-2 clock from the tunnel-mode data stream.
-+ */
-+#define MAX96717_PHY_CAL_2D6_ADDR	0x2D6
-+#define MAX96717_PHY_CAL_2C7_ADDR	0x2C7
-+#define MAX96717_PHY_CAL_2BE_ADDR	0x2BE
-+#define MAX96717_PHY_CAL_2C1_ADDR	0x2C1
-+#define MAX96717_PHY_CAL_3F0_ADDR	0x3F0
-+#define MAX96717_PHY_CAL_3F1_ADDR	0x3F1
-+
-+/* [SG2 working config] PHY calibration stage-1 value */
++/* PHY calibration stage-1 value */
 +#define MAX96717_PHY_CAL_STAGE1		0x80
-+/* [SG2 working config] PHY calibration stage-2 value */
++/* PHY calibration stage-2 value */
 +#define MAX96717_PHY_CAL_STAGE2		0x90
-+/* [SG2 working config] CSI input timing / frequency config */
++/* CSI input timing / frequency config */
 +#define MAX96717_CSI_TIMING_3F0		0x59
 +#define MAX96717_CSI_TIMING_3F1		0x09
 +
 +/* ===== Register Values ===== */
 +
-+/* [XML] Soft reset value for PIPE_EN register */
++/* Soft reset value for PIPE_EN register */
 +#define MAX96717_SOFT_RESET		0x03
 +
-+/* [XML] Final enable: pipes enabled + video init */
++/* Final enable: pipes enabled + video init */
 +#define MAX96717_PIPE_EN_ALL		0x43
 +
-+/* [PPTX slide 7] CTRL0: GMSL2 mode + TX enable (Link A) */
++/* CTRL0: GMSL2 mode + TX enable (Link A) */
 +#define MAX96717_CTRL0_LINK_A		0x21
 +/* CTRL0: GMSL2 mode + TX enable (Link B) */
 +#define MAX96717_CTRL0_LINK_B		0x22
 +
-+/* [PPTX slide 7] CTRL0 reset all */
++/* CTRL0 reset all */
 +#define MAX96717_RESET_ALL		0x80
 +
-+/* [PPTX slide 7] EXT11 tunnel mode enable value */
++/* EXT11 tunnel mode enable value */
 +#define MAX96717_TUN_MODE_EN		0x80
 +#define MAX96717_TUN_MODE_DIS		0x00
 +
-+/* [XML] VIDEO_TX0 tunnel mode data path enable */
++/* VIDEO_TX0 tunnel mode data path enable */
 +#define MAX96717_VIDEO_TX0_TUN		0xE9
-+/* [XML] VIDEO_TX1 tunnel mode config */
++/* VIDEO_TX1 tunnel mode config */
 +#define MAX96717_VIDEO_TX1_TUN		0x10
 +#define MAX96717_VIDEO_TX0_BPP_MANUAL	0x60
 +#define MAX96717_VIDEO_TX1_BPP16	0x50
 +#define MAX96717_VIDEO_TX2_ADDR		0x112
 +#define MAX96717_VIDEO_TX2_DRIFT_DIS	0x08
 +
-+/* [SG2 working config] MIPI RX1: 4-lane CSI-2.
-+ *   bits[5:4]=11 (4 lanes).  bits[1:0]=11 (PHY mode / lane ordering
-+ *   matching SG2 working config; was 0x30, SG2 uses 0x33). */
++/* 
++ *   MIPI RX1: 4-lane CSI-2.
++ *   bits[5:4]=11 (4 lanes).  bits[1:0]=11
++ */
 +#define MAX96717_CSI_4_LANES		0x33
 +/* 2-lane CSI-2, bits[5:4]=01 */
 +#define MAX96717_CSI_2_LANES		0x10
 +
-+/* [XML] Lane mapping for 1x4 mode (matches MAX9295 1x4 values) */
++/* Lane mapping for 1x4 mode */
 +#define MAX96717_CSI_1X4_LANE_MAP1	0xE0
 +#define MAX96717_CSI_1X4_LANE_MAP2	0x04
 +
-+/* [PPTX slide 7] FRONTTOP_0: single port A, all VCs */
++/* FRONTTOP_0: single port A, all VCs */
 +#define MAX96717_FRONTTOP0_PORT_A	0x12
-+/* [UG Use Case Example 1] Pixel mode from Port B into Pipe Z */
++/* Pixel mode from Port B into Pipe Z */
 +#define MAX96717_FRONTTOP0_PIXEL_PORT_B	0x64
 +#define MAX96717_FRONTTOP5_ADDR		0x30D
 +#define MAX96717_FRONTTOP9_ADDR		0x311
@@ -235,17 +210,17 @@ index 0000000..1dd24d3
 +#define MAX96717_FRONTTOP17_ADDR	0x319
 +#define MAX96717_FRONTTOP9_START_VIDEO	0x40
 +
-+/* [XML] MIPI_RX0: CSI reset on + non-continuous clock */
++/* MIPI_RX0: CSI reset on + non-continuous clock */
 +#define MAX96717_MIPI_RX0_RESET		0x08
-+/* [PPTX slide 7] MIPI_RX0: Normal operation */
++/* MIPI_RX0: Normal operation */
 +#define MAX96717_MIPI_RX0_NORMAL	0x00
 +
-+/* [PPTX slide 9] REG1: 3 Gbps link speed, bit[3]=1 */
++/* REG1: 3 Gbps link speed, bit[3]=1 */
 +#define MAX96717_LINK_SPEED_3GBPS	0x08
-+/* [PPTX slide 9] REG1: 6 Gbps link speed, bit[4]=1 */
++/* REG1: 6 Gbps link speed, bit[4]=1 */
 +#define MAX96717_LINK_SPEED_6GBPS	0x10
 +
-+/* [XML] EXT11 tunnel mode pre-config (0x0383=0x80) */
++/* EXT11 tunnel mode pre-config (0x0383=0x80) */
 +#define MAX96717_EXT11_TUN_PRE		0x80
 +
 +#define MAX96717_MAX_PIPES		4
@@ -323,43 +298,6 @@ index 0000000..1dd24d3
 +	int err = 0;
 +	struct gmsl_link_ctx *g_ctx;
 +
-+	/*
-+	 * [XML] Full initialization sequence:
-+	 *   0x0002 = 0x03  (soft reset)
-+	 *   0x0383 = 0x80  (tunnel mode enable)
-+	 *   0x0331 = 0x30  (4-lane CSI)
-+	 *   0x0332 = 0xE0  (lane map1)
-+	 *   0x0333 = 0x04  (lane map2)
-+	 *   0x0110 = 0xE9  (video TX0 tunnel path)
-+	 *   0x0111 = 0x10  (video TX1 tunnel config)
-+	 *   0x0330 = 0x08  (CSI reset on)
-+	 *   0x0330 = 0x00  (CSI reset off)
-+	 *   0x0002 = 0x43  (final enable)
-+	 */
-+	struct reg_pair tunnel_init[] = {
-+		/* [PPTX slide 7] EXT11: Tunnel Mode Enable */
-+		{MAX96717_EXT11_ADDR, MAX96717_TUN_MODE_EN},
-+		/* [XML] MIPI_RX1: 4-lane CSI-2 (CTRL1_NUM_LANES[5:4]=11) */
-+		{MAX96717_MIPI_RX1_ADDR, MAX96717_CSI_4_LANES},
-+		/* [XML] MIPI_RX2/RX3: 1x4 lane mapping */
-+		{MAX96717_MIPI_RX2_ADDR, MAX96717_CSI_1X4_LANE_MAP1},
-+		{MAX96717_MIPI_RX3_ADDR, MAX96717_CSI_1X4_LANE_MAP2},
-+		/* [XML] VIDEO_TX0/TX1: tunnel data path */
-+		{MAX96717_VIDEO_TX0_ADDR, MAX96717_VIDEO_TX0_TUN},
-+		{MAX96717_VIDEO_TX1_ADDR, MAX96717_VIDEO_TX1_TUN},
-+	};
-+	struct reg_pair pixel_init[] = {
-+		{MAX96717_EXT11_ADDR, MAX96717_TUN_MODE_DIS},
-+		{MAX96717_MIPI_RX1_ADDR, MAX96717_CSI_4_LANES},
-+		{MAX96717_MIPI_RX2_ADDR, MAX96717_CSI_1X4_LANE_MAP1},
-+		{MAX96717_MIPI_RX3_ADDR, MAX96717_CSI_1X4_LANE_MAP2},
-+		{MAX96717_FRONTTOP0_ADDR, MAX96717_FRONTTOP0_PIXEL_PORT_B},
-+		{MAX96717_FRONTTOP9_ADDR, MAX96717_FRONTTOP9_START_VIDEO},
-+		{MAX96717_VIDEO_TX0_ADDR, MAX96717_VIDEO_TX0_BPP_MANUAL},
-+		{MAX96717_VIDEO_TX1_ADDR, MAX96717_VIDEO_TX1_BPP16},
-+		{MAX96717_VIDEO_TX2_ADDR, MAX96717_VIDEO_TX2_DRIFT_DIS},
-+	};
-+
 +	mutex_lock(&priv->lock);
 +
 +	if (!priv->g_client.g_ctx) {
@@ -375,80 +313,19 @@ index 0000000..1dd24d3
 +
 +	g_ctx = priv->g_client.g_ctx;
 +
-+	/*
-+	 * [SG2 working config] SER PHY/DLL pre-calibration.
-+	 * These device-level registers calibrate the serializer's
-+	 * differential output pairs and clock recovery.  The staged
-+	 * write pattern (0x80 stage-1 now, 0x90 stage-2 after tunnel
-+	 * init) matches every SG2 sensor variant's init table.
-+	 * Applied BEFORE soft reset + tunnel config.
-+	 */
-+	max96717_write_reg(dev, MAX96717_PHY_CAL_2D6_ADDR,
-+			   MAX96717_PHY_CAL_STAGE1);
-+	max96717_write_reg(dev, MAX96717_PHY_CAL_2C7_ADDR,
-+			   MAX96717_PHY_CAL_STAGE1);
-+	max96717_write_reg(dev, MAX96717_PHY_CAL_2BE_ADDR,
-+			   MAX96717_PHY_CAL_STAGE1);
-+	max96717_write_reg(dev, MAX96717_PHY_CAL_2C1_ADDR,
-+			   MAX96717_PHY_CAL_STAGE1);
-+	max96717_write_reg(dev, MAX96717_PHY_CAL_3F0_ADDR,
-+			   MAX96717_CSI_TIMING_3F0);
-+	max96717_write_reg(dev, MAX96717_PHY_CAL_3F1_ADDR,
-+			   MAX96717_CSI_TIMING_3F1);
-+	msleep(100);
++	max96717_write_reg(dev, MAX96717_EXT11_ADDR, MAX96717_TUN_MODE_EN);
++	max96717_write_reg(dev, MAX96717_MIPI_RX1_ADDR, MAX96717_CSI_4_LANES);
++	max96717_write_reg(dev, MAX96717_MIPI_RX2_ADDR, MAX96717_CSI_1X4_LANE_MAP1);
++	max96717_write_reg(dev, MAX96717_MIPI_RX3_ADDR, MAX96717_CSI_1X4_LANE_MAP2);
++	max96717_write_reg(dev, MAX96717_VIDEO_TX0_ADDR, MAX96717_VIDEO_TX0_TUN);
++	max96717_write_reg(dev, MAX96717_VIDEO_TX1_ADDR, MAX96717_VIDEO_TX1_TUN);
 +
-+	/*
-+	 * [Aardvark-verified] Soft reset before tunnel mode configuration
-+	 * Clears stale pipe/CSI state for clean initialization.
-+	 * Aardvark: 0x0002=0x03, sleep 30ms, then proceed with config.
-+	 */
-+	max96717_write_reg(dev, MAX96717_PIPE_EN_ADDR, MAX96717_SOFT_RESET);
-+	msleep(30);
-+
-+	if (priv->pixel_mode)
-+		err = max96717_set_registers(dev, pixel_init,
-+					 ARRAY_SIZE(pixel_init));
-+	else
-+		err = max96717_set_registers(dev, tunnel_init,
-+					 ARRAY_SIZE(tunnel_init));
-+	if (err)
-+		goto error;
-+
-+	/*
-+	 * [FIX] Re-enable GMSL2 mode + TX after soft reset.
-+	 * setup_control() previously set CTRL0=0x21 (GMSL2+TX), but the
-+	 * PIPE_EN=0x03 soft reset above clears it back to the power-on
-+	 * default 0x01 (TX only, GMSL2 mode disabled).  Without this
-+	 * re-write the SER operates in GMSL1 mode while the DES expects
-+	 * GMSL2 — the link trains but the video data path silently breaks.
-+	 */
-+	if (g_ctx->serdes_csi_link == GMSL_SERDES_CSI_LINK_A)
-+		max96717_write_reg(dev, MAX96717_CTRL0_ADDR,
-+				   MAX96717_CTRL0_LINK_A);
-+	else
-+		max96717_write_reg(dev, MAX96717_CTRL0_ADDR,
-+				   MAX96717_CTRL0_LINK_B);
-+
-+	/*
-+	 * [SG2 working config] PHY calibration stage-2: ramp 0x80 -> 0x90.
-+	 * Applied AFTER tunnel mode + lane config, BEFORE CSI reset.
-+	 */
-+	max96717_write_reg(dev, MAX96717_PHY_CAL_2D6_ADDR,
-+			   MAX96717_PHY_CAL_STAGE2);
-+	max96717_write_reg(dev, MAX96717_PHY_CAL_2C7_ADDR,
-+			   MAX96717_PHY_CAL_STAGE2);
-+	msleep(20);
-+
-+	/* [Aardvark-verified] CSI reset cycle with 2ms delay */
-+	max96717_write_reg(dev, MAX96717_MIPI_RX0_ADDR,
-+			   MAX96717_MIPI_RX0_RESET);
++	max96717_write_reg(dev, MAX96717_MIPI_RX0_ADDR, MAX96717_MIPI_RX0_RESET);
 +	usleep_range(2000, 2100);
-+	max96717_write_reg(dev, MAX96717_MIPI_RX0_ADDR,
-+			   MAX96717_MIPI_RX0_NORMAL);
++	max96717_write_reg(dev, MAX96717_MIPI_RX0_ADDR, MAX96717_MIPI_RX0_NORMAL);
 +
-+	/* [XML] Final enable: pipes on + video init */
-+	max96717_write_reg(dev, MAX96717_PIPE_EN_ADDR,
-+			   MAX96717_PIPE_EN_ALL);
++	/* pipes on + video init */
++	max96717_write_reg(dev, MAX96717_PIPE_EN_ADDR, MAX96717_PIPE_EN_ALL);
 +
 +	priv->g_client.st_done = true;
 +
@@ -470,9 +347,6 @@ index 0000000..1dd24d3
 + *      I2C4/SRC_B (0x44) <- (sdev_reg << 1): proxy addr visible to host
 + *      I2C5/DST_B (0x45) <- (sdev_def << 1): real addr on back-channel
 + *
-+ * This lets the Orin host access the D5xx sensor (def-addr 0x42) via
-+ * the aliased proxy address (e.g. 0x1a) through the GMSL link.
-+ *
 + */
 +int max96717_setup_control(struct device *dev)
 +{
@@ -491,17 +365,6 @@ index 0000000..1dd24d3
 +	g_ctx = priv->g_client.g_ctx;
 +
 +	if (prim_priv__) {
-+		/*
-+		 * [HW note] The MAX96717 retains its I2C address across
-+		 * reboots (PoC stays on).  If already at the aliased address,
-+		 * the DEV_ADDR write to 0x40 NACKs.  Skip reassignment when
-+		 * the primary and alias are the same physical device and the
-+		 * serializer is already responsive at a non-default address.
-+		 *
-+		 * For cold-start (first power-on), this write is required.
-+		 * We detect "already reassigned" by trying a read first:
-+		 * if the primary address (0x40) NACKs, skip the reassign.
-+		 */
 +		unsigned int dev_id;
 +		int probe_ret;
 +
@@ -519,7 +382,7 @@ index 0000000..1dd24d3
 +		}
 +	}
 +
-+	/* [PPTX slide 7] CTRL0: GMSL2 mode + TX enable */
++	/* CTRL0: GMSL2 mode + TX enable */
 +	if (g_ctx->serdes_csi_link == GMSL_SERDES_CSI_LINK_A)
 +		err = max96717_write_reg(dev, MAX96717_CTRL0_ADDR,
 +					 MAX96717_CTRL0_LINK_A);
@@ -537,7 +400,6 @@ index 0000000..1dd24d3
 +
 +	/*
 +	 * I2C address translation for sensor passthrough.
-+	 * [MAX96724 Users Guide, I2C Broadcasting, p44-46]
 +	 *
 +	 * I2C4 / SRC_B (0x44): sensor proxy addr visible to Orin host
 +	 * I2C5 / DST_B (0x45): sensor real addr on GMSL back-channel
@@ -568,17 +430,13 @@ index 0000000..1dd24d3
 +/*
 + * max96717_setup_gpio_tunneling - GPIO-over-GMSL no-op hook
 + *
-+ * [PPTX slide 10] GPIO Signal Mapping:
++ *   GPIO Signal Mapping:
 + *   MFP0 → GPIO0: FSIN (DES→SER, frame sync in)
 + *   MFP1 → GPIO1: FOUT/STROBE (SER→DES, frame sync out)
 + *   MFP4 → GPIO4: RESET_N (DES→SER, hard reset)
 + *   MFP5 → GPIO5: IRQ (SER→DES, interrupt request)
 + *   MFP6 → GPIO6: ZV_SYNC (DES→SER, IR stereo sync)
 + *
-+ * The PPTX defines the signal mapping and MFP_CFG register range,
-+ * but not the confirmed direction/function values. Keep this as
-+ * an explicit no-op hook until the MAX96717 GPIO register values
-+ * are available from ADI.
 + */
 +int max96717_setup_gpio_tunneling(struct device *dev)
 +{
@@ -644,7 +502,8 @@ index 0000000..1dd24d3
 +	priv = dev_get_drvdata(dev);
 +	mutex_lock(&priv->lock);
 +	if (priv->g_client.g_ctx) {
-+		/* Already paired — tolerate if this is a re-probe of
++		/* 
++		 * Already paired — tolerate if this is a re-probe of
 +		 * the same camera after a failed first attempt.
 +		 * Simply overwrite with the new g_ctx.
 +		 */
@@ -774,7 +633,8 @@ index 0000000..1dd24d3
 +	struct max96717 *priv = dev_get_drvdata(dev);
 +
 +	struct reg_pair map_init[] = {
-+		/* [XML seq] PIPE_EN soft reset first, then enable tunnel mode.
++		/* 
++		 * PIPE_EN soft reset first, then enable tunnel mode.
 +		 * Note: FRONTTOP0 is bypassed in tunnel mode (per UG) —
 +		 * CSI-2 input goes directly into the tunnel, no port config needed.
 +		 */
@@ -796,7 +656,7 @@ index 0000000..1dd24d3
 +	mutex_lock(&priv->lock);
 +
 +	/*
-+	 * [HW requirement] After CTRL0 + I2C translation writes in
++	 * After CTRL0 + I2C translation writes in
 +	 * setup_control, the MAX96717 needs settling time before
 +	 * accepting writes to PIPE_EN (0x02) and FRONTTOP registers.
 +	 */
@@ -846,7 +706,7 @@ index 0000000..1dd24d3
 +}
 +EXPORT_SYMBOL(max96717_set_pipe);
 +
-+/**
++/*
 + * max96717_retrigger_tx - Toggle SER TX to restore tunnel detection after
 + * a DES ONESHOT.  DES ONESHOT resets the data path; the SER must cycle
 + * its TX enable for the DES to re-acquire the tunnel stream.
@@ -971,10 +831,10 @@ index 0000000..1dd24d3
 +MODULE_LICENSE("GPL v2");
 diff --git a/drivers/media/i2c/max96724.c b/drivers/media/i2c/max96724.c
 new file mode 100644
-index 0000000..4a1708c
+index 0000000..4e73c60
 --- /dev/null
 +++ b/drivers/media/i2c/max96724.c
-@@ -0,0 +1,1927 @@
+@@ -0,0 +1,1905 @@
 +/*
 + * max96724.c - MAX96724 GMSL2 Quad Deserializer driver (Tunnel Mode)
 + *
@@ -1010,40 +870,44 @@ index 0000000..4a1708c
 +
 +/* --- Device ID / Configuration --- */
 +
-+/* [UG p.3] REG0: Device ID (read-only, returns 0xA2) */
++/* REG0: Device ID (read-only, returns 0xA2) */
 +#define MAX96724_DEV_ID_ADDR		0x00
 +
-+/* [Errata §5] ERRB master reset register */
++/* ERRB master reset register */
 +#define MAX96724_ERRB_MST_RST_ADDR	0x05
 +
-+/* [UG Table 3, p.11] 0x0006: GMSL Link/PHY Enable and Mode Select
++/* 
++ *   GMSL Link/PHY Enable and Mode Select
 + *   bits[7:4]: PHY mode (0=GMSL1, 1=GMSL2) per link D/C/B/A
 + *   bits[3:0]: Link Enable per link D/C/B/A
 + */
 +#define MAX96724_LINK_EN_ADDR		0x0006
 +
-+/* [UG Table 3, p.11] 0x0010: GMSL Link/PHY Rate Select (Links A&B)
++/* 
++ *   GMSL Link/PHY Rate Select (Links A&B)
 + *   bits[7:6]: Tx Rate Link B, bits[5:4]: Rx Rate Link B
 + *   bits[3:2]: Tx Rate Link A, bits[1:0]: Rx Rate Link A
 + *   Tx: 00=187.5Mbps, Rx: 01=3Gbps, 10=6Gbps
 + */
 +#define MAX96724_LINK_RATE_AB_ADDR	0x0010
 +
-+/* [UG Table 3, p.12] 0x0011: GMSL Link/PHY Rate Select (Links C&D) */
++/* GMSL Link/PHY Rate Select (Links C&D) */
 +#define MAX96724_LINK_RATE_CD_ADDR	0x0011
 +
-+/* [UG p.13] 0x001A: Link A lock status (bit[3]=LOCK) */
++/* Link A lock status (bit[3]=LOCK) */
 +#define MAX96724_LINK_A_LOCK_ADDR	0x001A
 +
-+/* [UG Table 3, p.12] 0x0018: GMSL Link Reset
++/* 
++ *   GMSL Link Reset
 + *   bits[7:4]: Link reset D/C/B/A, bits[3:0]: One-shot reset D/C/B/A
 + */
 +#define MAX96724_ONESHOT_ADDR		0x0018
 +
-+/* [UG p.11] REG13: Soft Reset (write 0x40, wait 5ms) */
++/* Soft Reset (write 0x40, wait 5ms) */
 +#define MAX96724_REG13_ADDR		0x000D
 +
-+/* [Errata §5] Error Channel Power Up registers (required for 6Gbps)
++/* 
++ *   Error Channel Power Up registers (required for 6Gbps)
 + *   Write 0x75 immediately after power-up for robust 6Gbps operation
 + */
 +#define MAX96724_ERRCH_A_ADDR		0x1449
@@ -1054,7 +918,8 @@ index 0000000..4a1708c
 +
 +/* --- I2C Control Channel / Errata --- */
 +
-+/* [Errata #2] Tunnel Mode SRAM LCRC error suppression
++/* 
++ *   Tunnel Mode SRAM LCRC error suppression
 + *   Set 0x458[7:4] = 0x0 to suppress spurious ERRB in tunnel mode
 + */
 +#define MAX96724_SRAM_LCRC_ERR_ADDR	0x0458
@@ -1073,9 +938,6 @@ index 0000000..4a1708c
 + */
 +#define MAX96724_PIPE_SEL1_ADDR		0xF1
 +
-+/*
-+ *   bit[0]=Pipe 0, bit[1]=Pipe 1, bit[2]=Pipe 2, bit[3]=Pipe 3
-+ */
 +#define MAX96724_PIPE_EN_ADDR		0xF4
 +
 +/* --- Pipe Receiver / Tunnel Mode --- */
@@ -1092,14 +954,15 @@ index 0000000..4a1708c
 +
 +/* --- CSI-2 Output (BACKTOP) --- */
 +
-+/* [UG p.19] BACKTOP: CSI-2 output port enable
++/* BACKTOP: CSI-2 output port enable
 + *   0x040B bit[1]=CSIB_EN, bit[0]=CSIA_EN
 + */
 +#define MAX96724_BACKTOP_EN_ADDR	0x040B
 +
 +/* --- MIPI DPLL (Data Rate) --- */
 +
-+/* [UG Table 12, p.27] MIPI PHY DPLL Freq registers
++/* 
++ *   MIPI PHY DPLL Freq registers
 + *   bits[4:0] = frequency in multiples of 100MHz
 + *   bit[5]    = DPLL enable (must be set for DPLL to lock)
 + *   E.g., 0x27 = 700MHz + enable = 700Mbps/lane D-PHY
@@ -1110,7 +973,8 @@ index 0000000..4a1708c
 +#define MAX96724_DPLL_FREQ2_ADDR	0x041B
 +#define MAX96724_DPLL_FREQ3_ADDR	0x041E
 +
-+/* [UG] DPLL PHY reset control
++/* 
++ *   DPLL PHY reset control
 + *   0x1D00 = DPLL CSI PHY1 control
 + *   Write 0xF4 to disable/reset, 0xF5 to enable
 + */
@@ -1120,49 +984,47 @@ index 0000000..4a1708c
 +
 +/* --- CSI-2 Output PHY Configuration --- */
 +
-+/* [UG rev2 Table 12 + MIPI PHY section] CSI output mode/config register.
++/* 
++ * CSI output mode/config register.
 + * Mode bits (set exactly one of [4:0]):
 + *   bit[0]=0x01: 4x2 mode
 + *   bit[2]=0x04: 2x4 mode        (Ctrl 1 = master for Port A, Ctrl 2 = Port B)
 + *   bit[3]=0x08: 1x4a + 2x2 mode (Ctrl 1 = master for Port A)
 + *   bit[4]=0x10: 1x4b + 2x2 mode (Ctrl 2 = master for Port B)
-+ * In ALL x4 D-PHY modes Port A = PHY0+PHY1 and Port B = PHY2+PHY3 (UG:
-+ * "PHY 1 and PHY 2 are the master PHYs providing the MIPI clock for ports
-+ * A and B").  bit[2] vs bit[3] only differ in how the OTHER port is grouped,
-+ * not in which PHYs carry Port A.
-+ * Clock-force bits (high nibble):
++ *
++ * Clock-force bits:
 + *   bit[7]=0x80: force ALL MIPI clocks running (continuous HS clock)
 + *   bit[6]=0x40: force PHY 3 MIPI clock running
 + *   bit[5]=0x20: force PHY 0 MIPI clock running
 + */
 +#define MAX96724_CSI_OUT_CFG_ADDR	0x08A0
 +
-+/* [UG Table 12, p.25] MIPI PHY Enable register
++/* 
++ *   MIPI PHY Enable register
 + *   bits[7:4]: Enable PHY 3/2/1/0 (1=enabled, 0=standby)
 + */
 +#define MAX96724_CSI_PHY_EN_ADDR	0x08A2
 +
-+/* [UG Table 12, p.25] MIPI PHY 0 and 1 Lane Mapping */
++/* MIPI PHY 0 and 1 Lane Mapping */
 +#define MAX96724_CSI_LANE_MAP1_ADDR	0x08A3
 +
-+/* [UG Table 12, p.26] MIPI PHY 2 and 3 Lane Mapping */
++/* MIPI PHY 2 and 3 Lane Mapping */
 +#define MAX96724_CSI_LANE_MAP2_ADDR	0x08A4
 +
-+/* [FG24-4CH board] MIPI output lane polarity (P/N swap) registers.
++/* 
++ *   MIPI output lane polarity (P/N swap) registers.
 + *   0x08A5 = PHY0/PHY1 lane polarity, 0x08A6 = PHY2/PHY3 lane polarity.
 + *   The FangZhu FG24-4CH PCB swaps the differential P/N pairs on the
 + *   MAX96724 CSI output, so the deserializer must invert lane polarity
-+ *   or the Orin CIL never locks the HS clock (total silence/2500ms timeout).
-+ *   Per FangZhu MAX4CH_FG24_POC_Enable table: write 0x3F to both.
 + */
 +#define MAX96724_CSI_PHY_POL0_ADDR	0x08A5
 +#define MAX96724_CSI_PHY_POL1_ADDR	0x08A6
 +#define MAX96724_CSI_PHY_POL_SWAP	0x3F
 +
-+/* [UG p.22] Pipe-to-controller mapping (Method 1) */
++/* Pipe-to-controller mapping */
 +#define MAX96724_MIPI_CTRL_SEL_ADDR	0x08CA
 +
-+/* [OG03C reference dump] Method-1 controller mapping */
++/* Method-1 controller mapping */
 +#define MAX96724_MIPI_CTRL_SEL_PIXEL	0xE4
 +
 +/* --- Lane Control per pipe (stride 0x40) --- */
@@ -1201,7 +1063,8 @@ index 0000000..4a1708c
 +
 +/* --- Extended Pipe Mapping (DST_CTRL2-4 / TX49) --- */
 +
-+/* [Excel: MIPI_TX46-48] Extended DST_CTRL for additional mapping pairs
++/* 
++ *   Extended DST_CTRL for additional mapping pairs
 + *   All to PHY1 (0x55), same as TX45
 + *   Stride: 0x40 per pipe (base = Pipe X)
 + */
@@ -1209,7 +1072,8 @@ index 0000000..4a1708c
 +#define MAX96724_TX47_PIPE_X_ADDR	0x092F
 +#define MAX96724_TX48_PIPE_X_ADDR	0x0930
 +
-+/* [UG p.30] MIPI_TX49 synchronous concatenation control
++/* 
++ *   MIPI_TX49 synchronous concatenation control
 + *   Set to 0x00 (no concat) for single-camera tunnel mode.
 + *   For 4W concat use 0x87.
 + *   Stride: 0x40 per pipe (base = Pipe X)
@@ -1240,10 +1104,11 @@ index 0000000..4a1708c
 + * Register Values
 + * ================================================================ */
 +
-+/* [UG p.12] Soft reset value (write to 0x000D) */
++/* Soft reset value (write to 0x000D) */
 +#define MAX96724_SOFT_RESET		0x40
 +
-+/* [UG Table 3, p.11-12] Link Rate values for 0x0010/0x0011
++/* 
++ * Link Rate values for 0x0010/0x0011
 + *   Per link pair: bits[1:0]=RxA, [3:2]=TxA, [5:4]=RxB, [7:6]=TxB
 + *   Tx = 00 (187.5Mbps), Rx = 01 (3Gbps) or 10 (6Gbps)
 + *   3Gbps: Tx=00, Rx=01 → per pair 0x01, both pairs = 0x01 in low nibble
@@ -1251,7 +1116,8 @@ index 0000000..4a1708c
 +#define MAX96724_LINK_RATE_3GBPS	0x01  /* Rx=3G, Tx=187.5M for one link pair */
 +#define MAX96724_LINK_RATE_6GBPS	0x02  /* Rx=6G, Tx=187.5M for one link pair */
 +
-+/* [UG Table 3, p.11] 0x0006: Link enable / mode values
++/* 
++ * 0x0006: Link enable / mode values
 + *   bits[7:4] = PHY mode (1=GMSL2 per link)
 + *   bits[3:0] = Link enable per link
 + *   0xF1 = all GMSL2-mode, only Link A enabled
@@ -1260,98 +1126,97 @@ index 0000000..4a1708c
 +#define MAX96724_LINK_EN_SIOA		0xF1  /* GMSL2 all, enable Link A only */
 +#define MAX96724_LINK_EN_ALL		0xFF  /* GMSL2 all, enable all links */
 +
-+/* [UG p.19] BACKTOP_EN (0x040B): CSI output port enable */
++/* BACKTOP_EN (0x040B): CSI output port enable */
 +#define MAX96724_BACKTOP_CSIB_EN	0x02
 +#define MAX96724_BACKTOP_CSIA_EN	0x01
 +
-+/* [XML] VIDEO_RX0: DIS_PKT_DET=1 (bit0) required for tunnel mode.
++/* 
++ *   VIDEO_RX0: DIS_PKT_DET=1 (bit0) required for tunnel mode.
 + *   Without it, DES rejects tunnel data as invalid GMSL2 video packets.
 + *   SEQ_MISS_EN=1 (bit4), LINE_CRC_EN=1 (bit1).  XML value: 0x33.
 + */
 +#define MAX96724_VID_RX0_CFG_VAL	0x33
 +#define MAX96724_VID_RX6_CFG_VAL	0x0A
 +
-+/* [OG03C reference dump] Pixel-mode receiver settings */
++/* Pixel-mode receiver settings */
 +#define MAX96724_VID_RX0_PIXEL_VAL	0x32
 +#define MAX96724_VID_RX6_PIXEL_VAL	0x12
 +
-+/* [XML] Tunnel mode enable (MIPI_TX54, 0x0936):
++/* 
++ *   Tunnel mode enable (MIPI_TX54, 0x0936):
 + *   bit[0] = TUN_EN = 1
 + *   Verified value: 0x01
 + */
 +#define MAX96724_TUN_EN			0x01
 +
-+/* [OG03C reference dump] Default/reset state when tunnel is disabled */
++/* Default/reset state when tunnel is disabled */
 +#define MAX96724_TUN_DISABLED		0x08
 +
-+/* [XML] Tunnel controller destination (MIPI_TX57, 0x0939):
++/* 
++ *   Tunnel controller destination (MIPI_TX57, 0x0939):
 + *   bits[5:4]: TUN_DEST (00=PHY0, 01=PHY1, 10=PHY2, 11=PHY3)
 + *   Verified value: 0x10 = PHY1 destination with auto-detect enabled
 + */
 +#define MAX96724_TUN_DEST_CTRL0		0x00  /* Auto-detect + PHY0 */
 +#define MAX96724_TUN_DEST_CTRL1		0x10  /* Auto-detect + PHY1 (Port A master) */
 +
-+/* [UG rev2 Table 12] CSI output mode values written to 0x08A0.
-+ *   We use bit[2] = 0x04 = clean 2x4 mode (Port A = PHY0+PHY1, Ctrl 1 master).
-+ *   This matches the ADI reference "Lane Swap Programming Example"
-+ *   (0x4E,0x08A0,0x04) and the FangZhu working config.  Note bit[3]=0x08
-+ *   (1x4a+2x2) ALSO keeps Port A on PHY0+PHY1; for a single 4-lane Port A
-+ *   output either presents a valid Port A, so 0x04 is the spec-clean choice
-+ *   rather than a hard requirement.
-+ */
 +#define MAX96724_CSI_MODE_2X4_VAL	0x04  /* bit[2] = clean 2x4: Port A = PHY0+PHY1 */
-+/* 0x84 = 2x4 mode (bit2) + bit[7] "force ALL MIPI clocks running".  The bit[7]
-+ * clock-force is the key part: it keeps the D-PHY clock lane in continuous HS
-+ * mode so the Orin NVCSI/CIL can lock.  Asserted LAST in setup_streaming(),
-+ * matching the FangZhu End_Common 0x08A0=0x84 write. */
++
++/* 
++ *   0x84 = 2x4 mode (bit2) + bit[7] "force ALL MIPI clocks running".  The bit[7]
++ *   clock-force is the key part: it keeps the D-PHY clock lane in continuous HS
++ *   mode so the Orin NVCSI/CIL can lock.
++ */
 +#define MAX96724_CSI_OUT_EN_VAL		0x84  /* 2x4 + bit[7] force all MIPI clocks running */
-+#define MAX96724_CSI_MODE_4X2_VAL	0x01  /* bit[0] = 4x2 mode */
 +
 +#define MAX96724_CSI_PHY_EN_ALL		0xF0
 +#define MAX96724_CSI_PHY_EN_01		0x30  /* PHY0+PHY1 only (Port A) */
 +#define MAX96724_CSI_PHY_EN_23		0xC0  /* PHY2+PHY3 only (Port B) */
 +
-+/* [UG Table 12, p.25-26] Lane mapping default */
++/* Lane mapping default */
 +#define MAX96724_CSI_LANE_MAP_DEFAULT	0xE4
 +
-+/* [UG Table 12, p.26-27] Lane control: 4-lane enabled */
++/* Lane control: 4-lane enabled */
 +#define MAX96724_LANE_CTRL_4LANE	0xC0
 +
-+/* [UG Table 12, p.26-27] Lane control: 2-lane enabled.
++/*
++ *   Lane control: 2-lane enabled.
 + *   bits[7:6] = (num_lanes - 1): 01=2-lane(0x40), 11=4-lane(0xC0)
-+ *   Ref: gmsl_ser_des_guide §8.2, E2E_enable_guide §5.6.4 */
++ *   Ref: gmsl_ser_des_guide §8.2, E2E_enable_guide §5.6.4 
++ */
 +#define MAX96724_LANE_CTRL_2LANE	0x40
 +
-+/* [SC20190112 2-lane] CSI PHY enable: all PHYs powered for DPLL lock
-+ *   stability.  Even though only PHY0 data lanes reach Orin, the MAX96724
-+ *   DPLL requires all PHYs to be powered.  Tested: single PHY → PLL never locks. */
++/* 
++ *   CSI PHY enable: all PHYs powered for DPLL lock.
++ */
 +#define MAX96724_CSI_PHY_EN_2LANE	0xF0
 +
-+/* [SC20190112 2-lane] DPLL for Controller 0 (drives PHY0, 2 lanes).
++/* 
++ *   DPLL for Controller 0 (drives PHY0, 2 lanes).
 + *   bits[4:0] = data-rate / 100 MHz.  700 Mbps / 100 = 7 = 0x07.
 + *   bit[5]    = DPLL enable = 1.
-+ *   Result: 0x27 = 700 Mbps/lane D-PHY. */
++ *   Result: 0x27 = 700 Mbps/lane D-PHY.
++ */
 +#define MAX96724_DPLL_700MBPS_CTRL0	0x27
 +
-+/* [FG24-4CH working-config verified] CSI-output DPLL data rate = 1500 Mbps.
++/* 
++ *   CSI-output DPLL data rate = 1500 Mbps.
 + *   bits[4:0] = data-rate / 100 MHz -> 1500/100 = 15 = 0x0F. bit[5] = DPLL en.
-+ *   Result 0x2F.  The FangZhu MAX4CH config writes this to ALL FOUR controllers
-+ *   (0x0415/0x0418/0x041B/0x041E), matching DT max_lane_speed = 1500000.  The
-+ *   old 0x27 (700 Mbps, 2 controllers only) is a 2-lane-variant leftover that
-+ *   left the Orin CIL unable to lock the HS clock (empty rtcpu trace). */
++ */
 +#define MAX96724_DPLL_1500MBPS		0x2F
 +
-+/* [UG Table 3, p.12] One-shot reset: all links */
++/* One-shot reset: all links */
 +#define MAX96724_ONESHOT_ALL		0x0F
 +
-+/* [UG Table 4, p.15] Pipe source selection values
-+ *   Encoding per pipe nibble in tunnel mode (Aardvark-verified):
++/* 
++ *   Pipe source selection values
++ *   Encoding per pipe nibble in tunnel mode:
 + *   0x22 routes all pipes from Link A in tunnel mode.
 + */
-+#define MAX96724_PIPE_SEL0_SINGLE	0x22  /* All pipes from Link A (Aardvark-verified) */
-+#define MAX96724_PIPE_SEL1_SINGLE	0x22  /* All pipes from Link A (Aardvark-verified) */
-+#define MAX96724_PIPE_SEL0_PIXEL	0x62  /* OG03C pixel-mode reference */
-+#define MAX96724_PIPE_SEL1_PIXEL	0xEA  /* OG03C pixel-mode reference */
++#define MAX96724_PIPE_SEL0_SINGLE	0x22  /* All pipes from Link A */
++#define MAX96724_PIPE_SEL1_SINGLE	0x22  /* All pipes from Link A */
++#define MAX96724_PIPE_SEL0_PIXEL	0x62  /* pixel-mode reference */
++#define MAX96724_PIPE_SEL1_PIXEL	0xEA  /* pixel-mode reference */
 +#define MAX96724_PIPE_SEL0_DUAL		0x40  /* Pipe 0 ← A/X, Pipe 1 ← B/X */
 +#define MAX96724_PIPE_SEL0_QUAD_LO	0x40  /* Pipe 0 ← A/X, Pipe 1 ← B/X */
 +#define MAX96724_PIPE_SEL1_QUAD_HI	0xC8  /* Pipe 2 ← C/X, Pipe 3 ← D/X */
@@ -1373,12 +1238,12 @@ index 0000000..4a1708c
 +#define MAX96724_RESET_ST_ID		0x00
 +#define MAX96724_ST_ID_SEL_INVALID	0xF
 +
-+/* Controller mapping: all mappings → Controller 0 (not working in tunnel mode) */
++/* Controller mapping: all mappings → Controller 0 */
 +#define MAX96724_ALL_MAP_CTRL0		0x00
-+/* Controller mapping: all mappings → Controller 1 (Aardvark-verified working) */
++/* Controller mapping: all mappings → Controller 1 */
 +#define MAX96724_ALL_MAP_CTRL1		0x55
 +
-+/* [OG03C reference dump] Three mappings to controller 1 */
++/* Three mappings to controller 1 */
 +#define MAX96724_MAP3_CTRL1		0x15
 +
 +/* ================================================================
@@ -1400,16 +1265,9 @@ index 0000000..4a1708c
 +#define MAX96724_CSI_CTRL_2		2
 +#define MAX96724_CSI_CTRL_3		3
 +
-+/* Internal csi_mode enum flags (NOT the register value written to 0x08A0;
-+ * see MAX96724_CSI_MODE_2X4_VAL for the actual register value).  These are
-+ * only compared against priv->csi_mode to select a code path. */
-+#define MAX96724_CSI_MODE_4X2		0x01
 +#define MAX96724_CSI_MODE_2X4		0x08  /* enum tag for the 4-lane Port A (Ctrl1) path */
-+#define MAX96724_CSI_MODE_2X4_ALT	0x04  /* enum tag (unused alt path) */
 +
 +/* Lane map presets */
-+#define MAX96724_LANE_MAP1_4X2		0x44
-+#define MAX96724_LANE_MAP2_4X2		0x44
 +#define MAX96724_LANE_MAP1_2X4		0xE4  /* SC20190112 subset: PHY0 data + PHY1 clock */
 +#define MAX96724_LANE_MAP2_2X4		0x44  /* keep unused PHY2/3 straight in 0x08 mode */
 +
@@ -2042,10 +1900,6 @@ index 0000000..4a1708c
 +		goto error;
 +	}
 +
-+	/* Check csi mode compatibility.
-+	 * 2x4 DES → gmsl-link: 1x4 or 2x4.
-+	 * 4x2 DES → gmsl-link: 1x4, 2x2, or 4x2.
-+	 */
 +	if (priv->csi_mode == MAX96724_CSI_MODE_2X4) {
 +		if (!((g_ctx->csi_mode == GMSL_CSI_1X4_MODE) ||
 +		      (g_ctx->csi_mode == GMSL_CSI_2X4_MODE))) {
@@ -2054,14 +1908,9 @@ index 0000000..4a1708c
 +			goto error;
 +		}
 +	} else {
-+		/* 4x2 DES mode: accept 1x4, 2x2, or 4x2 gmsl-link mode */
-+		if (!((g_ctx->csi_mode == GMSL_CSI_1X4_MODE) ||
-+		      (g_ctx->csi_mode == GMSL_CSI_2X2_MODE) ||
-+		      (g_ctx->csi_mode == GMSL_CSI_4X2_MODE))) {
-+			dev_err(dev, "%s: csi mode not supported\n", __func__);
-+			err = -EINVAL;
-+			goto error;
-+		}
++		dev_err(dev, "%s: only csi 2x4 mode is supported\n", __func__);
++		err = -EINVAL;
++		goto error;
 +	}
 +
 +	for (i = 0; i < priv->num_src; i++) {
@@ -2144,7 +1993,7 @@ index 0000000..4a1708c
 + * with all VCs and DTs preserved from the serializer.
 + *
 + * The pipeline configuration:
-+ *   1. Configure pipe-to-link routing (which GMSL input → which pipe)
++ *   1. Configure pipe-to-link routing
 + *   2. Enable tunnel mode on active pipes
 + *   3. Configure MIPI CSI-2 output lanes and PHY
 + *   4. Enable BACKTOP output port
@@ -2195,9 +2044,9 @@ index 0000000..4a1708c
 +	}
 +
 +	/*
-+	 * [Aardvark-verified] Pipe source routing
-+	 *   Single cam: all pipes from Link A (0x22/0x22)
-+	 *   Disable pipes before configuration, enable at the end
++	 * Pipe source routing
++	 * Single cam: all pipes from Link A (0x22/0x22)
++	 * Disable pipes before configuration, enable at the end
 +	 */
 +	max96724_write_reg(dev, MAX96724_PIPE_SEL0_ADDR, pipe_sel0);
 +	max96724_write_reg(dev, MAX96724_PIPE_SEL1_ADDR, pipe_sel1);
@@ -2205,16 +2054,14 @@ index 0000000..4a1708c
 +	max96724_write_reg(dev, MAX96724_PIPE_EN_ADDR, 0x00);
 +
 +	/*
-+	 * [SC20190112] Keep 0x08 mode so PHY1 remains the Port A clock master,
++	 * Keep 0x08 mode so PHY1 remains the Port A clock master,
 +	 * but restore the live 2-lane subset used by the bridge board.
 +	 */
 +	max96724_apply_porta_subset(dev, priv);
 +
 +	/*
-+	 * [D585 700Mbps fix] CSI-output DPLL data rate = 700 Mbps
-+	 * on ALL FOUR controller freq registers, matching D585 native
-+	 * MIPI rate (pix_clk_hz=175M, 16bpp, 4-lane).
-+	 * DT serdes_pix_clk_hz=175MHz drives correct THS_SETTLE for 700Mbps.
++	 * CSI-output DPLL data rate = 700 Mbps
++	 * on ALL FOUR controller freq registers
 +	 */
 +	if (!priv->lane_setup) {
 +		max96724_write_reg(dev, MAX96724_DPLL_FREQ0_ADDR,
@@ -2233,7 +2080,7 @@ index 0000000..4a1708c
 +			   MAX96724_MIPI_CTRL_SEL_PIXEL);
 +
 +	/*
-+	 * [Aardvark-verified] Stream ID select for all pipes
++	 * Stream ID select for all pipes
 +	 * 0x0933 + 0x40*pipe = stream select register
 +	 * Value 0x10 selects the appropriate stream for tunnel mode
 +	 */
@@ -2243,7 +2090,8 @@ index 0000000..4a1708c
 +				   st_sel_cfg);
 +	}
 +
-+	/* BACKTOP: enable Controller 1 / CSI-B (0x02).
++	/* 
++	 * BACKTOP: enable Controller 1 / CSI-B (0x02).
 +	 * In 2x4 mode, Controller 1 is master for Port A -> Orin CSI.
 +	 */
 +	max96724_write_reg(dev, MAX96724_BACKTOP_EN_ADDR,
@@ -2252,10 +2100,9 @@ index 0000000..4a1708c
 +	dev_info(dev, "=== setup_streaming: writing 0x84 (force all MIPI clocks) ===\n");
 +
 +	/*
-+	 * [FG24-4CH working-config verified] Assert 0x08A0=0x84 LAST: 2x4 mode +
-+	 * bit[7] "force all MIPI clocks running".  The clock-force keeps the
-+	 * D-PHY clock lane continuous so the Orin CIL can lock; written only
-+	 * after the full pipeline is configured, matching FangZhu End_Common.
++	 * Assert 0x08A0=0x84 LAST: 2x4 mode + bit[7] "force all MIPI clocks running".  
++	 * The clock-force keeps the D-PHY clock lane continuous so the Orin CIL can lock;
++	 * written only after the full pipeline is configured.
 +	 */
 +	max96724_write_reg(dev, MAX96724_CSI_OUT_CFG_ADDR,
 +			   MAX96724_CSI_OUT_EN_VAL);
@@ -2280,7 +2127,7 @@ index 0000000..4a1708c
 +	max96724_write_reg(dev, MAX96724_ONESHOT_ADDR,
 +			   MAX96724_ONESHOT_ALL);
 +
-+	/* Enable all 4 pipes (Aardvark-verified: 0x0F at end) */
++	/* Enable all 4 pipes */
 +	max96724_write_reg(dev, MAX96724_PIPE_EN_ADDR, MAX96724_PIPE_EN_4);
 +
 +	priv->sources[src_idx].st_enabled = true;
@@ -2393,10 +2240,7 @@ index 0000000..4a1708c
 +
 +int max96724_get_ser_pipe_id(struct device *dev, int dser_pipe_id, int vc_id)
 +{
-+	/*
-+	 * In Tunnel Mode with MAX96717, all VCs are carried in a single
-+	 * tunnel pipe. The pipe mapping is 1:1 for d4xx compatibility.
-+	 */
++	/* In Tunnel Mode with MAX96717, all VCs are carried in a single tunnel pipe. */
 +	return dser_pipe_id;
 +}
 +EXPORT_SYMBOL(max96724_get_ser_pipe_id);
@@ -2414,7 +2258,7 @@ index 0000000..4a1708c
 +
 +	mutex_lock(&priv->lock);
 +	if (priv->splitter_enabled) {
-+		/* [UG] Multi-camera: reset all links */
++		/* Multi-camera: reset all links */
 +		u8 link_rate = (priv->link_speed == 6) ? 0x22 : 0x11;
 +
 +		max96724_write_reg(dev, MAX96724_LINK_RATE_AB_ADDR,
@@ -2445,20 +2289,21 @@ index 0000000..4a1708c
 +		dpll_cfg = MAX96724_DPLL_1500MBPS;
 +	}
 +
-+	/* ONESHOT resets CSI/tunnel state. Restore the full pipeline config.
++	/* 
++	 * ONESHOT resets CSI/tunnel state. Restore the full pipeline config.
 +	 * Mirror setup_streaming() order: disable pipes -> restore everything ->
 +	 * BACKTOP/0x84 -> VID_RX -> final ONESHOT to latch -> enable pipes.
 +	 */
 +	max96724_write_reg(dev, MAX96724_PIPE_EN_ADDR, 0x00);
 +
-+	/* Pipe source routing (same as setup_streaming): all pipes from Link A */
++	/* Pipe source routing: all pipes from Link A */
 +	max96724_write_reg(dev, MAX96724_PIPE_SEL0_ADDR, pipe_sel0);
 +	max96724_write_reg(dev, MAX96724_PIPE_SEL1_ADDR, pipe_sel1);
 +
 +	max96724_apply_porta_subset(dev, priv);
 +
 +	/*
-+	 * [D585 700Mbps fix] CSI-output DPLL data rate = 700 Mbps on ALL
++	 * CSI-output DPLL data rate = 700 Mbps on ALL
 +	 * FOUR controllers, matching D585 native MIPI rate.
 +	 * reset_oneshot is called by the sensor after setup_streaming, so it must
 +	 * mirror the same DPLL values.
@@ -2518,7 +2363,7 @@ index 0000000..4a1708c
 +			   MAX96724_PIPE_EN_4);
 +
 +	/*
-+	 * [FG24-4CH working-config verified] Assert 0x08A0=0x84 LAST:
++	 * Assert 0x08A0=0x84 LAST:
 +	 * 2x4 mode + bit[7] force all MIPI clocks running.  Must mirror
 +	 * setup_streaming because the sensor's oneshot path overwrites it.
 +	 */
@@ -2566,7 +2411,7 @@ index 0000000..4a1708c
 +		{MAX96724_TX46_PIPE_X_ADDR, MAX96724_ALL_MAP_CTRL1},
 +		{MAX96724_TX47_PIPE_X_ADDR, MAX96724_ALL_MAP_CTRL1},
 +		{MAX96724_TX48_PIPE_X_ADDR, MAX96724_ALL_MAP_CTRL1},
-+		/* TX49: concat disabled (single-camera) */
++		/* TX49: concat disabled */
 +		{MAX96724_TX49_PIPE_X_ADDR, 0x00},
 +		/*
 +		 * Keep DES heartbeat handling aligned with the serializer's
@@ -2576,12 +2421,13 @@ index 0000000..4a1708c
 +		{0x0106, MAX96724_VID_RX6_CFG_VAL},
 +		/*
 +		 * Pipe stream control (offset 0x36 per pipe block).
-+		 * [XML] TUN_EN = 0x01.
++		 * TUN_EN = 0x01.
 +		 */
 +		{0x0936, MAX96724_TUN_EN},
 +	};
 +
-+	/* Adjust addresses for pipe offset (stride 0x40 per pipe)
++	/* 
++	 * Adjust addresses for pipe offset (stride 0x40 per pipe)
 +	 * Entries 0-13: TX11, SRC/DST maps, TX45-TX49 (all stride 0x40)
 +	 * Entries 14-15: VID_RX0/6 (stride 0x12)
 +	 * Entry 16: Pipe stream control (stride 0x40)
@@ -2589,7 +2435,7 @@ index 0000000..4a1708c
 +	for (i = 0; i < 14; i++)
 +		map_pipe_control[i].addr += 0x40 * pipe_id;
 +
-+	/* [max9296.c pattern] VID_RX offset: 0x12 per pipe */
++	/* VID_RX offset: 0x12 per pipe */
 +	map_pipe_control[14].addr += 0x12 * pipe_id;
 +	map_pipe_control[15].addr += 0x12 * pipe_id;
 +
@@ -2610,7 +2456,7 @@ index 0000000..4a1708c
 +		map_pipe_control[15].val = MAX96724_VID_RX6_PIXEL_VAL;
 +		map_pipe_control[16].val = MAX96724_TUN_DISABLED;
 +	} else {
-+		/* Single-RGB tunnel: no concatenation needed */
++		/* no concatenation needed */
 +		map_pipe_control[13].val = 0x00;
 +	}
 +
@@ -2628,7 +2474,7 @@ index 0000000..4a1708c
 +	map_pipe_control[9].val = all_mapping_phy;
 +	/* TX46-TX48 keep 0x55 (Ctrl1) from initializer */
 +	/* TX49 set to 0x00 above — overridden per mode in pixel/tunnel branch */
-+	/* VID_RX (entry 14) and pipe stream ctrl (entry 15) keep init values */
++	/* VID_RX and pipe stream ctrl keep init values */
 +
 +	err = max96724_set_registers(dev, map_pipe_control,
 +				     ARRAY_SIZE(map_pipe_control));
@@ -2731,16 +2577,8 @@ index 0000000..4a1708c
 +
 +	if (!strcmp(str_value, "2x4")) {
 +		priv->csi_mode = MAX96724_CSI_MODE_2X4;
-+		/*
-+		 * SC20190112 keeps the 0x08 Port-A clocking scheme but only brings
-+		 * PHY0 data lanes and the PHY1 clock lane to Orin.
-+		 */
 +		priv->lane_mp1 = MAX96724_LANE_MAP1_2X4;
 +		priv->lane_mp2 = MAX96724_LANE_MAP2_2X4;
-+	} else if (!strcmp(str_value, "4x2")) {
-+		priv->csi_mode = MAX96724_CSI_MODE_4X2;
-+		priv->lane_mp1 = MAX96724_LANE_MAP1_4X2;
-+		priv->lane_mp2 = MAX96724_LANE_MAP2_4X2;
 +	} else {
 +		dev_err(&client->dev, "invalid csi mode\n");
 +		return -EINVAL;
@@ -2762,7 +2600,7 @@ index 0000000..4a1708c
 +		priv->reset_gpio = -1;
 +	}
 +
-+	/* [User requirement] GMSL link speed from DT: 3 or 6 (Gbps) */
++	/* GMSL link speed from DT: 3 or 6 (Gbps) */
 +	err = of_property_read_u32(node, "gmsl-link-speed", &value);
 +	if (err < 0) {
 +		/* Default to 3 Gbps if not specified */

--- a/nvidia-oot/7.0/0011-Add-MAX96717-serializer-and-MAX96724-deserializer-dr.patch
+++ b/nvidia-oot/7.0/0011-Add-MAX96717-serializer-and-MAX96724-deserializer-dr.patch
@@ -22,36 +22,22 @@ MAX96724 quad deserializer features:
 
 Signed-off-by: RealSense AI <realsense@realsenseai.com>
 ---
- drivers/media/i2c/Makefile   |    2 +
- drivers/media/i2c/max96717.c |  917 ++++++++++++++++
- drivers/media/i2c/max96724.c | 1927 ++++++++++++++++++++++++++++++++++
+ drivers/media/i2c/max96717.c |  791 ++++++++++++++
+ drivers/media/i2c/max96724.c | 1905 ++++++++++++++++++++++++++++++++++
  include/media/max96717.h     |  151 ++
  include/media/max96724.h     |  183 +++
- 5 files changed, 3180 insertions(+)
+ 4 files changed, 3030 insertions(+)
  create mode 100644 drivers/media/i2c/max96717.c
  create mode 100644 drivers/media/i2c/max96724.c
  create mode 100644 include/media/max96717.h
  create mode 100644 include/media/max96724.h
 
-diff --git a/drivers/media/i2c/Makefile b/drivers/media/i2c/Makefile
-index b284938..947e6e9 100644
---- a/drivers/media/i2c/Makefile
-+++ b/drivers/media/i2c/Makefile
-@@ -8,6 +8,8 @@ obj-m += max9296.o
- subdir-ccflags-y += -DCONFIG_VIDEO_D4XX_SERDES
- subdir-ccflags-y += -DCONFIG_TEGRA_CAMERA_PLATFORM
- obj-m += d4xx.o
-+obj-m += max96717.o
-+obj-m += max96724.o
- ifeq ($(findstring ack_src,$(NV_BUILD_KERNEL_OPTIONS)),)
- obj-m += max96712.o
- 
 diff --git a/drivers/media/i2c/max96717.c b/drivers/media/i2c/max96717.c
 new file mode 100644
-index 0000000..1dd24d3
+index 0000000..c26c24b
 --- /dev/null
 +++ b/drivers/media/i2c/max96717.c
-@@ -0,0 +1,917 @@
+@@ -0,0 +1,791 @@
 +/*
 + * max96717.c - MAX96717 GMSL2 Serializer driver (Tunnel Mode)
 + *
@@ -70,14 +56,6 @@ index 0000000..1dd24d3
 + * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
-+/*
-+ * Register Reference Sources:
-+ * [PPTX]  = GMSL_MAX96717_MAX96724_TechOverview - V1.pptx
-+ * [XML]   = MAX96717_MAX96724_HKR_EVB_700mbps_tunnel_mode_basedonexcelsheet_D585.xml
-+ *
-+ * Every register address and value below is traceable to one of these sources.
-+ */
-+
 +#include <media/camera_common.h>
 +#include <linux/of.h>
 +#include <linux/module.h>
@@ -85,149 +63,146 @@ index 0000000..1dd24d3
 +
 +/* ===== Register Addresses ===== */
 +
-+/* [PPTX slide 7] REG0: Device ID (read-only, returns 0x40) */
++/* REG0: Device ID (read-only, returns 0x40) */
 +#define MAX96717_DEV_ADDR		0x00
 +
-+/* [PPTX slide 7] REG1: Link Speed
++/* 
++ *   REG1: Link Speed
 + *   bit[3]=1: 3 Gbps, bit[4]=1: 6 Gbps
 + */
 +#define MAX96717_REG1_ADDR		0x01
 +
-+/* [PPTX slide 7 / XML 0x0002] PIPE_EN: Pipe enable / soft reset
-+ *   [XML] 0x03 = soft reset, 0x43 = pipes enabled + video init
-+ *   [PPTX slide 7] Matches MAX9295 PIPE_EN at 0x02
++/* 
++ *   PIPE_EN: Pipe enable / soft reset
++ *   0x03 = soft reset, 0x43 = pipes enabled + video init
++ *   Matches MAX9295 PIPE_EN at 0x02
 + */
 +#define MAX96717_PIPE_EN_ADDR		0x02
 +
-+/* [PPTX slide 7] CTRL0: GMSL2 TX Control
++/* 
++ *   CTRL0: GMSL2 TX Control
 + *   bit[5]=1: GMSL2 mode, bit[0]=1: enable transmitter
 + *   0x21 = GMSL2 mode + TX enable on Link A
 + */
 +#define MAX96717_CTRL0_ADDR		0x10
 +
-+/* [PPTX slide 7] CTRL3: Start Video - final enable bit
++/* 
++ *   CTRL3: Start Video - final enable bit
 + *   bit[0]=1: activate video stream
 + */
 +#define MAX96717_CTRL3_ADDR		0x13
 +
-+/* [PPTX slide 7] TX1: FEC Enable
++/* 
++ *   TX1: FEC Enable
 + *   bit[6]=1: Reed-Solomon FEC enabled
 + */
 +#define MAX96717_TX1_ADDR		0x29
 +
-+/* [MAX96724 Users Guide, I2C Broadcasting section, p44-46]
-+ * MAX96717 I2C address translation registers (GMSL2 standard):
++/*
++ *   MAX96717 I2C address translation registers (GMSL2 standard):
 + *   SRC_A / DST_A (0x42/0x43): Translation pair A (SER broadcast addr)
 + *   SRC_B / DST_B (0x44/0x45): Translation pair B (sensor passthrough)
 + *
-+ * When host writes to SRC_B address, the MAX96717 translates it to
-+ * DST_B and forwards via GMSL back-channel to the remote sensor.
++ *   When host writes to SRC_B address, the MAX96717 translates it to
++ *   DST_B and forwards via GMSL back-channel to the remote sensor.
 + *
 + */
 +#define MAX96717_SRC_A_ADDR		0x42
 +#define MAX96717_DST_A_ADDR		0x43
-+#define MAX96717_I2C4_ADDR		0x44	/* SRC_B: sensor proxy addr */
-+#define MAX96717_I2C5_ADDR		0x45	/* DST_B: sensor default addr */
++#define MAX96717_I2C4_ADDR		0x44
++#define MAX96717_I2C5_ADDR		0x45
 +
-+/* [PPTX slide 14] TX_STR_SEL: Stream ID select
++/* 
++ *   TX_STR_SEL: Stream ID select
 + *   bits[1:0]: stream ID for DES pipe routing
 + */
 +#define MAX96717_TX_STR_SEL_ADDR	0x5B
 +
-+/* [PPTX slide 7 / XML 0x0110-0x0111] VIDEO_TX0/TX1: Video TX path config
-+ *   [XML] 0x0110=0xE9, 0x0111=0x10 for tunnel mode data path
++/* 
++ *   VIDEO_TX0/TX1: Video TX path config
++ *   0x0110=0xE9, 0x0111=0x10 for tunnel mode data path
 + */
 +#define MAX96717_VIDEO_TX0_ADDR		0x110
 +#define MAX96717_VIDEO_TX1_ADDR		0x111
 +
-+/* [PPTX slide 7] FRONTTOP_0: Front-end topology
++/* 
++ *   FRONTTOP_0: Front-end topology
 + *   0x12 = single CSI-2 port A, all VCs pass through
 + */
 +#define MAX96717_FRONTTOP0_ADDR		0x308
 +
-+/* [XML / PPTX slide 7] MIPI_RX0-RX3: CSI-2 receiver configuration
++/* 
++ *   MIPI_RX0-RX3: CSI-2 receiver configuration
 + *   RX0 (0x330): CSI mode (0x00 = D-PHY controller A)
-+ *   RX1 (0x331): Lane count - [PPTX slide 14] ctrl1_num_lanes bits[5:4]
-+ *                 [XML] 0x30 = bits[5:4]=11 (4 lanes)
-+ *   RX2 (0x332): Lane mapping - [XML] 0xE0 = default 1x4 map
-+ *   RX3 (0x333): Lane mapping - [XML] 0x04 = default 1x4 map
++ *   RX1 (0x331): Lane count - ctrl1_num_lanes bits[5:4]
++ *                0x30 = bits[5:4]=11 (4 lanes)
++ *   RX2 (0x332): Lane mapping - 0xE0 = default 1x4 map
++ *   RX3 (0x333): Lane mapping - 0x04 = default 1x4 map
 + */
 +#define MAX96717_MIPI_RX0_ADDR		0x330
 +#define MAX96717_MIPI_RX1_ADDR		0x331
 +#define MAX96717_MIPI_RX2_ADDR		0x332
 +#define MAX96717_MIPI_RX3_ADDR		0x333
 +
-+/* [PPTX slide 7 / slide 14] EXT11: TUNNEL MODE ENABLE
-+ *   bit[7]=1: Tun_Mode = ON  *** CRITICAL REGISTER ***
-+ *   [PPTX slide 7] 0x383 = 0x80
++/* 
++ *   EXT11: TUNNEL MODE ENABLE
++ *   bit[7]=1: Tun_Mode = ON
++ *   0x383 = 0x80
 + */
 +#define MAX96717_EXT11_ADDR		0x383
 +
-+/* [SG2 working config] SER PHY / DLL calibration registers.
-+ *   These are device-level (not sensor-specific) and appear in every
-+ *   SG2 sensor variant (OX03C, ISX031, etc.).  The staged write pattern
-+ *   (0x80 -> 0x90) on 0x2D6/0x2C7 is a PHY calibration ramp sequence.
-+ *   Without these writes the GMSL2 link trains but the DES cannot
-+ *   recover a clean CSI-2 clock from the tunnel-mode data stream.
-+ */
-+#define MAX96717_PHY_CAL_2D6_ADDR	0x2D6
-+#define MAX96717_PHY_CAL_2C7_ADDR	0x2C7
-+#define MAX96717_PHY_CAL_2BE_ADDR	0x2BE
-+#define MAX96717_PHY_CAL_2C1_ADDR	0x2C1
-+#define MAX96717_PHY_CAL_3F0_ADDR	0x3F0
-+#define MAX96717_PHY_CAL_3F1_ADDR	0x3F1
-+
-+/* [SG2 working config] PHY calibration stage-1 value */
++/* PHY calibration stage-1 value */
 +#define MAX96717_PHY_CAL_STAGE1		0x80
-+/* [SG2 working config] PHY calibration stage-2 value */
++/* PHY calibration stage-2 value */
 +#define MAX96717_PHY_CAL_STAGE2		0x90
-+/* [SG2 working config] CSI input timing / frequency config */
++/* CSI input timing / frequency config */
 +#define MAX96717_CSI_TIMING_3F0		0x59
 +#define MAX96717_CSI_TIMING_3F1		0x09
 +
 +/* ===== Register Values ===== */
 +
-+/* [XML] Soft reset value for PIPE_EN register */
++/* Soft reset value for PIPE_EN register */
 +#define MAX96717_SOFT_RESET		0x03
 +
-+/* [XML] Final enable: pipes enabled + video init */
++/* Final enable: pipes enabled + video init */
 +#define MAX96717_PIPE_EN_ALL		0x43
 +
-+/* [PPTX slide 7] CTRL0: GMSL2 mode + TX enable (Link A) */
++/* CTRL0: GMSL2 mode + TX enable (Link A) */
 +#define MAX96717_CTRL0_LINK_A		0x21
 +/* CTRL0: GMSL2 mode + TX enable (Link B) */
 +#define MAX96717_CTRL0_LINK_B		0x22
 +
-+/* [PPTX slide 7] CTRL0 reset all */
++/* CTRL0 reset all */
 +#define MAX96717_RESET_ALL		0x80
 +
-+/* [PPTX slide 7] EXT11 tunnel mode enable value */
++/* EXT11 tunnel mode enable value */
 +#define MAX96717_TUN_MODE_EN		0x80
 +#define MAX96717_TUN_MODE_DIS		0x00
 +
-+/* [XML] VIDEO_TX0 tunnel mode data path enable */
++/* VIDEO_TX0 tunnel mode data path enable */
 +#define MAX96717_VIDEO_TX0_TUN		0xE9
-+/* [XML] VIDEO_TX1 tunnel mode config */
++/* VIDEO_TX1 tunnel mode config */
 +#define MAX96717_VIDEO_TX1_TUN		0x10
 +#define MAX96717_VIDEO_TX0_BPP_MANUAL	0x60
 +#define MAX96717_VIDEO_TX1_BPP16	0x50
 +#define MAX96717_VIDEO_TX2_ADDR		0x112
 +#define MAX96717_VIDEO_TX2_DRIFT_DIS	0x08
 +
-+/* [SG2 working config] MIPI RX1: 4-lane CSI-2.
-+ *   bits[5:4]=11 (4 lanes).  bits[1:0]=11 (PHY mode / lane ordering
-+ *   matching SG2 working config; was 0x30, SG2 uses 0x33). */
++/* 
++ *   MIPI RX1: 4-lane CSI-2.
++ *   bits[5:4]=11 (4 lanes).  bits[1:0]=11
++ */
 +#define MAX96717_CSI_4_LANES		0x33
 +/* 2-lane CSI-2, bits[5:4]=01 */
 +#define MAX96717_CSI_2_LANES		0x10
 +
-+/* [XML] Lane mapping for 1x4 mode (matches MAX9295 1x4 values) */
++/* Lane mapping for 1x4 mode */
 +#define MAX96717_CSI_1X4_LANE_MAP1	0xE0
 +#define MAX96717_CSI_1X4_LANE_MAP2	0x04
 +
-+/* [PPTX slide 7] FRONTTOP_0: single port A, all VCs */
++/* FRONTTOP_0: single port A, all VCs */
 +#define MAX96717_FRONTTOP0_PORT_A	0x12
-+/* [UG Use Case Example 1] Pixel mode from Port B into Pipe Z */
++/* Pixel mode from Port B into Pipe Z */
 +#define MAX96717_FRONTTOP0_PIXEL_PORT_B	0x64
 +#define MAX96717_FRONTTOP5_ADDR		0x30D
 +#define MAX96717_FRONTTOP9_ADDR		0x311
@@ -235,17 +210,17 @@ index 0000000..1dd24d3
 +#define MAX96717_FRONTTOP17_ADDR	0x319
 +#define MAX96717_FRONTTOP9_START_VIDEO	0x40
 +
-+/* [XML] MIPI_RX0: CSI reset on + non-continuous clock */
++/* MIPI_RX0: CSI reset on + non-continuous clock */
 +#define MAX96717_MIPI_RX0_RESET		0x08
-+/* [PPTX slide 7] MIPI_RX0: Normal operation */
++/* MIPI_RX0: Normal operation */
 +#define MAX96717_MIPI_RX0_NORMAL	0x00
 +
-+/* [PPTX slide 9] REG1: 3 Gbps link speed, bit[3]=1 */
++/* REG1: 3 Gbps link speed, bit[3]=1 */
 +#define MAX96717_LINK_SPEED_3GBPS	0x08
-+/* [PPTX slide 9] REG1: 6 Gbps link speed, bit[4]=1 */
++/* REG1: 6 Gbps link speed, bit[4]=1 */
 +#define MAX96717_LINK_SPEED_6GBPS	0x10
 +
-+/* [XML] EXT11 tunnel mode pre-config (0x0383=0x80) */
++/* EXT11 tunnel mode pre-config (0x0383=0x80) */
 +#define MAX96717_EXT11_TUN_PRE		0x80
 +
 +#define MAX96717_MAX_PIPES		4
@@ -323,43 +298,6 @@ index 0000000..1dd24d3
 +	int err = 0;
 +	struct gmsl_link_ctx *g_ctx;
 +
-+	/*
-+	 * [XML] Full initialization sequence:
-+	 *   0x0002 = 0x03  (soft reset)
-+	 *   0x0383 = 0x80  (tunnel mode enable)
-+	 *   0x0331 = 0x30  (4-lane CSI)
-+	 *   0x0332 = 0xE0  (lane map1)
-+	 *   0x0333 = 0x04  (lane map2)
-+	 *   0x0110 = 0xE9  (video TX0 tunnel path)
-+	 *   0x0111 = 0x10  (video TX1 tunnel config)
-+	 *   0x0330 = 0x08  (CSI reset on)
-+	 *   0x0330 = 0x00  (CSI reset off)
-+	 *   0x0002 = 0x43  (final enable)
-+	 */
-+	struct reg_pair tunnel_init[] = {
-+		/* [PPTX slide 7] EXT11: Tunnel Mode Enable */
-+		{MAX96717_EXT11_ADDR, MAX96717_TUN_MODE_EN},
-+		/* [XML] MIPI_RX1: 4-lane CSI-2 (CTRL1_NUM_LANES[5:4]=11) */
-+		{MAX96717_MIPI_RX1_ADDR, MAX96717_CSI_4_LANES},
-+		/* [XML] MIPI_RX2/RX3: 1x4 lane mapping */
-+		{MAX96717_MIPI_RX2_ADDR, MAX96717_CSI_1X4_LANE_MAP1},
-+		{MAX96717_MIPI_RX3_ADDR, MAX96717_CSI_1X4_LANE_MAP2},
-+		/* [XML] VIDEO_TX0/TX1: tunnel data path */
-+		{MAX96717_VIDEO_TX0_ADDR, MAX96717_VIDEO_TX0_TUN},
-+		{MAX96717_VIDEO_TX1_ADDR, MAX96717_VIDEO_TX1_TUN},
-+	};
-+	struct reg_pair pixel_init[] = {
-+		{MAX96717_EXT11_ADDR, MAX96717_TUN_MODE_DIS},
-+		{MAX96717_MIPI_RX1_ADDR, MAX96717_CSI_4_LANES},
-+		{MAX96717_MIPI_RX2_ADDR, MAX96717_CSI_1X4_LANE_MAP1},
-+		{MAX96717_MIPI_RX3_ADDR, MAX96717_CSI_1X4_LANE_MAP2},
-+		{MAX96717_FRONTTOP0_ADDR, MAX96717_FRONTTOP0_PIXEL_PORT_B},
-+		{MAX96717_FRONTTOP9_ADDR, MAX96717_FRONTTOP9_START_VIDEO},
-+		{MAX96717_VIDEO_TX0_ADDR, MAX96717_VIDEO_TX0_BPP_MANUAL},
-+		{MAX96717_VIDEO_TX1_ADDR, MAX96717_VIDEO_TX1_BPP16},
-+		{MAX96717_VIDEO_TX2_ADDR, MAX96717_VIDEO_TX2_DRIFT_DIS},
-+	};
-+
 +	mutex_lock(&priv->lock);
 +
 +	if (!priv->g_client.g_ctx) {
@@ -375,80 +313,19 @@ index 0000000..1dd24d3
 +
 +	g_ctx = priv->g_client.g_ctx;
 +
-+	/*
-+	 * [SG2 working config] SER PHY/DLL pre-calibration.
-+	 * These device-level registers calibrate the serializer's
-+	 * differential output pairs and clock recovery.  The staged
-+	 * write pattern (0x80 stage-1 now, 0x90 stage-2 after tunnel
-+	 * init) matches every SG2 sensor variant's init table.
-+	 * Applied BEFORE soft reset + tunnel config.
-+	 */
-+	max96717_write_reg(dev, MAX96717_PHY_CAL_2D6_ADDR,
-+			   MAX96717_PHY_CAL_STAGE1);
-+	max96717_write_reg(dev, MAX96717_PHY_CAL_2C7_ADDR,
-+			   MAX96717_PHY_CAL_STAGE1);
-+	max96717_write_reg(dev, MAX96717_PHY_CAL_2BE_ADDR,
-+			   MAX96717_PHY_CAL_STAGE1);
-+	max96717_write_reg(dev, MAX96717_PHY_CAL_2C1_ADDR,
-+			   MAX96717_PHY_CAL_STAGE1);
-+	max96717_write_reg(dev, MAX96717_PHY_CAL_3F0_ADDR,
-+			   MAX96717_CSI_TIMING_3F0);
-+	max96717_write_reg(dev, MAX96717_PHY_CAL_3F1_ADDR,
-+			   MAX96717_CSI_TIMING_3F1);
-+	msleep(100);
++	max96717_write_reg(dev, MAX96717_EXT11_ADDR, MAX96717_TUN_MODE_EN);
++	max96717_write_reg(dev, MAX96717_MIPI_RX1_ADDR, MAX96717_CSI_4_LANES);
++	max96717_write_reg(dev, MAX96717_MIPI_RX2_ADDR, MAX96717_CSI_1X4_LANE_MAP1);
++	max96717_write_reg(dev, MAX96717_MIPI_RX3_ADDR, MAX96717_CSI_1X4_LANE_MAP2);
++	max96717_write_reg(dev, MAX96717_VIDEO_TX0_ADDR, MAX96717_VIDEO_TX0_TUN);
++	max96717_write_reg(dev, MAX96717_VIDEO_TX1_ADDR, MAX96717_VIDEO_TX1_TUN);
 +
-+	/*
-+	 * [Aardvark-verified] Soft reset before tunnel mode configuration
-+	 * Clears stale pipe/CSI state for clean initialization.
-+	 * Aardvark: 0x0002=0x03, sleep 30ms, then proceed with config.
-+	 */
-+	max96717_write_reg(dev, MAX96717_PIPE_EN_ADDR, MAX96717_SOFT_RESET);
-+	msleep(30);
-+
-+	if (priv->pixel_mode)
-+		err = max96717_set_registers(dev, pixel_init,
-+					 ARRAY_SIZE(pixel_init));
-+	else
-+		err = max96717_set_registers(dev, tunnel_init,
-+					 ARRAY_SIZE(tunnel_init));
-+	if (err)
-+		goto error;
-+
-+	/*
-+	 * [FIX] Re-enable GMSL2 mode + TX after soft reset.
-+	 * setup_control() previously set CTRL0=0x21 (GMSL2+TX), but the
-+	 * PIPE_EN=0x03 soft reset above clears it back to the power-on
-+	 * default 0x01 (TX only, GMSL2 mode disabled).  Without this
-+	 * re-write the SER operates in GMSL1 mode while the DES expects
-+	 * GMSL2 — the link trains but the video data path silently breaks.
-+	 */
-+	if (g_ctx->serdes_csi_link == GMSL_SERDES_CSI_LINK_A)
-+		max96717_write_reg(dev, MAX96717_CTRL0_ADDR,
-+				   MAX96717_CTRL0_LINK_A);
-+	else
-+		max96717_write_reg(dev, MAX96717_CTRL0_ADDR,
-+				   MAX96717_CTRL0_LINK_B);
-+
-+	/*
-+	 * [SG2 working config] PHY calibration stage-2: ramp 0x80 -> 0x90.
-+	 * Applied AFTER tunnel mode + lane config, BEFORE CSI reset.
-+	 */
-+	max96717_write_reg(dev, MAX96717_PHY_CAL_2D6_ADDR,
-+			   MAX96717_PHY_CAL_STAGE2);
-+	max96717_write_reg(dev, MAX96717_PHY_CAL_2C7_ADDR,
-+			   MAX96717_PHY_CAL_STAGE2);
-+	msleep(20);
-+
-+	/* [Aardvark-verified] CSI reset cycle with 2ms delay */
-+	max96717_write_reg(dev, MAX96717_MIPI_RX0_ADDR,
-+			   MAX96717_MIPI_RX0_RESET);
++	max96717_write_reg(dev, MAX96717_MIPI_RX0_ADDR, MAX96717_MIPI_RX0_RESET);
 +	usleep_range(2000, 2100);
-+	max96717_write_reg(dev, MAX96717_MIPI_RX0_ADDR,
-+			   MAX96717_MIPI_RX0_NORMAL);
++	max96717_write_reg(dev, MAX96717_MIPI_RX0_ADDR, MAX96717_MIPI_RX0_NORMAL);
 +
-+	/* [XML] Final enable: pipes on + video init */
-+	max96717_write_reg(dev, MAX96717_PIPE_EN_ADDR,
-+			   MAX96717_PIPE_EN_ALL);
++	/* pipes on + video init */
++	max96717_write_reg(dev, MAX96717_PIPE_EN_ADDR, MAX96717_PIPE_EN_ALL);
 +
 +	priv->g_client.st_done = true;
 +
@@ -470,9 +347,6 @@ index 0000000..1dd24d3
 + *      I2C4/SRC_B (0x44) <- (sdev_reg << 1): proxy addr visible to host
 + *      I2C5/DST_B (0x45) <- (sdev_def << 1): real addr on back-channel
 + *
-+ * This lets the Orin host access the D5xx sensor (def-addr 0x42) via
-+ * the aliased proxy address (e.g. 0x1a) through the GMSL link.
-+ *
 + */
 +int max96717_setup_control(struct device *dev)
 +{
@@ -491,17 +365,6 @@ index 0000000..1dd24d3
 +	g_ctx = priv->g_client.g_ctx;
 +
 +	if (prim_priv__) {
-+		/*
-+		 * [HW note] The MAX96717 retains its I2C address across
-+		 * reboots (PoC stays on).  If already at the aliased address,
-+		 * the DEV_ADDR write to 0x40 NACKs.  Skip reassignment when
-+		 * the primary and alias are the same physical device and the
-+		 * serializer is already responsive at a non-default address.
-+		 *
-+		 * For cold-start (first power-on), this write is required.
-+		 * We detect "already reassigned" by trying a read first:
-+		 * if the primary address (0x40) NACKs, skip the reassign.
-+		 */
 +		unsigned int dev_id;
 +		int probe_ret;
 +
@@ -519,7 +382,7 @@ index 0000000..1dd24d3
 +		}
 +	}
 +
-+	/* [PPTX slide 7] CTRL0: GMSL2 mode + TX enable */
++	/* CTRL0: GMSL2 mode + TX enable */
 +	if (g_ctx->serdes_csi_link == GMSL_SERDES_CSI_LINK_A)
 +		err = max96717_write_reg(dev, MAX96717_CTRL0_ADDR,
 +					 MAX96717_CTRL0_LINK_A);
@@ -537,7 +400,6 @@ index 0000000..1dd24d3
 +
 +	/*
 +	 * I2C address translation for sensor passthrough.
-+	 * [MAX96724 Users Guide, I2C Broadcasting, p44-46]
 +	 *
 +	 * I2C4 / SRC_B (0x44): sensor proxy addr visible to Orin host
 +	 * I2C5 / DST_B (0x45): sensor real addr on GMSL back-channel
@@ -568,17 +430,13 @@ index 0000000..1dd24d3
 +/*
 + * max96717_setup_gpio_tunneling - GPIO-over-GMSL no-op hook
 + *
-+ * [PPTX slide 10] GPIO Signal Mapping:
++ *   GPIO Signal Mapping:
 + *   MFP0 → GPIO0: FSIN (DES→SER, frame sync in)
 + *   MFP1 → GPIO1: FOUT/STROBE (SER→DES, frame sync out)
 + *   MFP4 → GPIO4: RESET_N (DES→SER, hard reset)
 + *   MFP5 → GPIO5: IRQ (SER→DES, interrupt request)
 + *   MFP6 → GPIO6: ZV_SYNC (DES→SER, IR stereo sync)
 + *
-+ * The PPTX defines the signal mapping and MFP_CFG register range,
-+ * but not the confirmed direction/function values. Keep this as
-+ * an explicit no-op hook until the MAX96717 GPIO register values
-+ * are available from ADI.
 + */
 +int max96717_setup_gpio_tunneling(struct device *dev)
 +{
@@ -644,7 +502,8 @@ index 0000000..1dd24d3
 +	priv = dev_get_drvdata(dev);
 +	mutex_lock(&priv->lock);
 +	if (priv->g_client.g_ctx) {
-+		/* Already paired — tolerate if this is a re-probe of
++		/* 
++		 * Already paired — tolerate if this is a re-probe of
 +		 * the same camera after a failed first attempt.
 +		 * Simply overwrite with the new g_ctx.
 +		 */
@@ -774,7 +633,8 @@ index 0000000..1dd24d3
 +	struct max96717 *priv = dev_get_drvdata(dev);
 +
 +	struct reg_pair map_init[] = {
-+		/* [XML seq] PIPE_EN soft reset first, then enable tunnel mode.
++		/* 
++		 * PIPE_EN soft reset first, then enable tunnel mode.
 +		 * Note: FRONTTOP0 is bypassed in tunnel mode (per UG) —
 +		 * CSI-2 input goes directly into the tunnel, no port config needed.
 +		 */
@@ -796,7 +656,7 @@ index 0000000..1dd24d3
 +	mutex_lock(&priv->lock);
 +
 +	/*
-+	 * [HW requirement] After CTRL0 + I2C translation writes in
++	 * After CTRL0 + I2C translation writes in
 +	 * setup_control, the MAX96717 needs settling time before
 +	 * accepting writes to PIPE_EN (0x02) and FRONTTOP registers.
 +	 */
@@ -846,7 +706,7 @@ index 0000000..1dd24d3
 +}
 +EXPORT_SYMBOL(max96717_set_pipe);
 +
-+/**
++/*
 + * max96717_retrigger_tx - Toggle SER TX to restore tunnel detection after
 + * a DES ONESHOT.  DES ONESHOT resets the data path; the SER must cycle
 + * its TX enable for the DES to re-acquire the tunnel stream.
@@ -971,10 +831,10 @@ index 0000000..1dd24d3
 +MODULE_LICENSE("GPL v2");
 diff --git a/drivers/media/i2c/max96724.c b/drivers/media/i2c/max96724.c
 new file mode 100644
-index 0000000..4a1708c
+index 0000000..4e73c60
 --- /dev/null
 +++ b/drivers/media/i2c/max96724.c
-@@ -0,0 +1,1927 @@
+@@ -0,0 +1,1905 @@
 +/*
 + * max96724.c - MAX96724 GMSL2 Quad Deserializer driver (Tunnel Mode)
 + *
@@ -1010,40 +870,44 @@ index 0000000..4a1708c
 +
 +/* --- Device ID / Configuration --- */
 +
-+/* [UG p.3] REG0: Device ID (read-only, returns 0xA2) */
++/* REG0: Device ID (read-only, returns 0xA2) */
 +#define MAX96724_DEV_ID_ADDR		0x00
 +
-+/* [Errata §5] ERRB master reset register */
++/* ERRB master reset register */
 +#define MAX96724_ERRB_MST_RST_ADDR	0x05
 +
-+/* [UG Table 3, p.11] 0x0006: GMSL Link/PHY Enable and Mode Select
++/* 
++ *   GMSL Link/PHY Enable and Mode Select
 + *   bits[7:4]: PHY mode (0=GMSL1, 1=GMSL2) per link D/C/B/A
 + *   bits[3:0]: Link Enable per link D/C/B/A
 + */
 +#define MAX96724_LINK_EN_ADDR		0x0006
 +
-+/* [UG Table 3, p.11] 0x0010: GMSL Link/PHY Rate Select (Links A&B)
++/* 
++ *   GMSL Link/PHY Rate Select (Links A&B)
 + *   bits[7:6]: Tx Rate Link B, bits[5:4]: Rx Rate Link B
 + *   bits[3:2]: Tx Rate Link A, bits[1:0]: Rx Rate Link A
 + *   Tx: 00=187.5Mbps, Rx: 01=3Gbps, 10=6Gbps
 + */
 +#define MAX96724_LINK_RATE_AB_ADDR	0x0010
 +
-+/* [UG Table 3, p.12] 0x0011: GMSL Link/PHY Rate Select (Links C&D) */
++/* GMSL Link/PHY Rate Select (Links C&D) */
 +#define MAX96724_LINK_RATE_CD_ADDR	0x0011
 +
-+/* [UG p.13] 0x001A: Link A lock status (bit[3]=LOCK) */
++/* Link A lock status (bit[3]=LOCK) */
 +#define MAX96724_LINK_A_LOCK_ADDR	0x001A
 +
-+/* [UG Table 3, p.12] 0x0018: GMSL Link Reset
++/* 
++ *   GMSL Link Reset
 + *   bits[7:4]: Link reset D/C/B/A, bits[3:0]: One-shot reset D/C/B/A
 + */
 +#define MAX96724_ONESHOT_ADDR		0x0018
 +
-+/* [UG p.11] REG13: Soft Reset (write 0x40, wait 5ms) */
++/* Soft Reset (write 0x40, wait 5ms) */
 +#define MAX96724_REG13_ADDR		0x000D
 +
-+/* [Errata §5] Error Channel Power Up registers (required for 6Gbps)
++/* 
++ *   Error Channel Power Up registers (required for 6Gbps)
 + *   Write 0x75 immediately after power-up for robust 6Gbps operation
 + */
 +#define MAX96724_ERRCH_A_ADDR		0x1449
@@ -1054,7 +918,8 @@ index 0000000..4a1708c
 +
 +/* --- I2C Control Channel / Errata --- */
 +
-+/* [Errata #2] Tunnel Mode SRAM LCRC error suppression
++/* 
++ *   Tunnel Mode SRAM LCRC error suppression
 + *   Set 0x458[7:4] = 0x0 to suppress spurious ERRB in tunnel mode
 + */
 +#define MAX96724_SRAM_LCRC_ERR_ADDR	0x0458
@@ -1073,9 +938,6 @@ index 0000000..4a1708c
 + */
 +#define MAX96724_PIPE_SEL1_ADDR		0xF1
 +
-+/*
-+ *   bit[0]=Pipe 0, bit[1]=Pipe 1, bit[2]=Pipe 2, bit[3]=Pipe 3
-+ */
 +#define MAX96724_PIPE_EN_ADDR		0xF4
 +
 +/* --- Pipe Receiver / Tunnel Mode --- */
@@ -1092,14 +954,15 @@ index 0000000..4a1708c
 +
 +/* --- CSI-2 Output (BACKTOP) --- */
 +
-+/* [UG p.19] BACKTOP: CSI-2 output port enable
++/* BACKTOP: CSI-2 output port enable
 + *   0x040B bit[1]=CSIB_EN, bit[0]=CSIA_EN
 + */
 +#define MAX96724_BACKTOP_EN_ADDR	0x040B
 +
 +/* --- MIPI DPLL (Data Rate) --- */
 +
-+/* [UG Table 12, p.27] MIPI PHY DPLL Freq registers
++/* 
++ *   MIPI PHY DPLL Freq registers
 + *   bits[4:0] = frequency in multiples of 100MHz
 + *   bit[5]    = DPLL enable (must be set for DPLL to lock)
 + *   E.g., 0x27 = 700MHz + enable = 700Mbps/lane D-PHY
@@ -1110,7 +973,8 @@ index 0000000..4a1708c
 +#define MAX96724_DPLL_FREQ2_ADDR	0x041B
 +#define MAX96724_DPLL_FREQ3_ADDR	0x041E
 +
-+/* [UG] DPLL PHY reset control
++/* 
++ *   DPLL PHY reset control
 + *   0x1D00 = DPLL CSI PHY1 control
 + *   Write 0xF4 to disable/reset, 0xF5 to enable
 + */
@@ -1120,49 +984,47 @@ index 0000000..4a1708c
 +
 +/* --- CSI-2 Output PHY Configuration --- */
 +
-+/* [UG rev2 Table 12 + MIPI PHY section] CSI output mode/config register.
++/* 
++ * CSI output mode/config register.
 + * Mode bits (set exactly one of [4:0]):
 + *   bit[0]=0x01: 4x2 mode
 + *   bit[2]=0x04: 2x4 mode        (Ctrl 1 = master for Port A, Ctrl 2 = Port B)
 + *   bit[3]=0x08: 1x4a + 2x2 mode (Ctrl 1 = master for Port A)
 + *   bit[4]=0x10: 1x4b + 2x2 mode (Ctrl 2 = master for Port B)
-+ * In ALL x4 D-PHY modes Port A = PHY0+PHY1 and Port B = PHY2+PHY3 (UG:
-+ * "PHY 1 and PHY 2 are the master PHYs providing the MIPI clock for ports
-+ * A and B").  bit[2] vs bit[3] only differ in how the OTHER port is grouped,
-+ * not in which PHYs carry Port A.
-+ * Clock-force bits (high nibble):
++ *
++ * Clock-force bits:
 + *   bit[7]=0x80: force ALL MIPI clocks running (continuous HS clock)
 + *   bit[6]=0x40: force PHY 3 MIPI clock running
 + *   bit[5]=0x20: force PHY 0 MIPI clock running
 + */
 +#define MAX96724_CSI_OUT_CFG_ADDR	0x08A0
 +
-+/* [UG Table 12, p.25] MIPI PHY Enable register
++/* 
++ *   MIPI PHY Enable register
 + *   bits[7:4]: Enable PHY 3/2/1/0 (1=enabled, 0=standby)
 + */
 +#define MAX96724_CSI_PHY_EN_ADDR	0x08A2
 +
-+/* [UG Table 12, p.25] MIPI PHY 0 and 1 Lane Mapping */
++/* MIPI PHY 0 and 1 Lane Mapping */
 +#define MAX96724_CSI_LANE_MAP1_ADDR	0x08A3
 +
-+/* [UG Table 12, p.26] MIPI PHY 2 and 3 Lane Mapping */
++/* MIPI PHY 2 and 3 Lane Mapping */
 +#define MAX96724_CSI_LANE_MAP2_ADDR	0x08A4
 +
-+/* [FG24-4CH board] MIPI output lane polarity (P/N swap) registers.
++/* 
++ *   MIPI output lane polarity (P/N swap) registers.
 + *   0x08A5 = PHY0/PHY1 lane polarity, 0x08A6 = PHY2/PHY3 lane polarity.
 + *   The FangZhu FG24-4CH PCB swaps the differential P/N pairs on the
 + *   MAX96724 CSI output, so the deserializer must invert lane polarity
-+ *   or the Orin CIL never locks the HS clock (total silence/2500ms timeout).
-+ *   Per FangZhu MAX4CH_FG24_POC_Enable table: write 0x3F to both.
 + */
 +#define MAX96724_CSI_PHY_POL0_ADDR	0x08A5
 +#define MAX96724_CSI_PHY_POL1_ADDR	0x08A6
 +#define MAX96724_CSI_PHY_POL_SWAP	0x3F
 +
-+/* [UG p.22] Pipe-to-controller mapping (Method 1) */
++/* Pipe-to-controller mapping */
 +#define MAX96724_MIPI_CTRL_SEL_ADDR	0x08CA
 +
-+/* [OG03C reference dump] Method-1 controller mapping */
++/* Method-1 controller mapping */
 +#define MAX96724_MIPI_CTRL_SEL_PIXEL	0xE4
 +
 +/* --- Lane Control per pipe (stride 0x40) --- */
@@ -1201,7 +1063,8 @@ index 0000000..4a1708c
 +
 +/* --- Extended Pipe Mapping (DST_CTRL2-4 / TX49) --- */
 +
-+/* [Excel: MIPI_TX46-48] Extended DST_CTRL for additional mapping pairs
++/* 
++ *   Extended DST_CTRL for additional mapping pairs
 + *   All to PHY1 (0x55), same as TX45
 + *   Stride: 0x40 per pipe (base = Pipe X)
 + */
@@ -1209,7 +1072,8 @@ index 0000000..4a1708c
 +#define MAX96724_TX47_PIPE_X_ADDR	0x092F
 +#define MAX96724_TX48_PIPE_X_ADDR	0x0930
 +
-+/* [UG p.30] MIPI_TX49 synchronous concatenation control
++/* 
++ *   MIPI_TX49 synchronous concatenation control
 + *   Set to 0x00 (no concat) for single-camera tunnel mode.
 + *   For 4W concat use 0x87.
 + *   Stride: 0x40 per pipe (base = Pipe X)
@@ -1240,10 +1104,11 @@ index 0000000..4a1708c
 + * Register Values
 + * ================================================================ */
 +
-+/* [UG p.12] Soft reset value (write to 0x000D) */
++/* Soft reset value (write to 0x000D) */
 +#define MAX96724_SOFT_RESET		0x40
 +
-+/* [UG Table 3, p.11-12] Link Rate values for 0x0010/0x0011
++/* 
++ * Link Rate values for 0x0010/0x0011
 + *   Per link pair: bits[1:0]=RxA, [3:2]=TxA, [5:4]=RxB, [7:6]=TxB
 + *   Tx = 00 (187.5Mbps), Rx = 01 (3Gbps) or 10 (6Gbps)
 + *   3Gbps: Tx=00, Rx=01 → per pair 0x01, both pairs = 0x01 in low nibble
@@ -1251,7 +1116,8 @@ index 0000000..4a1708c
 +#define MAX96724_LINK_RATE_3GBPS	0x01  /* Rx=3G, Tx=187.5M for one link pair */
 +#define MAX96724_LINK_RATE_6GBPS	0x02  /* Rx=6G, Tx=187.5M for one link pair */
 +
-+/* [UG Table 3, p.11] 0x0006: Link enable / mode values
++/* 
++ * 0x0006: Link enable / mode values
 + *   bits[7:4] = PHY mode (1=GMSL2 per link)
 + *   bits[3:0] = Link enable per link
 + *   0xF1 = all GMSL2-mode, only Link A enabled
@@ -1260,98 +1126,97 @@ index 0000000..4a1708c
 +#define MAX96724_LINK_EN_SIOA		0xF1  /* GMSL2 all, enable Link A only */
 +#define MAX96724_LINK_EN_ALL		0xFF  /* GMSL2 all, enable all links */
 +
-+/* [UG p.19] BACKTOP_EN (0x040B): CSI output port enable */
++/* BACKTOP_EN (0x040B): CSI output port enable */
 +#define MAX96724_BACKTOP_CSIB_EN	0x02
 +#define MAX96724_BACKTOP_CSIA_EN	0x01
 +
-+/* [XML] VIDEO_RX0: DIS_PKT_DET=1 (bit0) required for tunnel mode.
++/* 
++ *   VIDEO_RX0: DIS_PKT_DET=1 (bit0) required for tunnel mode.
 + *   Without it, DES rejects tunnel data as invalid GMSL2 video packets.
 + *   SEQ_MISS_EN=1 (bit4), LINE_CRC_EN=1 (bit1).  XML value: 0x33.
 + */
 +#define MAX96724_VID_RX0_CFG_VAL	0x33
 +#define MAX96724_VID_RX6_CFG_VAL	0x0A
 +
-+/* [OG03C reference dump] Pixel-mode receiver settings */
++/* Pixel-mode receiver settings */
 +#define MAX96724_VID_RX0_PIXEL_VAL	0x32
 +#define MAX96724_VID_RX6_PIXEL_VAL	0x12
 +
-+/* [XML] Tunnel mode enable (MIPI_TX54, 0x0936):
++/* 
++ *   Tunnel mode enable (MIPI_TX54, 0x0936):
 + *   bit[0] = TUN_EN = 1
 + *   Verified value: 0x01
 + */
 +#define MAX96724_TUN_EN			0x01
 +
-+/* [OG03C reference dump] Default/reset state when tunnel is disabled */
++/* Default/reset state when tunnel is disabled */
 +#define MAX96724_TUN_DISABLED		0x08
 +
-+/* [XML] Tunnel controller destination (MIPI_TX57, 0x0939):
++/* 
++ *   Tunnel controller destination (MIPI_TX57, 0x0939):
 + *   bits[5:4]: TUN_DEST (00=PHY0, 01=PHY1, 10=PHY2, 11=PHY3)
 + *   Verified value: 0x10 = PHY1 destination with auto-detect enabled
 + */
 +#define MAX96724_TUN_DEST_CTRL0		0x00  /* Auto-detect + PHY0 */
 +#define MAX96724_TUN_DEST_CTRL1		0x10  /* Auto-detect + PHY1 (Port A master) */
 +
-+/* [UG rev2 Table 12] CSI output mode values written to 0x08A0.
-+ *   We use bit[2] = 0x04 = clean 2x4 mode (Port A = PHY0+PHY1, Ctrl 1 master).
-+ *   This matches the ADI reference "Lane Swap Programming Example"
-+ *   (0x4E,0x08A0,0x04) and the FangZhu working config.  Note bit[3]=0x08
-+ *   (1x4a+2x2) ALSO keeps Port A on PHY0+PHY1; for a single 4-lane Port A
-+ *   output either presents a valid Port A, so 0x04 is the spec-clean choice
-+ *   rather than a hard requirement.
-+ */
 +#define MAX96724_CSI_MODE_2X4_VAL	0x04  /* bit[2] = clean 2x4: Port A = PHY0+PHY1 */
-+/* 0x84 = 2x4 mode (bit2) + bit[7] "force ALL MIPI clocks running".  The bit[7]
-+ * clock-force is the key part: it keeps the D-PHY clock lane in continuous HS
-+ * mode so the Orin NVCSI/CIL can lock.  Asserted LAST in setup_streaming(),
-+ * matching the FangZhu End_Common 0x08A0=0x84 write. */
++
++/* 
++ *   0x84 = 2x4 mode (bit2) + bit[7] "force ALL MIPI clocks running".  The bit[7]
++ *   clock-force is the key part: it keeps the D-PHY clock lane in continuous HS
++ *   mode so the Orin NVCSI/CIL can lock.
++ */
 +#define MAX96724_CSI_OUT_EN_VAL		0x84  /* 2x4 + bit[7] force all MIPI clocks running */
-+#define MAX96724_CSI_MODE_4X2_VAL	0x01  /* bit[0] = 4x2 mode */
 +
 +#define MAX96724_CSI_PHY_EN_ALL		0xF0
 +#define MAX96724_CSI_PHY_EN_01		0x30  /* PHY0+PHY1 only (Port A) */
 +#define MAX96724_CSI_PHY_EN_23		0xC0  /* PHY2+PHY3 only (Port B) */
 +
-+/* [UG Table 12, p.25-26] Lane mapping default */
++/* Lane mapping default */
 +#define MAX96724_CSI_LANE_MAP_DEFAULT	0xE4
 +
-+/* [UG Table 12, p.26-27] Lane control: 4-lane enabled */
++/* Lane control: 4-lane enabled */
 +#define MAX96724_LANE_CTRL_4LANE	0xC0
 +
-+/* [UG Table 12, p.26-27] Lane control: 2-lane enabled.
++/*
++ *   Lane control: 2-lane enabled.
 + *   bits[7:6] = (num_lanes - 1): 01=2-lane(0x40), 11=4-lane(0xC0)
-+ *   Ref: gmsl_ser_des_guide §8.2, E2E_enable_guide §5.6.4 */
++ *   Ref: gmsl_ser_des_guide §8.2, E2E_enable_guide §5.6.4 
++ */
 +#define MAX96724_LANE_CTRL_2LANE	0x40
 +
-+/* [SC20190112 2-lane] CSI PHY enable: all PHYs powered for DPLL lock
-+ *   stability.  Even though only PHY0 data lanes reach Orin, the MAX96724
-+ *   DPLL requires all PHYs to be powered.  Tested: single PHY → PLL never locks. */
++/* 
++ *   CSI PHY enable: all PHYs powered for DPLL lock.
++ */
 +#define MAX96724_CSI_PHY_EN_2LANE	0xF0
 +
-+/* [SC20190112 2-lane] DPLL for Controller 0 (drives PHY0, 2 lanes).
++/* 
++ *   DPLL for Controller 0 (drives PHY0, 2 lanes).
 + *   bits[4:0] = data-rate / 100 MHz.  700 Mbps / 100 = 7 = 0x07.
 + *   bit[5]    = DPLL enable = 1.
-+ *   Result: 0x27 = 700 Mbps/lane D-PHY. */
++ *   Result: 0x27 = 700 Mbps/lane D-PHY.
++ */
 +#define MAX96724_DPLL_700MBPS_CTRL0	0x27
 +
-+/* [FG24-4CH working-config verified] CSI-output DPLL data rate = 1500 Mbps.
++/* 
++ *   CSI-output DPLL data rate = 1500 Mbps.
 + *   bits[4:0] = data-rate / 100 MHz -> 1500/100 = 15 = 0x0F. bit[5] = DPLL en.
-+ *   Result 0x2F.  The FangZhu MAX4CH config writes this to ALL FOUR controllers
-+ *   (0x0415/0x0418/0x041B/0x041E), matching DT max_lane_speed = 1500000.  The
-+ *   old 0x27 (700 Mbps, 2 controllers only) is a 2-lane-variant leftover that
-+ *   left the Orin CIL unable to lock the HS clock (empty rtcpu trace). */
++ */
 +#define MAX96724_DPLL_1500MBPS		0x2F
 +
-+/* [UG Table 3, p.12] One-shot reset: all links */
++/* One-shot reset: all links */
 +#define MAX96724_ONESHOT_ALL		0x0F
 +
-+/* [UG Table 4, p.15] Pipe source selection values
-+ *   Encoding per pipe nibble in tunnel mode (Aardvark-verified):
++/* 
++ *   Pipe source selection values
++ *   Encoding per pipe nibble in tunnel mode:
 + *   0x22 routes all pipes from Link A in tunnel mode.
 + */
-+#define MAX96724_PIPE_SEL0_SINGLE	0x22  /* All pipes from Link A (Aardvark-verified) */
-+#define MAX96724_PIPE_SEL1_SINGLE	0x22  /* All pipes from Link A (Aardvark-verified) */
-+#define MAX96724_PIPE_SEL0_PIXEL	0x62  /* OG03C pixel-mode reference */
-+#define MAX96724_PIPE_SEL1_PIXEL	0xEA  /* OG03C pixel-mode reference */
++#define MAX96724_PIPE_SEL0_SINGLE	0x22  /* All pipes from Link A */
++#define MAX96724_PIPE_SEL1_SINGLE	0x22  /* All pipes from Link A */
++#define MAX96724_PIPE_SEL0_PIXEL	0x62  /* pixel-mode reference */
++#define MAX96724_PIPE_SEL1_PIXEL	0xEA  /* pixel-mode reference */
 +#define MAX96724_PIPE_SEL0_DUAL		0x40  /* Pipe 0 ← A/X, Pipe 1 ← B/X */
 +#define MAX96724_PIPE_SEL0_QUAD_LO	0x40  /* Pipe 0 ← A/X, Pipe 1 ← B/X */
 +#define MAX96724_PIPE_SEL1_QUAD_HI	0xC8  /* Pipe 2 ← C/X, Pipe 3 ← D/X */
@@ -1373,12 +1238,12 @@ index 0000000..4a1708c
 +#define MAX96724_RESET_ST_ID		0x00
 +#define MAX96724_ST_ID_SEL_INVALID	0xF
 +
-+/* Controller mapping: all mappings → Controller 0 (not working in tunnel mode) */
++/* Controller mapping: all mappings → Controller 0 */
 +#define MAX96724_ALL_MAP_CTRL0		0x00
-+/* Controller mapping: all mappings → Controller 1 (Aardvark-verified working) */
++/* Controller mapping: all mappings → Controller 1 */
 +#define MAX96724_ALL_MAP_CTRL1		0x55
 +
-+/* [OG03C reference dump] Three mappings to controller 1 */
++/* Three mappings to controller 1 */
 +#define MAX96724_MAP3_CTRL1		0x15
 +
 +/* ================================================================
@@ -1400,16 +1265,9 @@ index 0000000..4a1708c
 +#define MAX96724_CSI_CTRL_2		2
 +#define MAX96724_CSI_CTRL_3		3
 +
-+/* Internal csi_mode enum flags (NOT the register value written to 0x08A0;
-+ * see MAX96724_CSI_MODE_2X4_VAL for the actual register value).  These are
-+ * only compared against priv->csi_mode to select a code path. */
-+#define MAX96724_CSI_MODE_4X2		0x01
 +#define MAX96724_CSI_MODE_2X4		0x08  /* enum tag for the 4-lane Port A (Ctrl1) path */
-+#define MAX96724_CSI_MODE_2X4_ALT	0x04  /* enum tag (unused alt path) */
 +
 +/* Lane map presets */
-+#define MAX96724_LANE_MAP1_4X2		0x44
-+#define MAX96724_LANE_MAP2_4X2		0x44
 +#define MAX96724_LANE_MAP1_2X4		0xE4  /* SC20190112 subset: PHY0 data + PHY1 clock */
 +#define MAX96724_LANE_MAP2_2X4		0x44  /* keep unused PHY2/3 straight in 0x08 mode */
 +
@@ -2042,10 +1900,6 @@ index 0000000..4a1708c
 +		goto error;
 +	}
 +
-+	/* Check csi mode compatibility.
-+	 * 2x4 DES → gmsl-link: 1x4 or 2x4.
-+	 * 4x2 DES → gmsl-link: 1x4, 2x2, or 4x2.
-+	 */
 +	if (priv->csi_mode == MAX96724_CSI_MODE_2X4) {
 +		if (!((g_ctx->csi_mode == GMSL_CSI_1X4_MODE) ||
 +		      (g_ctx->csi_mode == GMSL_CSI_2X4_MODE))) {
@@ -2054,14 +1908,9 @@ index 0000000..4a1708c
 +			goto error;
 +		}
 +	} else {
-+		/* 4x2 DES mode: accept 1x4, 2x2, or 4x2 gmsl-link mode */
-+		if (!((g_ctx->csi_mode == GMSL_CSI_1X4_MODE) ||
-+		      (g_ctx->csi_mode == GMSL_CSI_2X2_MODE) ||
-+		      (g_ctx->csi_mode == GMSL_CSI_4X2_MODE))) {
-+			dev_err(dev, "%s: csi mode not supported\n", __func__);
-+			err = -EINVAL;
-+			goto error;
-+		}
++		dev_err(dev, "%s: only csi 2x4 mode is supported\n", __func__);
++		err = -EINVAL;
++		goto error;
 +	}
 +
 +	for (i = 0; i < priv->num_src; i++) {
@@ -2144,7 +1993,7 @@ index 0000000..4a1708c
 + * with all VCs and DTs preserved from the serializer.
 + *
 + * The pipeline configuration:
-+ *   1. Configure pipe-to-link routing (which GMSL input → which pipe)
++ *   1. Configure pipe-to-link routing
 + *   2. Enable tunnel mode on active pipes
 + *   3. Configure MIPI CSI-2 output lanes and PHY
 + *   4. Enable BACKTOP output port
@@ -2195,9 +2044,9 @@ index 0000000..4a1708c
 +	}
 +
 +	/*
-+	 * [Aardvark-verified] Pipe source routing
-+	 *   Single cam: all pipes from Link A (0x22/0x22)
-+	 *   Disable pipes before configuration, enable at the end
++	 * Pipe source routing
++	 * Single cam: all pipes from Link A (0x22/0x22)
++	 * Disable pipes before configuration, enable at the end
 +	 */
 +	max96724_write_reg(dev, MAX96724_PIPE_SEL0_ADDR, pipe_sel0);
 +	max96724_write_reg(dev, MAX96724_PIPE_SEL1_ADDR, pipe_sel1);
@@ -2205,16 +2054,14 @@ index 0000000..4a1708c
 +	max96724_write_reg(dev, MAX96724_PIPE_EN_ADDR, 0x00);
 +
 +	/*
-+	 * [SC20190112] Keep 0x08 mode so PHY1 remains the Port A clock master,
++	 * Keep 0x08 mode so PHY1 remains the Port A clock master,
 +	 * but restore the live 2-lane subset used by the bridge board.
 +	 */
 +	max96724_apply_porta_subset(dev, priv);
 +
 +	/*
-+	 * [D585 700Mbps fix] CSI-output DPLL data rate = 700 Mbps
-+	 * on ALL FOUR controller freq registers, matching D585 native
-+	 * MIPI rate (pix_clk_hz=175M, 16bpp, 4-lane).
-+	 * DT serdes_pix_clk_hz=175MHz drives correct THS_SETTLE for 700Mbps.
++	 * CSI-output DPLL data rate = 700 Mbps
++	 * on ALL FOUR controller freq registers
 +	 */
 +	if (!priv->lane_setup) {
 +		max96724_write_reg(dev, MAX96724_DPLL_FREQ0_ADDR,
@@ -2233,7 +2080,7 @@ index 0000000..4a1708c
 +			   MAX96724_MIPI_CTRL_SEL_PIXEL);
 +
 +	/*
-+	 * [Aardvark-verified] Stream ID select for all pipes
++	 * Stream ID select for all pipes
 +	 * 0x0933 + 0x40*pipe = stream select register
 +	 * Value 0x10 selects the appropriate stream for tunnel mode
 +	 */
@@ -2243,7 +2090,8 @@ index 0000000..4a1708c
 +				   st_sel_cfg);
 +	}
 +
-+	/* BACKTOP: enable Controller 1 / CSI-B (0x02).
++	/* 
++	 * BACKTOP: enable Controller 1 / CSI-B (0x02).
 +	 * In 2x4 mode, Controller 1 is master for Port A -> Orin CSI.
 +	 */
 +	max96724_write_reg(dev, MAX96724_BACKTOP_EN_ADDR,
@@ -2252,10 +2100,9 @@ index 0000000..4a1708c
 +	dev_info(dev, "=== setup_streaming: writing 0x84 (force all MIPI clocks) ===\n");
 +
 +	/*
-+	 * [FG24-4CH working-config verified] Assert 0x08A0=0x84 LAST: 2x4 mode +
-+	 * bit[7] "force all MIPI clocks running".  The clock-force keeps the
-+	 * D-PHY clock lane continuous so the Orin CIL can lock; written only
-+	 * after the full pipeline is configured, matching FangZhu End_Common.
++	 * Assert 0x08A0=0x84 LAST: 2x4 mode + bit[7] "force all MIPI clocks running".  
++	 * The clock-force keeps the D-PHY clock lane continuous so the Orin CIL can lock;
++	 * written only after the full pipeline is configured.
 +	 */
 +	max96724_write_reg(dev, MAX96724_CSI_OUT_CFG_ADDR,
 +			   MAX96724_CSI_OUT_EN_VAL);
@@ -2280,7 +2127,7 @@ index 0000000..4a1708c
 +	max96724_write_reg(dev, MAX96724_ONESHOT_ADDR,
 +			   MAX96724_ONESHOT_ALL);
 +
-+	/* Enable all 4 pipes (Aardvark-verified: 0x0F at end) */
++	/* Enable all 4 pipes */
 +	max96724_write_reg(dev, MAX96724_PIPE_EN_ADDR, MAX96724_PIPE_EN_4);
 +
 +	priv->sources[src_idx].st_enabled = true;
@@ -2393,10 +2240,7 @@ index 0000000..4a1708c
 +
 +int max96724_get_ser_pipe_id(struct device *dev, int dser_pipe_id, int vc_id)
 +{
-+	/*
-+	 * In Tunnel Mode with MAX96717, all VCs are carried in a single
-+	 * tunnel pipe. The pipe mapping is 1:1 for d4xx compatibility.
-+	 */
++	/* In Tunnel Mode with MAX96717, all VCs are carried in a single tunnel pipe. */
 +	return dser_pipe_id;
 +}
 +EXPORT_SYMBOL(max96724_get_ser_pipe_id);
@@ -2414,7 +2258,7 @@ index 0000000..4a1708c
 +
 +	mutex_lock(&priv->lock);
 +	if (priv->splitter_enabled) {
-+		/* [UG] Multi-camera: reset all links */
++		/* Multi-camera: reset all links */
 +		u8 link_rate = (priv->link_speed == 6) ? 0x22 : 0x11;
 +
 +		max96724_write_reg(dev, MAX96724_LINK_RATE_AB_ADDR,
@@ -2445,20 +2289,21 @@ index 0000000..4a1708c
 +		dpll_cfg = MAX96724_DPLL_1500MBPS;
 +	}
 +
-+	/* ONESHOT resets CSI/tunnel state. Restore the full pipeline config.
++	/* 
++	 * ONESHOT resets CSI/tunnel state. Restore the full pipeline config.
 +	 * Mirror setup_streaming() order: disable pipes -> restore everything ->
 +	 * BACKTOP/0x84 -> VID_RX -> final ONESHOT to latch -> enable pipes.
 +	 */
 +	max96724_write_reg(dev, MAX96724_PIPE_EN_ADDR, 0x00);
 +
-+	/* Pipe source routing (same as setup_streaming): all pipes from Link A */
++	/* Pipe source routing: all pipes from Link A */
 +	max96724_write_reg(dev, MAX96724_PIPE_SEL0_ADDR, pipe_sel0);
 +	max96724_write_reg(dev, MAX96724_PIPE_SEL1_ADDR, pipe_sel1);
 +
 +	max96724_apply_porta_subset(dev, priv);
 +
 +	/*
-+	 * [D585 700Mbps fix] CSI-output DPLL data rate = 700 Mbps on ALL
++	 * CSI-output DPLL data rate = 700 Mbps on ALL
 +	 * FOUR controllers, matching D585 native MIPI rate.
 +	 * reset_oneshot is called by the sensor after setup_streaming, so it must
 +	 * mirror the same DPLL values.
@@ -2518,7 +2363,7 @@ index 0000000..4a1708c
 +			   MAX96724_PIPE_EN_4);
 +
 +	/*
-+	 * [FG24-4CH working-config verified] Assert 0x08A0=0x84 LAST:
++	 * Assert 0x08A0=0x84 LAST:
 +	 * 2x4 mode + bit[7] force all MIPI clocks running.  Must mirror
 +	 * setup_streaming because the sensor's oneshot path overwrites it.
 +	 */
@@ -2566,7 +2411,7 @@ index 0000000..4a1708c
 +		{MAX96724_TX46_PIPE_X_ADDR, MAX96724_ALL_MAP_CTRL1},
 +		{MAX96724_TX47_PIPE_X_ADDR, MAX96724_ALL_MAP_CTRL1},
 +		{MAX96724_TX48_PIPE_X_ADDR, MAX96724_ALL_MAP_CTRL1},
-+		/* TX49: concat disabled (single-camera) */
++		/* TX49: concat disabled */
 +		{MAX96724_TX49_PIPE_X_ADDR, 0x00},
 +		/*
 +		 * Keep DES heartbeat handling aligned with the serializer's
@@ -2576,12 +2421,13 @@ index 0000000..4a1708c
 +		{0x0106, MAX96724_VID_RX6_CFG_VAL},
 +		/*
 +		 * Pipe stream control (offset 0x36 per pipe block).
-+		 * [XML] TUN_EN = 0x01.
++		 * TUN_EN = 0x01.
 +		 */
 +		{0x0936, MAX96724_TUN_EN},
 +	};
 +
-+	/* Adjust addresses for pipe offset (stride 0x40 per pipe)
++	/* 
++	 * Adjust addresses for pipe offset (stride 0x40 per pipe)
 +	 * Entries 0-13: TX11, SRC/DST maps, TX45-TX49 (all stride 0x40)
 +	 * Entries 14-15: VID_RX0/6 (stride 0x12)
 +	 * Entry 16: Pipe stream control (stride 0x40)
@@ -2589,7 +2435,7 @@ index 0000000..4a1708c
 +	for (i = 0; i < 14; i++)
 +		map_pipe_control[i].addr += 0x40 * pipe_id;
 +
-+	/* [max9296.c pattern] VID_RX offset: 0x12 per pipe */
++	/* VID_RX offset: 0x12 per pipe */
 +	map_pipe_control[14].addr += 0x12 * pipe_id;
 +	map_pipe_control[15].addr += 0x12 * pipe_id;
 +
@@ -2610,7 +2456,7 @@ index 0000000..4a1708c
 +		map_pipe_control[15].val = MAX96724_VID_RX6_PIXEL_VAL;
 +		map_pipe_control[16].val = MAX96724_TUN_DISABLED;
 +	} else {
-+		/* Single-RGB tunnel: no concatenation needed */
++		/* no concatenation needed */
 +		map_pipe_control[13].val = 0x00;
 +	}
 +
@@ -2628,7 +2474,7 @@ index 0000000..4a1708c
 +	map_pipe_control[9].val = all_mapping_phy;
 +	/* TX46-TX48 keep 0x55 (Ctrl1) from initializer */
 +	/* TX49 set to 0x00 above — overridden per mode in pixel/tunnel branch */
-+	/* VID_RX (entry 14) and pipe stream ctrl (entry 15) keep init values */
++	/* VID_RX and pipe stream ctrl keep init values */
 +
 +	err = max96724_set_registers(dev, map_pipe_control,
 +				     ARRAY_SIZE(map_pipe_control));
@@ -2731,16 +2577,8 @@ index 0000000..4a1708c
 +
 +	if (!strcmp(str_value, "2x4")) {
 +		priv->csi_mode = MAX96724_CSI_MODE_2X4;
-+		/*
-+		 * SC20190112 keeps the 0x08 Port-A clocking scheme but only brings
-+		 * PHY0 data lanes and the PHY1 clock lane to Orin.
-+		 */
 +		priv->lane_mp1 = MAX96724_LANE_MAP1_2X4;
 +		priv->lane_mp2 = MAX96724_LANE_MAP2_2X4;
-+	} else if (!strcmp(str_value, "4x2")) {
-+		priv->csi_mode = MAX96724_CSI_MODE_4X2;
-+		priv->lane_mp1 = MAX96724_LANE_MAP1_4X2;
-+		priv->lane_mp2 = MAX96724_LANE_MAP2_4X2;
 +	} else {
 +		dev_err(&client->dev, "invalid csi mode\n");
 +		return -EINVAL;
@@ -2762,7 +2600,7 @@ index 0000000..4a1708c
 +		priv->reset_gpio = -1;
 +	}
 +
-+	/* [User requirement] GMSL link speed from DT: 3 or 6 (Gbps) */
++	/* GMSL link speed from DT: 3 or 6 (Gbps) */
 +	err = of_property_read_u32(node, "gmsl-link-speed", &value);
 +	if (err < 0) {
 +		/* Default to 3 Gbps if not specified */

--- a/nvidia-oot/7.1/0011-Add-MAX96717-serializer-and-MAX96724-deserializer-dr.patch
+++ b/nvidia-oot/7.1/0011-Add-MAX96717-serializer-and-MAX96724-deserializer-dr.patch
@@ -22,36 +22,22 @@ MAX96724 quad deserializer features:
 
 Signed-off-by: RealSense AI <realsense@realsenseai.com>
 ---
- drivers/media/i2c/Makefile   |    2 +
- drivers/media/i2c/max96717.c |  917 ++++++++++++++++
- drivers/media/i2c/max96724.c | 1927 ++++++++++++++++++++++++++++++++++
+ drivers/media/i2c/max96717.c |  791 ++++++++++++++
+ drivers/media/i2c/max96724.c | 1905 ++++++++++++++++++++++++++++++++++
  include/media/max96717.h     |  151 ++
  include/media/max96724.h     |  183 +++
- 5 files changed, 3180 insertions(+)
+ 4 files changed, 3030 insertions(+)
  create mode 100644 drivers/media/i2c/max96717.c
  create mode 100644 drivers/media/i2c/max96724.c
  create mode 100644 include/media/max96717.h
  create mode 100644 include/media/max96724.h
 
-diff --git a/drivers/media/i2c/Makefile b/drivers/media/i2c/Makefile
-index b284938..947e6e9 100644
---- a/drivers/media/i2c/Makefile
-+++ b/drivers/media/i2c/Makefile
-@@ -8,6 +8,8 @@ obj-m += max9296.o
- subdir-ccflags-y += -DCONFIG_VIDEO_D4XX_SERDES
- subdir-ccflags-y += -DCONFIG_TEGRA_CAMERA_PLATFORM
- obj-m += d4xx.o
-+obj-m += max96717.o
-+obj-m += max96724.o
- ifeq ($(findstring ack_src,$(NV_BUILD_KERNEL_OPTIONS)),)
- obj-m += max96712.o
- 
 diff --git a/drivers/media/i2c/max96717.c b/drivers/media/i2c/max96717.c
 new file mode 100644
-index 0000000..1dd24d3
+index 0000000..c26c24b
 --- /dev/null
 +++ b/drivers/media/i2c/max96717.c
-@@ -0,0 +1,917 @@
+@@ -0,0 +1,791 @@
 +/*
 + * max96717.c - MAX96717 GMSL2 Serializer driver (Tunnel Mode)
 + *
@@ -70,14 +56,6 @@ index 0000000..1dd24d3
 + * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
-+/*
-+ * Register Reference Sources:
-+ * [PPTX]  = GMSL_MAX96717_MAX96724_TechOverview - V1.pptx
-+ * [XML]   = MAX96717_MAX96724_HKR_EVB_700mbps_tunnel_mode_basedonexcelsheet_D585.xml
-+ *
-+ * Every register address and value below is traceable to one of these sources.
-+ */
-+
 +#include <media/camera_common.h>
 +#include <linux/of.h>
 +#include <linux/module.h>
@@ -85,149 +63,146 @@ index 0000000..1dd24d3
 +
 +/* ===== Register Addresses ===== */
 +
-+/* [PPTX slide 7] REG0: Device ID (read-only, returns 0x40) */
++/* REG0: Device ID (read-only, returns 0x40) */
 +#define MAX96717_DEV_ADDR		0x00
 +
-+/* [PPTX slide 7] REG1: Link Speed
++/* 
++ *   REG1: Link Speed
 + *   bit[3]=1: 3 Gbps, bit[4]=1: 6 Gbps
 + */
 +#define MAX96717_REG1_ADDR		0x01
 +
-+/* [PPTX slide 7 / XML 0x0002] PIPE_EN: Pipe enable / soft reset
-+ *   [XML] 0x03 = soft reset, 0x43 = pipes enabled + video init
-+ *   [PPTX slide 7] Matches MAX9295 PIPE_EN at 0x02
++/* 
++ *   PIPE_EN: Pipe enable / soft reset
++ *   0x03 = soft reset, 0x43 = pipes enabled + video init
++ *   Matches MAX9295 PIPE_EN at 0x02
 + */
 +#define MAX96717_PIPE_EN_ADDR		0x02
 +
-+/* [PPTX slide 7] CTRL0: GMSL2 TX Control
++/* 
++ *   CTRL0: GMSL2 TX Control
 + *   bit[5]=1: GMSL2 mode, bit[0]=1: enable transmitter
 + *   0x21 = GMSL2 mode + TX enable on Link A
 + */
 +#define MAX96717_CTRL0_ADDR		0x10
 +
-+/* [PPTX slide 7] CTRL3: Start Video - final enable bit
++/* 
++ *   CTRL3: Start Video - final enable bit
 + *   bit[0]=1: activate video stream
 + */
 +#define MAX96717_CTRL3_ADDR		0x13
 +
-+/* [PPTX slide 7] TX1: FEC Enable
++/* 
++ *   TX1: FEC Enable
 + *   bit[6]=1: Reed-Solomon FEC enabled
 + */
 +#define MAX96717_TX1_ADDR		0x29
 +
-+/* [MAX96724 Users Guide, I2C Broadcasting section, p44-46]
-+ * MAX96717 I2C address translation registers (GMSL2 standard):
++/*
++ *   MAX96717 I2C address translation registers (GMSL2 standard):
 + *   SRC_A / DST_A (0x42/0x43): Translation pair A (SER broadcast addr)
 + *   SRC_B / DST_B (0x44/0x45): Translation pair B (sensor passthrough)
 + *
-+ * When host writes to SRC_B address, the MAX96717 translates it to
-+ * DST_B and forwards via GMSL back-channel to the remote sensor.
++ *   When host writes to SRC_B address, the MAX96717 translates it to
++ *   DST_B and forwards via GMSL back-channel to the remote sensor.
 + *
 + */
 +#define MAX96717_SRC_A_ADDR		0x42
 +#define MAX96717_DST_A_ADDR		0x43
-+#define MAX96717_I2C4_ADDR		0x44	/* SRC_B: sensor proxy addr */
-+#define MAX96717_I2C5_ADDR		0x45	/* DST_B: sensor default addr */
++#define MAX96717_I2C4_ADDR		0x44
++#define MAX96717_I2C5_ADDR		0x45
 +
-+/* [PPTX slide 14] TX_STR_SEL: Stream ID select
++/* 
++ *   TX_STR_SEL: Stream ID select
 + *   bits[1:0]: stream ID for DES pipe routing
 + */
 +#define MAX96717_TX_STR_SEL_ADDR	0x5B
 +
-+/* [PPTX slide 7 / XML 0x0110-0x0111] VIDEO_TX0/TX1: Video TX path config
-+ *   [XML] 0x0110=0xE9, 0x0111=0x10 for tunnel mode data path
++/* 
++ *   VIDEO_TX0/TX1: Video TX path config
++ *   0x0110=0xE9, 0x0111=0x10 for tunnel mode data path
 + */
 +#define MAX96717_VIDEO_TX0_ADDR		0x110
 +#define MAX96717_VIDEO_TX1_ADDR		0x111
 +
-+/* [PPTX slide 7] FRONTTOP_0: Front-end topology
++/* 
++ *   FRONTTOP_0: Front-end topology
 + *   0x12 = single CSI-2 port A, all VCs pass through
 + */
 +#define MAX96717_FRONTTOP0_ADDR		0x308
 +
-+/* [XML / PPTX slide 7] MIPI_RX0-RX3: CSI-2 receiver configuration
++/* 
++ *   MIPI_RX0-RX3: CSI-2 receiver configuration
 + *   RX0 (0x330): CSI mode (0x00 = D-PHY controller A)
-+ *   RX1 (0x331): Lane count - [PPTX slide 14] ctrl1_num_lanes bits[5:4]
-+ *                 [XML] 0x30 = bits[5:4]=11 (4 lanes)
-+ *   RX2 (0x332): Lane mapping - [XML] 0xE0 = default 1x4 map
-+ *   RX3 (0x333): Lane mapping - [XML] 0x04 = default 1x4 map
++ *   RX1 (0x331): Lane count - ctrl1_num_lanes bits[5:4]
++ *                0x30 = bits[5:4]=11 (4 lanes)
++ *   RX2 (0x332): Lane mapping - 0xE0 = default 1x4 map
++ *   RX3 (0x333): Lane mapping - 0x04 = default 1x4 map
 + */
 +#define MAX96717_MIPI_RX0_ADDR		0x330
 +#define MAX96717_MIPI_RX1_ADDR		0x331
 +#define MAX96717_MIPI_RX2_ADDR		0x332
 +#define MAX96717_MIPI_RX3_ADDR		0x333
 +
-+/* [PPTX slide 7 / slide 14] EXT11: TUNNEL MODE ENABLE
-+ *   bit[7]=1: Tun_Mode = ON  *** CRITICAL REGISTER ***
-+ *   [PPTX slide 7] 0x383 = 0x80
++/* 
++ *   EXT11: TUNNEL MODE ENABLE
++ *   bit[7]=1: Tun_Mode = ON
++ *   0x383 = 0x80
 + */
 +#define MAX96717_EXT11_ADDR		0x383
 +
-+/* [SG2 working config] SER PHY / DLL calibration registers.
-+ *   These are device-level (not sensor-specific) and appear in every
-+ *   SG2 sensor variant (OX03C, ISX031, etc.).  The staged write pattern
-+ *   (0x80 -> 0x90) on 0x2D6/0x2C7 is a PHY calibration ramp sequence.
-+ *   Without these writes the GMSL2 link trains but the DES cannot
-+ *   recover a clean CSI-2 clock from the tunnel-mode data stream.
-+ */
-+#define MAX96717_PHY_CAL_2D6_ADDR	0x2D6
-+#define MAX96717_PHY_CAL_2C7_ADDR	0x2C7
-+#define MAX96717_PHY_CAL_2BE_ADDR	0x2BE
-+#define MAX96717_PHY_CAL_2C1_ADDR	0x2C1
-+#define MAX96717_PHY_CAL_3F0_ADDR	0x3F0
-+#define MAX96717_PHY_CAL_3F1_ADDR	0x3F1
-+
-+/* [SG2 working config] PHY calibration stage-1 value */
++/* PHY calibration stage-1 value */
 +#define MAX96717_PHY_CAL_STAGE1		0x80
-+/* [SG2 working config] PHY calibration stage-2 value */
++/* PHY calibration stage-2 value */
 +#define MAX96717_PHY_CAL_STAGE2		0x90
-+/* [SG2 working config] CSI input timing / frequency config */
++/* CSI input timing / frequency config */
 +#define MAX96717_CSI_TIMING_3F0		0x59
 +#define MAX96717_CSI_TIMING_3F1		0x09
 +
 +/* ===== Register Values ===== */
 +
-+/* [XML] Soft reset value for PIPE_EN register */
++/* Soft reset value for PIPE_EN register */
 +#define MAX96717_SOFT_RESET		0x03
 +
-+/* [XML] Final enable: pipes enabled + video init */
++/* Final enable: pipes enabled + video init */
 +#define MAX96717_PIPE_EN_ALL		0x43
 +
-+/* [PPTX slide 7] CTRL0: GMSL2 mode + TX enable (Link A) */
++/* CTRL0: GMSL2 mode + TX enable (Link A) */
 +#define MAX96717_CTRL0_LINK_A		0x21
 +/* CTRL0: GMSL2 mode + TX enable (Link B) */
 +#define MAX96717_CTRL0_LINK_B		0x22
 +
-+/* [PPTX slide 7] CTRL0 reset all */
++/* CTRL0 reset all */
 +#define MAX96717_RESET_ALL		0x80
 +
-+/* [PPTX slide 7] EXT11 tunnel mode enable value */
++/* EXT11 tunnel mode enable value */
 +#define MAX96717_TUN_MODE_EN		0x80
 +#define MAX96717_TUN_MODE_DIS		0x00
 +
-+/* [XML] VIDEO_TX0 tunnel mode data path enable */
++/* VIDEO_TX0 tunnel mode data path enable */
 +#define MAX96717_VIDEO_TX0_TUN		0xE9
-+/* [XML] VIDEO_TX1 tunnel mode config */
++/* VIDEO_TX1 tunnel mode config */
 +#define MAX96717_VIDEO_TX1_TUN		0x10
 +#define MAX96717_VIDEO_TX0_BPP_MANUAL	0x60
 +#define MAX96717_VIDEO_TX1_BPP16	0x50
 +#define MAX96717_VIDEO_TX2_ADDR		0x112
 +#define MAX96717_VIDEO_TX2_DRIFT_DIS	0x08
 +
-+/* [SG2 working config] MIPI RX1: 4-lane CSI-2.
-+ *   bits[5:4]=11 (4 lanes).  bits[1:0]=11 (PHY mode / lane ordering
-+ *   matching SG2 working config; was 0x30, SG2 uses 0x33). */
++/* 
++ *   MIPI RX1: 4-lane CSI-2.
++ *   bits[5:4]=11 (4 lanes).  bits[1:0]=11
++ */
 +#define MAX96717_CSI_4_LANES		0x33
 +/* 2-lane CSI-2, bits[5:4]=01 */
 +#define MAX96717_CSI_2_LANES		0x10
 +
-+/* [XML] Lane mapping for 1x4 mode (matches MAX9295 1x4 values) */
++/* Lane mapping for 1x4 mode */
 +#define MAX96717_CSI_1X4_LANE_MAP1	0xE0
 +#define MAX96717_CSI_1X4_LANE_MAP2	0x04
 +
-+/* [PPTX slide 7] FRONTTOP_0: single port A, all VCs */
++/* FRONTTOP_0: single port A, all VCs */
 +#define MAX96717_FRONTTOP0_PORT_A	0x12
-+/* [UG Use Case Example 1] Pixel mode from Port B into Pipe Z */
++/* Pixel mode from Port B into Pipe Z */
 +#define MAX96717_FRONTTOP0_PIXEL_PORT_B	0x64
 +#define MAX96717_FRONTTOP5_ADDR		0x30D
 +#define MAX96717_FRONTTOP9_ADDR		0x311
@@ -235,17 +210,17 @@ index 0000000..1dd24d3
 +#define MAX96717_FRONTTOP17_ADDR	0x319
 +#define MAX96717_FRONTTOP9_START_VIDEO	0x40
 +
-+/* [XML] MIPI_RX0: CSI reset on + non-continuous clock */
++/* MIPI_RX0: CSI reset on + non-continuous clock */
 +#define MAX96717_MIPI_RX0_RESET		0x08
-+/* [PPTX slide 7] MIPI_RX0: Normal operation */
++/* MIPI_RX0: Normal operation */
 +#define MAX96717_MIPI_RX0_NORMAL	0x00
 +
-+/* [PPTX slide 9] REG1: 3 Gbps link speed, bit[3]=1 */
++/* REG1: 3 Gbps link speed, bit[3]=1 */
 +#define MAX96717_LINK_SPEED_3GBPS	0x08
-+/* [PPTX slide 9] REG1: 6 Gbps link speed, bit[4]=1 */
++/* REG1: 6 Gbps link speed, bit[4]=1 */
 +#define MAX96717_LINK_SPEED_6GBPS	0x10
 +
-+/* [XML] EXT11 tunnel mode pre-config (0x0383=0x80) */
++/* EXT11 tunnel mode pre-config (0x0383=0x80) */
 +#define MAX96717_EXT11_TUN_PRE		0x80
 +
 +#define MAX96717_MAX_PIPES		4
@@ -323,43 +298,6 @@ index 0000000..1dd24d3
 +	int err = 0;
 +	struct gmsl_link_ctx *g_ctx;
 +
-+	/*
-+	 * [XML] Full initialization sequence:
-+	 *   0x0002 = 0x03  (soft reset)
-+	 *   0x0383 = 0x80  (tunnel mode enable)
-+	 *   0x0331 = 0x30  (4-lane CSI)
-+	 *   0x0332 = 0xE0  (lane map1)
-+	 *   0x0333 = 0x04  (lane map2)
-+	 *   0x0110 = 0xE9  (video TX0 tunnel path)
-+	 *   0x0111 = 0x10  (video TX1 tunnel config)
-+	 *   0x0330 = 0x08  (CSI reset on)
-+	 *   0x0330 = 0x00  (CSI reset off)
-+	 *   0x0002 = 0x43  (final enable)
-+	 */
-+	struct reg_pair tunnel_init[] = {
-+		/* [PPTX slide 7] EXT11: Tunnel Mode Enable */
-+		{MAX96717_EXT11_ADDR, MAX96717_TUN_MODE_EN},
-+		/* [XML] MIPI_RX1: 4-lane CSI-2 (CTRL1_NUM_LANES[5:4]=11) */
-+		{MAX96717_MIPI_RX1_ADDR, MAX96717_CSI_4_LANES},
-+		/* [XML] MIPI_RX2/RX3: 1x4 lane mapping */
-+		{MAX96717_MIPI_RX2_ADDR, MAX96717_CSI_1X4_LANE_MAP1},
-+		{MAX96717_MIPI_RX3_ADDR, MAX96717_CSI_1X4_LANE_MAP2},
-+		/* [XML] VIDEO_TX0/TX1: tunnel data path */
-+		{MAX96717_VIDEO_TX0_ADDR, MAX96717_VIDEO_TX0_TUN},
-+		{MAX96717_VIDEO_TX1_ADDR, MAX96717_VIDEO_TX1_TUN},
-+	};
-+	struct reg_pair pixel_init[] = {
-+		{MAX96717_EXT11_ADDR, MAX96717_TUN_MODE_DIS},
-+		{MAX96717_MIPI_RX1_ADDR, MAX96717_CSI_4_LANES},
-+		{MAX96717_MIPI_RX2_ADDR, MAX96717_CSI_1X4_LANE_MAP1},
-+		{MAX96717_MIPI_RX3_ADDR, MAX96717_CSI_1X4_LANE_MAP2},
-+		{MAX96717_FRONTTOP0_ADDR, MAX96717_FRONTTOP0_PIXEL_PORT_B},
-+		{MAX96717_FRONTTOP9_ADDR, MAX96717_FRONTTOP9_START_VIDEO},
-+		{MAX96717_VIDEO_TX0_ADDR, MAX96717_VIDEO_TX0_BPP_MANUAL},
-+		{MAX96717_VIDEO_TX1_ADDR, MAX96717_VIDEO_TX1_BPP16},
-+		{MAX96717_VIDEO_TX2_ADDR, MAX96717_VIDEO_TX2_DRIFT_DIS},
-+	};
-+
 +	mutex_lock(&priv->lock);
 +
 +	if (!priv->g_client.g_ctx) {
@@ -375,80 +313,19 @@ index 0000000..1dd24d3
 +
 +	g_ctx = priv->g_client.g_ctx;
 +
-+	/*
-+	 * [SG2 working config] SER PHY/DLL pre-calibration.
-+	 * These device-level registers calibrate the serializer's
-+	 * differential output pairs and clock recovery.  The staged
-+	 * write pattern (0x80 stage-1 now, 0x90 stage-2 after tunnel
-+	 * init) matches every SG2 sensor variant's init table.
-+	 * Applied BEFORE soft reset + tunnel config.
-+	 */
-+	max96717_write_reg(dev, MAX96717_PHY_CAL_2D6_ADDR,
-+			   MAX96717_PHY_CAL_STAGE1);
-+	max96717_write_reg(dev, MAX96717_PHY_CAL_2C7_ADDR,
-+			   MAX96717_PHY_CAL_STAGE1);
-+	max96717_write_reg(dev, MAX96717_PHY_CAL_2BE_ADDR,
-+			   MAX96717_PHY_CAL_STAGE1);
-+	max96717_write_reg(dev, MAX96717_PHY_CAL_2C1_ADDR,
-+			   MAX96717_PHY_CAL_STAGE1);
-+	max96717_write_reg(dev, MAX96717_PHY_CAL_3F0_ADDR,
-+			   MAX96717_CSI_TIMING_3F0);
-+	max96717_write_reg(dev, MAX96717_PHY_CAL_3F1_ADDR,
-+			   MAX96717_CSI_TIMING_3F1);
-+	msleep(100);
++	max96717_write_reg(dev, MAX96717_EXT11_ADDR, MAX96717_TUN_MODE_EN);
++	max96717_write_reg(dev, MAX96717_MIPI_RX1_ADDR, MAX96717_CSI_4_LANES);
++	max96717_write_reg(dev, MAX96717_MIPI_RX2_ADDR, MAX96717_CSI_1X4_LANE_MAP1);
++	max96717_write_reg(dev, MAX96717_MIPI_RX3_ADDR, MAX96717_CSI_1X4_LANE_MAP2);
++	max96717_write_reg(dev, MAX96717_VIDEO_TX0_ADDR, MAX96717_VIDEO_TX0_TUN);
++	max96717_write_reg(dev, MAX96717_VIDEO_TX1_ADDR, MAX96717_VIDEO_TX1_TUN);
 +
-+	/*
-+	 * [Aardvark-verified] Soft reset before tunnel mode configuration
-+	 * Clears stale pipe/CSI state for clean initialization.
-+	 * Aardvark: 0x0002=0x03, sleep 30ms, then proceed with config.
-+	 */
-+	max96717_write_reg(dev, MAX96717_PIPE_EN_ADDR, MAX96717_SOFT_RESET);
-+	msleep(30);
-+
-+	if (priv->pixel_mode)
-+		err = max96717_set_registers(dev, pixel_init,
-+					 ARRAY_SIZE(pixel_init));
-+	else
-+		err = max96717_set_registers(dev, tunnel_init,
-+					 ARRAY_SIZE(tunnel_init));
-+	if (err)
-+		goto error;
-+
-+	/*
-+	 * [FIX] Re-enable GMSL2 mode + TX after soft reset.
-+	 * setup_control() previously set CTRL0=0x21 (GMSL2+TX), but the
-+	 * PIPE_EN=0x03 soft reset above clears it back to the power-on
-+	 * default 0x01 (TX only, GMSL2 mode disabled).  Without this
-+	 * re-write the SER operates in GMSL1 mode while the DES expects
-+	 * GMSL2 — the link trains but the video data path silently breaks.
-+	 */
-+	if (g_ctx->serdes_csi_link == GMSL_SERDES_CSI_LINK_A)
-+		max96717_write_reg(dev, MAX96717_CTRL0_ADDR,
-+				   MAX96717_CTRL0_LINK_A);
-+	else
-+		max96717_write_reg(dev, MAX96717_CTRL0_ADDR,
-+				   MAX96717_CTRL0_LINK_B);
-+
-+	/*
-+	 * [SG2 working config] PHY calibration stage-2: ramp 0x80 -> 0x90.
-+	 * Applied AFTER tunnel mode + lane config, BEFORE CSI reset.
-+	 */
-+	max96717_write_reg(dev, MAX96717_PHY_CAL_2D6_ADDR,
-+			   MAX96717_PHY_CAL_STAGE2);
-+	max96717_write_reg(dev, MAX96717_PHY_CAL_2C7_ADDR,
-+			   MAX96717_PHY_CAL_STAGE2);
-+	msleep(20);
-+
-+	/* [Aardvark-verified] CSI reset cycle with 2ms delay */
-+	max96717_write_reg(dev, MAX96717_MIPI_RX0_ADDR,
-+			   MAX96717_MIPI_RX0_RESET);
++	max96717_write_reg(dev, MAX96717_MIPI_RX0_ADDR, MAX96717_MIPI_RX0_RESET);
 +	usleep_range(2000, 2100);
-+	max96717_write_reg(dev, MAX96717_MIPI_RX0_ADDR,
-+			   MAX96717_MIPI_RX0_NORMAL);
++	max96717_write_reg(dev, MAX96717_MIPI_RX0_ADDR, MAX96717_MIPI_RX0_NORMAL);
 +
-+	/* [XML] Final enable: pipes on + video init */
-+	max96717_write_reg(dev, MAX96717_PIPE_EN_ADDR,
-+			   MAX96717_PIPE_EN_ALL);
++	/* pipes on + video init */
++	max96717_write_reg(dev, MAX96717_PIPE_EN_ADDR, MAX96717_PIPE_EN_ALL);
 +
 +	priv->g_client.st_done = true;
 +
@@ -470,9 +347,6 @@ index 0000000..1dd24d3
 + *      I2C4/SRC_B (0x44) <- (sdev_reg << 1): proxy addr visible to host
 + *      I2C5/DST_B (0x45) <- (sdev_def << 1): real addr on back-channel
 + *
-+ * This lets the Orin host access the D5xx sensor (def-addr 0x42) via
-+ * the aliased proxy address (e.g. 0x1a) through the GMSL link.
-+ *
 + */
 +int max96717_setup_control(struct device *dev)
 +{
@@ -491,17 +365,6 @@ index 0000000..1dd24d3
 +	g_ctx = priv->g_client.g_ctx;
 +
 +	if (prim_priv__) {
-+		/*
-+		 * [HW note] The MAX96717 retains its I2C address across
-+		 * reboots (PoC stays on).  If already at the aliased address,
-+		 * the DEV_ADDR write to 0x40 NACKs.  Skip reassignment when
-+		 * the primary and alias are the same physical device and the
-+		 * serializer is already responsive at a non-default address.
-+		 *
-+		 * For cold-start (first power-on), this write is required.
-+		 * We detect "already reassigned" by trying a read first:
-+		 * if the primary address (0x40) NACKs, skip the reassign.
-+		 */
 +		unsigned int dev_id;
 +		int probe_ret;
 +
@@ -519,7 +382,7 @@ index 0000000..1dd24d3
 +		}
 +	}
 +
-+	/* [PPTX slide 7] CTRL0: GMSL2 mode + TX enable */
++	/* CTRL0: GMSL2 mode + TX enable */
 +	if (g_ctx->serdes_csi_link == GMSL_SERDES_CSI_LINK_A)
 +		err = max96717_write_reg(dev, MAX96717_CTRL0_ADDR,
 +					 MAX96717_CTRL0_LINK_A);
@@ -537,7 +400,6 @@ index 0000000..1dd24d3
 +
 +	/*
 +	 * I2C address translation for sensor passthrough.
-+	 * [MAX96724 Users Guide, I2C Broadcasting, p44-46]
 +	 *
 +	 * I2C4 / SRC_B (0x44): sensor proxy addr visible to Orin host
 +	 * I2C5 / DST_B (0x45): sensor real addr on GMSL back-channel
@@ -568,17 +430,13 @@ index 0000000..1dd24d3
 +/*
 + * max96717_setup_gpio_tunneling - GPIO-over-GMSL no-op hook
 + *
-+ * [PPTX slide 10] GPIO Signal Mapping:
++ *   GPIO Signal Mapping:
 + *   MFP0 → GPIO0: FSIN (DES→SER, frame sync in)
 + *   MFP1 → GPIO1: FOUT/STROBE (SER→DES, frame sync out)
 + *   MFP4 → GPIO4: RESET_N (DES→SER, hard reset)
 + *   MFP5 → GPIO5: IRQ (SER→DES, interrupt request)
 + *   MFP6 → GPIO6: ZV_SYNC (DES→SER, IR stereo sync)
 + *
-+ * The PPTX defines the signal mapping and MFP_CFG register range,
-+ * but not the confirmed direction/function values. Keep this as
-+ * an explicit no-op hook until the MAX96717 GPIO register values
-+ * are available from ADI.
 + */
 +int max96717_setup_gpio_tunneling(struct device *dev)
 +{
@@ -644,7 +502,8 @@ index 0000000..1dd24d3
 +	priv = dev_get_drvdata(dev);
 +	mutex_lock(&priv->lock);
 +	if (priv->g_client.g_ctx) {
-+		/* Already paired — tolerate if this is a re-probe of
++		/* 
++		 * Already paired — tolerate if this is a re-probe of
 +		 * the same camera after a failed first attempt.
 +		 * Simply overwrite with the new g_ctx.
 +		 */
@@ -774,7 +633,8 @@ index 0000000..1dd24d3
 +	struct max96717 *priv = dev_get_drvdata(dev);
 +
 +	struct reg_pair map_init[] = {
-+		/* [XML seq] PIPE_EN soft reset first, then enable tunnel mode.
++		/* 
++		 * PIPE_EN soft reset first, then enable tunnel mode.
 +		 * Note: FRONTTOP0 is bypassed in tunnel mode (per UG) —
 +		 * CSI-2 input goes directly into the tunnel, no port config needed.
 +		 */
@@ -796,7 +656,7 @@ index 0000000..1dd24d3
 +	mutex_lock(&priv->lock);
 +
 +	/*
-+	 * [HW requirement] After CTRL0 + I2C translation writes in
++	 * After CTRL0 + I2C translation writes in
 +	 * setup_control, the MAX96717 needs settling time before
 +	 * accepting writes to PIPE_EN (0x02) and FRONTTOP registers.
 +	 */
@@ -846,7 +706,7 @@ index 0000000..1dd24d3
 +}
 +EXPORT_SYMBOL(max96717_set_pipe);
 +
-+/**
++/*
 + * max96717_retrigger_tx - Toggle SER TX to restore tunnel detection after
 + * a DES ONESHOT.  DES ONESHOT resets the data path; the SER must cycle
 + * its TX enable for the DES to re-acquire the tunnel stream.
@@ -971,10 +831,10 @@ index 0000000..1dd24d3
 +MODULE_LICENSE("GPL v2");
 diff --git a/drivers/media/i2c/max96724.c b/drivers/media/i2c/max96724.c
 new file mode 100644
-index 0000000..4a1708c
+index 0000000..4e73c60
 --- /dev/null
 +++ b/drivers/media/i2c/max96724.c
-@@ -0,0 +1,1927 @@
+@@ -0,0 +1,1905 @@
 +/*
 + * max96724.c - MAX96724 GMSL2 Quad Deserializer driver (Tunnel Mode)
 + *
@@ -1010,40 +870,44 @@ index 0000000..4a1708c
 +
 +/* --- Device ID / Configuration --- */
 +
-+/* [UG p.3] REG0: Device ID (read-only, returns 0xA2) */
++/* REG0: Device ID (read-only, returns 0xA2) */
 +#define MAX96724_DEV_ID_ADDR		0x00
 +
-+/* [Errata §5] ERRB master reset register */
++/* ERRB master reset register */
 +#define MAX96724_ERRB_MST_RST_ADDR	0x05
 +
-+/* [UG Table 3, p.11] 0x0006: GMSL Link/PHY Enable and Mode Select
++/* 
++ *   GMSL Link/PHY Enable and Mode Select
 + *   bits[7:4]: PHY mode (0=GMSL1, 1=GMSL2) per link D/C/B/A
 + *   bits[3:0]: Link Enable per link D/C/B/A
 + */
 +#define MAX96724_LINK_EN_ADDR		0x0006
 +
-+/* [UG Table 3, p.11] 0x0010: GMSL Link/PHY Rate Select (Links A&B)
++/* 
++ *   GMSL Link/PHY Rate Select (Links A&B)
 + *   bits[7:6]: Tx Rate Link B, bits[5:4]: Rx Rate Link B
 + *   bits[3:2]: Tx Rate Link A, bits[1:0]: Rx Rate Link A
 + *   Tx: 00=187.5Mbps, Rx: 01=3Gbps, 10=6Gbps
 + */
 +#define MAX96724_LINK_RATE_AB_ADDR	0x0010
 +
-+/* [UG Table 3, p.12] 0x0011: GMSL Link/PHY Rate Select (Links C&D) */
++/* GMSL Link/PHY Rate Select (Links C&D) */
 +#define MAX96724_LINK_RATE_CD_ADDR	0x0011
 +
-+/* [UG p.13] 0x001A: Link A lock status (bit[3]=LOCK) */
++/* Link A lock status (bit[3]=LOCK) */
 +#define MAX96724_LINK_A_LOCK_ADDR	0x001A
 +
-+/* [UG Table 3, p.12] 0x0018: GMSL Link Reset
++/* 
++ *   GMSL Link Reset
 + *   bits[7:4]: Link reset D/C/B/A, bits[3:0]: One-shot reset D/C/B/A
 + */
 +#define MAX96724_ONESHOT_ADDR		0x0018
 +
-+/* [UG p.11] REG13: Soft Reset (write 0x40, wait 5ms) */
++/* Soft Reset (write 0x40, wait 5ms) */
 +#define MAX96724_REG13_ADDR		0x000D
 +
-+/* [Errata §5] Error Channel Power Up registers (required for 6Gbps)
++/* 
++ *   Error Channel Power Up registers (required for 6Gbps)
 + *   Write 0x75 immediately after power-up for robust 6Gbps operation
 + */
 +#define MAX96724_ERRCH_A_ADDR		0x1449
@@ -1054,7 +918,8 @@ index 0000000..4a1708c
 +
 +/* --- I2C Control Channel / Errata --- */
 +
-+/* [Errata #2] Tunnel Mode SRAM LCRC error suppression
++/* 
++ *   Tunnel Mode SRAM LCRC error suppression
 + *   Set 0x458[7:4] = 0x0 to suppress spurious ERRB in tunnel mode
 + */
 +#define MAX96724_SRAM_LCRC_ERR_ADDR	0x0458
@@ -1073,9 +938,6 @@ index 0000000..4a1708c
 + */
 +#define MAX96724_PIPE_SEL1_ADDR		0xF1
 +
-+/*
-+ *   bit[0]=Pipe 0, bit[1]=Pipe 1, bit[2]=Pipe 2, bit[3]=Pipe 3
-+ */
 +#define MAX96724_PIPE_EN_ADDR		0xF4
 +
 +/* --- Pipe Receiver / Tunnel Mode --- */
@@ -1092,14 +954,15 @@ index 0000000..4a1708c
 +
 +/* --- CSI-2 Output (BACKTOP) --- */
 +
-+/* [UG p.19] BACKTOP: CSI-2 output port enable
++/* BACKTOP: CSI-2 output port enable
 + *   0x040B bit[1]=CSIB_EN, bit[0]=CSIA_EN
 + */
 +#define MAX96724_BACKTOP_EN_ADDR	0x040B
 +
 +/* --- MIPI DPLL (Data Rate) --- */
 +
-+/* [UG Table 12, p.27] MIPI PHY DPLL Freq registers
++/* 
++ *   MIPI PHY DPLL Freq registers
 + *   bits[4:0] = frequency in multiples of 100MHz
 + *   bit[5]    = DPLL enable (must be set for DPLL to lock)
 + *   E.g., 0x27 = 700MHz + enable = 700Mbps/lane D-PHY
@@ -1110,7 +973,8 @@ index 0000000..4a1708c
 +#define MAX96724_DPLL_FREQ2_ADDR	0x041B
 +#define MAX96724_DPLL_FREQ3_ADDR	0x041E
 +
-+/* [UG] DPLL PHY reset control
++/* 
++ *   DPLL PHY reset control
 + *   0x1D00 = DPLL CSI PHY1 control
 + *   Write 0xF4 to disable/reset, 0xF5 to enable
 + */
@@ -1120,49 +984,47 @@ index 0000000..4a1708c
 +
 +/* --- CSI-2 Output PHY Configuration --- */
 +
-+/* [UG rev2 Table 12 + MIPI PHY section] CSI output mode/config register.
++/* 
++ * CSI output mode/config register.
 + * Mode bits (set exactly one of [4:0]):
 + *   bit[0]=0x01: 4x2 mode
 + *   bit[2]=0x04: 2x4 mode        (Ctrl 1 = master for Port A, Ctrl 2 = Port B)
 + *   bit[3]=0x08: 1x4a + 2x2 mode (Ctrl 1 = master for Port A)
 + *   bit[4]=0x10: 1x4b + 2x2 mode (Ctrl 2 = master for Port B)
-+ * In ALL x4 D-PHY modes Port A = PHY0+PHY1 and Port B = PHY2+PHY3 (UG:
-+ * "PHY 1 and PHY 2 are the master PHYs providing the MIPI clock for ports
-+ * A and B").  bit[2] vs bit[3] only differ in how the OTHER port is grouped,
-+ * not in which PHYs carry Port A.
-+ * Clock-force bits (high nibble):
++ *
++ * Clock-force bits:
 + *   bit[7]=0x80: force ALL MIPI clocks running (continuous HS clock)
 + *   bit[6]=0x40: force PHY 3 MIPI clock running
 + *   bit[5]=0x20: force PHY 0 MIPI clock running
 + */
 +#define MAX96724_CSI_OUT_CFG_ADDR	0x08A0
 +
-+/* [UG Table 12, p.25] MIPI PHY Enable register
++/* 
++ *   MIPI PHY Enable register
 + *   bits[7:4]: Enable PHY 3/2/1/0 (1=enabled, 0=standby)
 + */
 +#define MAX96724_CSI_PHY_EN_ADDR	0x08A2
 +
-+/* [UG Table 12, p.25] MIPI PHY 0 and 1 Lane Mapping */
++/* MIPI PHY 0 and 1 Lane Mapping */
 +#define MAX96724_CSI_LANE_MAP1_ADDR	0x08A3
 +
-+/* [UG Table 12, p.26] MIPI PHY 2 and 3 Lane Mapping */
++/* MIPI PHY 2 and 3 Lane Mapping */
 +#define MAX96724_CSI_LANE_MAP2_ADDR	0x08A4
 +
-+/* [FG24-4CH board] MIPI output lane polarity (P/N swap) registers.
++/* 
++ *   MIPI output lane polarity (P/N swap) registers.
 + *   0x08A5 = PHY0/PHY1 lane polarity, 0x08A6 = PHY2/PHY3 lane polarity.
 + *   The FangZhu FG24-4CH PCB swaps the differential P/N pairs on the
 + *   MAX96724 CSI output, so the deserializer must invert lane polarity
-+ *   or the Orin CIL never locks the HS clock (total silence/2500ms timeout).
-+ *   Per FangZhu MAX4CH_FG24_POC_Enable table: write 0x3F to both.
 + */
 +#define MAX96724_CSI_PHY_POL0_ADDR	0x08A5
 +#define MAX96724_CSI_PHY_POL1_ADDR	0x08A6
 +#define MAX96724_CSI_PHY_POL_SWAP	0x3F
 +
-+/* [UG p.22] Pipe-to-controller mapping (Method 1) */
++/* Pipe-to-controller mapping */
 +#define MAX96724_MIPI_CTRL_SEL_ADDR	0x08CA
 +
-+/* [OG03C reference dump] Method-1 controller mapping */
++/* Method-1 controller mapping */
 +#define MAX96724_MIPI_CTRL_SEL_PIXEL	0xE4
 +
 +/* --- Lane Control per pipe (stride 0x40) --- */
@@ -1201,7 +1063,8 @@ index 0000000..4a1708c
 +
 +/* --- Extended Pipe Mapping (DST_CTRL2-4 / TX49) --- */
 +
-+/* [Excel: MIPI_TX46-48] Extended DST_CTRL for additional mapping pairs
++/* 
++ *   Extended DST_CTRL for additional mapping pairs
 + *   All to PHY1 (0x55), same as TX45
 + *   Stride: 0x40 per pipe (base = Pipe X)
 + */
@@ -1209,7 +1072,8 @@ index 0000000..4a1708c
 +#define MAX96724_TX47_PIPE_X_ADDR	0x092F
 +#define MAX96724_TX48_PIPE_X_ADDR	0x0930
 +
-+/* [UG p.30] MIPI_TX49 synchronous concatenation control
++/* 
++ *   MIPI_TX49 synchronous concatenation control
 + *   Set to 0x00 (no concat) for single-camera tunnel mode.
 + *   For 4W concat use 0x87.
 + *   Stride: 0x40 per pipe (base = Pipe X)
@@ -1240,10 +1104,11 @@ index 0000000..4a1708c
 + * Register Values
 + * ================================================================ */
 +
-+/* [UG p.12] Soft reset value (write to 0x000D) */
++/* Soft reset value (write to 0x000D) */
 +#define MAX96724_SOFT_RESET		0x40
 +
-+/* [UG Table 3, p.11-12] Link Rate values for 0x0010/0x0011
++/* 
++ * Link Rate values for 0x0010/0x0011
 + *   Per link pair: bits[1:0]=RxA, [3:2]=TxA, [5:4]=RxB, [7:6]=TxB
 + *   Tx = 00 (187.5Mbps), Rx = 01 (3Gbps) or 10 (6Gbps)
 + *   3Gbps: Tx=00, Rx=01 → per pair 0x01, both pairs = 0x01 in low nibble
@@ -1251,7 +1116,8 @@ index 0000000..4a1708c
 +#define MAX96724_LINK_RATE_3GBPS	0x01  /* Rx=3G, Tx=187.5M for one link pair */
 +#define MAX96724_LINK_RATE_6GBPS	0x02  /* Rx=6G, Tx=187.5M for one link pair */
 +
-+/* [UG Table 3, p.11] 0x0006: Link enable / mode values
++/* 
++ * 0x0006: Link enable / mode values
 + *   bits[7:4] = PHY mode (1=GMSL2 per link)
 + *   bits[3:0] = Link enable per link
 + *   0xF1 = all GMSL2-mode, only Link A enabled
@@ -1260,98 +1126,97 @@ index 0000000..4a1708c
 +#define MAX96724_LINK_EN_SIOA		0xF1  /* GMSL2 all, enable Link A only */
 +#define MAX96724_LINK_EN_ALL		0xFF  /* GMSL2 all, enable all links */
 +
-+/* [UG p.19] BACKTOP_EN (0x040B): CSI output port enable */
++/* BACKTOP_EN (0x040B): CSI output port enable */
 +#define MAX96724_BACKTOP_CSIB_EN	0x02
 +#define MAX96724_BACKTOP_CSIA_EN	0x01
 +
-+/* [XML] VIDEO_RX0: DIS_PKT_DET=1 (bit0) required for tunnel mode.
++/* 
++ *   VIDEO_RX0: DIS_PKT_DET=1 (bit0) required for tunnel mode.
 + *   Without it, DES rejects tunnel data as invalid GMSL2 video packets.
 + *   SEQ_MISS_EN=1 (bit4), LINE_CRC_EN=1 (bit1).  XML value: 0x33.
 + */
 +#define MAX96724_VID_RX0_CFG_VAL	0x33
 +#define MAX96724_VID_RX6_CFG_VAL	0x0A
 +
-+/* [OG03C reference dump] Pixel-mode receiver settings */
++/* Pixel-mode receiver settings */
 +#define MAX96724_VID_RX0_PIXEL_VAL	0x32
 +#define MAX96724_VID_RX6_PIXEL_VAL	0x12
 +
-+/* [XML] Tunnel mode enable (MIPI_TX54, 0x0936):
++/* 
++ *   Tunnel mode enable (MIPI_TX54, 0x0936):
 + *   bit[0] = TUN_EN = 1
 + *   Verified value: 0x01
 + */
 +#define MAX96724_TUN_EN			0x01
 +
-+/* [OG03C reference dump] Default/reset state when tunnel is disabled */
++/* Default/reset state when tunnel is disabled */
 +#define MAX96724_TUN_DISABLED		0x08
 +
-+/* [XML] Tunnel controller destination (MIPI_TX57, 0x0939):
++/* 
++ *   Tunnel controller destination (MIPI_TX57, 0x0939):
 + *   bits[5:4]: TUN_DEST (00=PHY0, 01=PHY1, 10=PHY2, 11=PHY3)
 + *   Verified value: 0x10 = PHY1 destination with auto-detect enabled
 + */
 +#define MAX96724_TUN_DEST_CTRL0		0x00  /* Auto-detect + PHY0 */
 +#define MAX96724_TUN_DEST_CTRL1		0x10  /* Auto-detect + PHY1 (Port A master) */
 +
-+/* [UG rev2 Table 12] CSI output mode values written to 0x08A0.
-+ *   We use bit[2] = 0x04 = clean 2x4 mode (Port A = PHY0+PHY1, Ctrl 1 master).
-+ *   This matches the ADI reference "Lane Swap Programming Example"
-+ *   (0x4E,0x08A0,0x04) and the FangZhu working config.  Note bit[3]=0x08
-+ *   (1x4a+2x2) ALSO keeps Port A on PHY0+PHY1; for a single 4-lane Port A
-+ *   output either presents a valid Port A, so 0x04 is the spec-clean choice
-+ *   rather than a hard requirement.
-+ */
 +#define MAX96724_CSI_MODE_2X4_VAL	0x04  /* bit[2] = clean 2x4: Port A = PHY0+PHY1 */
-+/* 0x84 = 2x4 mode (bit2) + bit[7] "force ALL MIPI clocks running".  The bit[7]
-+ * clock-force is the key part: it keeps the D-PHY clock lane in continuous HS
-+ * mode so the Orin NVCSI/CIL can lock.  Asserted LAST in setup_streaming(),
-+ * matching the FangZhu End_Common 0x08A0=0x84 write. */
++
++/* 
++ *   0x84 = 2x4 mode (bit2) + bit[7] "force ALL MIPI clocks running".  The bit[7]
++ *   clock-force is the key part: it keeps the D-PHY clock lane in continuous HS
++ *   mode so the Orin NVCSI/CIL can lock.
++ */
 +#define MAX96724_CSI_OUT_EN_VAL		0x84  /* 2x4 + bit[7] force all MIPI clocks running */
-+#define MAX96724_CSI_MODE_4X2_VAL	0x01  /* bit[0] = 4x2 mode */
 +
 +#define MAX96724_CSI_PHY_EN_ALL		0xF0
 +#define MAX96724_CSI_PHY_EN_01		0x30  /* PHY0+PHY1 only (Port A) */
 +#define MAX96724_CSI_PHY_EN_23		0xC0  /* PHY2+PHY3 only (Port B) */
 +
-+/* [UG Table 12, p.25-26] Lane mapping default */
++/* Lane mapping default */
 +#define MAX96724_CSI_LANE_MAP_DEFAULT	0xE4
 +
-+/* [UG Table 12, p.26-27] Lane control: 4-lane enabled */
++/* Lane control: 4-lane enabled */
 +#define MAX96724_LANE_CTRL_4LANE	0xC0
 +
-+/* [UG Table 12, p.26-27] Lane control: 2-lane enabled.
++/*
++ *   Lane control: 2-lane enabled.
 + *   bits[7:6] = (num_lanes - 1): 01=2-lane(0x40), 11=4-lane(0xC0)
-+ *   Ref: gmsl_ser_des_guide §8.2, E2E_enable_guide §5.6.4 */
++ *   Ref: gmsl_ser_des_guide §8.2, E2E_enable_guide §5.6.4 
++ */
 +#define MAX96724_LANE_CTRL_2LANE	0x40
 +
-+/* [SC20190112 2-lane] CSI PHY enable: all PHYs powered for DPLL lock
-+ *   stability.  Even though only PHY0 data lanes reach Orin, the MAX96724
-+ *   DPLL requires all PHYs to be powered.  Tested: single PHY → PLL never locks. */
++/* 
++ *   CSI PHY enable: all PHYs powered for DPLL lock.
++ */
 +#define MAX96724_CSI_PHY_EN_2LANE	0xF0
 +
-+/* [SC20190112 2-lane] DPLL for Controller 0 (drives PHY0, 2 lanes).
++/* 
++ *   DPLL for Controller 0 (drives PHY0, 2 lanes).
 + *   bits[4:0] = data-rate / 100 MHz.  700 Mbps / 100 = 7 = 0x07.
 + *   bit[5]    = DPLL enable = 1.
-+ *   Result: 0x27 = 700 Mbps/lane D-PHY. */
++ *   Result: 0x27 = 700 Mbps/lane D-PHY.
++ */
 +#define MAX96724_DPLL_700MBPS_CTRL0	0x27
 +
-+/* [FG24-4CH working-config verified] CSI-output DPLL data rate = 1500 Mbps.
++/* 
++ *   CSI-output DPLL data rate = 1500 Mbps.
 + *   bits[4:0] = data-rate / 100 MHz -> 1500/100 = 15 = 0x0F. bit[5] = DPLL en.
-+ *   Result 0x2F.  The FangZhu MAX4CH config writes this to ALL FOUR controllers
-+ *   (0x0415/0x0418/0x041B/0x041E), matching DT max_lane_speed = 1500000.  The
-+ *   old 0x27 (700 Mbps, 2 controllers only) is a 2-lane-variant leftover that
-+ *   left the Orin CIL unable to lock the HS clock (empty rtcpu trace). */
++ */
 +#define MAX96724_DPLL_1500MBPS		0x2F
 +
-+/* [UG Table 3, p.12] One-shot reset: all links */
++/* One-shot reset: all links */
 +#define MAX96724_ONESHOT_ALL		0x0F
 +
-+/* [UG Table 4, p.15] Pipe source selection values
-+ *   Encoding per pipe nibble in tunnel mode (Aardvark-verified):
++/* 
++ *   Pipe source selection values
++ *   Encoding per pipe nibble in tunnel mode:
 + *   0x22 routes all pipes from Link A in tunnel mode.
 + */
-+#define MAX96724_PIPE_SEL0_SINGLE	0x22  /* All pipes from Link A (Aardvark-verified) */
-+#define MAX96724_PIPE_SEL1_SINGLE	0x22  /* All pipes from Link A (Aardvark-verified) */
-+#define MAX96724_PIPE_SEL0_PIXEL	0x62  /* OG03C pixel-mode reference */
-+#define MAX96724_PIPE_SEL1_PIXEL	0xEA  /* OG03C pixel-mode reference */
++#define MAX96724_PIPE_SEL0_SINGLE	0x22  /* All pipes from Link A */
++#define MAX96724_PIPE_SEL1_SINGLE	0x22  /* All pipes from Link A */
++#define MAX96724_PIPE_SEL0_PIXEL	0x62  /* pixel-mode reference */
++#define MAX96724_PIPE_SEL1_PIXEL	0xEA  /* pixel-mode reference */
 +#define MAX96724_PIPE_SEL0_DUAL		0x40  /* Pipe 0 ← A/X, Pipe 1 ← B/X */
 +#define MAX96724_PIPE_SEL0_QUAD_LO	0x40  /* Pipe 0 ← A/X, Pipe 1 ← B/X */
 +#define MAX96724_PIPE_SEL1_QUAD_HI	0xC8  /* Pipe 2 ← C/X, Pipe 3 ← D/X */
@@ -1373,12 +1238,12 @@ index 0000000..4a1708c
 +#define MAX96724_RESET_ST_ID		0x00
 +#define MAX96724_ST_ID_SEL_INVALID	0xF
 +
-+/* Controller mapping: all mappings → Controller 0 (not working in tunnel mode) */
++/* Controller mapping: all mappings → Controller 0 */
 +#define MAX96724_ALL_MAP_CTRL0		0x00
-+/* Controller mapping: all mappings → Controller 1 (Aardvark-verified working) */
++/* Controller mapping: all mappings → Controller 1 */
 +#define MAX96724_ALL_MAP_CTRL1		0x55
 +
-+/* [OG03C reference dump] Three mappings to controller 1 */
++/* Three mappings to controller 1 */
 +#define MAX96724_MAP3_CTRL1		0x15
 +
 +/* ================================================================
@@ -1400,16 +1265,9 @@ index 0000000..4a1708c
 +#define MAX96724_CSI_CTRL_2		2
 +#define MAX96724_CSI_CTRL_3		3
 +
-+/* Internal csi_mode enum flags (NOT the register value written to 0x08A0;
-+ * see MAX96724_CSI_MODE_2X4_VAL for the actual register value).  These are
-+ * only compared against priv->csi_mode to select a code path. */
-+#define MAX96724_CSI_MODE_4X2		0x01
 +#define MAX96724_CSI_MODE_2X4		0x08  /* enum tag for the 4-lane Port A (Ctrl1) path */
-+#define MAX96724_CSI_MODE_2X4_ALT	0x04  /* enum tag (unused alt path) */
 +
 +/* Lane map presets */
-+#define MAX96724_LANE_MAP1_4X2		0x44
-+#define MAX96724_LANE_MAP2_4X2		0x44
 +#define MAX96724_LANE_MAP1_2X4		0xE4  /* SC20190112 subset: PHY0 data + PHY1 clock */
 +#define MAX96724_LANE_MAP2_2X4		0x44  /* keep unused PHY2/3 straight in 0x08 mode */
 +
@@ -2042,10 +1900,6 @@ index 0000000..4a1708c
 +		goto error;
 +	}
 +
-+	/* Check csi mode compatibility.
-+	 * 2x4 DES → gmsl-link: 1x4 or 2x4.
-+	 * 4x2 DES → gmsl-link: 1x4, 2x2, or 4x2.
-+	 */
 +	if (priv->csi_mode == MAX96724_CSI_MODE_2X4) {
 +		if (!((g_ctx->csi_mode == GMSL_CSI_1X4_MODE) ||
 +		      (g_ctx->csi_mode == GMSL_CSI_2X4_MODE))) {
@@ -2054,14 +1908,9 @@ index 0000000..4a1708c
 +			goto error;
 +		}
 +	} else {
-+		/* 4x2 DES mode: accept 1x4, 2x2, or 4x2 gmsl-link mode */
-+		if (!((g_ctx->csi_mode == GMSL_CSI_1X4_MODE) ||
-+		      (g_ctx->csi_mode == GMSL_CSI_2X2_MODE) ||
-+		      (g_ctx->csi_mode == GMSL_CSI_4X2_MODE))) {
-+			dev_err(dev, "%s: csi mode not supported\n", __func__);
-+			err = -EINVAL;
-+			goto error;
-+		}
++		dev_err(dev, "%s: only csi 2x4 mode is supported\n", __func__);
++		err = -EINVAL;
++		goto error;
 +	}
 +
 +	for (i = 0; i < priv->num_src; i++) {
@@ -2144,7 +1993,7 @@ index 0000000..4a1708c
 + * with all VCs and DTs preserved from the serializer.
 + *
 + * The pipeline configuration:
-+ *   1. Configure pipe-to-link routing (which GMSL input → which pipe)
++ *   1. Configure pipe-to-link routing
 + *   2. Enable tunnel mode on active pipes
 + *   3. Configure MIPI CSI-2 output lanes and PHY
 + *   4. Enable BACKTOP output port
@@ -2195,9 +2044,9 @@ index 0000000..4a1708c
 +	}
 +
 +	/*
-+	 * [Aardvark-verified] Pipe source routing
-+	 *   Single cam: all pipes from Link A (0x22/0x22)
-+	 *   Disable pipes before configuration, enable at the end
++	 * Pipe source routing
++	 * Single cam: all pipes from Link A (0x22/0x22)
++	 * Disable pipes before configuration, enable at the end
 +	 */
 +	max96724_write_reg(dev, MAX96724_PIPE_SEL0_ADDR, pipe_sel0);
 +	max96724_write_reg(dev, MAX96724_PIPE_SEL1_ADDR, pipe_sel1);
@@ -2205,16 +2054,14 @@ index 0000000..4a1708c
 +	max96724_write_reg(dev, MAX96724_PIPE_EN_ADDR, 0x00);
 +
 +	/*
-+	 * [SC20190112] Keep 0x08 mode so PHY1 remains the Port A clock master,
++	 * Keep 0x08 mode so PHY1 remains the Port A clock master,
 +	 * but restore the live 2-lane subset used by the bridge board.
 +	 */
 +	max96724_apply_porta_subset(dev, priv);
 +
 +	/*
-+	 * [D585 700Mbps fix] CSI-output DPLL data rate = 700 Mbps
-+	 * on ALL FOUR controller freq registers, matching D585 native
-+	 * MIPI rate (pix_clk_hz=175M, 16bpp, 4-lane).
-+	 * DT serdes_pix_clk_hz=175MHz drives correct THS_SETTLE for 700Mbps.
++	 * CSI-output DPLL data rate = 700 Mbps
++	 * on ALL FOUR controller freq registers
 +	 */
 +	if (!priv->lane_setup) {
 +		max96724_write_reg(dev, MAX96724_DPLL_FREQ0_ADDR,
@@ -2233,7 +2080,7 @@ index 0000000..4a1708c
 +			   MAX96724_MIPI_CTRL_SEL_PIXEL);
 +
 +	/*
-+	 * [Aardvark-verified] Stream ID select for all pipes
++	 * Stream ID select for all pipes
 +	 * 0x0933 + 0x40*pipe = stream select register
 +	 * Value 0x10 selects the appropriate stream for tunnel mode
 +	 */
@@ -2243,7 +2090,8 @@ index 0000000..4a1708c
 +				   st_sel_cfg);
 +	}
 +
-+	/* BACKTOP: enable Controller 1 / CSI-B (0x02).
++	/* 
++	 * BACKTOP: enable Controller 1 / CSI-B (0x02).
 +	 * In 2x4 mode, Controller 1 is master for Port A -> Orin CSI.
 +	 */
 +	max96724_write_reg(dev, MAX96724_BACKTOP_EN_ADDR,
@@ -2252,10 +2100,9 @@ index 0000000..4a1708c
 +	dev_info(dev, "=== setup_streaming: writing 0x84 (force all MIPI clocks) ===\n");
 +
 +	/*
-+	 * [FG24-4CH working-config verified] Assert 0x08A0=0x84 LAST: 2x4 mode +
-+	 * bit[7] "force all MIPI clocks running".  The clock-force keeps the
-+	 * D-PHY clock lane continuous so the Orin CIL can lock; written only
-+	 * after the full pipeline is configured, matching FangZhu End_Common.
++	 * Assert 0x08A0=0x84 LAST: 2x4 mode + bit[7] "force all MIPI clocks running".  
++	 * The clock-force keeps the D-PHY clock lane continuous so the Orin CIL can lock;
++	 * written only after the full pipeline is configured.
 +	 */
 +	max96724_write_reg(dev, MAX96724_CSI_OUT_CFG_ADDR,
 +			   MAX96724_CSI_OUT_EN_VAL);
@@ -2280,7 +2127,7 @@ index 0000000..4a1708c
 +	max96724_write_reg(dev, MAX96724_ONESHOT_ADDR,
 +			   MAX96724_ONESHOT_ALL);
 +
-+	/* Enable all 4 pipes (Aardvark-verified: 0x0F at end) */
++	/* Enable all 4 pipes */
 +	max96724_write_reg(dev, MAX96724_PIPE_EN_ADDR, MAX96724_PIPE_EN_4);
 +
 +	priv->sources[src_idx].st_enabled = true;
@@ -2393,10 +2240,7 @@ index 0000000..4a1708c
 +
 +int max96724_get_ser_pipe_id(struct device *dev, int dser_pipe_id, int vc_id)
 +{
-+	/*
-+	 * In Tunnel Mode with MAX96717, all VCs are carried in a single
-+	 * tunnel pipe. The pipe mapping is 1:1 for d4xx compatibility.
-+	 */
++	/* In Tunnel Mode with MAX96717, all VCs are carried in a single tunnel pipe. */
 +	return dser_pipe_id;
 +}
 +EXPORT_SYMBOL(max96724_get_ser_pipe_id);
@@ -2414,7 +2258,7 @@ index 0000000..4a1708c
 +
 +	mutex_lock(&priv->lock);
 +	if (priv->splitter_enabled) {
-+		/* [UG] Multi-camera: reset all links */
++		/* Multi-camera: reset all links */
 +		u8 link_rate = (priv->link_speed == 6) ? 0x22 : 0x11;
 +
 +		max96724_write_reg(dev, MAX96724_LINK_RATE_AB_ADDR,
@@ -2445,20 +2289,21 @@ index 0000000..4a1708c
 +		dpll_cfg = MAX96724_DPLL_1500MBPS;
 +	}
 +
-+	/* ONESHOT resets CSI/tunnel state. Restore the full pipeline config.
++	/* 
++	 * ONESHOT resets CSI/tunnel state. Restore the full pipeline config.
 +	 * Mirror setup_streaming() order: disable pipes -> restore everything ->
 +	 * BACKTOP/0x84 -> VID_RX -> final ONESHOT to latch -> enable pipes.
 +	 */
 +	max96724_write_reg(dev, MAX96724_PIPE_EN_ADDR, 0x00);
 +
-+	/* Pipe source routing (same as setup_streaming): all pipes from Link A */
++	/* Pipe source routing: all pipes from Link A */
 +	max96724_write_reg(dev, MAX96724_PIPE_SEL0_ADDR, pipe_sel0);
 +	max96724_write_reg(dev, MAX96724_PIPE_SEL1_ADDR, pipe_sel1);
 +
 +	max96724_apply_porta_subset(dev, priv);
 +
 +	/*
-+	 * [D585 700Mbps fix] CSI-output DPLL data rate = 700 Mbps on ALL
++	 * CSI-output DPLL data rate = 700 Mbps on ALL
 +	 * FOUR controllers, matching D585 native MIPI rate.
 +	 * reset_oneshot is called by the sensor after setup_streaming, so it must
 +	 * mirror the same DPLL values.
@@ -2518,7 +2363,7 @@ index 0000000..4a1708c
 +			   MAX96724_PIPE_EN_4);
 +
 +	/*
-+	 * [FG24-4CH working-config verified] Assert 0x08A0=0x84 LAST:
++	 * Assert 0x08A0=0x84 LAST:
 +	 * 2x4 mode + bit[7] force all MIPI clocks running.  Must mirror
 +	 * setup_streaming because the sensor's oneshot path overwrites it.
 +	 */
@@ -2566,7 +2411,7 @@ index 0000000..4a1708c
 +		{MAX96724_TX46_PIPE_X_ADDR, MAX96724_ALL_MAP_CTRL1},
 +		{MAX96724_TX47_PIPE_X_ADDR, MAX96724_ALL_MAP_CTRL1},
 +		{MAX96724_TX48_PIPE_X_ADDR, MAX96724_ALL_MAP_CTRL1},
-+		/* TX49: concat disabled (single-camera) */
++		/* TX49: concat disabled */
 +		{MAX96724_TX49_PIPE_X_ADDR, 0x00},
 +		/*
 +		 * Keep DES heartbeat handling aligned with the serializer's
@@ -2576,12 +2421,13 @@ index 0000000..4a1708c
 +		{0x0106, MAX96724_VID_RX6_CFG_VAL},
 +		/*
 +		 * Pipe stream control (offset 0x36 per pipe block).
-+		 * [XML] TUN_EN = 0x01.
++		 * TUN_EN = 0x01.
 +		 */
 +		{0x0936, MAX96724_TUN_EN},
 +	};
 +
-+	/* Adjust addresses for pipe offset (stride 0x40 per pipe)
++	/* 
++	 * Adjust addresses for pipe offset (stride 0x40 per pipe)
 +	 * Entries 0-13: TX11, SRC/DST maps, TX45-TX49 (all stride 0x40)
 +	 * Entries 14-15: VID_RX0/6 (stride 0x12)
 +	 * Entry 16: Pipe stream control (stride 0x40)
@@ -2589,7 +2435,7 @@ index 0000000..4a1708c
 +	for (i = 0; i < 14; i++)
 +		map_pipe_control[i].addr += 0x40 * pipe_id;
 +
-+	/* [max9296.c pattern] VID_RX offset: 0x12 per pipe */
++	/* VID_RX offset: 0x12 per pipe */
 +	map_pipe_control[14].addr += 0x12 * pipe_id;
 +	map_pipe_control[15].addr += 0x12 * pipe_id;
 +
@@ -2610,7 +2456,7 @@ index 0000000..4a1708c
 +		map_pipe_control[15].val = MAX96724_VID_RX6_PIXEL_VAL;
 +		map_pipe_control[16].val = MAX96724_TUN_DISABLED;
 +	} else {
-+		/* Single-RGB tunnel: no concatenation needed */
++		/* no concatenation needed */
 +		map_pipe_control[13].val = 0x00;
 +	}
 +
@@ -2628,7 +2474,7 @@ index 0000000..4a1708c
 +	map_pipe_control[9].val = all_mapping_phy;
 +	/* TX46-TX48 keep 0x55 (Ctrl1) from initializer */
 +	/* TX49 set to 0x00 above — overridden per mode in pixel/tunnel branch */
-+	/* VID_RX (entry 14) and pipe stream ctrl (entry 15) keep init values */
++	/* VID_RX and pipe stream ctrl keep init values */
 +
 +	err = max96724_set_registers(dev, map_pipe_control,
 +				     ARRAY_SIZE(map_pipe_control));
@@ -2731,16 +2577,8 @@ index 0000000..4a1708c
 +
 +	if (!strcmp(str_value, "2x4")) {
 +		priv->csi_mode = MAX96724_CSI_MODE_2X4;
-+		/*
-+		 * SC20190112 keeps the 0x08 Port-A clocking scheme but only brings
-+		 * PHY0 data lanes and the PHY1 clock lane to Orin.
-+		 */
 +		priv->lane_mp1 = MAX96724_LANE_MAP1_2X4;
 +		priv->lane_mp2 = MAX96724_LANE_MAP2_2X4;
-+	} else if (!strcmp(str_value, "4x2")) {
-+		priv->csi_mode = MAX96724_CSI_MODE_4X2;
-+		priv->lane_mp1 = MAX96724_LANE_MAP1_4X2;
-+		priv->lane_mp2 = MAX96724_LANE_MAP2_4X2;
 +	} else {
 +		dev_err(&client->dev, "invalid csi mode\n");
 +		return -EINVAL;
@@ -2762,7 +2600,7 @@ index 0000000..4a1708c
 +		priv->reset_gpio = -1;
 +	}
 +
-+	/* [User requirement] GMSL link speed from DT: 3 or 6 (Gbps) */
++	/* GMSL link speed from DT: 3 or 6 (Gbps) */
 +	err = of_property_read_u32(node, "gmsl-link-speed", &value);
 +	if (err < 0) {
 +		/* Default to 3 Gbps if not specified */


### PR DESCRIPTION
## Summary

This PR merges the HKR 4VC + Tunnel Mode feature branch into `d500_gmsl_dev`.

### Commits

- **`59938daf`** — HKR 4VC + Tunnel Mode
- **`7bba719`** — d5xx: fix build_all.sh fg24 copy resilience and clean up code style
  - `build_all.sh`: suppress cp error when fg24 dts source is missing
  - `d5xx.c`: normalize register macro indentation/alignment
  - `nvidia-oot` patches (6.0–7.1): remove Makefile modification from MAX96717/MAX96724 serdes patches

### Files Changed

| File | Description |
|------|-------------|
| `build_all.sh` | Fix fg24 DTS copy error handling |
| `kernel/realsense/d5xx.c` | Register macro alignment cleanup |
| `nvidia-oot/6.x-7.x/0011-...patch` | Simplified serdes patches (5 versions) |