### PR TITLE
[RSDSO-21614] DFU/recovery robustness: finalize on close, route unsupported device types to DFU-only

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,8 @@ pytest -vs -m d457 test/                   # Direct pytest invocation
 
 Pytest marker: `d457` (defined in `test/pytest.ini`). Test timeout: 200 seconds.
 
+CI also runs a V4L2 test workflow on a self-hosted Jetson runner when `kernel/realsense/**` or `test/v4l2_test/**` paths change.
+
 ## Architecture
 
 ### Driver stack (top to bottom)
@@ -113,6 +115,32 @@ The build system cross-compiles for ARM64. Toolchains vary by JetPack:
 | 6.2     | 36.4.3      | kernel/kernel-jammy-src |
 | 6.2.1   | 36.4.4      | kernel/kernel-jammy-src |
 
+## Coding conventions
+
+### Kernel driver (C — `kernel/realsense/d4xx.c`)
+
+- **Keep changes minimal**: no code inflation. Prefer concise single-line forms; reuse existing helpers and paths instead of adding new ones.
+- **Before adding new code, check callers**: verify equivalent logic doesn't already exist in the call chain. If a function has one caller, put the logic there. Never duplicate logic — consolidate first.
+- **After removing code, clean up stale references**: immediately remove defines, variables, struct fields, forward declarations, and comments that were only used by the removed code. Do not leave dead code behind.
+- **Naming**: functions prefixed `ds5_` (mux functions `ds5_mux_`), structs prefixed `ds5_`, macros prefixed `DS5_`. Driver name `DS5_DRIVER_NAME = "d4xx"` with variants `-awg`, `-asr`, `-class`, `-dfu`.
+- **I2C helpers**: `ds5_read()` / `ds5_write()` — retry wrappers (`DS5_I2C_RETRY_COUNT=5`, `DS5_I2C_RETRY_DELAY_US=5000`). `ds5_read_with_check()` / `ds5_write_with_check()` / `ds5_raw_read_with_check()` / `ds5_raw_write_with_check()` — return on error. `ds5_read_poll()` — single-shot no-retry for polling loops (see Concurrency notes).
+- **Logging**: `dev_err()`, `dev_warn()`, `dev_info()`, `dev_dbg()` with `&state->client->dev`. Always include `__func__` in log messages.
+- **Conditional compilation**: `CONFIG_VIDEO_D4XX_SERDES` (GMSL vs. non-SerDes path), `CONFIG_TEGRA_CAMERA_PLATFORM` (Tegra integration), `LINUX_VERSION_CODE` checks for kernel API differences.
+- **Lazy invalidation over explicit loops**: when state must be invalidated across instances (e.g. after a deserializer reset), increment an atomic generation counter (`atomic_inc()`) and let instances detect the bump lazily in `ds5_configure()`. Avoid O(N) loops over `ds5_inited[]`. Add new invalidation logic to an existing mismatch-detection site rather than introducing a separate check.
+
+### V4L2 subdev architecture
+
+- **SerDes pipe configuration**: the **driver** configures all four SerDes pipes (Depth, RGB, IR, IMU) at stream start via `ds5_configure()`. The D457 firmware does **not** configure any pipes. Do not add probe-time pipe setup or special-case individual pipes in `ds5_probe()`.
+- **Device tree assumptions**: all supported device trees include all four sensor instances (Depth, RGB, IR, IMU). Do not add DT-scanning logic to check for the presence of individual sensor types.
+- **Unsupported device types are DFU-only, not probe failures**: `ds5_probe()` must not tear down the DFU chardev just because the device reports a type the driver does not operationally support (e.g. legacy/old firmware such as D430 GS reporting type 3, which reports type 5 once updated). The probe device-type wait calls `ds5_wait_device_type(state, &type, /*require_supported=*/false)` — it returns as soon as the type register is **populated** (non-zero), accepting unknown types. Probe then checks `ds5_is_valid_device_type(type)`: supported → full `ds5_v4l_init()`; unsupported → early `return 0` (DFU-only, before `ds5_v4l_init()`). Mirror the recovery early-return: `i2c_set_clientdata(c, state)` so `ds5_remove()` can recover `state`, but leave `dfu_state_flag` at `IDLE` (do **not** set `DS5_DFU_RECOVERY` — the device is in app mode, so opening the chardev must drive `DS5_DFU_OPEN` → `ds5_dfu_switch_to_dfu()`). Keep `ds5_is_valid_device_type()` as the list of *operationally-supported* types only — do not add legacy/DFU-only types to it, and do not add per-type cases to the format/sync `switch(dev_type)` blocks; for such types the goal is FW update only.
+- **`ds5_wait_device_type()` contract**: takes `require_supported`. Pass `true` from the reset/recovery path (`ds5_hw_reset_with_recovery()`) — only an operationally-supported type confirms GMSL link recovery for a known device. Pass `false` from `ds5_probe()` — any FW-populated (non-zero) type satisfies the wait so unknown/legacy types reach the DFU-only routing above. Non-zero is treated as "FW populated the type"; this assumes the register transitions `0 → final value` without transient non-zero garbage (by probe time the device has settled via prior FW_VERSION/SerDes/DFU-magic reads).
+- **DFU download finalizes once, at `close()`**: the firmware-image chardev download follows standard size-agnostic USB DFU — block transfers carry data, and a single zero-length `DFU_DNLOAD` (`ds5_write(0x4a04, 0)`) is the *sole* end-of-transfer marker that drives `DOWNLOAD_IDLE → MANIFEST → flash-commit → reboot`. `ds5_dfu_device_write()` is **transfer-only**: it streams blocks (with per-block `dfuDNLOAD_IDLE` sync) and stays in `DS5_DFU_IN_PROGRESS` — it must **not** emit `0x4a04=0`/manifest. The finalize lives only in `ds5_dfu_device_release()` (gated on `DS5_DFU_IN_PROGRESS`), because `close()` is the only reliable end-of-image signal — a `write()` length is not (userspace buffering, e.g. `std::ofstream`, splits the image across syscalls in arbitrary, possibly non-`DFU_BLOCK_SIZE`-aligned chunks; finalizing on a partial block both stalls 1024-aligned images and prematurely commits truncated ones). Do not reintroduce finalization into the write path.
+
+### Patches
+
+- **Separate patches per kernel module**: when changes span different kernel modules (e.g. max9295, max9296, max96712, d4xx), each module must get its own patch file. Do not combine changes to different modules in a single patch.
+- **Signed-off-by in every patch**: every `.patch` file must include a `Signed-off-by:` trailer. When modifying a patch, add your own using the current `git config user.name` / `user.email`.
+
 ## Branching
 
 - `master` — primary/release branch
