### PR TITLE
realsense-metadata: add D436 (PID 0x1156) to JP6.x and JP7.x patches

### DIFF
--- a/kernel/kernel-jammy-src/6.0/0003-realsense-metadata-jammy-master.patch
+++ b/kernel/kernel-jammy-src/6.0/0003-realsense-metadata-jammy-master.patch
@@ -8,15 +8,15 @@ Co-developed-by: Yu MENG <yu1.meng@intel.com>
 Co-developed-by: Evgeni Raikhel <evgeni.raikhel@intel.com>
 Signed-off-by: Dmitry Perchanov <dmitry.perchanov@intel.com>
 ---
- drivers/media/usb/uvc/uvc_driver.c | 279 +++++++++++++++++++++++++++++
+ drivers/media/usb/uvc/uvc_driver.c | 288 +++++++++++++++++++++++++++++
  drivers/media/usb/uvc/uvcvideo.h   |   2 +-
- 2 files changed, 280 insertions(+), 1 deletion(-)
+ 2 files changed, 289 insertions(+), 1 deletion(-)
 
 diff --git a/drivers/media/usb/uvc/uvc_driver.c b/drivers/media/usb/uvc/uvc_driver.c
 index 2e7df1de0..848417912 100644
 --- a/drivers/media/usb/uvc/uvc_driver.c
 +++ b/drivers/media/usb/uvc/uvc_driver.c
