### PR TITLE
[RSDEV-12089] d4xx: bound ds5_hwmc_wait by wall-clock deadline (fix mid-stream preset at low fps)

### DIFF
--- a/kernel/realsense/d4xx.c
+++ b/kernel/realsense/d4xx.c
@@ -217,6 +217,13 @@ enum ds5_mux_pad {
 #define DS5_START_POLL_TIME	10
 #define DS5_START_MAX_TIME	2000
 #define DS5_START_MAX_COUNT	(DS5_START_MAX_TIME / DS5_START_POLL_TIME)
+/*
+ * RSDEV-12089: max wall-clock to wait for an HWMC command to complete. Must cover
+ * a worst-case low-fps stream re-arm (ds5_mux_s_stream, bounded by
+ * DS5_START_MAX_TIME) that monopolises the shared I2C bus while an HWMC is in
+ * flight; a shorter budget makes the HWMC falsely time out (-110 to the host).
+ */
+#define DS5_HWMC_MAX_TIME	2000
 #define MAX_DS5_CONFIG_RETRIES	5
 
 /* I2C retry configuration */
@@ -2234,18 +2241,27 @@ static int ds5_hwmc_wait(struct ds5 *state)
 {
 	int ret = 0;
 	u16 status = DS5_HWMC_STATUS_WIP;
-	int retries = 100;
 	int errorCode;
+	/*
+	 * RSDEV-12089: bound the poll by wall-clock (DS5_HWMC_MAX_TIME) rather than a
+	 * fixed retry count. The old ~100 ms budget was too short on MIPI: a concurrent
+	 * stream re-arm at low fps hogs the shared I2C bus for up to DS5_START_MAX_TIME,
+	 * starving this poll so the FW's completion was missed and the command falsely
+	 * returned -ETIMEDOUT (-110 in librealsense). Matches the s_stream/hw-reset
+	 * deadline idiom; the happy path still returns as soon as status leaves WIP.
+	 */
+	unsigned long timeout = jiffies + msecs_to_jiffies(DS5_HWMC_MAX_TIME);
+	bool first = true;
 	do {
-		if (retries != 100)
+		if (!first)
 			msleep_range(1);
+		first = false;
 		ret = ds5_read_poll(state, DS5_HWMC_STATUS, &status);
 		if (ret) {
 			dev_dbg(&state->client->dev,
-				"%s(): I2C read failed (%d), retries left: %d\n",
-				__func__, ret, retries);
+				"%s(): I2C read failed (%d)\n", __func__, ret);
 		}
-	} while (retries-- && (ret || status == DS5_HWMC_STATUS_WIP));
+	} while (time_before(jiffies, timeout) && (ret || status == DS5_HWMC_STATUS_WIP));
 	dev_dbg(&state->client->dev,
 		"%s(): ret: 0x%x, status: 0x%x\n",
 		__func__, ret, status);


### PR DESCRIPTION
## Problem
On D457 over MIPI/GMSL, changing a depth **visual preset mid-stream** fails at **low fps** (5 fps reliably, some 15 fps) with librealsense `error code=-110`. Works at 30/60 fps, and works if the stream starts with the preset preselected. No issue over USB.

## Root cause
A preset apply is a burst of ~35 HWMC round-trips + a few V4L2 control writes (laser/AE/gain). One of those control writes makes the driver **re-arm the stream** (`ds5_mux_s_stream`), whose confirm-poll waits on the FW `DS5_STATUS_STREAMING` bit until a **frame boundary** — 0.6–1.4 s at 5 fps — while **hogging the single shared I2C bus**. Meanwhile `ds5_hwmc_wait()` had only a ~100 ms budget (`retries=100` × `msleep_range(1)`), so a concurrent HWMC in the burst couldn't get enough bus turns before the re-arm finished → false `-ETIMEDOUT` → `-110`. It's fps-gated because the confirm bit flips on a frame boundary (instant at 30/60 fps, 200 ms at 5 fps). librealsense and the firmware were both confirmed correct; the short driver-side wait budget is the cause.

## Fix
`ds5_hwmc_wait()`: replace the fixed retry count with a **2 s jiffies deadline** (`DS5_HWMC_MAX_TIME`), matching the existing `s_stream` (`DS5_START_MAX_TIME`) and hw-reset deadline idiom in this file. The happy path still returns as soon as status leaves WIP; it only waits longer when the FW genuinely needs more time (e.g. behind a low-fps stream re-arm). No locking change — `ds5_hwmc_wait` runs under the depth subdev `state->lock` while the re-arm uses `ds5_dev->lock`, so the longer wait cannot deadlock the re-arm (deliberately **no** shared mutex added).

## Validation (fw-orin-nano-1, D457/MIPI, FW 5.17.3.22 held constant)
A/B with only the d4xx module changed:
- **Baseline** (stock d4xx 1.0.4.4): 5 fps preset-mid-stream **FAILS -110**.
- **This fix**: **ALL fps PASS** — 848×480 @ 5/15/30/60/90, 1280×720 @ 5/15/30, 640×360 @ 5/90, 424×240@5, 480×270@5 — every preset (Medium/High Accuracy/Default/High Density). **dmesg shows zero `ds5_hwmc_wait` timeouts.**

Ref: RSDEV-12089. Related: RSDEV-12096 (add a low-fps preset-switch-during-stream regression test — 30 fps masks this), RSDEV-12109 (rs-fw-update GMSL no-progress, separate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)