@@ -131,11 +159,15 @@ The build system cross-compiles for ARM64. Toolchains vary by JetPack:
 - On each HW reset, clear cached values for firmware-populated readiness registers before polling readiness (for example clear `cached_device_type` before waiting for `DS5_DEVICE_TYPE`). Do not let pre-reset cache values short-circuit post-reset readiness checks.
 - For polling loops expecting transient I2C failures (HWMC status checks, reset readiness polls, DFU timeout checks), use `ds5_read_poll()` which performs a single-shot regmap read without retry or logging. This prevents false warnings and excessive log spam. Reserve `ds5_read()` for normal I2C operations where retry semantics are desired.
 - In `ds5_mux_s_stream()`, treat pre-toggle "already streaming" as no-op only when state is coherent; after reset-generation invalidation on start path, force stop + state clear and proceed with normal reconfiguration flow.
-- In `ds5_probe()`, the DFU-magic recovery check (`DS5_DFU_MAGIC_REG` 0x5020 → `DS5_DFU_MAGIC_LSW` 0x0201) must run **before** `ds5_wait_device_type()`. A device sitting in the bootloader after an interrupted FW upgrade never serves `DS5_DEVICE_TYPE` (0x0310) — placing the device-type wait first causes a ~10 s timeout followed by `goto e_chardev` which tears down the `/dev/d4xx-dfu*` chardev, leaving the device unrecoverable over MIPI. Early-return `DS5_DFU_RECOVERY` on magic match; only then proceed to the device-type wait for operational devices.
+- In `ds5_probe()`, the DFU-magic recovery check (`DS5_DFU_MAGIC_REG` 0x5020 → `DS5_DFU_MAGIC_LSW` 0x0201) must run **before** `ds5_wait_device_type()`. A device sitting in the bootloader after an interrupted FW upgrade never serves `DS5_DEVICE_TYPE` (0x0310) — placing the device-type wait first causes a ~10 s timeout followed by `goto e_chardev` which tears down the `/dev/d4xx-dfu*` chardev, leaving the device unrecoverable over MIPI. Early-return `DS5_DFU_RECOVERY` on magic match; only then proceed to the device-type wait for operational devices. Additionally, the initial `DS5_FW_VERSION` communication check (before the cam-type DT parsing) must also probe `DS5_DFU_MAGIC_REG` on failure before issuing `goto e_regulator`: the DFU bootloader does not respond to app registers (0x030c NAKs with -EREMOTEIO), so an unconditional abort on FW_VERSION failure prevents probe from ever reaching the DFU magic check.
+
+## Workflow rules
+
+- When the user establishes requirements during a conversation, treat them as fixed. Do not modify, reinterpret, or drop requirements on your own initiative. Only change requirements when the user explicitly requests it. If a requirement seems wrong or conflicting, raise it as a question — do not silently adjust.
 
 ## Post-patch instruction hygiene
 