-@@ -3152,6 +3152,285 @@ static const struct usb_device_id uvc_ids[] = {
+@@ -3152,6 +3152,294 @@ static const struct usb_device_id uvc_ids[] = {
  	  .bInterfaceSubClass	= 1,
  	  .bInterfaceProtocol	= 0,
  	  .driver_info		= UVC_INFO_META(V4L2_META_FMT_D4XX) },
@@ -187,6 +187,15 @@ index 2e7df1de0..848417912 100644
 +				| USB_DEVICE_ID_MATCH_INT_INFO,
 +	  .idVendor			= 0x8086,
 +	  .idProduct		= 0x0b3a,
++	  .bInterfaceClass	= USB_CLASS_VIDEO,
++	  .bInterfaceSubClass	= 1,
++	  .bInterfaceProtocol	= 0,
++	  .driver_info		= UVC_INFO_META(V4L2_META_FMT_D4XX) },
++	  /* Intel D436 depth camera */
++	{ .match_flags		= USB_DEVICE_ID_MATCH_DEVICE
++				| USB_DEVICE_ID_MATCH_INT_INFO,
++	  .idVendor			= 0x8086,
++	  .idProduct		= 0x1156,
 +	  .bInterfaceClass	= USB_CLASS_VIDEO,
 +	  .bInterfaceSubClass	= 1,
 +	  .bInterfaceProtocol	= 0,

--- a/kernel/kernel-jammy-src/6.2.1/0003-realsense-metadata-jammy-master.patch
+++ b/kernel/kernel-jammy-src/6.2.1/0003-realsense-metadata-jammy-master.patch
@@ -8,15 +8,15 @@ Co-developed-by: Yu MENG <yu1.meng@intel.com>
 Co-developed-by: Evgeni Raikhel <evgeni.raikhel@intel.com>
 Signed-off-by: Dmitry Perchanov <dmitry.perchanov@intel.com>
 ---
- drivers/media/usb/uvc/uvc_driver.c | 279 +++++++++++++++++++++++++++++
+ drivers/media/usb/uvc/uvc_driver.c | 288 +++++++++++++++++++++++++++++
  drivers/media/usb/uvc/uvcvideo.h   |   2 +-
- 2 files changed, 280 insertions(+), 1 deletion(-)
+ 2 files changed, 289 insertions(+), 1 deletion(-)
 
 diff --git a/drivers/media/usb/uvc/uvc_driver.c b/drivers/media/usb/uvc/uvc_driver.c
 index 2e7df1de0..848417912 100644
 --- a/drivers/media/usb/uvc/uvc_driver.c
 +++ b/drivers/media/usb/uvc/uvc_driver.c
-@@ -3152,6 +3152,285 @@ static const struct usb_device_id uvc_ids[] = {
+@@ -3152,6 +3152,294 @@ static const struct usb_device_id uvc_ids[] = {
  	  .bInterfaceSubClass	= 1,
  	  .bInterfaceProtocol	= 0,
  	  .driver_info		= UVC_INFO_META(V4L2_META_FMT_D4XX) },
@@ -187,6 +187,15 @@ index 2e7df1de0..848417912 100644
 +				| USB_DEVICE_ID_MATCH_INT_INFO,
 +	  .idVendor			= 0x8086,
 +	  .idProduct		= 0x0b3a,
++	  .bInterfaceClass	= USB_CLASS_VIDEO,
++	  .bInterfaceSubClass	= 1,
++	  .bInterfaceProtocol	= 0,
++	  .driver_info		= UVC_INFO_META(V4L2_META_FMT_D4XX) },
++	  /* Intel D436 depth camera */
++	{ .match_flags		= USB_DEVICE_ID_MATCH_DEVICE
++				| USB_DEVICE_ID_MATCH_INT_INFO,
++	  .idVendor			= 0x8086,
++	  .idProduct		= 0x1156,
 +	  .bInterfaceClass	= USB_CLASS_VIDEO,
 +	  .bInterfaceSubClass	= 1,
 +	  .bInterfaceProtocol	= 0,

--- a/kernel/kernel-jammy-src/6.2/0003-realsense-metadata-jammy-master.patch
+++ b/kernel/kernel-jammy-src/6.2/0003-realsense-metadata-jammy-master.patch
@@ -8,15 +8,15 @@ Co-developed-by: Yu MENG <yu1.meng@intel.com>
 Co-developed-by: Evgeni Raikhel <evgeni.raikhel@intel.com>
 Signed-off-by: Dmitry Perchanov <dmitry.perchanov@intel.com>
 ---
- drivers/media/usb/uvc/uvc_driver.c | 279 +++++++++++++++++++++++++++++
+ drivers/media/usb/uvc/uvc_driver.c | 288 +++++++++++++++++++++++++++++
  drivers/media/usb/uvc/uvcvideo.h   |   2 +-
- 2 files changed, 280 insertions(+), 1 deletion(-)
+ 2 files changed, 289 insertions(+), 1 deletion(-)
 
 diff --git a/drivers/media/usb/uvc/uvc_driver.c b/drivers/media/usb/uvc/uvc_driver.c
 index 2e7df1de0..848417912 100644
 --- a/drivers/media/usb/uvc/uvc_driver.c
 +++ b/drivers/media/usb/uvc/uvc_driver.c
-@@ -3152,6 +3152,285 @@ static const struct usb_device_id uvc_ids[] = {
+@@ -3152,6 +3152,294 @@ static const struct usb_device_id uvc_ids[] = {
  	  .bInterfaceSubClass	= 1,
  	  .bInterfaceProtocol	= 0,
  	  .driver_info		= UVC_INFO_META(V4L2_META_FMT_D4XX) },
@@ -187,6 +187,15 @@ index 2e7df1de0..848417912 100644
 +				| USB_DEVICE_ID_MATCH_INT_INFO,
 +	  .idVendor			= 0x8086,
 +	  .idProduct		= 0x0b3a,
++	  .bInterfaceClass	= USB_CLASS_VIDEO,
++	  .bInterfaceSubClass	= 1,
++	  .bInterfaceProtocol	= 0,
++	  .driver_info		= UVC_INFO_META(V4L2_META_FMT_D4XX) },
++	  /* Intel D436 depth camera */
++	{ .match_flags		= USB_DEVICE_ID_MATCH_DEVICE
++				| USB_DEVICE_ID_MATCH_INT_INFO,
++	  .idVendor			= 0x8086,
++	  .idProduct		= 0x1156,
 +	  .bInterfaceClass	= USB_CLASS_VIDEO,
 +	  .bInterfaceSubClass	= 1,
 +	  .bInterfaceProtocol	= 0,

--- a/kernel/kernel-noble-src/7.0/0003-realsense-metadata-jammy-master.patch
+++ b/kernel/kernel-noble-src/7.0/0003-realsense-metadata-jammy-master.patch
@@ -8,14 +8,14 @@ Co-developed-by: Yu MENG <yu1.meng@intel.com>
 Co-developed-by: Evgeni Raikhel <evgeni.raikhel@intel.com>
 Signed-off-by: Dmitry Perchanov <dmitry.perchanov@intel.com>
 ---
- drivers/media/usb/uvc/uvc_driver.c | 279 +++++++++++++++++++++++++++++
- 2 files changed, 280 insertions(+), 1 deletion(-)
+ drivers/media/usb/uvc/uvc_driver.c | 288 +++++++++++++++++++++++++++++
+ 2 files changed, 289 insertions(+), 1 deletion(-)
 
 diff --git a/drivers/media/usb/uvc/uvc_driver.c b/drivers/media/usb/uvc/uvc_driver.c
 index 2e7df1de0..848417912 100644
 --- a/drivers/media/usb/uvc/uvc_driver.c
 +++ b/drivers/media/usb/uvc/uvc_driver.c
-@@ -3152,6 +3152,285 @@ static const struct usb_device_id uvc_ids[] = {
+@@ -3152,6 +3152,294 @@ static const struct usb_device_id uvc_ids[] = {
  	  .bInterfaceSubClass	= 1,
  	  .bInterfaceProtocol	= 0,
  	  .driver_info		= UVC_INFO_META(V4L2_META_FMT_D4XX) },
@@ -186,6 +186,15 @@ index 2e7df1de0..848417912 100644
 +				| USB_DEVICE_ID_MATCH_INT_INFO,
 +	  .idVendor			= 0x8086,
 +	  .idProduct		= 0x0b3a,
++	  .bInterfaceClass	= USB_CLASS_VIDEO,
++	  .bInterfaceSubClass	= 1,
++	  .bInterfaceProtocol	= 0,
++	  .driver_info		= UVC_INFO_META(V4L2_META_FMT_D4XX) },
++	  /* Intel D436 depth camera */
++	{ .match_flags		= USB_DEVICE_ID_MATCH_DEVICE
++				| USB_DEVICE_ID_MATCH_INT_INFO,
++	  .idVendor			= 0x8086,
++	  .idProduct		= 0x1156,
 +	  .bInterfaceClass	= USB_CLASS_VIDEO,
 +	  .bInterfaceSubClass	= 1,
 +	  .bInterfaceProtocol	= 0,

--- a/kernel/kernel-noble-src/7.1/0003-realsense-metadata-jammy-master.patch
+++ b/kernel/kernel-noble-src/7.1/0003-realsense-metadata-jammy-master.patch
@@ -8,14 +8,14 @@ Co-developed-by: Yu MENG <yu1.meng@intel.com>
 Co-developed-by: Evgeni Raikhel <evgeni.raikhel@intel.com>
 Signed-off-by: Dmitry Perchanov <dmitry.perchanov@intel.com>
 ---
- drivers/media/usb/uvc/uvc_driver.c | 279 +++++++++++++++++++++++++++++
- 2 files changed, 280 insertions(+), 1 deletion(-)
+ drivers/media/usb/uvc/uvc_driver.c | 288 +++++++++++++++++++++++++++++
+ 2 files changed, 289 insertions(+), 1 deletion(-)
 
 diff --git a/drivers/media/usb/uvc/uvc_driver.c b/drivers/media/usb/uvc/uvc_driver.c
 index 2e7df1de0..848417912 100644
 --- a/drivers/media/usb/uvc/uvc_driver.c
 +++ b/drivers/media/usb/uvc/uvc_driver.c
-@@ -3152,6 +3152,285 @@ static const struct usb_device_id uvc_ids[] = {
+@@ -3152,6 +3152,294 @@ static const struct usb_device_id uvc_ids[] = {
  	  .bInterfaceSubClass	= 1,
  	  .bInterfaceProtocol	= 0,
  	  .driver_info		= UVC_INFO_META(V4L2_META_FMT_D4XX) },
@@ -186,6 +186,15 @@ index 2e7df1de0..848417912 100644
 +				| USB_DEVICE_ID_MATCH_INT_INFO,
 +	  .idVendor			= 0x8086,
 +	  .idProduct		= 0x0b3a,
++	  .bInterfaceClass	= USB_CLASS_VIDEO,
++	  .bInterfaceSubClass	= 1,
++	  .bInterfaceProtocol	= 0,
++	  .driver_info		= UVC_INFO_META(V4L2_META_FMT_D4XX) },
++	  /* Intel D436 depth camera */
++	{ .match_flags		= USB_DEVICE_ID_MATCH_DEVICE
++				| USB_DEVICE_ID_MATCH_INT_INFO,
++	  .idVendor			= 0x8086,
++	  .idProduct		= 0x1156,
 +	  .bInterfaceClass	= USB_CLASS_VIDEO,
 +	  .bInterfaceSubClass	= 1,
 +	  .bInterfaceProtocol	= 0,


### PR DESCRIPTION
## Summary
- D436 (`0x1156`) was the only PID from [librealsense's `realsense-metadata-focal-master.patch`](https://github.com/realsenseai/librealsense/blob/development/scripts/realsense-metadata-focal-master.patch) missing from the jammy/noble UVC metadata patches in this repo.
- Inserts the entry between D435i (`0x0b3a`) and L515 Pre-PRQ (`0x0b3d`), matching the order used in the librealsense reference patch.
- Touches 5 patches: `6.0`, `6.2`, `6.2.1` (jammy) and `7.0`, `7.1` (noble). `6.2.2` picks the change up via its existing symlink to `6.2.1`.
- Hunk header bumps from `+3152,285` to `+3152,294` (+9 lines) and the diffstat totals are updated to match.

## Companion PR
- JP 5.0.2 needs a separate patch (kernel-5.10 has no existing metadata patch file). Tracked in #465.

## Test plan
- [x] `./apply_patches.sh 6.2 && ./build_all.sh 6.2` applies and builds clean
- [ ] `./apply_patches.sh 6.2.1 && ./build_all.sh 6.2.1` applies and builds clean
- [ ] `./apply_patches.sh 6.2.2` (via symlink) applies clean
- [ ] `./apply_patches.sh 7.1 && ./build_all.sh 7.1` applies and builds clean
- [x] On Jetson with a D436 over USB: depth metadata video node attached

🤖 Generated with [Claude Code](https://claude.com/claude-code)