### PR TITLE
kernel-5.10: add UVC metadata PIDs missing from L4T 35.1 (incl. D436)

### DIFF
--- a/kernel/kernel-5.10/5.0.2/0005-realsense-metadata-jetpack-5.0.2.patch
+++ b/kernel/kernel-5.10/5.0.2/0005-realsense-metadata-jetpack-5.0.2.patch
@@ -1,0 +1,113 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Remi Bettan <remi.bettan@realsenseai.com>
+Date: Wed, 10 Jun 2026 00:00:00 +0000
+Subject: [PATCH] Add UVC metadata PIDs missing from L4T 35.1 kernel-5.10
+
+Adds the six Intel RealSense USB product IDs that are present in
+librealsense (scripts/realsense-metadata-focal-master.patch) but not
+yet in NVIDIA's L4T 35.1 (JetPack 5.0.2) kernel-5.10 uvc_ids[] table:
+
+  0x0aa3  SR306
+  0x1156  D436
+  0x0b56  D555           (UVC_PC_PROTOCOL_15)
+  0x0b68  L535
+  0x0b6a  D585           (UVC_PC_PROTOCOL_15)
+  0x0b6b  585 Camera     (UVC_PC_PROTOCOL_15)
+
+Each entry registers V4L2_META_FMT_D4XX so the UVC driver attaches the
+D4XX metadata format to the matching device. The other 26 PIDs from the
+librealsense focal patch are already present upstream in L4T 35.1.
+
+Signed-off-by: Remi Bettan <remi.bettan@realsenseai.com>
+---
+ drivers/media/usb/uvc/uvc_driver.c | 54 ++++++++++++++++++++++++++++++
+ 1 file changed, 54 insertions(+)
+
+diff --git a/drivers/media/usb/uvc/uvc_driver.c b/drivers/media/usb/uvc/uvc_driver.c
+--- a/drivers/media/usb/uvc/uvc_driver.c
++++ b/drivers/media/usb/uvc/uvc_driver.c
+@@ -3059,6 +3059,15 @@ static const struct usb_device_id uvc_ids[] = {
+ 	  .bInterfaceSubClass	= 1,
+ 	  .bInterfaceProtocol	= 0,
+ 	  .driver_info		= UVC_INFO_META(V4L2_META_FMT_D4XX) },
++	  /* Intel SR306 depth camera */
++	{ .match_flags		= USB_DEVICE_ID_MATCH_DEVICE
++				| USB_DEVICE_ID_MATCH_INT_INFO,
++	  .idVendor		= 0x8086,
++	  .idProduct		= 0x0aa3,
++	  .bInterfaceClass	= USB_CLASS_VIDEO,
++	  .bInterfaceSubClass	= 1,
++	  .bInterfaceProtocol	= 0,
++	  .driver_info		= UVC_INFO_META(V4L2_META_FMT_D4XX) },
+ 	  /* Intel SR300 depth camera */
+ 	{ .match_flags		= USB_DEVICE_ID_MATCH_DEVICE
+ 				| USB_DEVICE_ID_MATCH_INT_INFO,
+@@ -3221,6 +3230,15 @@ static const struct usb_device_id uvc_ids[] = {
+ 	  .bInterfaceSubClass	= 1,
+ 	  .bInterfaceProtocol	= 0,
+ 	  .driver_info		= UVC_INFO_META(V4L2_META_FMT_D4XX) },
++	  /* Intel D436 depth camera */
++	{ .match_flags		= USB_DEVICE_ID_MATCH_DEVICE
++				| USB_DEVICE_ID_MATCH_INT_INFO,
++	  .idVendor		= 0x8086,
++	  .idProduct		= 0x1156,
++	  .bInterfaceClass	= USB_CLASS_VIDEO,
++	  .bInterfaceSubClass	= 1,
++	  .bInterfaceProtocol	= 0,
++	  .driver_info		= UVC_INFO_META(V4L2_META_FMT_D4XX) },
+ 	  /* Intel L515 Pre-PRQ */
+ 	{ .match_flags		= USB_DEVICE_ID_MATCH_DEVICE
+ 				| USB_DEVICE_ID_MATCH_INT_INFO,
+@@ -3266,6 +3284,15 @@ static const struct usb_device_id uvc_ids[] = {
+ 	  .bInterfaceSubClass	= 1,
+ 	  .bInterfaceProtocol	= 0,
+ 	  .driver_info		= UVC_INFO_META(V4L2_META_FMT_D4XX) },
++	  /* Intel D555 depth camera */
++	{ .match_flags		= USB_DEVICE_ID_MATCH_DEVICE
++				| USB_DEVICE_ID_MATCH_INT_INFO,
++	  .idVendor		= 0x8086,
++	  .idProduct		= 0x0b56,
++	  .bInterfaceClass	= USB_CLASS_VIDEO,
++	  .bInterfaceSubClass	= 1,
++	  .bInterfaceProtocol	= UVC_PC_PROTOCOL_15,
++	  .driver_info		= UVC_INFO_META(V4L2_META_FMT_D4XX) },
+ 	  /* Intel D405 */
+ 	{ .match_flags		= USB_DEVICE_ID_MATCH_DEVICE
+ 				| USB_DEVICE_ID_MATCH_INT_INFO,
+@@ -3293,6 +3320,33 @@ static const struct usb_device_id uvc_ids[] = {
+ 	  .bInterfaceSubClass	= 1,
+ 	  .bInterfaceProtocol	= 0,
+ 	  .driver_info		= UVC_INFO_META(V4L2_META_FMT_D4XX) },
++	  /* Intel L535 depth camera */
++	{ .match_flags		= USB_DEVICE_ID_MATCH_DEVICE
++				| USB_DEVICE_ID_MATCH_INT_INFO,
++	  .idVendor		= 0x8086,
++	  .idProduct		= 0x0b68,
++	  .bInterfaceClass	= USB_CLASS_VIDEO,
++	  .bInterfaceSubClass	= 1,
++	  .bInterfaceProtocol	= 0,
++	  .driver_info		= UVC_INFO_META(V4L2_META_FMT_D4XX) },
++	  /* Intel D585 depth camera */
++	{ .match_flags		= USB_DEVICE_ID_MATCH_DEVICE
++				| USB_DEVICE_ID_MATCH_INT_INFO,
++	  .idVendor		= 0x8086,
++	  .idProduct		= 0x0b6a,
++	  .bInterfaceClass	= USB_CLASS_VIDEO,
++	  .bInterfaceSubClass	= 1,
++	  .bInterfaceProtocol	= UVC_PC_PROTOCOL_15,
++	  .driver_info		= UVC_INFO_META(V4L2_META_FMT_D4XX) },
++	  /* Intel 585 depth camera */
++	{ .match_flags		= USB_DEVICE_ID_MATCH_DEVICE
++				| USB_DEVICE_ID_MATCH_INT_INFO,
++	  .idVendor		= 0x8086,
++	  .idProduct		= 0x0b6b,
++	  .bInterfaceClass	= USB_CLASS_VIDEO,
++	  .bInterfaceSubClass	= 1,
++	  .bInterfaceProtocol	= UVC_PC_PROTOCOL_15,
++	  .driver_info		= UVC_INFO_META(V4L2_META_FMT_D4XX) },
+ 	/* Generic USB Video Class */
+ 	{ USB_INTERFACE_INFO(USB_CLASS_VIDEO, 1, UVC_PC_PROTOCOL_UNDEFINED) },
+ 	{ USB_INTERFACE_INFO(USB_CLASS_VIDEO, 1, UVC_PC_PROTOCOL_15) },
+--
+2.32.0
+


### PR DESCRIPTION
## Summary
- Adds the 6 Intel RealSense USB PIDs that are present in [librealsense's `realsense-metadata-focal-master.patch`](https://github.com/realsenseai/librealsense/blob/development/scripts/realsense-metadata-focal-master.patch) but **not** in NVIDIA's L4T 35.1 kernel-5.10 `uvc_ids[]` table — including **D436 (`0x1156`)**.
- Adds a new patch file: `kernel/kernel-5.10/5.0.2/0005-realsense-metadata-jetpack-5.0.2.patch`.
- The other 26 PIDs from the librealsense focal patch are already upstream in L4T 35.1 — no changes needed there.

### PIDs added
| PID | Camera | `bInterfaceProtocol` |
|---|---|---|
| `0x0aa3` | SR306 | `0` |
| `0x1156` | **D436** | `0` |
| `0x0b56` | D555 | `UVC_PC_PROTOCOL_15` |
| `0x0b68` | L535 | `0` |
| `0x0b6a` | D585 | `UVC_PC_PROTOCOL_15` |
| `0x0b6b` | 585 Camera | `UVC_PC_PROTOCOL_15` |

Each entry registers `V4L2_META_FMT_D4XX` so the UVC driver attaches the D4XX metadata format to the matching device.

## Validation
- Validated with `git apply --check` against the L4T 35.1 GA `uvc_driver.c` source (OE4T mirror branch `l4t/l4t-r35.1.ga-5.10`, byte-identical to NVIDIA upstream for this file).
- `apply_patches.sh` already globs `kernel/kernel-5.10/5.0.2/*` so no script changes needed.

## Test plan
- [ ] `./setup_workspace.sh 5.0.2 && ./apply_patches.sh 5.0.2` applies clean
- [ ] `./build_all.sh 5.0.2` builds without uvc_driver.c hunk failure
- [ ] On Jetson with a D436 over USB: `udevadm info` shows the depth metadata video node attached (e.g. `/dev/video1` registers as `D4XX metadata`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)