-After every confirmed code patch, review both `.github/copilot-instructions.md` and `CLAUDE.md` against the final net diff, including any follow-up tuning edits.
+After every confirmed code patch, review `CLAUDE.md` against the final net diff, including any follow-up tuning edits.
 
 - Check for stale architectural claims and remove or correct them immediately.
 - Check whether the patch exposed a reusable convention; if it did, write it down as a general rule instead of leaving it implicit in code.

--- a/kernel/realsense/d4xx.c
+++ b/kernel/realsense/d4xx.c
@@ -2424,7 +2424,17 @@ static int ds5_set_calibration_data(struct ds5 *state,
 #define DS5_DFU_MAGIC_REG	0x5020
 #define DS5_DFU_MAGIC_LSW		0x0201  /* Lower 16 bits of 0x04030201 */
 
-static int ds5_wait_device_type(struct ds5 *state, u16 *dev_type)
+/*
+ * Wait for DS5_DEVICE_TYPE to become usable.
+ * @require_supported: when true, only an operationally-supported type
+ *   (ds5_is_valid_device_type()) satisfies the wait — used by the reset path
+ *   to confirm GMSL link recovery for a known device.  When false, any
+ *   FW-populated (non-zero) type satisfies the wait — used by probe so an
+ *   alive device reporting an unknown/legacy type can be routed to a DFU-only
+ *   path instead of failing probe; the caller validates the type afterwards.
+ */
+static int ds5_wait_device_type(struct ds5 *state, u16 *dev_type,
+				bool require_supported)
 {
 	int ret = -ETIMEDOUT;
 	int retry;
@@ -2434,13 +2444,16 @@ static int ds5_wait_device_type(struct ds5 *state, u16 *dev_type)
 	for (retry = 0; retry < DS5_HW_RESET_MAX_RETRIES;
 	     retry++, msleep(DS5_HW_RESET_POLL_INTERVAL_MS)) {
 		cached_type = READ_ONCE(state->ds5_dev->cached_device_type);
-		if (ds5_is_valid_device_type(cached_type)) {
+		if (require_supported ? ds5_is_valid_device_type(cached_type)
+				      : cached_type != DS5_DEVICE_TYPE_UNKNOWN) {
 			*dev_type = cached_type;
 			return 0;
 		}
 
 		ret = ds5_read_poll(state, DS5_DEVICE_TYPE, &probed_type);
-		if (!ret && ds5_is_valid_device_type(probed_type)) {
+		if (!ret &&
+		    (require_supported ? ds5_is_valid_device_type(probed_type)
+				       : probed_type != DS5_DEVICE_TYPE_UNKNOWN)) {
 			WRITE_ONCE(state->ds5_dev->cached_device_type, probed_type);
 			*dev_type = probed_type;
 			return 0;
@@ -2669,7 +2682,7 @@ static int ds5_hw_reset_with_recovery(struct ds5 *state)
 	 *    handled by ds5_configure()->ds5_setup_pipeline()
 	 *    at the next STREAMON for each stream.
 	 */
-	ret = ds5_wait_device_type(state, &dev_type);
+	ret = ds5_wait_device_type(state, &dev_type, true);
 	if (ret < 0) {
 		dev_err(&state->client->dev,
 			"%s(): device type not ready after reset (ret=%d, val=0x%x)\n",
@@ -6097,14 +6110,15 @@ static ssize_t ds5_dfu_device_write(struct file *flip,
 					state->dfu_dev.dfu_msg, dfu_part_blocks);
 			if (!ret)
 				ret = ds5_dfu_wait_for_get_dfu_status(state, dfuDNLOAD_IDLE);
-			if (!ret)
-				ret = ds5_write(state, 0x4a04, 0x00); /*Download complete */
-			if (!ret)
-				ret = ds5_dfu_wait_for_get_dfu_status(state, dfuMANIFEST);
 			if (ret < 0)
 				goto dfu_write_error;
-			state->dfu_dev.dfu_state_flag = DS5_DFU_DONE;
 		}
+		/* Do not finalize here: a write() length is not a reliable
+		 * end-of-image marker (userspace buffering splits the image across
+		 * syscalls in arbitrary, possibly non-DFU_BLOCK_SIZE-aligned chunks).
+		 * Stay in DS5_DFU_IN_PROGRESS and let ds5_dfu_device_release() send
+		 * the single zero-length DFU_DNLOAD (0x4a04=0) at close().
+		 */
 		if (len)
 			dev_notice(&state->client->dev, "%s(): DFU block (%d) bytes written\n",
 				__func__, (int)len);
@@ -6330,6 +6344,22 @@ static int ds5_dfu_device_release(struct inode *inode, struct file *file)
 	int ret = 0, retry = 10;
 	mutex_lock(&state->lock);
 	state->dfu_dev.device_open_count--;
+	/* Finalize the download here, at close(). The write handler is
+	 * transfer-only: it streams blocks but never commits, because a write()
+	 * length is not a reliable end-of-image marker (userspace buffering,
+	 * e.g. std::ofstream, splits the image across syscalls in arbitrary,
+	 * possibly non-DFU_BLOCK_SIZE-aligned chunks). close() unambiguously
+	 * marks end-of-image, so issue the single zero-length DFU_DNLOAD
+	 * (0x4a04=0) to drive DOWNLOAD_IDLE -> MANIFEST -> flash-commit -> reboot.
+	 */
+	if (state->dfu_dev.dfu_state_flag == DS5_DFU_IN_PROGRESS) {
+		ret = ds5_write(state, 0x4a04, 0x00); /* zero-length DFU_DNLOAD */
+		if (!ret)
+			ret = ds5_dfu_wait_for_get_dfu_status(state, dfuMANIFEST);
+		if (ret < 0)
+			dev_err(&state->client->dev,
+				"%s(): DFU finalize failed (%d)\n", __func__, ret);
+	}
 	if (state->dfu_dev.dfu_state_flag != DS5_DFU_RECOVERY)
 		state->dfu_dev.dfu_state_flag = DS5_DFU_IDLE;
 	/* We disable this section as it has no effect when device in operational
@@ -6663,10 +6693,19 @@ static int ds5_probe(struct i2c_client *c
 	// Verify communication
 	ret = ds5_read(state, DS5_FW_VERSION, &state->fw_version);
 	if (ret < 0) {
-		dev_err(&c->dev,
-			"%s(): cannot communicate with D4XX: %d on addr: 0x%x\n",
-			__func__, ret, c->addr);
-		goto e_regulator;
+		u16 dfu_magic = 0;
+		if (!ds5_read(state, DS5_DFU_MAGIC_REG, &dfu_magic) &&
+		    dfu_magic == DS5_DFU_MAGIC_LSW) {
+			dev_info(&c->dev,
+				"%s(): D4XX in DFU recovery (FW_VERSION not served)\n",
+				__func__);
+			/* fall through — DFU chardev init + DFU magic check below handles it */
+		} else {
+			dev_err(&c->dev,
+				"%s(): cannot communicate with D4XX: %d on addr: 0x%x\n",
+				__func__, ret, c->addr);
+			goto e_regulator;
+		}
 	}
 
 	state->is_depth = 0;
@@ -6750,12 +6789,29 @@ static int ds5_probe(struct i2c_client *c
 	 * FW_VERSION becomes readable earlier than DS5_DEVICE_TYPE, while later
 	 * probe code depends on DEVICE_TYPE to pick the correct format tables.
 	 */
-	ret = ds5_wait_device_type(state, &rec_state);
+	ret = ds5_wait_device_type(state, &rec_state, false);
 	if (ret < 0) {
 		dev_err(&c->dev,
-			"%s(): device type is not valid: %d (last val 0x%x)\n",
+			"%s(): device type not populated: %d (last val 0x%x)\n",
 			__func__, ret, rec_state);
 		goto e_chardev;
+	}
+
+	/* Device responded with a populated type but this driver does not
+	 * operationally support it (e.g. legacy/old firmware such as D430 GS
+	 * reporting type 3, which reports type 5 once updated). Expose only the
+	 * DFU chardev (already created above) so the user can flash supported
+	 * firmware; skip V4L2 init. Leave dfu_state_flag at IDLE: the device is
+	 * in app mode, so opening the chardev drives DS5_DFU_OPEN ->
+	 * ds5_dfu_switch_to_dfu().
+	 */
+	if (!ds5_is_valid_device_type(rec_state)) {
+		dev_info(&c->dev,
+			"%s(): unsupported device type 0x%x - DFU-only, skipping V4L2 init\n",
+			__func__, rec_state);
+		/* Override I2C drvdata with state for use in remove function */
+		i2c_set_clientdata(c, state);
+		return 0;
 	}
 
 	ds5_read_with_check(state, DS5_FW_VERSION, &state->fw_version);


### PR DESCRIPTION
**Tracking:** RSDSO-21614 — https://rsjira.realsenseai.com/browse/RSDSO-21614

## Summary
Hardens the D4XX DFU / recovery paths so firmware can always be flashed when the device is reachable over I2C.

### DFU download finalization (the main fix)
The bootloader follows standard size-agnostic USB DFU: a single zero-length `DFU_DNLOAD` (`0x4a04=0`) is the **sole** end-of-transfer marker that drives `DOWNLOAD_IDLE → MANIFEST → flash-commit → reboot`. The old write handler emitted it via a heuristic (only when a `write()` carried a partial `< DFU_BLOCK_SIZE` block), which was wrong in both directions:
- **Stall:** a 1024-aligned image (e.g. 2048×1024 = 2,097,152 B) never produced a partial block → terminator never sent → camera stuck in `DOWNLOAD_IDLE`. `rs-fw-update` and raw `cat`/`dd` all hit this.
- **Premature commit:** userspace buffering (e.g. `std::ofstream`) can split the image so an *intermediate* `write()` is non-aligned → mid-image commit of a truncated image.

Fix: `ds5_dfu_device_write()` is now **transfer-only** (streams blocks, per-block `dfuDNLOAD_IDLE` sync, stays `DS5_DFU_IN_PROGRESS`); `ds5_dfu_device_release()` is the **sole** finalizer, sending the one `0x4a04=0` + manifest at `close()` — the only reliable end-of-image signal. Wire protocol is unchanged; only *when* the terminator fires moves to `close()`.

### Device-type readiness / DFU-only routing
- `ds5_wait_device_type()` gains `require_supported`: reset path still requires an operationally-supported type (confirms GMSL link recovery); probe accepts any FW-populated (non-zero) type.
- `ds5_probe()` routes alive-but-unsupported types (e.g. legacy D430 GS reporting type 3, which reports type 5 once updated) to a DFU-only path instead of failing probe and tearing down `/dev/d4xx-dfu` — so old firmware can still be flashed. The DFU flow needs only I2C (absolute HWMC registers), so the skipped `ds5_v4l_init()` doesn't matter.

CLAUDE.md updated with the finalize-at-close contract, the `ds5_wait_device_type()` contract, and the DFU-only routing rule.

## Backward compatibility
- FW/bootloader: identical traffic, fully compatible.
- Flashers (`rs-fw-update`, `cat`, `dd`): write→close, so they finalize at close; previously-broken aligned-image cases now work.
- No ABI change (no ioctl/struct/device-node changes).

## Testing
- [ ] Build + deploy (done locally by author)
- [ ] Flash a **1024-aligned** image (2048×1024) via `rs-fw-update` and raw `cat` → commits + reboots into new FW (was: stuck in `DOWNLOAD_IDLE`)
- [ ] Non-aligned-chunk writer (`dd bs=999`) → no early/truncated commit
- [ ] `dmesg | grep -i dfu` shows no `DFU finalize failed`
- [ ] Round-trip re-flash back to original FW

🤖 Generated with [Claude Code](https://claude.com/claude-code)
