### PR TITLE
Unify D4xx and D5xx into one driver (d4xx.ko)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -44,7 +44,11 @@ Each camera registers four sensor subdevices: Depth, RGB, IR (Y8/Y8I/Y12I), and 
 - `ds5_depth_subdev_ops`, `ds5_ir_subdev_ops`, `ds5_rgb_subdev_ops`, `ds5_imu_subdev_ops`
 - Mux ops: `ds5_mux_subdev_ops`, `ds5_mux_pad_ops`, `ds5_mux_core_ops`, `ds5_mux_video_ops`
 
-A deserializer abstraction layer (`struct dser_interface`) provides function pointer tables for MAX9296 vs MAX96712 variants.
+The driver is **unified across the D4xx (D40x–D46x) and D5xx (D58x) families** and probes both `intel,d4xx` and `realsense,d5xx` (one module, `d4xx.ko`). SerDes chips are abstracted behind two ops tables, selected at runtime in `ds5_board_setup()` from the DT node names:
+- `struct dser_interface *dser_ops` — deserializer: `max9296_interface` / `max96712_interface` / `max96724_interface` (D5xx). Matched by exact dser node name.
+- `struct ser_interface *ser_ops` — serializer: `max9295_interface` / `max96717_interface` (D5xx). Matched by **prefix** (`strncmp`), since ser node names carry a link suffix (e.g. `max96717_a`, `max96717_prim`).
+
+Tunnel-mode-only hooks (`ser_ops->retrigger_tx`, `ser_ops->setup_streaming`, `dser_ops->setup_streaming`) are NULL for the D4xx chips, so the legacy D4xx flow is unchanged. **Add a new SerDes chip by adding an ops-table instance — never branch on chip name in the stream/pipeline paths.** Family-specific resolution/format tables are keyed by `DS5_DEVICE_TYPE_*` (including `DS5_DEVICE_TYPE_D58X`) in `ds5_parse_cam()`.
 
 - **SerDes pipe configuration**: the **driver** configures all four SerDes pipes (Depth, RGB, IR, IMU) at stream start via `ds5_configure()`. The D457 firmware does **not** configure any pipes. Do not add probe-time pipe setup or special-case individual pipes (e.g. IMU) in `ds5_probe()`.
 - **Device tree assumptions**: all supported device trees include all four sensor instances (Depth, RGB, IR, IMU). Do not add DT-scanning logic to check for the presence of individual sensor types.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,19 +65,21 @@ V4L2 userspace (v4l2-ctl, gstreamer, etc.)
     ↓
 Kernel V4L2 / media framework
     ↓
-D4XX kernel driver (kernel/realsense/d4xx.c, ~6200 lines)
+D4XX kernel driver (kernel/realsense/d4xx.c, ~6500 lines) — unified D4xx + D5xx
     ↓ I2C
-SerDes (MAX9295 serializer / MAX9296 deserializer)
+SerDes — D4xx: MAX9295 ser / MAX9296|MAX96712 deser
+         D5xx: MAX96717 ser / MAX96724 deser (tunnel mode)
     ↓ GMSL link
-RealSense D4XX camera module
+RealSense D4XX (D40x–D46x) / D5XX (D58x) camera module
 ```
 
 ### Key directories
 
-- **`kernel/realsense/d4xx.c`** — The main driver. Single-file V4L2 subdevice driver handling I2C communication, MIPI CSI-2 stream config, firmware control (DFU), calibration data, metadata capture, and V4L2 controls (exposure, laser power, AE ROI, etc.). Registers four sensor subdevices per camera: Depth, RGB, IR (Y8/Y8I/Y12I), and IMU.
+- **`kernel/realsense/d4xx.c`** — The main driver, a single unified V4L2 subdevice driver for **both** the D4xx (D40x–D46x) and D5xx (D58x) camera families. Handles I2C communication, MIPI CSI-2 stream config, firmware control (DFU), calibration data, metadata capture, and V4L2 controls (exposure, laser power, AE ROI, device_type, etc.). Registers four sensor subdevices per camera: Depth, RGB, IR (Y8/Y8I/Y12I), and IMU. Family behavior is abstracted behind ops tables and device-type-keyed format tables — see the SerDes-abstraction note below. Probes both `intel,d4xx` and `realsense,d5xx` compatibles (one module, `d4xx.ko`).
+  - **SerDes abstraction:** the deserializer is selected at runtime via `struct dser_interface *dser_ops` (`max9296_interface` / `max96712_interface` / `max96724_interface`), and the serializer via `struct ser_interface *ser_ops` (`max9295_interface` / `max96717_interface`). Both are picked in `ds5_board_setup()` from the DT serializer/deserializer node-name (serializer matched by **prefix** with `strncmp`, since DT names carry a link suffix like `max96717_a`). Tunnel-mode-only steps (`ser_ops->retrigger_tx`, `ser_ops->setup_streaming`, `dser_ops->setup_streaming`) are NULL for the D4xx chips, so the legacy D4xx flow is unchanged. **Add any new SerDes chip by adding an ops-table instance, not by branching on chip name.**
 - **`kernel/kernel-4.9/`, `kernel/kernel-5.10/`, `kernel/kernel-jammy-src/`** — Kernel patches organized by JetPack generation: 4.6.1 uses kernel 4.9, 5.x uses kernel 5.10, 6.x uses kernel-jammy-src.
 - **`kernel/nvidia/`** — NVIDIA driver patches (max9295/max9296 SerDes, VI capture engine) organized by JetPack version.
-- **`nvidia-oot/`** — Out-of-tree NVIDIA module patches for JetPack 6.x (subdirs `6.0/`, `6.1/`, `6.2/`, `6.2.1/`). Has its own Makefile for building conftest, hwpm, nvidia-oot, nvgpu, nvidia-display modules.
+- **`nvidia-oot/`** — Out-of-tree NVIDIA module patches for JetPack 6.x (subdirs `6.0/`, `6.1/`, `6.2/`, `6.2.1/`; `7.0/`, `7.1/`). Has its own Makefile for building conftest, hwpm, nvidia-oot, nvgpu, nvidia-display modules. The `0001-Porting-...` patch wires the `drivers/media/i2c/Makefile` to build a single `d4xx.o` plus **all five** SerDes modules: `max9295`, `max9296`, `max96712` (D4xx) and `max96717`, `max96724` (D5xx, added by the `0011-Add-MAX96717-...` patch). There is no separate `d5xx.o`.
 - **`hardware/realsense/`** — Device tree source files. Xavier uses `.dtsi` includes (`tegra194-camera-d4xx-*.dtsi`), Orin uses DT overlays (`tegra234-camera-d4xx-overlay*.dts`). Single-camera and dual-camera variants exist, plus `.calib.` variants for calibration.
 - **`hardware/nvidia/`** — Platform-level DT patches (`t19x/galen/` for Xavier, `t23x/` for Orin T234).
 - **`scripts/`** — Build orchestration. `setup-common` defines version-to-revision mappings and kernel directory selection. `source_sync_*.sh` scripts clone NVIDIA kernel repos. `SerDes_D457_*.sh` scripts configure serializer/deserializer registers.

--- a/apply_patches.sh
+++ b/apply_patches.sh
@@ -63,6 +63,24 @@ if ! version_lt "$JETPACK_VERSION" 6.0; then
     fi
 fi
 
+cleanup_reset_artifacts() {
+    local source="$1"
+    # Patch-created files that are untracked in the subrepo and would survive a
+    # hard reset. The unified d4xx driver builds both SerDes families, so the
+    # MAX96717/MAX96724 sources/headers (added by the 0011 patch) are cleaned
+    # alongside d4xx.c so a re-apply starts from a clean tree.
+    local -a reset_artifacts=(
+        "drivers/media/i2c/d4xx.c"
+        "drivers/media/i2c/max96717.c"
+        "drivers/media/i2c/max96724.c"
+        "include/media/max96712.h"
+        "include/media/max96717.h"
+        "include/media/max96724.h"
+    )
+
+    git -C "${source}" clean -f -- "${reset_artifacts[@]}" > /dev/null 2>&1 || true
+}
+
 apply_external_patches() {
 	local source="${BUILD_SRCS}/$2"
     git -C "${source}" status > /dev/null
@@ -79,6 +97,7 @@ apply_external_patches() {
             read -p "Repo ${source} has changes that will be hard reset. Continue (Y/n)? " confirm
             [[ -n "$confirm" && "$confirm" != "y" && "$confirm" != "Y" ]] && exit 1
         fi
+        cleanup_reset_artifacts "${source}"
         echo -n "$(ls -d ${source}): "
         git -C "${source}" reset --hard $L4T_VERSION
     fi
@@ -114,7 +133,18 @@ if [[ "$ACTION" = "apply" ]]; then
         if version_lt "$JETPACK_VERSION" "7.0"; then
             # jp6 overlay
             ln -f hardware/realsense/tegra234-camera-d4xx-overlay*.dts "${BUILD_SRCS}/hardware/nvidia/t23x/nv-public/overlay/"
+            # d5xx (D58x) overlays share the unified driver; wire them into the overlay Makefile.
+            ln -f hardware/realsense/tegra234-camera-d5xx-overlay*.dts "${BUILD_SRCS}/hardware/nvidia/t23x/nv-public/overlay/"
+            JP6_OVERLAY_MAKEFILE="${BUILD_SRCS}/hardware/nvidia/t23x/nv-public/overlay/Makefile"
+            if [[ -f "$JP6_OVERLAY_MAKEFILE" ]] && ! grep -q '^dtbo-y += tegra234-camera-d5xx-overlay.dtbo$' "$JP6_OVERLAY_MAKEFILE"; then
+                sed -i '/^dtbo-y += tegra234-camera-d4xx-overlay.dtbo$/a dtbo-y += tegra234-camera-d5xx-overlay.dtbo' "$JP6_OVERLAY_MAKEFILE"
+            fi
+            # NOTE: the FG24-4CH d5xx overlay variant has no committed .dts source
+            # yet, so it is intentionally NOT wired into the overlay Makefile
+            # (doing so breaks `make dtbs`). Re-add once the .dts is committed.
             ln -f ${BUILD_SRCS}/hardware/nvidia/t23x/nv-public/include/platforms/dt-bindings/tegra234-p3737-0000+p3701-0000.h \
+                    ${BUILD_SRCS}/$KERNEL_DIR/include/dt-bindings/
+            ln -f ${BUILD_SRCS}/hardware/nvidia/t23x/nv-public/include/platforms/dt-bindings/tegra234-p3767-0000-common.h \
                     ${BUILD_SRCS}/$KERNEL_DIR/include/dt-bindings/
         else
             # Copy tegra264-gpio.h for Thor overlay compilation if not already present

--- a/build_all.sh
+++ b/build_all.sh
@@ -4,6 +4,8 @@ set -e
 
 CLEAN=0
 DEVDBG=0
+FG24=0
+CSI_LANES=4
 
 # Parse optional flags
 while [[ "$1" == --* ]]; do
@@ -14,6 +16,19 @@ while [[ "$1" == --* ]]; do
             ;;
         --dev-dbg)
             DEVDBG=1
+            shift
+            ;;
+        --fg)
+            FG24=1
+            shift
+            ;;
+        --lane)
+            shift
+            CSI_LANES="$1"
+            if [[ "$CSI_LANES" != "2" && "$CSI_LANES" != "4" ]]; then
+                echo "Error: --lane must be 2 or 4 (got: $CSI_LANES)"
+                exit 1
+            fi
             shift
             ;;
         *)
@@ -27,7 +42,10 @@ export DEVDIR=$(cd `dirname $0` && pwd)
 NPROC=$(nproc)
 
 if [[ "$1" == "-h" ]]; then
-    echo "build_all.sh [--clean] [--dev-dbg] [JetPack_version [JetPack_Linux_source]]"
+    echo "build_all.sh [--clean] [--dev-dbg] [--fg] [--lane 2|4] [JetPack_version [JetPack_Linux_source]]"
+    echo "  --fg       Build D5xx overlay for FangZhu FG24-4CH board (4-lane CSI-C)"
+    echo "  --lane 2   Build with 2-lane CSI output (SC20190112 adapter, experimental)"
+    echo "  --lane 4   Build with 4-lane CSI output (default, verified working)"
     echo "build_all.sh -h"
 fi
 
@@ -57,6 +75,16 @@ fi
 
 export LOCALVERSION=-tegra
 export TEGRA_KERNEL_OUT="$DEVDIR/images/${JP_INPUT_VERSION}"
+
+# FG24-4CH board selection (D5xx overlay variant)
+export RS_FG24=$FG24
+if [[ "$FG24" == "1" ]]; then
+    echo "Building for FangZhu FG24-4CH board (4-lane CSI-C)"
+    CSI_LANES=4
+fi
+
+# CSI lane configuration (consumed by the D5xx overlay build)
+export RS_CSI_LANES=$CSI_LANES
 
 # Clean if requested
 if [[ $CLEAN == 1 ]]; then
@@ -109,20 +137,33 @@ else
         # Building the Image with default defconfig
         make -C kernel
     fi
-    make modules
+    make RS_CSI_LANES=$RS_CSI_LANES modules
+    # Unified driver: always a single d4xx.o (no separate d5xx.o).
     D4XX_CMD_FILE="$BUILD_SRCS/nvidia-oot/drivers/media/i2c/.d4xx.o.cmd"
     mkdir -p $TEGRA_KERNEL_OUT/rootfs/boot/dtb
     if version_lt "$JETPACK_VERSION" "7.0"; then
-        make dtbs
-        cp $BUILD_SRCS/nvidia-oot/device-tree/platform/generic-dts/dtbs/tegra234-camera-d4xx-overlay*.dtbo $TEGRA_KERNEL_OUT/rootfs/boot/
-        cp $BUILD_SRCS/nvidia-oot/device-tree/platform/generic-dts/dtbs/tegra234-p3737-0000+p3701-0000-nv.dtb $TEGRA_KERNEL_OUT/rootfs/boot/dtb/
-        cp $BUILD_SRCS/nvidia-oot/device-tree/platform/generic-dts/dtbs/tegra234-p3737-0000+p3701-0005-nv.dtb $TEGRA_KERNEL_OUT/rootfs/boot/dtb/
+        # Sync FG24 DTS into build tree before make dtbs (apply_patches ln may fail cross-fs)
+        if [[ "$FG24" == "1" ]]; then
+            cp -f "$DEVDIR/hardware/realsense/tegra234-camera-d5xx-overlay-fg24-4ch.dts" \
+                  "$BUILD_SRCS/hardware/nvidia/t23x/nv-public/overlay/" 2>/dev/null || true
+        fi
+        make RS_CSI_LANES=$RS_CSI_LANES dtbs
+        cp $BUILD_SRCS/nvidia-oot/device-tree/platform/generic-dts/dtbs/tegra234-camera-d4xx-overlay*.dtbo $TEGRA_KERNEL_OUT/rootfs/boot/ 2>/dev/null || true
+        # D5xx overlays build from the same tree; copy them when present.
+        cp $BUILD_SRCS/nvidia-oot/device-tree/platform/generic-dts/dtbs/tegra234-camera-d5xx-overlay*.dtbo $TEGRA_KERNEL_OUT/rootfs/boot/ 2>/dev/null || true
+        if [[ "$FG24" == "1" ]]; then
+            cp $BUILD_SRCS/nvidia-oot/device-tree/platform/generic-dts/dtbs/tegra234-p3768-0000+p3767-0005-nv-super.dtb $TEGRA_KERNEL_OUT/rootfs/boot/dtb/kernel_tegra234-p3768-0000+p3767-0005-nv-super.dtb 2>/dev/null || true
+        else
+            cp $BUILD_SRCS/nvidia-oot/device-tree/platform/generic-dts/dtbs/tegra234-p3737-0000+p3701-0000-nv.dtb $TEGRA_KERNEL_OUT/rootfs/boot/dtb/
+            cp $BUILD_SRCS/nvidia-oot/device-tree/platform/generic-dts/dtbs/tegra234-p3737-0000+p3701-0005-nv.dtb $TEGRA_KERNEL_OUT/rootfs/boot/dtb/
+        fi
     else
-        cp $BUILD_SRCS/$KERNEL_DIR/arch/arm64/boot/dts/nvidia/tegra2[36]4-camera-d4xx-overlay*.dtbo $TEGRA_KERNEL_OUT/rootfs/boot/
+        cp $BUILD_SRCS/$KERNEL_DIR/arch/arm64/boot/dts/nvidia/tegra2[36]4-camera-d4xx-overlay*.dtbo $TEGRA_KERNEL_OUT/rootfs/boot/ 2>/dev/null || true
+        cp $BUILD_SRCS/$KERNEL_DIR/arch/arm64/boot/dts/nvidia/tegra2[36]4-camera-d5xx-overlay*.dtbo $TEGRA_KERNEL_OUT/rootfs/boot/ 2>/dev/null || true
     fi
     export INSTALL_MOD_PATH=$TEGRA_KERNEL_OUT/rootfs/
     make -C kernel install
-    make modules_install
+    make RS_CSI_LANES=$RS_CSI_LANES modules_install
     # iio support
     KERNELVERSION=$(cat $KERNEL_HEADERS/include/config/kernel.release)
     KERNEL_MODULES_OUT=$INSTALL_MOD_PATH/lib/modules/${KERNELVERSION}

--- a/hardware/realsense/tegra234-camera-d5xx-overlay.dts
+++ b/hardware/realsense/tegra234-camera-d5xx-overlay.dts
@@ -1,0 +1,577 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// SPDX-FileCopyrightText: Copyright (c) 2026, RealSense CORPORATION.  All rights reserved.
+
+/*
+ * Device tree overlay for RealSense D585-3C depth camera with:
+ *   Serializer:   MAX96717
+ *   Deserializer: MAX96724
+ *   Camera SoC:   HKR
+ *   I2C Mux:      TCA9548
+ *
+ * VC assignment
+ *   VC0 = Depth  (Z16,  1280x720  @60fps)
+ *   VC1 = RGB    (YUY2, 1920x1080 @30fps)
+ *   VC2 = IR     (Y8/Y8I/Y12I, 1280x720 @60fps)
+ *   VC3 = IMU    (RAW8)
+ *
+ * GMSL link:
+ *   GMSL2 Tunnel Mode, 6 Gbps
+ *   HKR MIPI Tx → MAX96717: 4-lane CSI-2
+ *   MAX96724 → Orin NVCSI:  2-lane CSI-2 (SC20190112 board routes only D0/D1)
+ *
+ * I2C address map (7-bit):
+ *   TCA9548  mux:    0x72  (same as D4xx deser board)
+ *   MAX96724 deser:  0x27  (user-confirmed)
+ *   MAX96717 ser:    0x40  (default), 0x60 (aliased, user-confirmed)
+ *   HKR camera SoC:  0x42  (def-addr, user-confirmed)
+ *   Sensor aliases:   0x1a (Depth), 0x1b (RGB), 0x1c (IR), 0x1d (IMU)
+ *
+ * The four logical streams follow the D5xx driver stream model:
+ * Depth=0, RGB=1, IR=2, IMU=3.
+ */
+
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/clock/tegra234-clock.h>
+#include <dt-bindings/gpio/tegra234-gpio.h>
+#include <dt-bindings/tegra234-p3737-0000+p3701-0000.h>
+
+#define CAM0_RST_L	TEGRA234_MAIN_GPIO(H, 3)
+#define CAMERA_I2C_MUX_BUS(x) (0x1E + x)
+
+/ {
+	overlay-name = "Jetson RealSense Camera D5xx with max96724 and tca9548";
+	jetson-header-name = "Jetson AGX CSI Connector";
+	compatible = JETSON_COMPATIBLE;
+
+	fragment@0 {
+		target-path = "/";
+		__overlay__ {
+			tegra-capture-vi {
+				/* 4 channels: Depth(VC0), RGB(VC1), IR(VC2), IMU(VC3) */
+				num-channels = <4>;
+				ports {
+					status = "okay";
+
+					/* VC0: Depth — Z16 1280x720 @60fps */
+					port@0 {
+						status = "okay";
+						reg = <0>;
+						d5xx_vi_in0: endpoint {
+							status = "okay";
+							vc-id = <0>;
+							port-index = <0>;
+							bus-width = <2>; /* 2-lane CSI from MAX96724 (SC20190112: only D0/D1 routed) */
+							remote-endpoint = <&d5xx_csi_out0>;
+						};
+					};
+
+					/* VC1: RGB — YUY2 1920x1080 @30fps */
+					port@1 {
+						status = "okay";
+						reg = <1>;
+						d5xx_vi_in1: endpoint {
+							status = "okay";
+							vc-id = <1>;
+							port-index = <0>;
+							bus-width = <2>;
+							remote-endpoint = <&d5xx_csi_out1>;
+						};
+					};
+
+					/* VC2: IR — Y8/Y8I/Y12I 1280x720 @60fps */
+					port@2 {
+						status = "okay";
+						reg = <2>;
+						d5xx_vi_in2: endpoint {
+							status = "okay";
+							vc-id = <2>;
+							port-index = <0>;
+							bus-width = <2>;
+							remote-endpoint = <&d5xx_csi_out2>;
+						};
+					};
+
+					/* VC3: IMU — RAW8 */
+					port@3 {
+						status = "okay";
+						reg = <3>;
+						d5xx_vi_in3: endpoint {
+							status = "okay";
+							vc-id = <3>;
+							port-index = <0>;
+							bus-width = <2>;
+							remote-endpoint = <&d5xx_csi_out3>;
+						};
+					};
+				};
+			};
+
+			bus@0 {
+				host1x@13e00000 {
+					nvcsi@15a00000 {
+						num-channels = <4>;
+
+						/* NVCSI channel 0: Depth (VC0) */
+						channel@0 {
+							status = "okay";
+							reg = <0>;
+							ports {
+								status = "okay";
+								port@0 {
+									status = "okay";
+									reg = <0>;
+									d5xx_csi_in0: endpoint@0 {
+										status = "okay";
+										port-index = <0>;
+									bus-width = <2>;
+										vc-id = <0>;
+
+										remote-endpoint = <&d5xx_depth_out>;
+									};
+								};
+								port@1 {
+									status = "okay";
+									reg = <1>;
+									d5xx_csi_out0: endpoint@1 {
+										status = "okay";
+										remote-endpoint = <&d5xx_vi_in0>;
+									};
+								};
+							};
+						};
+
+						/* NVCSI channel 1: RGB (VC1) */
+						channel@1 {
+							status = "okay";
+							reg = <1>;
+							ports {
+								status = "okay";
+								port@0 {
+									status = "okay";
+									reg = <0>;
+									d5xx_csi_in1: endpoint@2 {
+										status = "okay";
+										port-index = <0>;
+									bus-width = <2>;
+										vc-id = <1>;
+
+										remote-endpoint = <&d5xx_rgb_out>;
+									};
+								};
+								port@1 {
+									status = "okay";
+									reg = <1>;
+									d5xx_csi_out1: endpoint@3 {
+										status = "okay";
+										remote-endpoint = <&d5xx_vi_in1>;
+									};
+								};
+							};
+						};
+
+						/* NVCSI channel 2: IR (VC2) */
+						channel@2 {
+							status = "okay";
+							reg = <2>;
+							ports {
+								status = "okay";
+								port@0 {
+									status = "okay";
+									reg = <0>;
+									d5xx_csi_in2: endpoint@4 {
+										status = "okay";
+										port-index = <0>;
+									bus-width = <2>;
+										vc-id = <2>;
+									remote-endpoint = <&d5xx_ir_out>;
+									};
+								};
+								port@1 {
+									status = "okay";
+									reg = <1>;
+									d5xx_csi_out2: endpoint@5 {
+										status = "okay";
+										remote-endpoint = <&d5xx_vi_in2>;
+									};
+								};
+							};
+						};
+
+						/* NVCSI channel 3: IMU (VC3) */
+						channel@3 {
+							status = "okay";
+							reg = <3>;
+							ports {
+								status = "okay";
+								port@0 {
+									status = "okay";
+									reg = <0>;
+									d5xx_csi_in3: endpoint@6 {
+										status = "okay";
+										port-index = <0>;
+									bus-width = <2>;
+										vc-id = <3>;
+									remote-endpoint = <&d5xx_imu_out>;
+									};
+								};
+								port@1 {
+									status = "okay";
+									reg = <1>;
+									d5xx_csi_out3: endpoint@7 {
+										status = "okay";
+										remote-endpoint = <&d5xx_vi_in3>;
+									};
+								};
+							};
+						};
+					};
+				};
+
+				i2c@3180000 {
+					clock-frequency = <400000>;
+					tca9548@72 {
+						status = "okay";
+						reg = <0x72>;
+						compatible = "nxp,pca9548";
+						#address-cells = <1>;
+						#size-cells = <0>;
+						skip_mux_detect = "yes";
+						vcc-supply = <&vdd_1v8_ls>;
+						force_bus_start = <CAMERA_I2C_MUX_BUS(0)>;
+						vcc_lp = "vcc";
+
+						i2c@0 {
+							status = "okay";
+							reg = <0>;
+							i2c-mux,deselect-on-exit;
+							#address-cells = <1>;
+							#size-cells = <0>;
+
+							/*
+							 * MAX96724 Deserializer
+							 * [DS2] MAX96724 Datasheet rev4
+							 * I2C addr: 0x27 (7-bit, user-confirmed)
+							 * csi-mode: "2x4" — XML baseline, Controller1→PortA 2-lane output
+							 * max-src: 1 — single D585 camera on link B
+							 * gmsl-link-speed: 6 — 6Gbps (matching XML reference)
+							 * csi-mode: "2x4" — phy_1x4a mode, Controller1→PortA, only PHY0(2 lane) enabled
+							 */
+							dser: max96724@27 {
+								status = "okay";
+								reg = <0x27>;
+								compatible = "adi,max96724";
+								csi-mode = "2x4";
+								max-src = <1>;
+								gmsl-link-speed = <6>;
+								reset-gpios = <&gpio CAM0_RST_L GPIO_ACTIVE_HIGH>;
+							};
+
+							/*
+							 * MAX96717 primary serializer node at power-on address.
+							 * max96717_setup_control() uses this handle to move
+							 * the serializer from 0x40 to the aliased 0x60 address.
+							 */
+							ser_prim: max96717_prim@40 {
+								status = "okay";
+								compatible = "adi,max96717";
+								reg = <0x40>;
+								is-prim-ser;
+							};
+
+							/*
+							 * MAX96717 Serializer alias used after address reassignment.
+							 * [DS1] MAX96717 Datasheet rev6
+							 * [HAS] Section 1.2: "GMSL serializer (MAX96717)"
+							 * I2C alias addr: 0x60 (7-bit, user-confirmed)
+							 * MAX96717 has single 4-lane CSI-2 D-PHY input
+							 */
+							ser_a: max96717_a@60 {
+								status = "okay";
+								compatible = "adi,max96717";
+								reg = <0x60>;
+								maxim,gmsl-dser-device = <&dser>;
+							};
+
+							/*
+							 * D585 Depth stream — VC0
+							 * [HAS] Table 3-5: Depth, Z16, 1280x720, 60fps, VC0
+							 * [HAS] Section 4.1: "HKR assigns output streams to
+							 *        MIPI VC: Depth→VC0"
+							 *
+							 * def-addr: 0x42 = HKR SoC I2C base (user-confirmed)
+							 * reg: 0x1a = primary aliased address (user-confirmed)
+							 */
+							d5xx_depth: d5xx@1a {
+								status = "okay";
+								def-addr = <0x42>;
+								reg = <0x1a>;
+								compatible = "realsense,d5xx";
+								use_sensor_mode_id = "true";
+								vcc-supply = <&vdd_1v8_ls>;
+								cam-type = "Depth";
+								nvidia,gmsl-ser-device = <&ser_a>;
+								nvidia,gmsl-dser-device = <&dser>;
+
+								ports {
+									#address-cells = <1>;
+									#size-cells = <0>;
+
+									port@0 {
+										reg = <0>;
+										d5xx_depth_out: endpoint {
+											vc-id = <0>;
+											port-index = <0>;
+										bus-width = <2>;
+											remote-endpoint = <&d5xx_csi_in0>;
+										};
+									};
+								};
+
+								/*
+								 * Depth mode: Z16 (16bpp), 1280x720
+								 * [HAS] Table 3-5: "Z16 (16-bit depth), 1280×720, 60fps"
+								 * [FAS] Table 4-1: "Depth - VC0, DT 0x1E (YUV422), 16bpp"
+								 * num_lanes: 2 — MAX96724 outputs 2 CSI lanes via SC20190112
+								 * embedded_metadata_height: 1 — depth metadata row
+								 */
+								mode0 {
+									pixel_t = "yuv_uyvy16";
+									num_lanes = "2";
+									csi_pixel_bit_depth = "16";
+									active_w = "1280";
+									active_h = "720";
+									tegra_sinterface = "serial_a";
+									phy_mode = "DPHY";
+									discontinuous_clk = "no";
+									mclk_khz = "24000";
+									pix_clk_hz = "175000000";
+									line_length = "1280";
+									embedded_metadata_height = "1";
+								};
+
+								/*
+								 * GMSL link config for Depth stream
+								 * src-csi-port: "a" — MAX96717 single CSI input port
+								 *   [DS1] MAX96717 has one 4-lane D-PHY CSI-2 input (Port A)
+								 * dst-csi-port: "a" — MAX96724 CSI output port A
+								 * serdes-csi-link: "b" — GMSL Link B (cable on port B)
+								 * csi-mode: "1x4" — single link, 4 video pipes
+								 * st-vc: 0 — starting VC offset
+								 * vc-id: 0 — [HAS] Table 3-5: Depth → VC0
+								 * num-lanes: 2 — SC20190112 only routes 2 CSI lanes to Orin
+								 */
+								gmsl-link {
+									src-csi-port = "a";
+									dst-csi-port = "a";
+									serdes-csi-link = "a";
+									csi-mode = "1x4";
+									st-vc = <0>;
+									vc-id = <0>;
+									num-lanes = <2>;
+								};
+							};
+
+							/*
+							 * D585 RGB stream — VC1
+							 * RGB follows the D5xx stream model as stream 1 / VC1.
+							 *
+							 * def-addr: 0x42 = HKR SoC I2C base
+							 * reg: 0x1b = aliased address
+							 * override_reg: 0x1a = redirect to primary node
+							 */
+							d5xx_rgb: d5xx@1b {
+								status = "okay";
+								def-addr = <0x42>;
+								reg = <0x1b>;
+								override_reg = <0x1a>;
+								compatible = "realsense,d5xx";
+								use_sensor_mode_id = "true";
+								vcc-supply = <&vdd_1v8_ls>;
+								cam-type = "RGB";
+								nvidia,gmsl-ser-device = <&ser_a>;
+								nvidia,gmsl-dser-device = <&dser>;
+
+								ports {
+									#address-cells = <1>;
+									#size-cells = <0>;
+
+									port@0 {
+										reg = <0>;
+										d5xx_rgb_out: endpoint {
+											vc-id = <1>;
+											port-index = <0>;
+										bus-width = <2>;
+											remote-endpoint = <&d5xx_csi_in1>;
+										};
+									};
+								};
+
+								/*
+								 * RGB mode: YUY2 (16bpp), 1920x1080
+								 * embedded_metadata_height: 1 — RGB metadata row
+								 */
+								mode0 {
+									pixel_t = "yuv_yuyv16";
+									num_lanes = "2";
+									csi_pixel_bit_depth = "16";
+									active_w = "1920";
+									active_h = "1080";
+									tegra_sinterface = "serial_a";
+									phy_mode = "DPHY";
+									discontinuous_clk = "no";
+									mclk_khz = "24000";
+									pix_clk_hz = "175000000";
+									line_length = "1920";
+									embedded_metadata_height = "1";
+								};
+
+								gmsl-link {
+									src-csi-port = "a";
+									dst-csi-port = "a";
+									serdes-csi-link = "a";
+									csi-mode = "1x4";
+									st-vc = <1>;
+									vc-id = <1>;
+									num-lanes = <2>;
+								};
+							};
+
+							/*
+							 * D585 IR stream — VC2
+							 * Y8, Y8I, and Y12I are mutually exclusive formats on
+							 * one logical IR stream, not separate left/right nodes.
+							 *
+							 * def-addr: 0x42 = HKR SoC I2C base
+							 * reg: 0x1c = aliased address
+							 * override_reg: 0x1a = redirect to primary node
+							 */
+							d5xx_ir: d5xx@1c {
+								status = "okay";
+								def-addr = <0x42>;
+								reg = <0x1c>;
+								override_reg = <0x1a>;
+								compatible = "realsense,d5xx";
+								use_sensor_mode_id = "true";
+								vcc-supply = <&vdd_1v8_ls>;
+								cam-type = "Y8";
+								nvidia,gmsl-ser-device = <&ser_a>;
+								nvidia,gmsl-dser-device = <&dser>;
+
+								ports {
+									#address-cells = <1>;
+									#size-cells = <0>;
+
+									port@0 {
+										reg = <0>;
+										d5xx_ir_out: endpoint {
+											vc-id = <2>;
+											port-index = <0>;
+										bus-width = <2>;
+											remote-endpoint = <&d5xx_csi_in2>;
+										};
+									};
+								};
+
+								/*
+								 * IR mode: Y8/Y8I/Y12I, 1280x720
+								 * embedded_metadata_height: 1 — IR metadata row
+								 */
+								mode0 {
+									pixel_t = "grey_y8";
+									num_lanes = "2";
+									csi_pixel_bit_depth = "8";
+									active_w = "1280";
+									active_h = "720";
+									tegra_sinterface = "serial_a";
+									phy_mode = "DPHY";
+									discontinuous_clk = "no";
+									mclk_khz = "24000";
+									pix_clk_hz = "175000000";
+									line_length = "1280";
+									embedded_metadata_height = "1";
+								};
+
+								gmsl-link {
+									src-csi-port = "a";
+									dst-csi-port = "a";
+									serdes-csi-link = "a";
+									csi-mode = "1x4";
+									st-vc = <2>;
+									vc-id = <2>;
+									num-lanes = <2>;
+								};
+							};
+
+							/*
+							 * D585 IMU stream — VC3
+							 * IMU follows the D5xx stream model as stream 3 / VC3.
+							 *
+							 * def-addr: 0x42 = HKR SoC I2C base
+							 * reg: 0x1d = aliased address
+							 * override_reg: 0x1a = redirect to primary node
+							 */
+							d5xx_imu: d5xx@1d {
+								status = "okay";
+								def-addr = <0x42>;
+								reg = <0x1d>;
+								override_reg = <0x1a>;
+								compatible = "realsense,d5xx";
+								use_sensor_mode_id = "true";
+								vcc-supply = <&vdd_1v8_ls>;
+								cam-type = "IMU";
+								nvidia,gmsl-ser-device = <&ser_a>;
+								nvidia,gmsl-dser-device = <&dser>;
+
+								ports {
+									#address-cells = <1>;
+									#size-cells = <0>;
+
+									port@0 {
+										reg = <0>;
+										d5xx_imu_out: endpoint {
+											vc-id = <3>;
+											port-index = <0>;
+										bus-width = <2>;
+											remote-endpoint = <&d5xx_csi_in3>;
+										};
+									};
+								};
+
+								/*
+								 * IMU mode: RAW8 logical stream on VC3.
+								 * embedded_metadata_height: 0 — IMU has no metadata row.
+								 */
+								mode0 {
+									pixel_t = "grey_y8";
+									num_lanes = "2";
+									csi_pixel_bit_depth = "8";
+									active_w = "640";
+									active_h = "480";
+									tegra_sinterface = "serial_a";
+									phy_mode = "DPHY";
+									discontinuous_clk = "no";
+									mclk_khz = "24000";
+									pix_clk_hz = "175000000";
+									line_length = "1280";
+									embedded_metadata_height = "0";
+								};
+
+								gmsl-link {
+									src-csi-port = "a";
+									dst-csi-port = "a";
+									serdes-csi-link = "a";
+									csi-mode = "1x4";
+									st-vc = <3>;
+									vc-id = <3>;
+									num-lanes = <2>;
+								};
+							};
+						};
+					};
+				};
+			};
+		};
+	};
+};

--- a/kernel/realsense/d4xx.c
+++ b/kernel/realsense/d4xx.c
@@ -41,6 +41,8 @@
 #include <media/max9295.h>
 #include <media/max9296.h>
 #include <media/max96712.h>
+#include <media/max96717.h>
+#include <media/max96724.h>
 
 /* Deserializer interface structure for abstraction */
 struct dser_interface {
@@ -67,7 +69,46 @@ struct dser_interface {
 	void (*power_off)(struct device *dev);
 	int (*init_settings)(struct device *dev);
 
+	/*
+	 * Optional CSI output streaming setup (PHY/DPLL/lane-map/CSI enable).
+	 * Only required by tunnel-mode deserializers (e.g. max96724); NULL for
+	 * deserializers (max9296/max96712) that need no explicit streaming setup.
+	 */
+	int (*setup_streaming)(struct device *dev, struct device *s_dev);
+
 	/* Identification */
+	const char *name;
+};
+
+/*
+ * Serializer interface abstraction. D4xx-family cameras use max9295; the
+ * D5xx (D58x) family uses max96717 in GMSL tunnel mode. Callers go through
+ * state->ser_ops so the single driver supports both serializer chips.
+ */
+struct ser_interface {
+	int (*set_pipe)(struct device *dev, int pipe_id, u8 data_type1,
+			u8 data_type2, u32 vc_id);
+	int (*setup_control)(struct device *dev);
+	int (*init_settings)(struct device *dev);
+	int (*reset_control)(struct device *dev);
+	int (*sdev_pair)(struct device *dev, struct gmsl_link_ctx *g_ctx);
+	int (*sdev_unpair)(struct device *dev, struct device *s_dev);
+
+	/*
+	 * ESYNC GPIO tunneling. max9295 has explicit enable/disable; max96717
+	 * has a single setup (enable-only). Implementations hide the difference
+	 * behind the @enable flag.
+	 */
+	int (*set_esync_tunneling)(struct device *dev, bool enable);
+
+	/*
+	 * Tunnel-mode-only hooks (max96717). NULL for max9295.
+	 * retrigger_tx re-acquires the tunnel TX after a deserializer one-shot
+	 * reset; setup_streaming enables CSI input + tunnel mode.
+	 */
+	void (*retrigger_tx)(struct device *dev);
+	int (*setup_streaming)(struct device *dev);
+
 	const char *name;
 };
 
@@ -98,6 +139,7 @@ struct dser_interface {
 #define DS5_DEVICE_TYPE_D45X		6
 #define DS5_DEVICE_TYPE_D43X		5
 #define DS5_DEVICE_TYPE_D46X		4
+#define DS5_DEVICE_TYPE_D58X		9
 #define DS5_DEVICE_TYPE_UNKNOWN		0
 
 #define DS5_MIPI_LANE_NUMS		0x0400
@@ -387,6 +429,7 @@ struct ds5_ctrls {
 	struct {
 		struct v4l2_ctrl *log;
 		struct v4l2_ctrl *fw_version;
+		struct v4l2_ctrl *device_type;
 		struct v4l2_ctrl *gvd;
 		struct v4l2_ctrl *get_depth_calib;
 		struct v4l2_ctrl *set_depth_calib;
@@ -522,6 +565,7 @@ struct ds5 {
 	struct i2c_client *ser_i2c;
 	struct i2c_client *dser_i2c;
 	const struct dser_interface *dser_ops;
+	const struct ser_interface *ser_ops;
 	bool ser_primary; /* true for the first instance per serializer (first stream of a specific camera) */
 	bool dser_primary; /* true for the first instance per deserializer (first camera of a specific dser) */
 #endif
@@ -645,6 +689,70 @@ static const struct dser_interface max96712_interface = {
 	.name = "max96712",
 };
 
+/* MAX96724 (D5xx / tunnel mode) deserializer interface implementation */
+static const struct dser_interface max96724_interface = {
+	.get_available_pipe_id = max96724_get_available_pipe_id,
+	.get_ser_pipe_id = max96724_get_ser_pipe_id,
+	.bind_ser_to_dser_pipe = max96724_bind_ser_to_dser_pipe,
+	.set_pipe = max96724_set_pipe,
+	.release_pipe = max96724_release_pipe,
+	.reset_oneshot = max96724_reset_oneshot,
+	.setup_link = max96724_setup_link,
+	.setup_control = max96724_setup_control,
+	.reset_control = max96724_reset_control,
+	.sdev_register = max96724_sdev_register,
+	.sdev_unregister = max96724_sdev_unregister,
+	.power_on = max96724_power_on,
+	.power_off = max96724_power_off,
+	.init_settings = max96724_init_settings,
+	.setup_streaming = max96724_setup_streaming,
+	.name = "max96724",
+};
+
+/*
+ * Serializer ESYNC tunneling adapters: unify max9295's enable/disable pair and
+ * max96717's enable-only setup behind the common set_esync_tunneling(@enable).
+ */
+static int max9295_set_esync_tunneling(struct device *dev, bool enable)
+{
+	return enable ? max9295_enable_gpio_tunneling(dev)
+		      : max9295_disable_gpio_tunneling(dev);
+}
+
+static int max96717_set_esync_tunneling(struct device *dev, bool enable)
+{
+	/* MAX96717 GPIO tunneling has no disable path. */
+	return enable ? max96717_setup_gpio_tunneling(dev) : 0;
+}
+
+/* MAX9295 (D4xx family) serializer interface implementation */
+static const struct ser_interface max9295_interface = {
+	.set_pipe = max9295_set_pipe,
+	.setup_control = max9295_setup_control,
+	.init_settings = max9295_init_settings,
+	.reset_control = max9295_reset_control,
+	.sdev_pair = max9295_sdev_pair,
+	.sdev_unpair = max9295_sdev_unpair,
+	.set_esync_tunneling = max9295_set_esync_tunneling,
+	.retrigger_tx = NULL,
+	.setup_streaming = NULL,
+	.name = "max9295",
+};
+
+/* MAX96717 (D5xx / tunnel mode) serializer interface implementation */
+static const struct ser_interface max96717_interface = {
+	.set_pipe = max96717_set_pipe,
+	.setup_control = max96717_setup_control,
+	.init_settings = max96717_init_settings,
+	.reset_control = max96717_reset_control,
+	.sdev_pair = max96717_sdev_pair,
+	.sdev_unpair = max96717_sdev_unpair,
+	.set_esync_tunneling = max96717_set_esync_tunneling,
+	.retrigger_tx = max96717_retrigger_tx,
+	.setup_streaming = max96717_setup_streaming,
+	.name = "max96717",
+};
+
 #else /* !CONFIG_VIDEO_D4XX_SERDES */
 
 static atomic_t ds5_reset_gen = ATOMIC_INIT(0);
@@ -689,6 +797,7 @@ static bool ds5_is_valid_device_type(u16 dev_type)
 	case DS5_DEVICE_TYPE_D43X:
 	case DS5_DEVICE_TYPE_D45X:
 	case DS5_DEVICE_TYPE_D46X:
+	case DS5_DEVICE_TYPE_D58X:
 		return true;
 	default:
 		return false;
@@ -1450,6 +1559,78 @@ static const struct ds5_format ds5_onsemi_rgb_format = {
 };
 #define DS5_ONSEMI_RGB_N_FORMATS 1
 
+/*
+ * D58x (D5xx) family resolution and format tables. The D5xx camera reports
+ * DS5_DEVICE_TYPE_D58X and uses a single, simplified set of resolutions
+ * compared to the per-SKU D4xx tables above.
+ */
+static const struct ds5_resolution d58x_depth_sizes[] = {
+	DS5_RES(640, 360, ds5_framerate_to_60)
+	DS5_RES(1280, 720, ds5_framerate_to_60)
+	DS5_RES(1280, 960, ds5_depth_framerate_to_30)
+};
+
+static const struct ds5_resolution d58x_y8_sizes[] = {
+	DS5_RES(1280, 720, ds5_framerate_to_60)
+	DS5_RES(1280, 960, ds5_depth_framerate_to_30)
+};
+
+static const struct ds5_resolution d58x_calibration_sizes[] = {
+	DS5_RES(1600, 1300, ds5_framerate_15_30)
+};
+
+static const struct ds5_resolution d58x_rgb_sizes[] = {
+	DS5_RES(640, 360, ds5_depth_framerate_to_30)
+	DS5_RES(1280, 720, ds5_depth_framerate_to_30)
+};
+
+static const struct ds5_format ds5_depth_formats_d58x[] = {
+	{
+		.data_type = GMSL_CSI_DT_YUV422_8,	/* Z16 */
+		.mbus_code = MEDIA_BUS_FMT_UYVY8_1X16,
+		.n_resolutions = ARRAY_SIZE(d58x_depth_sizes),
+		.resolutions = d58x_depth_sizes,
+	}, {
+		.data_type = GMSL_CSI_DT_RAW_8,		/* Y8 */
+		.mbus_code = MEDIA_BUS_FMT_Y8_1X8,
+		.n_resolutions = ARRAY_SIZE(d58x_depth_sizes),
+		.resolutions = d58x_depth_sizes,
+	}, {
+		.data_type = GMSL_CSI_DT_RGB_888,	/* 24-bit Calibration */
+		.mbus_code = MEDIA_BUS_FMT_RGB888_1X24,
+		.n_resolutions = ARRAY_SIZE(d58x_calibration_sizes),
+		.resolutions = d58x_calibration_sizes,
+	},
+};
+
+static const struct ds5_format ds5_y_formats_d58x[] = {
+	{
+		/* First format: default */
+		.data_type = GMSL_CSI_DT_RAW_8,		/* Y8 */
+		.mbus_code = MEDIA_BUS_FMT_Y8_1X8,
+		.n_resolutions = ARRAY_SIZE(d58x_y8_sizes),
+		.resolutions = d58x_y8_sizes,
+	}, {
+		.data_type = GMSL_CSI_DT_YUV422_8,	/* Y8I */
+		.mbus_code = MEDIA_BUS_FMT_VYUY8_1X16,
+		.n_resolutions = ARRAY_SIZE(d58x_y8_sizes),
+		.resolutions = d58x_y8_sizes,
+	}, {
+		.data_type = GMSL_CSI_DT_RGB_888,	/* Y12I, 24-bit Calibration */
+		.mbus_code = MEDIA_BUS_FMT_RGB888_1X24,
+		.n_resolutions = ARRAY_SIZE(d58x_calibration_sizes),
+		.resolutions = d58x_calibration_sizes,
+	},
+};
+
+static const struct ds5_format ds5_d58x_rgb_format = {
+	.data_type = GMSL_CSI_DT_YUV422_8,	/* UYVY */
+	.mbus_code = MEDIA_BUS_FMT_YUYV8_1X16,
+	.n_resolutions = ARRAY_SIZE(d58x_rgb_sizes),
+	.resolutions = d58x_rgb_sizes,
+};
+#define DS5_D58X_RGB_N_FORMATS 1
+
 static const struct ds5_variant ds5_variants[] = {
 	[DS5_DS5U] = {
 		.formats = ds5_y_formats_ds5u,
@@ -1839,10 +2020,20 @@ static int ds5_setup_pipeline(struct ds5 *state, u8 data_type1, u8 data_type2,
 	dev_dbg(&state->client->dev,
 			"set ser pipe %d, dser pipe %d, data_type1: 0x%x, data_type2: 0x%x, ser_vc_id: %u, vc_id: %u\n",
 			ser_pipe_id, pipe_id, data_type1, data_type2, ser_vc_id, vc_id);
-	ret |= max9295_set_pipe(state->ser_dev, ser_pipe_id,
+	ret |= state->ser_ops->set_pipe(state->ser_dev, ser_pipe_id,
 				data_type1, data_type2, ser_vc_id);
 	ret |= state->dser_ops->set_pipe(state->dser_dev, pipe_id,
 				data_type1, data_type2, vc_id);
+	if (state->ser_ops->retrigger_tx) {
+		/*
+		 * Tunnel mode (max96717/max96724): the deserializer one-shot
+		 * reset clears the data path, so the serializer must retrigger
+		 * TX for the deserializer to re-acquire the tunnel stream.
+		 */
+		state->dser_ops->reset_oneshot(state->dser_dev);
+		state->ser_ops->retrigger_tx(state->ser_dev);
+		msleep(200);
+	}
 	if (ret)
 		dev_warn(&state->client->dev,
 			 "failed to set pipe %d, data_type1: 0x%x, data_type2: 0x%x, vc_id: %u\n",
@@ -2207,6 +2398,8 @@ static int ds5_hw_set_exposure(struct ds5 *state, u32 base, s32 val)
 #define DS5_CAMERA_COEFF_CALIBRATION_TABLE_SET	(DS5_CAMERA_CID_BASE+6)
 #define DS5_CAMERA_CID_FW_VERSION		(DS5_CAMERA_CID_BASE+7)
 #define DS5_CAMERA_CID_GVD			(DS5_CAMERA_CID_BASE+8)
+/* RO device-type exposure (used by D5xx/D58x; harmless for D4xx). */
+#define DS5_CAMERA_CID_DEVICE_TYPE		(DS5_CAMERA_CID_BASE+23)
 #define DS5_CAMERA_CID_AE_ROI_GET		(DS5_CAMERA_CID_BASE+9)
 #define DS5_CAMERA_CID_AE_ROI_SET		(DS5_CAMERA_CID_BASE+10)
 #define DS5_CAMERA_CID_AE_SETPOINT_GET		(DS5_CAMERA_CID_BASE+11)
@@ -2442,19 +2635,18 @@ static int ds5_set_ser_esync_tunneling(struct ds5 *state, bool enable)
 #ifdef CONFIG_VIDEO_D4XX_SERDES
 	int ret;
 
-	if (!state || !state->ser_dev)
+	if (!state || !state->ser_dev || !state->ser_ops)
 		return -EINVAL;
-	if (state->dser_ops != &max96712_interface)
+	/* ESYNC tunneling is only used on the max96712 / max96724 stacks. */
+	if (state->dser_ops != &max96712_interface &&
+	    state->dser_ops != &max96724_interface)
 		return 0;
 
 	dev_dbg(&state->client->dev,
 		"%s(): serializer ESYNC %s requested\n",
 		__func__, enable ? "enable" : "disable");
 
-	if (enable)
-		ret = max9295_enable_gpio_tunneling(state->ser_dev);
-	else
-		ret = max9295_disable_gpio_tunneling(state->ser_dev);
+	ret = state->ser_ops->set_esync_tunneling(state->ser_dev, enable);
 
 	if (ret)
 		dev_warn(&state->client->dev,
@@ -3278,6 +3470,19 @@ static int ds5_g_volatile_ctrl(struct v4l2_ctrl *ctrl)
 		*ctrl->p_new.p_u32 = state->fw_version << 16;
 		*ctrl->p_new.p_u32 |= state->fw_build;
 		break;
+	case DS5_CAMERA_CID_DEVICE_TYPE: {
+		u16 dev_type = DS5_DEVICE_TYPE_UNKNOWN;
+
+		ret = ds5_read(state, DS5_DEVICE_TYPE, &dev_type);
+		dev_type = ds5_dev_type(state, dev_type);
+		if (ret && !ds5_is_valid_device_type(dev_type))
+			break;
+		if (ds5_is_valid_device_type(dev_type))
+			WRITE_ONCE(state->ds5_dev->cached_device_type, dev_type);
+		*ctrl->p_new.p_u32 = dev_type;
+		ret = 0;
+		break;
+	}
 	case DS5_CAMERA_CID_GVD:
 		ret = ds5_gvd(state, ctrl->p_new.p_u8);
 		break;
@@ -3407,6 +3612,17 @@ static const struct v4l2_ctrl_config ds5_ctrl_fw_version = {
 	.ops = &ds5_ctrl_ops,
 	.id = DS5_CAMERA_CID_FW_VERSION,
 	.name = "fw version",
+	.type = V4L2_CTRL_TYPE_U32,
+	.dims = {1},
+	.elem_size = sizeof(u32),
+	.flags = V4L2_CTRL_FLAG_VOLATILE | V4L2_CTRL_FLAG_READ_ONLY,
+	.step = 1,
+};
+
+static const struct v4l2_ctrl_config ds5_ctrl_device_type = {
+	.ops = &ds5_ctrl_ops,
+	.id = DS5_CAMERA_CID_DEVICE_TYPE,
+	.name = "device type",
 	.type = V4L2_CTRL_TYPE_U32,
 	.dims = {1},
 	.elem_size = sizeof(u32),
@@ -3874,6 +4090,24 @@ static int ds5_board_setup(struct ds5 *state)
 	}
 
 	ser_i2c = of_find_i2c_device_by_node(ser_node);
+
+	/*
+	 * Initialize serializer interface based on serializer DT node name.
+	 * Node names carry a link suffix (e.g. "max9295_a", "max96717_a",
+	 * "max96717_prim"), so match on the chip-name prefix.
+	 */
+	if (!strncmp(ser_node->name, "max9295", strlen("max9295"))) {
+		state->ser_ops = &max9295_interface;
+	} else if (!strncmp(ser_node->name, "max96717", strlen("max96717"))) {
+		state->ser_ops = &max96717_interface;
+	} else {
+		dev_err(dev, "%s: Unsupported serializer = %s\n",
+			__func__, ser_node->name);
+		state->ser_ops = &max9295_interface;
+		of_node_put(ser_node);
+		goto error;
+	}
+	dev_info(dev, "Using serializer %s\n", state->ser_ops->name);
 	of_node_put(ser_node);
 
 	if (ser_i2c == NULL) {
@@ -3913,6 +4147,8 @@ static int ds5_board_setup(struct ds5 *state)
 		state->dser_ops = &max9296_interface;
 	} else if (!strcmp(dser_node->name, "max96712")) {
 		state->dser_ops = &max96712_interface;
+	} else if (!strcmp(dser_node->name, "max96724")) {
+		state->dser_ops = &max96724_interface;
 	} else {
 		dev_err(dev, "%s: Unsupported deserializer = %s\n", __func__, dser_node->name);
 		/* Should not be used, this is just to make sure we don't have NULL pointers */
@@ -4121,9 +4357,10 @@ static int ds5_board_setup(struct ds5 *state)
 
 
 	state->dser_dev = &state->dser_i2c->dev;
-	/* Initialize deserializer interface */
+	/* Initialize SerDes interfaces (non-OF fallback: D4xx/max9295+max9296) */
 	state->dser_ops = &max9296_interface;
-	
+	state->ser_ops = &max9295_interface;
+
 
 	/* populate g_ctx from pdata */
 	state->g_ctx.dst_csi_port = GMSL_CSI_PORT_A;
@@ -4187,7 +4424,7 @@ static int ds5_gmsl_serdes_setup(struct ds5 *state)
 		DS5_SERDES_STARTUP_RETRY_DELAY_MS - 1) /
 		DS5_SERDES_STARTUP_RETRY_DELAY_MS;
 	for (retry = 0; retry < attempts; retry++) {
-		err = max9295_setup_control(state->ser_dev);
+		err = state->ser_ops->setup_control(state->ser_dev);
 		if (!err)
 			break;
 		if (retry < attempts - 1)
@@ -4238,7 +4475,7 @@ static int ds5_serdes_setup(struct ds5 *state)
 	}
 
 	/* Pair sensor to serializer dev */
-	ret = max9295_sdev_pair(state->ser_dev, &state->g_ctx);
+	ret = state->ser_ops->sdev_pair(state->ser_dev, &state->g_ctx);
 	if (ret) {
 		dev_err(&c->dev, "gmsl ser pairing failed\n");
 		goto serdes_setup_end;
@@ -4257,10 +4494,10 @@ static int ds5_serdes_setup(struct ds5 *state)
 		goto serdes_setup_end;
 	}
 
-	ret = max9295_init_settings(state->ser_dev);
+	ret = state->ser_ops->init_settings(state->ser_dev);
 	if (ret) {
-		dev_warn(&c->dev, "%s, failed to init max9295 settings\n",
-			__func__);
+		dev_warn(&c->dev, "%s, failed to init %s settings\n",
+			__func__, state->ser_ops->name);
 		goto serdes_setup_end;
 	}
 
@@ -4273,13 +4510,52 @@ static int ds5_serdes_setup(struct ds5 *state)
 		}
 	}
 
+	/*
+	 * Tunnel-mode SerDes (max96717/max96724) needs explicit CSI streaming
+	 * setup (PHY/DPLL/lane-map/CSI-enable + serializer tunnel mode) on both
+	 * ends. For max9295/max9296/max96712 these ops are NULL and the block
+	 * is skipped, preserving the legacy D4xx flow.
+	 */
+	if (state->dser_ops->setup_streaming) {
+		ret = state->dser_ops->setup_streaming(state->dser_dev,
+						       state->g_ctx.s_dev);
+		if (ret) {
+			dev_warn(&c->dev, "%s, failed to setup %s streaming\n",
+				__func__, state->dser_ops->name);
+			goto serdes_setup_end;
+		}
+		/*
+		 * The deserializer streaming setup issues a one-shot reset that
+		 * briefly drops the GMSL link; I2C pass-through to the remote
+		 * serializer needs the link to re-lock first.
+		 */
+		msleep(1000);
+
+		if (state->ser_ops->setup_streaming) {
+			ret = state->ser_ops->setup_streaming(state->ser_dev);
+			if (ret) {
+				dev_warn(&c->dev,
+					"%s, failed to setup %s streaming\n",
+					__func__, state->ser_ops->name);
+				goto serdes_setup_end;
+			}
+		}
+		/*
+		 * Serializer enable re-trains the link; the deserializer needs a
+		 * one-shot reset to resync its CSI TX to the now-active tunnel
+		 * stream. Delay first to let the link re-lock.
+		 */
+		msleep(500);
+		state->dser_ops->reset_oneshot(state->dser_dev);
+	}
+
 serdes_setup_end:
 	/* Set/clear serdes_setup_complete from the same exit gate: error branch
 	 * clears it, success branch sets it. This ensures flag state is
 	 * synchronized with actual setup completion status.
 	 */
 	if (ret) {
-		max9295_sdev_unpair(state->ser_dev, state->g_ctx.s_dev);
+		state->ser_ops->sdev_unpair(state->ser_dev, state->g_ctx.s_dev);
 		state->dser_ops->sdev_unregister(state->dser_dev, state->g_ctx.s_dev);
 		if (state->ser_primary)
 			ds5_release_slot(state);
@@ -4476,6 +4752,8 @@ static int ds5_ctrl_init(struct ds5 *state, int sid)
 	if (sid >= DEPTH_SID && sid < IMU_SID) {
 		ctrls->log = v4l2_ctrl_new_custom(hdl, &ds5_ctrl_log, sensor);
 		ctrls->fw_version = v4l2_ctrl_new_custom(hdl, &ds5_ctrl_fw_version, sensor);
+		ctrls->device_type =
+				v4l2_ctrl_new_custom(hdl, &ds5_ctrl_device_type, sensor);
 		ctrls->gvd = v4l2_ctrl_new_custom(hdl, &ds5_ctrl_gvd, sensor);
 		ctrls->get_depth_calib =
 				v4l2_ctrl_new_custom(hdl, &ds5_ctrl_get_depth_calib, sensor);
@@ -5625,6 +5903,9 @@ static int ds5_fixed_configuration(struct i2c_client *client, struct ds5 *state)
 	case DS5_DEVICE_TYPE_D46X:
 		sensor->formats = ds5_depth_formats_d46x;
 		break;
+	case DS5_DEVICE_TYPE_D58X:
+		sensor->formats = ds5_depth_formats_d58x;
+		break;
 	default:
 		dev_warn(&client->dev,
 			"%s(): unknown device type 0x%x, using D43X format tables\n",
@@ -5647,6 +5928,10 @@ static int ds5_fixed_configuration(struct i2c_client *client, struct ds5 *state)
 	case DS5_DEVICE_TYPE_D45X:
 		sensor->formats = ds5_y_formats_45x;
 		sensor->n_formats = ARRAY_SIZE(ds5_y_formats_45x);
+		break;
+	case DS5_DEVICE_TYPE_D58X:
+		sensor->formats = ds5_y_formats_d58x;
+		sensor->n_formats = ARRAY_SIZE(ds5_y_formats_d58x);
 		break;
 	default:
 		sensor->formats = state->variant->formats;
@@ -5672,6 +5957,10 @@ static int ds5_fixed_configuration(struct i2c_client *client, struct ds5 *state)
 	case DS5_DEVICE_TYPE_D45X:
 		sensor->formats = &ds5_rlt_rgb_format;
 		sensor->n_formats = DS5_RLT_RGB_N_FORMATS;
+		break;
+	case DS5_DEVICE_TYPE_D58X:
+		sensor->formats = &ds5_d58x_rgb_format;
+		sensor->n_formats = DS5_D58X_RGB_N_FORMATS;
 		break;
 	default:
 		sensor->formats = &ds5_onsemi_rgb_format;
@@ -6122,6 +6411,12 @@ static void ds5_adjust_sync_mode_control(struct i2c_client *client, struct ds5 *
 		/* D46X does not support sync mode */
 		dev_dbg(&client->dev, "%s(): D46X does not support sync mode\n", __func__);
 		__v4l2_ctrl_modify_range(state->ctrls.sync_mode, 0, 0, 0, 0);
+		break;
+	case DS5_DEVICE_TYPE_D58X:
+		/* D58X supports all 6 sync modes (0-5) */
+		__v4l2_ctrl_modify_range(state->ctrls.sync_mode, 0, 5, 0, 0);
+		state->ctrls.sync_mode->qmenu = sync_mode_menu_full;
+		dev_dbg(&client->dev, "%s(): D58X sync mode: all modes 0-5 supported\n", __func__);
 		break;
 	default:
 		/* Unknown device - disable sync mode */
@@ -6717,16 +7012,17 @@ static void ds5_remove(struct i2c_client *c)
 		do_cleanup = ds5_release_slot(state);
 
 		if (do_cleanup) {
-			ret = max9295_reset_control(state->ser_dev);
+			ret = state->ser_ops->reset_control(state->ser_dev);
 			if (ret)
 				dev_warn(&c->dev,
-					"failed in 9295 reset control\n");
+					"failed in %s reset control\n",
+					state->ser_ops->name);
 			ret = state->dser_ops->reset_control(state->dser_dev,
 				state->g_ctx.s_dev);
 			if (ret)
 				dev_warn(&c->dev,
 					"failed in %s reset control\n", state->dser_ops->name);
-			ret = max9295_sdev_unpair(state->ser_dev,
+			ret = state->ser_ops->sdev_unpair(state->ser_dev,
 				state->g_ctx.s_dev);
 			if (ret)
 				dev_warn(&c->dev, "failed to unpair sdev\n");
@@ -6780,6 +7076,8 @@ MODULE_DEVICE_TABLE(i2c, ds5_id);
 
 static const struct of_device_id d4xx_of_match[] = {
 	{ .compatible = "intel,d4xx", },
+	/* D5xx (D58x) family: same unified driver, different SerDes/family. */
+	{ .compatible = "realsense,d5xx", },
 	{ },
 };
 MODULE_DEVICE_TABLE(of, d4xx_of_match);

--- a/nvidia-oot/6.0/0001-Porting-nvidia-driver-patches-to-jetpack-6.0.patch
+++ b/nvidia-oot/6.0/0001-Porting-nvidia-driver-patches-to-jetpack-6.0.patch
@@ -25,13 +25,15 @@ diff --git a/drivers/media/i2c/Makefile b/drivers/media/i2c/Makefile
 index 7c5913c6..396b9bc3 100644
 --- a/drivers/media/i2c/Makefile
 +++ b/drivers/media/i2c/Makefile
-@@ -5,6 +5,9 @@ subdir-ccflags-y += -Werror
+@@ -5,6 +5,11 @@ subdir-ccflags-y += -Werror
  
  obj-m += max9295.o
  obj-m += max9296.o
 +subdir-ccflags-y += -DCONFIG_VIDEO_D4XX_SERDES
 +subdir-ccflags-y += -DCONFIG_TEGRA_CAMERA_PLATFORM
 +obj-m += d4xx.o
++obj-m += max96717.o
++obj-m += max96724.o
  ifeq ($(findstring ack_src,$(NV_BUILD_KERNEL_OPTIONS)),)
  obj-m += max96712.o
  

--- a/nvidia-oot/6.0/0011-Add-MAX96717-serializer-and-MAX96724-deserializer-dr.patch
+++ b/nvidia-oot/6.0/0011-Add-MAX96717-serializer-and-MAX96724-deserializer-dr.patch
@@ -1,0 +1,3147 @@
+From 40fac9b67ddea60055961d32fa89fe8f608396ff Mon Sep 17 00:00:00 2001
+From: RealSense AI <realsense@realsenseai.com>
+Date: Tue, 12 May 2026 17:06:23 +0800
+Subject: [PATCH] Add MAX96717 serializer and MAX96724 deserializer drivers for
+ tunnel mode
+
+Add MAX96717 GMSL2 serializer and MAX96724 GMSL2 quad deserializer
+drivers for Tunnel Mode operation with D5xx cameras.
+
+MAX96717 serializer features:
+- CSI-2 input with 2/4 lane support
+- Tunnel Mode encapsulation of full CSI-2 byte stream
+- I2C address translation for sensor passthrough
+- GPIO-over-GMSL tunneling hook for FSIN/FOUT signals
+
+MAX96724 quad deserializer features:
+- Up to 4 GMSL2 links (quad camera support)
+- Configurable link speed (3 Gbps / 6 Gbps via DT)
+- Tunnel Mode pipe routing and CSI-2 output
+- 2x4 and 4x2 CSI output mode support
+- Power management with GPIO reset and regulator control
+
+Signed-off-by: RealSense AI <realsense@realsenseai.com>
+---
+ drivers/media/i2c/Makefile   |    2 +
+ drivers/media/i2c/max96717.c |  835 ++++++++++++++
+ drivers/media/i2c/max96724.c | 1916 ++++++++++++++++++++++++++++++++++
+ include/media/max96717.h     |  151 ++
+ include/media/max96724.h     |  183 +++
+ 4 files changed, 3085 insertions(+)
+ create mode 100644 drivers/media/i2c/max96717.c
+ create mode 100644 drivers/media/i2c/max96724.c
+ create mode 100644 include/media/max96717.h
+ create mode 100644 include/media/max96724.h
+
+diff --git a/drivers/media/i2c/max96717.c b/drivers/media/i2c/max96717.c
+new file mode 100644
+index 0000000..70d25a3
+--- /dev/null
++++ b/drivers/media/i2c/max96717.c
+@@ -0,0 +1,835 @@
++/*
++ * max96717.c - MAX96717 GMSL2 Serializer driver (Tunnel Mode)
++ *
++ * Copyright (c) 2026, RealSense, Inc.  All rights reserved.
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms and conditions of the GNU General Public License,
++ * version 2, as published by the Free Software Foundation.
++ *
++ * This program is distributed in the hope it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
++ * more details.
++ *
++ * You should have received a copy of the GNU General Public License
++ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
++ */
++
++#include <media/camera_common.h>
++#include <linux/of.h>
++#include <linux/module.h>
++#include <media/max96717.h>
++
++/* ===== Register Addresses ===== */
++
++/* REG0: Device ID (read-only, returns 0x40) */
++#define MAX96717_DEV_ADDR		0x00
++
++/* 
++ *   REG1: Link Speed
++ *   bit[3]=1: 3 Gbps, bit[4]=1: 6 Gbps
++ */
++#define MAX96717_REG1_ADDR		0x01
++
++/* 
++ *   PIPE_EN: Pipe enable / soft reset
++ *   0x03 = soft reset, 0x43 = pipes enabled + video init
++ *   Matches MAX9295 PIPE_EN at 0x02
++ */
++#define MAX96717_PIPE_EN_ADDR		0x02
++
++/* 
++ *   CTRL0: GMSL2 TX Control
++ *   bit[5]=1: GMSL2 mode, bit[0]=1: enable transmitter
++ *   0x21 = GMSL2 mode + TX enable on Link A
++ */
++#define MAX96717_CTRL0_ADDR		0x10
++
++/* 
++ *   CTRL3: Start Video - final enable bit
++ *   bit[0]=1: activate video stream
++ */
++#define MAX96717_CTRL3_ADDR		0x13
++
++/* 
++ *   TX1: FEC Enable
++ *   bit[6]=1: Reed-Solomon FEC enabled
++ */
++#define MAX96717_TX1_ADDR		0x29
++
++/*
++ *   MAX96717 I2C address translation registers (GMSL2 standard):
++ *   SRC_A / DST_A (0x42/0x43): Translation pair A (SER broadcast addr)
++ *   SRC_B / DST_B (0x44/0x45): Translation pair B (sensor passthrough)
++ *
++ *   When host writes to SRC_B address, the MAX96717 translates it to
++ *   DST_B and forwards via GMSL back-channel to the remote sensor.
++ *
++ */
++#define MAX96717_SRC_A_ADDR		0x42
++#define MAX96717_DST_A_ADDR		0x43
++#define MAX96717_I2C4_ADDR		0x44
++#define MAX96717_I2C5_ADDR		0x45
++
++/* 
++ *   TX_STR_SEL: Stream ID select
++ *   bits[1:0]: stream ID for DES pipe routing
++ */
++#define MAX96717_TX_STR_SEL_ADDR	0x5B
++
++/* 
++ *   VIDEO_TX0/TX1: Video TX path config
++ *   0x0110=0xE9, 0x0111=0x10 for tunnel mode data path
++ */
++#define MAX96717_VIDEO_TX0_ADDR		0x110
++#define MAX96717_VIDEO_TX1_ADDR		0x111
++
++/* 
++ *   FRONTTOP_0: Front-end topology
++ *   0x12 = single CSI-2 port A, all VCs pass through
++ */
++#define MAX96717_FRONTTOP0_ADDR		0x308
++
++/* 
++ *   MIPI_RX0-RX3: CSI-2 receiver configuration
++ *   RX0 (0x330): CSI mode (0x00 = D-PHY controller A)
++ *   RX1 (0x331): Lane count - ctrl1_num_lanes bits[5:4]
++ *                0x30 = bits[5:4]=11 (4 lanes)
++ *   RX2 (0x332): Lane mapping - 0xE0 = default 1x4 map
++ *   RX3 (0x333): Lane mapping - 0x04 = default 1x4 map
++ */
++#define MAX96717_MIPI_RX0_ADDR		0x330
++#define MAX96717_MIPI_RX1_ADDR		0x331
++#define MAX96717_MIPI_RX2_ADDR		0x332
++#define MAX96717_MIPI_RX3_ADDR		0x333
++
++/* 
++ *   EXT11: TUNNEL MODE ENABLE
++ *   bit[7]=1: Tun_Mode = ON
++ *   0x383 = 0x80
++ */
++#define MAX96717_EXT11_ADDR		0x383
++
++/* PHY calibration stage-1 value */
++#define MAX96717_PHY_CAL_STAGE1		0x80
++/* PHY calibration stage-2 value */
++#define MAX96717_PHY_CAL_STAGE2		0x90
++/* CSI input timing / frequency config */
++#define MAX96717_CSI_TIMING_3F0		0x59
++#define MAX96717_CSI_TIMING_3F1		0x09
++
++/* ===== Register Values ===== */
++
++/* Soft reset value for PIPE_EN register */
++#define MAX96717_SOFT_RESET		0x03
++
++/* Final enable: pipes enabled + video init */
++#define MAX96717_PIPE_EN_ALL		0x43
++
++/* CTRL0: GMSL2 mode + TX enable (Link A) */
++#define MAX96717_CTRL0_LINK_A		0x21
++/* CTRL0: GMSL2 mode + TX enable (Link B) */
++#define MAX96717_CTRL0_LINK_B		0x22
++
++/* CTRL0 reset all */
++#define MAX96717_RESET_ALL		0x80
++
++/* EXT11 tunnel mode enable value */
++#define MAX96717_TUN_MODE_EN		0x80
++#define MAX96717_TUN_MODE_DIS		0x00
++
++/* VIDEO_TX0 tunnel mode data path enable */
++#define MAX96717_VIDEO_TX0_TUN		0xE9
++/* VIDEO_TX1 tunnel mode config */
++#define MAX96717_VIDEO_TX1_TUN		0x10
++#define MAX96717_VIDEO_TX0_BPP_MANUAL	0x60
++#define MAX96717_VIDEO_TX1_BPP16	0x50
++#define MAX96717_VIDEO_TX2_ADDR		0x112
++#define MAX96717_VIDEO_TX2_DRIFT_DIS	0x08
++
++/* 
++ *   MIPI RX1: 4-lane CSI-2.
++ *   bits[5:4]=11 (4 lanes).  bits[1:0]=11
++ */
++#define MAX96717_CSI_4_LANES		0x33
++/* 2-lane CSI-2, bits[5:4]=01 */
++#define MAX96717_CSI_2_LANES		0x10
++
++/* Lane mapping for 1x4 mode */
++#define MAX96717_CSI_1X4_LANE_MAP1	0xE0
++#define MAX96717_CSI_1X4_LANE_MAP2	0x04
++
++/* FRONTTOP_0: single port A, all VCs */
++#define MAX96717_FRONTTOP0_PORT_A	0x12
++/* Pixel mode from Port B into Pipe Z */
++#define MAX96717_FRONTTOP0_PIXEL_PORT_B	0x64
++#define MAX96717_FRONTTOP5_ADDR		0x30D
++#define MAX96717_FRONTTOP9_ADDR		0x311
++#define MAX96717_FRONTTOP16_ADDR	0x318
++#define MAX96717_FRONTTOP17_ADDR	0x319
++#define MAX96717_FRONTTOP9_START_VIDEO	0x40
++
++/* MIPI_RX0: CSI reset on + non-continuous clock */
++#define MAX96717_MIPI_RX0_RESET		0x08
++/* MIPI_RX0: Normal operation */
++#define MAX96717_MIPI_RX0_NORMAL	0x00
++
++/* REG1: 3 Gbps link speed, bit[3]=1 */
++#define MAX96717_LINK_SPEED_3GBPS	0x08
++/* REG1: 6 Gbps link speed, bit[4]=1 */
++#define MAX96717_LINK_SPEED_6GBPS	0x10
++
++/* EXT11 tunnel mode pre-config (0x0383=0x80) */
++#define MAX96717_EXT11_TUN_PRE		0x80
++
++#define MAX96717_MAX_PIPES		4
++
++/*
++ * MFP8 (GPIO8) high-impedance release.
++ *
++ * At power-up GPIO8 comes up with GPIO_OUT_DIS=0 (output driver enabled,
++ * GPIO8_A=0x9c observed live), so the serializer actively drives the M2_I2C
++ * line and wedges the bus: any IMU I2C access by the camera FW times out
++ * whenever the serializer is powered.  This was confirmed on hardware -
++ * tri-stating GPIO8 alone immediately restored IMU I2C reads.
++ *
++ * GPIO8 is the ONLY serializer pin left driving its net (all other GPIOs,
++ * including MFP3/MFP4 interrupt lines, are already high-Z).  Release GPIO8
++ * (output driver off, no link TX/RX, no pull) so only the M2_I2C bus
++ * masters own the line.
++ *
++ * GPIO_n registers are a 3-byte group (A/B/C) starting at 0x02BE:
++ *   GPIO_n_A = 0x02BE + 3*n
++ */
++#define MAX96717_GPIO8_A_ADDR		0x02D6	/* MFP8 / M2_I2C (pass-through SCL1) */
++#define MAX96717_GPIO8_B_ADDR		0x02D7
++/* GPIO_A: GPIO_OUT_DIS=1 (high-Z), GPIO_TX_EN=0, GPIO_RX_EN=0 */
++#define MAX96717_GPIO_A_HIGH_Z		0x01
++/* GPIO_B: PULL_UPDN_SEL=None, TX_ID=0 */
++#define MAX96717_GPIO_B_NO_PULL		0x00
++
++/* ===== Data Structures ===== */
++
++struct max96717_client_ctx {
++	struct gmsl_link_ctx *g_ctx;
++	bool st_done;
++};
++
++struct max96717 {
++	struct i2c_client *i2c_client;
++	struct regmap *regmap;
++	struct max96717_client_ctx g_client;
++	struct mutex lock;
++	bool pixel_mode;
++	/* primary serializer properties */
++	__u32 def_addr;
++	__u32 pst2_ref;
++};
++
++static struct max96717 *prim_priv__;
++
++struct reg_pair {
++	u16 addr;
++	u8 val;
++};
++
++/* ===== Low-level I2C ===== */
++
++static int max96717_write_reg(struct device *dev, u16 addr, u8 val)
++{
++	struct max96717 *priv = dev_get_drvdata(dev);
++	int err;
++
++	err = regmap_write(priv->regmap, addr, val);
++	if (err)
++		dev_err(dev, "%s:i2c write failed, 0x%x = %x\n",
++			__func__, addr, val);
++
++	/* delay before next i2c command as required for SERDES link */
++	usleep_range(100, 110);
++
++	return err;
++}
++
++static int max96717_set_registers(struct device *dev, struct reg_pair *map,
++				  u32 count)
++{
++	int err = 0;
++	u32 j;
++
++	for (j = 0; j < count; j++) {
++		err = max96717_write_reg(dev, map[j].addr, map[j].val);
++		if (err)
++			break;
++	}
++
++	return err;
++}
++
++/* ===== Streaming Setup ===== */
++
++/*
++ * max96717_setup_streaming - Configure CSI-2 input and enable Tunnel Mode
++ *
++ * In Tunnel Mode (unlike MAX9295 Pixel Mode), the serializer encapsulates
++ * the entire CSI-2 byte stream verbatim into a single GMSL2 tunnel.
++ * All VCs (VC0-VC3) are preserved end-to-end.
++ */
++int max96717_setup_streaming(struct device *dev)
++{
++	struct max96717 *priv = dev_get_drvdata(dev);
++	int err = 0;
++	struct gmsl_link_ctx *g_ctx;
++
++	mutex_lock(&priv->lock);
++
++	if (!priv->g_client.g_ctx) {
++		dev_err(dev, "%s: no sdev client found\n", __func__);
++		err = -EINVAL;
++		goto error;
++	}
++
++	if (priv->g_client.st_done) {
++		dev_dbg(dev, "%s: stream setup is already done\n", __func__);
++		goto error;
++	}
++
++	g_ctx = priv->g_client.g_ctx;
++
++	max96717_write_reg(dev, MAX96717_EXT11_ADDR, MAX96717_TUN_MODE_EN);
++	max96717_write_reg(dev, MAX96717_MIPI_RX1_ADDR, MAX96717_CSI_4_LANES);
++	max96717_write_reg(dev, MAX96717_MIPI_RX2_ADDR, MAX96717_CSI_1X4_LANE_MAP1);
++	max96717_write_reg(dev, MAX96717_MIPI_RX3_ADDR, MAX96717_CSI_1X4_LANE_MAP2);
++	max96717_write_reg(dev, MAX96717_VIDEO_TX0_ADDR, MAX96717_VIDEO_TX0_TUN);
++	max96717_write_reg(dev, MAX96717_VIDEO_TX1_ADDR, MAX96717_VIDEO_TX1_TUN);
++
++	max96717_write_reg(dev, MAX96717_MIPI_RX0_ADDR, MAX96717_MIPI_RX0_RESET);
++	usleep_range(2000, 2100);
++	max96717_write_reg(dev, MAX96717_MIPI_RX0_ADDR, MAX96717_MIPI_RX0_NORMAL);
++
++	/* pipes on + video init */
++	max96717_write_reg(dev, MAX96717_PIPE_EN_ADDR, MAX96717_PIPE_EN_ALL);
++
++	priv->g_client.st_done = true;
++
++error:
++	mutex_unlock(&priv->lock);
++	return err;
++}
++EXPORT_SYMBOL(max96717_setup_streaming);
++
++/* ===== Control Setup ===== */
++
++/*
++ * max96717_setup_control - Set up I2C address translation and link control
++ *
++ * Steps:
++ *   1. Reassign serializer I2C address via DEV_ADDR (reg 0x00)
++ *   2. Configure GMSL2 link mode via CTRL0 (reg 0x10)
++ *   3. Set I2C address translation for sensor passthrough:
++ *      I2C4/SRC_B (0x44) <- (sdev_reg << 1): proxy addr visible to host
++ *      I2C5/DST_B (0x45) <- (sdev_def << 1): real addr on back-channel
++ *
++ */
++int max96717_setup_control(struct device *dev)
++{
++	struct max96717 *priv = dev_get_drvdata(dev);
++	int err = 0;
++	struct gmsl_link_ctx *g_ctx;
++
++	mutex_lock(&priv->lock);
++
++	if (!priv->g_client.g_ctx) {
++		dev_err(dev, "%s: no sensor dev client found\n", __func__);
++		err = -EINVAL;
++		goto error;
++	}
++
++	g_ctx = priv->g_client.g_ctx;
++
++	if (prim_priv__) {
++		unsigned int dev_id;
++		int probe_ret;
++
++		probe_ret = regmap_read(prim_priv__->regmap,
++					MAX96717_DEV_ADDR, &dev_id);
++		if (probe_ret == 0) {
++			/* Primary address (0x40) still responsive — do reassign */
++			max96717_write_reg(&prim_priv__->i2c_client->dev,
++					   MAX96717_DEV_ADDR,
++					   (g_ctx->ser_reg << 1));
++		} else {
++			dev_info(&prim_priv__->i2c_client->dev,
++				 "%s: SER already reassigned (addr 0x40 NACK), skipping DEV_ADDR write\n",
++				 __func__);
++		}
++	}
++
++	/* CTRL0: GMSL2 mode + TX enable */
++	if (g_ctx->serdes_csi_link == GMSL_SERDES_CSI_LINK_A)
++		err = max96717_write_reg(dev, MAX96717_CTRL0_ADDR,
++					 MAX96717_CTRL0_LINK_A);
++	else
++		err = max96717_write_reg(dev, MAX96717_CTRL0_ADDR,
++					 MAX96717_CTRL0_LINK_B);
++
++	if (err) {
++		dev_err(dev, "%s: ERROR: ser device not found\n", __func__);
++		goto error;
++	}
++
++	/* delay to settle link */
++	msleep(100);
++
++	/*
++	 * I2C address translation for sensor passthrough.
++	 *
++	 * I2C4 / SRC_B (0x44): sensor proxy addr visible to Orin host
++	 * I2C5 / DST_B (0x45): sensor real addr on GMSL back-channel
++	 *
++	 * When host sends I2C to sdev_reg (e.g., 0x1a), the MAX96717
++	 * translates it to sdev_def (e.g., 0x42) and forwards via GMSL
++	 * back-channel to the HKR sensor.
++	 */
++	max96717_write_reg(dev, MAX96717_I2C4_ADDR,
++			   (g_ctx->sdev_reg << 1));
++	max96717_write_reg(dev, MAX96717_I2C5_ADDR,
++			   (g_ctx->sdev_def << 1));
++
++	/* dev addr pass-through ref */
++	if (prim_priv__)
++		prim_priv__->pst2_ref++;
++
++	g_ctx->serdev_found = true;
++
++error:
++	mutex_unlock(&priv->lock);
++	return err;
++}
++EXPORT_SYMBOL(max96717_setup_control);
++
++/* ===== GPIO Tunneling ===== */
++
++/*
++ * max96717_setup_gpio_tunneling - GPIO-over-GMSL no-op hook
++ *
++ *   GPIO Signal Mapping:
++ *   MFP0 → GPIO0: FSIN (DES→SER, frame sync in)
++ *   MFP1 → GPIO1: FOUT/STROBE (SER→DES, frame sync out)
++ *   MFP4 → GPIO4: RESET_N (DES→SER, hard reset)
++ *   MFP5 → GPIO5: IRQ (SER→DES, interrupt request)
++ *   MFP6 → GPIO6: ZV_SYNC (DES→SER, IR stereo sync)
++ *
++ */
++int max96717_setup_gpio_tunneling(struct device *dev)
++{
++	struct max96717 *priv = dev_get_drvdata(dev);
++	int err = 0;
++
++	mutex_lock(&priv->lock);
++
++	dev_info(dev, "%s: GPIO tunneling hook is a no-op; MFP_CFG values are not defined yet\n",
++		 __func__);
++
++	mutex_unlock(&priv->lock);
++
++	return err;
++}
++EXPORT_SYMBOL(max96717_setup_gpio_tunneling);
++
++/* ===== Reset Control ===== */
++
++int max96717_reset_control(struct device *dev)
++{
++	struct max96717 *priv = dev_get_drvdata(dev);
++	int err = 0;
++
++	mutex_lock(&priv->lock);
++	if (!priv->g_client.g_ctx) {
++		dev_err(dev, "%s: no sdev client found\n", __func__);
++		err = -EINVAL;
++		goto error;
++	}
++
++	priv->g_client.st_done = false;
++
++	if (prim_priv__) {
++		prim_priv__->pst2_ref--;
++
++		max96717_write_reg(dev, MAX96717_DEV_ADDR,
++				   (prim_priv__->def_addr << 1));
++		if (prim_priv__->pst2_ref == 0)
++			max96717_write_reg(&prim_priv__->i2c_client->dev,
++					   MAX96717_CTRL0_ADDR,
++					   MAX96717_RESET_ALL);
++	}
++
++error:
++	mutex_unlock(&priv->lock);
++	return err;
++}
++EXPORT_SYMBOL(max96717_reset_control);
++
++/* ===== Device Pairing ===== */
++
++int max96717_sdev_pair(struct device *dev, struct gmsl_link_ctx *g_ctx)
++{
++	struct max96717 *priv;
++	int err = 0;
++
++	if (!dev || !g_ctx || !g_ctx->s_dev) {
++		dev_err(dev, "%s: invalid input params\n", __func__);
++		return -EINVAL;
++	}
++
++	priv = dev_get_drvdata(dev);
++	mutex_lock(&priv->lock);
++	if (priv->g_client.g_ctx) {
++		/* 
++		 * Already paired — tolerate if this is a re-probe of
++		 * the same camera after a failed first attempt.
++		 * Simply overwrite with the new g_ctx.
++		 */
++		dev_warn(dev, "%s: re-pairing (previous probe may have failed)\n",
++			 __func__);
++	}
++
++	priv->g_client.st_done = false;
++	priv->g_client.g_ctx = g_ctx;
++
++	/* mutex_unlock in error path, but we have none — inline the unlock */
++	mutex_unlock(&priv->lock);
++	return err;
++}
++EXPORT_SYMBOL(max96717_sdev_pair);
++
++int max96717_sdev_unpair(struct device *dev, struct device *s_dev)
++{
++	struct max96717 *priv = NULL;
++	int err = 0;
++
++	if (!dev || !s_dev) {
++		dev_err(dev, "%s: invalid input params\n", __func__);
++		return -EINVAL;
++	}
++
++	priv = dev_get_drvdata(dev);
++
++	mutex_lock(&priv->lock);
++
++	if (!priv->g_client.g_ctx) {
++		dev_dbg(dev, "%s: device is not paired\n", __func__);
++		err = 0; /* Not an error — already unpaired */
++		goto error;
++	}
++
++	if (priv->g_client.g_ctx->s_dev != s_dev) {
++		dev_warn(dev, "%s: s_dev mismatch, clearing anyway\n", __func__);
++	}
++
++	priv->g_client.g_ctx = NULL;
++	priv->g_client.st_done = false;
++
++error:
++	mutex_unlock(&priv->lock);
++	return err;
++}
++EXPORT_SYMBOL(max96717_sdev_unpair);
++
++/* ===== Pipe Configuration ===== */
++
++/*
++ * __max96717_set_pipe - Configure a single pipe's DT/VC mapping
++ *
++ * In Tunnel Mode, per-pipe DT/VC filtering is bypassed on the serializer。
++ * However, we still write the registers for d4xx framework compatibility.
++ *
++ */
++static int __max96717_set_pipe(struct device *dev, int pipe_id, u8 data_type1,
++			       u8 data_type2, u32 vc_id)
++{
++	int err = 0;
++	u8 bpp = 0x30;
++	struct max96717 *priv = dev_get_drvdata(dev);
++
++	if (priv->pixel_mode) {
++		struct reg_pair pixel_pipe_control[] = {
++			{MAX96717_FRONTTOP16_ADDR, 0x5E},
++			{MAX96717_FRONTTOP17_ADDR, 0x52},
++			{MAX96717_FRONTTOP5_ADDR, 0x01},
++		};
++
++		pixel_pipe_control[0].val = 0x40 | data_type1;
++		pixel_pipe_control[1].val = data_type2 ? (0x40 | data_type2) : 0x00;
++		pixel_pipe_control[2].val = 1 << vc_id;
++
++		return max96717_set_registers(dev, pixel_pipe_control,
++					     ARRAY_SIZE(pixel_pipe_control));
++	} else {
++		struct reg_pair map_pipe_control[] = {
++			/* Pipe X DT addr + 0x2*pipe_id */
++			{0x0314, 0x5E},  /* data_type1 */
++			{0x0315, 0x52},  /* data_type2 */
++			{0x0309, 0x01},  /* VC select */
++			{0x030A, 0x00},
++			{0x031C, 0x30},  /* BPP */
++			{0x0102, 0x0E},  /* LIM_HEART: Disabled */
++		};
++
++		if (data_type1 == GMSL_CSI_DT_RGB_888)
++			bpp = 0x18;
++
++		map_pipe_control[0].addr += 0x2 * pipe_id;
++		map_pipe_control[1].addr += 0x2 * pipe_id;
++		map_pipe_control[2].addr += 0x2 * pipe_id;
++		map_pipe_control[3].addr += 0x2 * pipe_id;
++		map_pipe_control[4].addr += 0x1 * pipe_id;
++		map_pipe_control[5].addr += 0x8 * pipe_id;
++
++		map_pipe_control[0].val = 0x40 | data_type1;
++		map_pipe_control[1].val = 0x40 | data_type2;
++		if (pipe_id == 0)
++			map_pipe_control[1].val |= 0x80;
++		map_pipe_control[2].val = 1 << vc_id;
++		map_pipe_control[3].val = 0x00;
++		map_pipe_control[4].val = bpp;
++		map_pipe_control[5].val = 0x0E;
++
++		err = max96717_set_registers(dev, map_pipe_control,
++					     ARRAY_SIZE(map_pipe_control));
++	}
++
++	return err;
++}
++
++/*
++ * max96717_init_settings - Initialize default pipe/streaming settings
++ *
++ * In Tunnel Mode, per-pipe DT config is not functionally needed
++ * but we configure pipes for d4xx compatibility.
++ * Default: 4 pipes with YUV422_8 + EMBED, VC0-3.
++ */
++int max96717_init_settings(struct device *dev)
++{
++	int err = 0;
++	int i;
++	struct max96717 *priv = dev_get_drvdata(dev);
++
++	struct reg_pair map_init[] = {
++		/* 
++		 * PIPE_EN soft reset first, then enable tunnel mode.
++		 * Note: FRONTTOP0 is bypassed in tunnel mode (per UG) —
++		 * CSI-2 input goes directly into the tunnel, no port config needed.
++		 */
++		{MAX96717_PIPE_EN_ADDR, MAX96717_SOFT_RESET},
++		{MAX96717_EXT11_ADDR, MAX96717_TUN_MODE_EN},
++		{MAX96717_PIPE_EN_ADDR, MAX96717_PIPE_EN_ALL},
++	};
++	struct reg_pair pixel_init[] = {
++		{MAX96717_PIPE_EN_ADDR, MAX96717_SOFT_RESET},
++		{MAX96717_EXT11_ADDR, MAX96717_TUN_MODE_DIS},
++		{MAX96717_FRONTTOP0_ADDR, MAX96717_FRONTTOP0_PIXEL_PORT_B},
++		{MAX96717_FRONTTOP9_ADDR, MAX96717_FRONTTOP9_START_VIDEO},
++		{MAX96717_VIDEO_TX0_ADDR, MAX96717_VIDEO_TX0_BPP_MANUAL},
++		{MAX96717_VIDEO_TX1_ADDR, MAX96717_VIDEO_TX1_BPP16},
++		{MAX96717_VIDEO_TX2_ADDR, MAX96717_VIDEO_TX2_DRIFT_DIS},
++		{MAX96717_PIPE_EN_ADDR, MAX96717_PIPE_EN_ALL},
++	};
++	/*
++	 * Release MFP8 (GPIO8) before any other config so the serializer
++	 * stops driving the camera-side M2_I2C bus shared with the BMI088
++	 * IMU. Confirmed on HW: tri-stating GPIO8 restores IMU I2C access.
++	 */
++	struct reg_pair gpio_release[] = {
++		{MAX96717_GPIO8_A_ADDR, MAX96717_GPIO_A_HIGH_Z},
++		{MAX96717_GPIO8_B_ADDR, MAX96717_GPIO_B_NO_PULL},
++	};
++
++	mutex_lock(&priv->lock);
++
++	/*
++	 * After CTRL0 + I2C translation writes in
++	 * setup_control, the MAX96717 needs settling time before
++	 * accepting writes to PIPE_EN (0x02) and FRONTTOP registers.
++	 */
++	usleep_range(5000, 6000);
++
++	/*
++	 * Tri-state MFP8 (GPIO8) first to release the camera-side M2_I2C
++	 * bus shared with the BMI088 IMU before configuring the rest of
++	 * the SER.
++	 */
++	err = max96717_set_registers(dev, gpio_release,
++				    ARRAY_SIZE(gpio_release));
++	if (err)
++		dev_warn(dev, "%s: failed to release MFP8 (IMU M2_I2C bus)\n",
++			 __func__);
++
++	if (priv->pixel_mode) {
++		err = max96717_set_registers(dev, pixel_init,
++					 ARRAY_SIZE(pixel_init));
++		err |= __max96717_set_pipe(dev, 0, GMSL_CSI_DT_YUV422_8,
++				   0, 0);
++	} else {
++		err = max96717_set_registers(dev, map_init, ARRAY_SIZE(map_init));
++
++		for (i = 0; i < MAX96717_MAX_PIPES; i++)
++			err |= __max96717_set_pipe(dev, i, GMSL_CSI_DT_YUV422_8,
++					   GMSL_CSI_DT_EMBED, i);
++	}
++
++	mutex_unlock(&priv->lock);
++
++	return err;
++}
++EXPORT_SYMBOL(max96717_init_settings);
++
++int max96717_set_pipe(struct device *dev, int pipe_id,
++		      u8 data_type1, u8 data_type2, u32 vc_id)
++{
++	struct max96717 *priv = dev_get_drvdata(dev);
++	int err = 0;
++
++	if (pipe_id > (MAX96717_MAX_PIPES - 1)) {
++		dev_info(dev, "%s: input pipe_id: %d exceeds max96717 max pipes\n",
++			 __func__, pipe_id);
++		return -EINVAL;
++	}
++
++	dev_dbg(dev, "%s pipe_id %d, data_type1 %u, data_type2 %u, vc_id %u\n",
++		__func__, pipe_id, data_type1, data_type2, vc_id);
++
++	mutex_lock(&priv->lock);
++
++	err = __max96717_set_pipe(dev, pipe_id, data_type1, data_type2, vc_id);
++
++	mutex_unlock(&priv->lock);
++
++	return err;
++}
++EXPORT_SYMBOL(max96717_set_pipe);
++
++/*
++ * max96717_retrigger_tx - Toggle SER TX to restore tunnel detection after
++ * a DES ONESHOT.  DES ONESHOT resets the data path; the SER must cycle
++ * its TX enable for the DES to re-acquire the tunnel stream.
++ */
++void max96717_retrigger_tx(struct device *dev)
++{
++	max96717_write_reg(dev, MAX96717_PIPE_EN_ADDR, MAX96717_SOFT_RESET);
++	msleep(30);
++	max96717_write_reg(dev, MAX96717_PIPE_EN_ADDR, MAX96717_PIPE_EN_ALL);
++}
++EXPORT_SYMBOL(max96717_retrigger_tx);
++
++/* ===== Probe / Remove ===== */
++
++static struct regmap_config max96717_regmap_config = {
++	.reg_bits = 16,
++	.val_bits = 8,
++	.cache_type = REGCACHE_RBTREE,
++};
++
++static int max96717_probe(struct i2c_client *client,
++			   const struct i2c_device_id *id)
++{
++	struct max96717 *priv;
++	int err = 0;
++	struct device_node *node = client->dev.of_node;
++
++	dev_info(&client->dev, "[MAX96717]: probing GMSL2 Serializer (Tunnel Mode)\n");
++
++	priv = devm_kzalloc(&client->dev, sizeof(*priv), GFP_KERNEL);
++	if (!priv)
++		return -ENOMEM;
++
++	priv->i2c_client = client;
++	priv->regmap = devm_regmap_init_i2c(priv->i2c_client,
++					     &max96717_regmap_config);
++	if (IS_ERR(priv->regmap)) {
++		dev_err(&client->dev,
++			"regmap init failed: %ld\n", PTR_ERR(priv->regmap));
++		return -ENODEV;
++	}
++
++	mutex_init(&priv->lock);
++	priv->pixel_mode = of_property_read_bool(node, "adi,pixel-mode");
++
++	if (of_get_property(node, "is-prim-ser", NULL)) {
++		if (prim_priv__) {
++			dev_err(&client->dev,
++				"prim-ser already exists\n");
++			return -EEXIST;
++		}
++
++		err = of_property_read_u32(node, "reg", &priv->def_addr);
++		if (err < 0) {
++			dev_err(&client->dev, "reg not found\n");
++			return -EINVAL;
++		}
++
++		prim_priv__ = priv;
++	}
++
++	dev_set_drvdata(&client->dev, priv);
++
++	dev_info(&client->dev, "%s: success\n", __func__);
++
++	return err;
++}
++
++static int max96717_remove(struct i2c_client *client)
++{
++	struct max96717 *priv;
++
++	if (client != NULL) {
++		priv = dev_get_drvdata(&client->dev);
++		mutex_destroy(&priv->lock);
++		i2c_unregister_device(client);
++		client = NULL;
++	}
++
++	return 0;
++}
++
++static const struct i2c_device_id max96717_id[] = {
++	{ "max96717", 0 },
++	{ },
++};
++
++static const struct of_device_id max96717_of_match[] = {
++	{ .compatible = "adi,max96717", },
++	{ .compatible = "maxim,max96717", },
++	{ },
++};
++MODULE_DEVICE_TABLE(of, max96717_of_match);
++MODULE_DEVICE_TABLE(i2c, max96717_id);
++
++static struct i2c_driver max96717_i2c_driver = {
++	.driver = {
++		.name = "max96717",
++		.owner = THIS_MODULE,
++		.of_match_table = of_match_ptr(max96717_of_match),
++	},
++	.probe = max96717_probe,
++	.remove = max96717_remove,
++	.id_table = max96717_id,
++};
++
++static int __init max96717_init(void)
++{
++	return i2c_add_driver(&max96717_i2c_driver);
++}
++
++static void __exit max96717_exit(void)
++{
++	i2c_del_driver(&max96717_i2c_driver);
++}
++
++module_init(max96717_init);
++module_exit(max96717_exit);
++
++MODULE_DESCRIPTION("GMSL2 Serializer driver max96717 (Tunnel Mode)");
++MODULE_AUTHOR("RealSense AI");
++MODULE_LICENSE("GPL v2");
+diff --git a/drivers/media/i2c/max96724.c b/drivers/media/i2c/max96724.c
+new file mode 100644
+index 0000000..22bfb47
+--- /dev/null
++++ b/drivers/media/i2c/max96724.c
+@@ -0,0 +1,1916 @@
++/*
++ * max96724.c - MAX96724 GMSL2 Quad Deserializer driver (Tunnel Mode)
++ *
++ * Copyright (c) 2026, RealSense, Inc.  All rights reserved.
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms and conditions of the GNU General Public License,
++ * version 2, as published by the Free Software Foundation.
++ *
++ * This program is distributed in the hope it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
++ * more details.
++ *
++ * You should have received a copy of the GNU General Public License
++ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
++ */
++
++
++#include <linux/gpio.h>
++#include <linux/types.h>
++#include <linux/module.h>
++#include <linux/of.h>
++#include <linux/of_device.h>
++#include <linux/of_gpio.h>
++#include <media/camera_common.h>
++#include <linux/module.h>
++#include <media/max96724.h>
++
++/* ================================================================
++ * Register Addresses
++ * ================================================================ */
++
++/* --- Device ID / Configuration --- */
++
++/* REG0: Device ID (read-only, returns 0xA2) */
++#define MAX96724_DEV_ID_ADDR		0x00
++
++/* ERRB master reset register */
++#define MAX96724_ERRB_MST_RST_ADDR	0x05
++
++/* 
++ *   GMSL Link/PHY Enable and Mode Select
++ *   bits[7:4]: PHY mode (0=GMSL1, 1=GMSL2) per link D/C/B/A
++ *   bits[3:0]: Link Enable per link D/C/B/A
++ */
++#define MAX96724_LINK_EN_ADDR		0x0006
++
++/* 
++ *   GMSL Link/PHY Rate Select (Links A&B)
++ *   bits[7:6]: Tx Rate Link B, bits[5:4]: Rx Rate Link B
++ *   bits[3:2]: Tx Rate Link A, bits[1:0]: Rx Rate Link A
++ *   Tx: 00=187.5Mbps, Rx: 01=3Gbps, 10=6Gbps
++ */
++#define MAX96724_LINK_RATE_AB_ADDR	0x0010
++
++/* GMSL Link/PHY Rate Select (Links C&D) */
++#define MAX96724_LINK_RATE_CD_ADDR	0x0011
++
++/* Link A lock status (bit[3]=LOCK) */
++#define MAX96724_LINK_A_LOCK_ADDR	0x001A
++
++/* 
++ *   GMSL Link Reset
++ *   bits[7:4]: Link reset D/C/B/A, bits[3:0]: One-shot reset D/C/B/A
++ */
++#define MAX96724_ONESHOT_ADDR		0x0018
++
++/* Soft Reset (write 0x40, wait 5ms) */
++#define MAX96724_REG13_ADDR		0x000D
++
++/* 
++ *   Error Channel Power Up registers (required for 6Gbps)
++ *   Write 0x75 immediately after power-up for robust 6Gbps operation
++ */
++#define MAX96724_ERRCH_A_ADDR		0x1449
++#define MAX96724_ERRCH_B_ADDR		0x1549
++#define MAX96724_ERRCH_C_ADDR		0x1649
++#define MAX96724_ERRCH_D_ADDR		0x1749
++#define MAX96724_ERRCH_FORCE_ON		0x75
++
++/* --- I2C Control Channel / Errata --- */
++
++/* 
++ *   Tunnel Mode SRAM LCRC error suppression
++ *   Set 0x458[7:4] = 0x0 to suppress spurious ERRB in tunnel mode
++ */
++#define MAX96724_SRAM_LCRC_ERR_ADDR	0x0458
++
++/* --- Video Pipe Selection --- */
++
++/*
++ *   bits[3:0] = Pipe 0 source (0x0=SIOA)
++ *   bits[7:4] = Pipe 1 source (0x1=SIOB)
++ */
++#define MAX96724_PIPE_SEL0_ADDR		0xF0
++
++/*
++ *   bits[3:0] = Pipe 2 source (0x2=SIOC)
++ *   bits[7:4] = Pipe 3 source (0x3=SIOD)
++ */
++#define MAX96724_PIPE_SEL1_ADDR		0xF1
++
++#define MAX96724_PIPE_EN_ADDR		0xF4
++
++/* --- Pipe Receiver / Tunnel Mode --- */
++
++/*
++ *   bit[5]=1: Tunnel Mode, bits[1:0]=11: 4-lane MIPI out
++ *   Stride: 0x12 per pipe (P0=0x100, P1=0x112, P2=0x124, P3=0x136)
++ */
++#define MAX96724_VID_RX0_P0_ADDR	0x100
++#define MAX96724_VID_RX6_P0_ADDR	0x106
++#define MAX96724_VID_RX_STRIDE		0x12
++
++#define MAX96724_VID_RX1_P0_ADDR	0x101
++
++/* --- CSI-2 Output (BACKTOP) --- */
++
++/* BACKTOP: CSI-2 output port enable
++ *   0x040B bit[1]=CSIB_EN, bit[0]=CSIA_EN
++ */
++#define MAX96724_BACKTOP_EN_ADDR	0x040B
++
++/* --- MIPI DPLL (Data Rate) --- */
++
++/* 
++ *   MIPI PHY DPLL Freq registers
++ *   bits[4:0] = frequency in multiples of 100MHz
++ *   bit[5]    = DPLL enable (must be set for DPLL to lock)
++ *   E.g., 0x27 = 700MHz + enable = 700Mbps/lane D-PHY
++ *   E.g., 0x2F = 1500MHz + enable = 1.5Gbps/lane
++ */
++#define MAX96724_DPLL_FREQ0_ADDR	0x0415
++#define MAX96724_DPLL_FREQ1_ADDR	0x0418
++#define MAX96724_DPLL_FREQ2_ADDR	0x041B
++#define MAX96724_DPLL_FREQ3_ADDR	0x041E
++
++/* 
++ *   DPLL PHY reset control
++ *   0x1D00 = DPLL CSI PHY1 control
++ *   Write 0xF4 to disable/reset, 0xF5 to enable
++ */
++#define MAX96724_DPLL_CSI2_ADDR		0x1D00
++#define MAX96724_DPLL_DISABLE		0xF4
++#define MAX96724_DPLL_ENABLE		0xF5
++
++/* --- CSI-2 Output PHY Configuration --- */
++
++/* 
++ * CSI output mode/config register.
++ * Mode bits (set exactly one of [4:0]):
++ *   bit[0]=0x01: 4x2 mode
++ *   bit[2]=0x04: 2x4 mode        (Ctrl 1 = master for Port A, Ctrl 2 = Port B)
++ *   bit[3]=0x08: 1x4a + 2x2 mode (Ctrl 1 = master for Port A)
++ *   bit[4]=0x10: 1x4b + 2x2 mode (Ctrl 2 = master for Port B)
++ *
++ * Clock-force bits:
++ *   bit[7]=0x80: force ALL MIPI clocks running (continuous HS clock)
++ *   bit[6]=0x40: force PHY 3 MIPI clock running
++ *   bit[5]=0x20: force PHY 0 MIPI clock running
++ */
++#define MAX96724_CSI_OUT_CFG_ADDR	0x08A0
++
++/* 
++ *   MIPI PHY Enable register
++ *   bits[7:4]: Enable PHY 3/2/1/0 (1=enabled, 0=standby)
++ */
++#define MAX96724_CSI_PHY_EN_ADDR	0x08A2
++
++/* MIPI PHY 0 and 1 Lane Mapping */
++#define MAX96724_CSI_LANE_MAP1_ADDR	0x08A3
++
++/* MIPI PHY 2 and 3 Lane Mapping */
++#define MAX96724_CSI_LANE_MAP2_ADDR	0x08A4
++
++/* 
++ *   MIPI output lane polarity (P/N swap) registers.
++ *   0x08A5 = PHY0/PHY1 lane polarity, 0x08A6 = PHY2/PHY3 lane polarity.
++ *   The FangZhu FG24-4CH PCB swaps the differential P/N pairs on the
++ *   MAX96724 CSI output, so the deserializer must invert lane polarity
++ */
++#define MAX96724_CSI_PHY_POL0_ADDR	0x08A5
++#define MAX96724_CSI_PHY_POL1_ADDR	0x08A6
++#define MAX96724_CSI_PHY_POL_SWAP	0x3F
++
++/* Pipe-to-controller mapping */
++#define MAX96724_MIPI_CTRL_SEL_ADDR	0x08CA
++
++/* Method-1 controller mapping */
++#define MAX96724_MIPI_CTRL_SEL_PIXEL	0xE4
++
++/* --- Lane Control per pipe (stride 0x40) --- */
++
++/*
++ *   0xC0 = 4-lane enabled
++ */
++#define MAX96724_LANE_CTRL0_ADDR	0x090A
++#define MAX96724_LANE_CTRL1_ADDR	0x094A
++#define MAX96724_LANE_CTRL2_ADDR	0x098A
++#define MAX96724_LANE_CTRL3_ADDR	0x09CA
++
++/* --- Pipe Mapping Registers (stride 0x40 per pipe) --- */
++
++/*
++ *   Base addresses for Pipe X (Pipe 0)
++ *   Stride: 0x40 per pipe
++ */
++#define MAX96724_TX11_PIPE_X_EN_ADDR		0x090B
++#define MAX96724_TX45_PIPE_X_DST_CTRL_ADDR	0x092D
++#define MAX96724_PIPE_X_SRC_0_MAP_ADDR		0x090D
++#define MAX96724_PIPE_X_DST_0_MAP_ADDR		0x090E
++#define MAX96724_PIPE_X_SRC_1_MAP_ADDR		0x090F
++#define MAX96724_PIPE_X_DST_1_MAP_ADDR		0x0910
++#define MAX96724_PIPE_X_SRC_2_MAP_ADDR		0x0911
++#define MAX96724_PIPE_X_DST_2_MAP_ADDR		0x0912
++#define MAX96724_PIPE_X_SRC_3_MAP_ADDR		0x0913
++#define MAX96724_PIPE_X_DST_3_MAP_ADDR		0x0914
++
++/* --- Stream Select --- */
++
++/*
++ *   Pipe X=0x0933, stride 0x40 per pipe
++ */
++#define MAX96724_PIPE_X_ST_SEL_ADDR	0x0933
++
++/* --- Extended Pipe Mapping (DST_CTRL2-4 / TX49) --- */
++
++/* 
++ *   Extended DST_CTRL for additional mapping pairs
++ *   All to PHY1 (0x55), same as TX45
++ *   Stride: 0x40 per pipe (base = Pipe X)
++ */
++#define MAX96724_TX46_PIPE_X_ADDR	0x092E
++#define MAX96724_TX47_PIPE_X_ADDR	0x092F
++#define MAX96724_TX48_PIPE_X_ADDR	0x0930
++
++/* 
++ *   MIPI_TX49 synchronous concatenation control
++ *   Set to 0x00 (no concat) for single-camera tunnel mode.
++ *   For 4W concat use 0x87.
++ *   Stride: 0x40 per pipe (base = Pipe X)
++ */
++#define MAX96724_TX49_PIPE_X_ADDR	0x0931
++#define MAX96724_TX49_CONCAT_4W		0x87
++
++/* --- Tunnel Mode per-pipe --- */
++
++/*
++ *   bit[0] = TUN_EN, Default=0x08, write 0x01 to enable
++ */
++#define MAX96724_PIPE0_TUN_EN_ADDR	0x0936
++#define MAX96724_PIPE1_TUN_EN_ADDR	0x0976
++#define MAX96724_PIPE2_TUN_EN_ADDR	0x09B6
++#define MAX96724_PIPE3_TUN_EN_ADDR	0x09F6
++
++/*
++ *   bit[6]: disable auto-tunnel-detect
++ *   bits[5:4]: TUN_DEST (00=PHY0, 01=PHY1, 10=PHY2, 11=PHY3)
++ */
++#define MAX96724_PIPE0_TUN_DEST_ADDR	0x0939
++#define MAX96724_PIPE1_TUN_DEST_ADDR	0x0979
++#define MAX96724_PIPE2_TUN_DEST_ADDR	0x09B9
++#define MAX96724_PIPE3_TUN_DEST_ADDR	0x09F9
++
++/* ================================================================
++ * Register Values
++ * ================================================================ */
++
++/* Soft reset value (write to 0x000D) */
++#define MAX96724_SOFT_RESET		0x40
++
++/* 
++ * Link Rate values for 0x0010/0x0011
++ *   Per link pair: bits[1:0]=RxA, [3:2]=TxA, [5:4]=RxB, [7:6]=TxB
++ *   Tx = 00 (187.5Mbps), Rx = 01 (3Gbps) or 10 (6Gbps)
++ *   3Gbps: Tx=00, Rx=01 → per pair 0x01, both pairs = 0x01 in low nibble
++ */
++#define MAX96724_LINK_RATE_3GBPS	0x01  /* Rx=3G, Tx=187.5M for one link pair */
++#define MAX96724_LINK_RATE_6GBPS	0x02  /* Rx=6G, Tx=187.5M for one link pair */
++
++/* 
++ * 0x0006: Link enable / mode values
++ *   bits[7:4] = PHY mode (1=GMSL2 per link)
++ *   bits[3:0] = Link enable per link
++ *   0xF1 = all GMSL2-mode, only Link A enabled
++ *   0xFF = all GMSL2-mode, all 4 links enabled
++ */
++#define MAX96724_LINK_EN_SIOA		0xF1  /* GMSL2 all, enable Link A only */
++#define MAX96724_LINK_EN_ALL		0xFF  /* GMSL2 all, enable all links */
++
++/* BACKTOP_EN (0x040B): CSI output port enable */
++#define MAX96724_BACKTOP_CSIB_EN	0x02
++#define MAX96724_BACKTOP_CSIA_EN	0x01
++
++/* 
++ *   VIDEO_RX0: DIS_PKT_DET=1 (bit0) required for tunnel mode.
++ *   Without it, DES rejects tunnel data as invalid GMSL2 video packets.
++ *   SEQ_MISS_EN=1 (bit4), LINE_CRC_EN=1 (bit1).  XML value: 0x33.
++ */
++#define MAX96724_VID_RX0_CFG_VAL	0x33
++#define MAX96724_VID_RX6_CFG_VAL	0x0A
++
++/* Pixel-mode receiver settings */
++#define MAX96724_VID_RX0_PIXEL_VAL	0x32
++#define MAX96724_VID_RX6_PIXEL_VAL	0x12
++
++/* 
++ *   Tunnel mode enable (MIPI_TX54, 0x0936):
++ *   bit[0] = TUN_EN = 1
++ *   Verified value: 0x01
++ */
++#define MAX96724_TUN_EN			0x01
++
++/* Default/reset state when tunnel is disabled */
++#define MAX96724_TUN_DISABLED		0x08
++
++/* 
++ *   Tunnel controller destination (MIPI_TX57, 0x0939):
++ *   bits[5:4]: TUN_DEST (00=PHY0, 01=PHY1, 10=PHY2, 11=PHY3)
++ *   Verified value: 0x10 = PHY1 destination with auto-detect enabled
++ */
++#define MAX96724_TUN_DEST_CTRL0		0x00  /* Auto-detect + PHY0 */
++#define MAX96724_TUN_DEST_CTRL1		0x10  /* Auto-detect + PHY1 (Port A master) */
++
++#define MAX96724_CSI_MODE_2X4_VAL	0x04  /* bit[2] = clean 2x4: Port A = PHY0+PHY1 */
++
++/* 
++ *   0x84 = 2x4 mode (bit2) + bit[7] "force ALL MIPI clocks running".  The bit[7]
++ *   clock-force is the key part: it keeps the D-PHY clock lane in continuous HS
++ *   mode so the Orin NVCSI/CIL can lock.
++ */
++#define MAX96724_CSI_OUT_EN_VAL		0x84  /* 2x4 + bit[7] force all MIPI clocks running */
++
++#define MAX96724_CSI_PHY_EN_ALL		0xF0
++#define MAX96724_CSI_PHY_EN_01		0x30  /* PHY0+PHY1 only (Port A) */
++#define MAX96724_CSI_PHY_EN_23		0xC0  /* PHY2+PHY3 only (Port B) */
++
++/* Lane mapping default */
++#define MAX96724_CSI_LANE_MAP_DEFAULT	0xE4
++
++/* Lane control: 4-lane enabled */
++#define MAX96724_LANE_CTRL_4LANE	0xC0
++
++/*
++ *   Lane control: 2-lane enabled.
++ *   bits[7:6] = (num_lanes - 1): 01=2-lane(0x40), 11=4-lane(0xC0)
++ *   Ref: gmsl_ser_des_guide §8.2, E2E_enable_guide §5.6.4 
++ */
++#define MAX96724_LANE_CTRL_2LANE	0x40
++
++/* 
++ *   CSI PHY enable: all PHYs powered for DPLL lock.
++ */
++#define MAX96724_CSI_PHY_EN_2LANE	0xF0
++
++/* 
++ *   DPLL for Controller 0 (drives PHY0, 2 lanes).
++ *   bits[4:0] = data-rate / 100 MHz.  700 Mbps / 100 = 7 = 0x07.
++ *   bit[5]    = DPLL enable = 1.
++ *   Result: 0x27 = 700 Mbps/lane D-PHY.
++ */
++#define MAX96724_DPLL_700MBPS_CTRL0	0x27
++
++/* 
++ *   CSI-output DPLL data rate = 1300 Mbps.
++ *   bits[4:0] = data-rate / 100 MHz -> 1300/100 = 13 = 0x0D. bit[5] = DPLL en.
++ */
++#define MAX96724_DPLL_1300MBPS		0x2D
++
++/* One-shot reset: all links */
++#define MAX96724_ONESHOT_ALL		0x0F
++
++/* 
++ *   Pipe source selection values
++ *   Encoding per pipe nibble in tunnel mode:
++ *   0x22 routes all pipes from Link A in tunnel mode.
++ */
++#define MAX96724_PIPE_SEL0_SINGLE	0x22  /* All pipes from Link A */
++#define MAX96724_PIPE_SEL1_SINGLE	0x22  /* All pipes from Link A */
++#define MAX96724_PIPE_SEL0_PIXEL	0x62  /* pixel-mode reference */
++#define MAX96724_PIPE_SEL1_PIXEL	0xEA  /* pixel-mode reference */
++#define MAX96724_PIPE_SEL0_DUAL		0x40  /* Pipe 0 ← A/X, Pipe 1 ← B/X */
++#define MAX96724_PIPE_SEL0_QUAD_LO	0x40  /* Pipe 0 ← A/X, Pipe 1 ← B/X */
++#define MAX96724_PIPE_SEL1_QUAD_HI	0xC8  /* Pipe 2 ← C/X, Pipe 3 ← D/X */
++
++/* Pipe enable values */
++#define MAX96724_PIPE_EN_1		0x01
++#define MAX96724_PIPE_EN_2		0x03
++#define MAX96724_PIPE_EN_4		0x0F
++
++/* Lane control map: bits[7:6] = (num_lanes - 1) */
++#define MAX96724_LANE_CTRL_MAP(num_lanes) \
++	((((num_lanes) - 1) << 6) & 0xC0)
++
++/* Reset all */
++#define MAX96724_RESET_ALL		0x80
++
++/* Stream ID invalid */
++#define MAX96724_INVAL_ST_ID		0xFF
++#define MAX96724_RESET_ST_ID		0x00
++#define MAX96724_ST_ID_SEL_INVALID	0xF
++
++/* Controller mapping: all mappings → Controller 0 */
++#define MAX96724_ALL_MAP_CTRL0		0x00
++/* Controller mapping: all mappings → Controller 1 */
++#define MAX96724_ALL_MAP_CTRL1		0x55
++
++/* Three mappings to controller 1 */
++#define MAX96724_MAP3_CTRL1		0x15
++
++/* ================================================================
++ * Data Structures
++ * ================================================================ */
++
++/* Quad GMSL: up to 4 sources */
++#define MAX96724_MAX_SOURCES		4
++#define MAX96724_MAX_PIPES		4
++
++#define MAX96724_PIPE_X			0
++#define MAX96724_PIPE_Y			1
++#define MAX96724_PIPE_Z			2
++#define MAX96724_PIPE_U			3
++#define MAX96724_PIPE_INVALID		0xF
++
++#define MAX96724_CSI_CTRL_0		0
++#define MAX96724_CSI_CTRL_1		1
++#define MAX96724_CSI_CTRL_2		2
++#define MAX96724_CSI_CTRL_3		3
++
++#define MAX96724_CSI_MODE_2X4		0x08  /* enum tag for the 4-lane Port A (Ctrl1) path */
++
++/* Lane map presets */
++#define MAX96724_LANE_MAP1_2X4		0xE4  /* SC20190112 subset: PHY0 data + PHY1 clock */
++#define MAX96724_LANE_MAP2_2X4		0x44  /* keep unused PHY2/3 straight in 0x08 mode */
++
++struct max96724_source_ctx {
++	struct gmsl_link_ctx *g_ctx;
++	bool st_enabled;
++};
++
++struct pipe_ctx {
++	u32 id;
++	u32 dt_type;
++	u32 dst_csi_ctrl;
++	u32 st_count;
++	u32 st_id_sel;
++};
++
++struct max96724 {
++	struct i2c_client *i2c_client;
++	struct regmap *regmap;
++	u32 num_src;
++	u32 max_src;
++	u32 num_src_found;
++	u32 src_link;
++	bool splitter_enabled;
++	struct max96724_source_ctx sources[MAX96724_MAX_SOURCES];
++	struct mutex lock;
++	u32 sdev_ref;
++	bool lane_setup;
++	bool link_setup;
++	struct pipe_ctx pipe[MAX96724_MAX_PIPES];
++	u8 csi_mode;
++	u8 lane_mp1;
++	u8 lane_mp2;
++	int reset_gpio;
++	int pw_ref;
++	struct regulator *vdd_cam_1v2;
++	u8 link_speed;  /* DT-configurable: 3 or 6 Gbps */
++	bool pixel_mode;
++	bool poc_enabled; /* FG24-4CH board POC/IO enable applied once */
++};
++
++struct reg_pair {
++	u16 addr;
++	u8 val;
++};
++
++/* ================================================================
++ * Low-level I2C
++ * ================================================================ */
++
++static int max96724_write_reg(struct device *dev, u16 addr, u8 val)
++{
++	struct max96724 *priv;
++	int err;
++
++	priv = dev_get_drvdata(dev);
++
++	err = regmap_write(priv->regmap, addr, val);
++	if (err)
++		dev_err(dev, "%s:i2c write failed, 0x%x = %x\n",
++			__func__, addr, val);
++
++	/* delay before next i2c command as required for SERDES link */
++	usleep_range(100, 110);
++
++	return err;
++}
++
++static int max96724_set_registers(struct device *dev, struct reg_pair *map,
++				  u32 count)
++{
++	int err = 0;
++	u32 j;
++
++	for (j = 0; j < count; j++) {
++		err = max96724_write_reg(dev, map[j].addr, map[j].val);
++		if (err)
++			break;
++	}
++
++	return err;
++}
++
++/* ================================================================
++ * Internal Helpers
++ * ================================================================ */
++
++static int max96724_get_sdev_idx(struct device *dev,
++				 struct device *s_dev, unsigned int *idx)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++	unsigned int i;
++	int err = 0;
++
++	mutex_lock(&priv->lock);
++	for (i = 0; i < priv->max_src; i++) {
++		if (priv->sources[i].g_ctx->s_dev == s_dev)
++			break;
++	}
++	if (i == priv->max_src) {
++		dev_err(dev, "no sdev found\n");
++		err = -EINVAL;
++		goto ret;
++	}
++
++	if (idx)
++		*idx = i;
++
++ret:
++	mutex_unlock(&priv->lock);
++	return err;
++}
++
++static void max96724_pipes_reset(struct max96724 *priv)
++{
++	/*
++	 * Default pipe configuration for D5xx/SC1.2:
++	 * In tunnel mode, DT types are not used for filtering
++	 * but we initialize them for d4xx framework compatibility.
++	 */
++	struct pipe_ctx pipe_defaults[] = {
++		{MAX96724_PIPE_X, GMSL_CSI_DT_RAW_12,
++			MAX96724_CSI_CTRL_1, 0, MAX96724_INVAL_ST_ID},
++		{MAX96724_PIPE_Y, GMSL_CSI_DT_RAW_12,
++			MAX96724_CSI_CTRL_1, 0, MAX96724_INVAL_ST_ID},
++		{MAX96724_PIPE_Z, GMSL_CSI_DT_EMBED,
++			MAX96724_CSI_CTRL_1, 0, MAX96724_INVAL_ST_ID},
++		{MAX96724_PIPE_U, GMSL_CSI_DT_EMBED,
++			MAX96724_CSI_CTRL_1, 0, MAX96724_INVAL_ST_ID}
++	};
++
++	memcpy(priv->pipe, pipe_defaults, sizeof(pipe_defaults));
++}
++
++static void max96724_reset_ctx(struct max96724 *priv)
++{
++	unsigned int i;
++
++	priv->link_setup = false;
++	priv->lane_setup = false;
++	priv->num_src_found = 0;
++	priv->src_link = 0;
++	priv->splitter_enabled = false;
++	max96724_pipes_reset(priv);
++	for (i = 0; i < priv->num_src; i++)
++		priv->sources[i].st_enabled = false;
++}
++
++static void max96724_apply_porta_subset(struct device *dev,
++						 struct max96724 *priv)
++{
++	/*
++	 * [XML-verified 4-lane] D-PHY Port A output, 4 data lanes.
++	 * [FG24-4CH working-config verified] 0x04 = 2x4 mode so Port A
++	 * maps to PHY0+PHY1 (the lanes the FG24 PCB wires to Orin).  Output is
++	 * not yet enabled here (bit7 = 0); setup_streaming() asserts 0x84 after
++	 * the full pipeline is configured.
++	 */
++	max96724_write_reg(dev, MAX96724_CSI_OUT_CFG_ADDR,
++			   MAX96724_CSI_MODE_2X4_VAL);
++	/*
++	 * [FG24-4CH working dump] Enable ALL four CSI PHYs (0x08A2=0xF0).
++	 * The working FangZhu config powers every PHY; the MAX96724 DPLL
++	 * needs all PHYs powered to lock reliably (single-PHY enable was
++	 * observed to never lock the output clock). Port A data still
++	 * leaves on PHY0/1 in 2x4 mode; PHY2/3 are just powered.
++	 */
++	max96724_write_reg(dev, MAX96724_CSI_PHY_EN_ADDR,
++			   MAX96724_CSI_PHY_EN_ALL);
++	max96724_write_reg(dev, MAX96724_CSI_LANE_MAP1_ADDR,
++			   priv->lane_mp1);
++	/*
++	 * [FG24-4CH working dump] LANE_MAP2 (PHY2/3) = 0xE4 straight mapping.
++	 * The working config writes 0x08A4=0xE4 (not the chip default 0x44).
++	 */
++	max96724_write_reg(dev, MAX96724_CSI_LANE_MAP2_ADDR,
++			   MAX96724_CSI_LANE_MAP_DEFAULT);
++	/*
++	 * [FG24-4CH board] Switch MIPI output lane polarity (P/N swap).
++	 * The FG24-4CH PCB inverts the differential pairs on the DES->Orin
++	 * output; without this the Orin CIL never locks the HS clock.
++	 * Per FangZhu MAX4CH_FG24_POC_Enable table: 0x08A5/0x08A6 = 0x3F.
++	 */
++	max96724_write_reg(dev, MAX96724_CSI_PHY_POL0_ADDR,
++			   MAX96724_CSI_PHY_POL_SWAP);
++	max96724_write_reg(dev, MAX96724_CSI_PHY_POL1_ADDR,
++			   MAX96724_CSI_PHY_POL_SWAP);
++	max96724_write_reg(dev, MAX96724_LANE_CTRL0_ADDR,
++			   MAX96724_LANE_CTRL_4LANE);
++	max96724_write_reg(dev, MAX96724_LANE_CTRL1_ADDR,
++			   MAX96724_LANE_CTRL_4LANE);
++	max96724_write_reg(dev, MAX96724_LANE_CTRL2_ADDR,
++			   MAX96724_LANE_CTRL_4LANE);
++	max96724_write_reg(dev, MAX96724_LANE_CTRL3_ADDR,
++			   MAX96724_LANE_CTRL_4LANE);
++}
++
++static inline bool max96724_is_pixel_mode(struct max96724 *priv)
++{
++	return priv->pixel_mode;
++}
++
++/* ================================================================
++ * Power Management
++ * ================================================================ */
++
++/* [FG24-4CH board] POC (Power-over-Coax) / IO enable sequence.
++ *   Per FangZhu MAX4CH_FG24_POC_Enable table. On the FG24-4CH board the
++ *   MFP8 line (0x0319 bit4) and the POC IO enable (0x0001 bit5) gate the
++ *   board-level output / POC path. Without these the DES PLL still locks
++ *   and shows internal activity, but no clock reaches the Orin connector.
++ */
++#define MAX96724_POC_IO_EN_ADDR		0x0001
++#define MAX96724_POC_IO_EN_VAL		0xE0  /* Enable POC IO (working dump: 0xE0) */
++#define MAX96724_POC_MFP8_ADDR		0x0319
++#define MAX96724_POC_MFP8_PRE		0x80  /* MFP8 pre-enable */
++#define MAX96724_POC_MFP8_HIGH		0x98  /* Enable POC MFP8 High (working dump: 0x98) */
++
++/*
++ * max96724_board_poc_enable - Apply FG24-4CH POC/IO enable (one-time).
++ * Mirrors the vendor MAX4CH_FG24_POC_Enable table.
++ */
++static void max96724_board_poc_enable(struct device *dev)
++{
++	max96724_write_reg(dev, MAX96724_POC_IO_EN_ADDR,
++			   MAX96724_POC_IO_EN_VAL);
++	max96724_write_reg(dev, MAX96724_POC_MFP8_ADDR,
++			   MAX96724_POC_MFP8_PRE);
++	msleep(100);
++	max96724_write_reg(dev, MAX96724_POC_MFP8_ADDR,
++			   MAX96724_POC_MFP8_HIGH);
++	msleep(500);
++}
++
++/*
++ * max96724_power_on - Power on the MAX96724 deserializer
++ */
++int max96724_power_on(struct device *dev)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++	int err = 0;
++
++	mutex_lock(&priv->lock);
++	if (priv->pw_ref == 0) {
++		usleep_range(1, 2);
++		if (gpio_is_valid(priv->reset_gpio))
++			gpio_set_value(priv->reset_gpio, 0);
++
++		usleep_range(30, 50);
++
++		if (priv->vdd_cam_1v2) {
++			err = regulator_enable(priv->vdd_cam_1v2);
++			if (unlikely(err))
++				goto ret;
++		}
++
++		usleep_range(30, 50);
++
++		/* exit reset mode: XCLR */
++		if (gpio_is_valid(priv->reset_gpio)) {
++			gpio_set_value(priv->reset_gpio, 0);
++			usleep_range(30, 50);
++			gpio_set_value(priv->reset_gpio, 1);
++			usleep_range(30, 50);
++		}
++
++		msleep(20);
++	}
++
++	priv->pw_ref++;
++
++ret:
++	mutex_unlock(&priv->lock);
++	return err;
++}
++EXPORT_SYMBOL(max96724_power_on);
++
++void max96724_power_off(struct device *dev)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++
++	mutex_lock(&priv->lock);
++	priv->pw_ref--;
++
++	if (priv->pw_ref < 0)
++		priv->pw_ref = 0;
++
++	if (priv->pw_ref == 0) {
++		usleep_range(1, 2);
++		if (gpio_is_valid(priv->reset_gpio))
++			gpio_set_value(priv->reset_gpio, 0);
++
++		if (priv->vdd_cam_1v2)
++			regulator_disable(priv->vdd_cam_1v2);
++	}
++
++	mutex_unlock(&priv->lock);
++}
++EXPORT_SYMBOL(max96724_power_off);
++
++/* ================================================================
++ * Link Setup
++ * ================================================================ */
++
++/*
++ * max96724_write_link - Configure a specific GMSL link
++ *
++ * [Users Guide, Link Initialization, p11-12]
++ *   Register 0x0006: Link Enable and Mode Select
++ *   Register 0x0010: Link Rate (Links A/B)
++ *
++ * The link speed is DT-configurable via the "gmsl-link-speed" property.
++ */
++static int max96724_write_link(struct device *dev, u32 link)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++	u8 link_rate_ab, link_rate_cd;
++	u8 link_en_val;
++
++	/*
++	 * [Aardvark-verified] Disable CSI output before link configuration
++	 * This prevents glitches on CSI bus during GMSL link setup.
++	 * Re-enabled in max96724_setup_streaming() after full pipeline config.
++	 */
++	max96724_write_reg(dev, MAX96724_BACKTOP_EN_ADDR, 0x00);
++
++	/* [UG Table 3 + Tech Overview REG26]
++	 * Register 0x0010:
++	 *   bits[7:2] = Link rate configuration
++	 *   bits[1:0] = I2C CC pass-through link select
++	 *     10 = route CC via SIOA (Link A)  [tech overview: 0x02 → SIOA]
++	 *     01 = route CC via SIOB (Link B)
++	 *
++	 * For 6G + Link A: bits[7:2]=001000, bits[1:0]=10 → 0x22
++	 * For 6G + Link B: bits[7:2]=001000, bits[1:0]=01 → 0x21
++	 * For 3G + Link A: bits[7:2]=000100, bits[1:0]=10 → 0x12 (? or 0x11)
++	 * For 3G + Link B: bits[7:2]=000100, bits[1:0]=01 → 0x11 (? or 0x09)
++	 */
++	if (priv->link_speed == 6) {
++		if (link == GMSL_SERDES_CSI_LINK_B) {
++			link_rate_ab = 0x21; /* 6G rate + CC via Link B */
++		} else {
++			link_rate_ab = 0x22; /* 6G rate + CC via Link A */
++		}
++		link_rate_cd = 0x22; /* C/D: 6G rate (CC routing don't care) */
++	} else {
++		if (link == GMSL_SERDES_CSI_LINK_B) {
++			link_rate_ab = 0x09; /* 3G rate + CC via Link B */
++		} else {
++			link_rate_ab = 0x12; /* 3G rate + CC via Link A */
++		}
++		link_rate_cd = 0x11; /* C/D: 3G rate */
++	}
++
++	if (link == GMSL_SERDES_CSI_LINK_A) {
++		link_en_val = MAX96724_LINK_EN_SIOA;
++	} else if (link == GMSL_SERDES_CSI_LINK_B) {
++		link_en_val = 0xF2; /* GMSL2 all, enable Link B only */
++	} else {
++		dev_err(dev, "%s: invalid gmsl link\n", __func__);
++		return -EINVAL;
++	}
++
++	/* [UG Table 3] Set link rates + CC routing */
++	max96724_write_reg(dev, MAX96724_LINK_RATE_AB_ADDR, link_rate_ab);
++	max96724_write_reg(dev, MAX96724_LINK_RATE_CD_ADDR, link_rate_cd);
++
++	/*
++	 * [XML-verified sequence] One-shot reset applies rate configuration
++	 * to the link state machine, then link enable starts training.
++	 * XML order: rate → ONE-SHOT → LINK_EN → wait 1000ms.
++	 * Note: Error channel registers omitted (not in reference XML).
++	 */
++	max96724_write_reg(dev, MAX96724_ONESHOT_ADDR,
++			   MAX96724_ONESHOT_ALL);
++	max96724_write_reg(dev, MAX96724_LINK_EN_ADDR, link_en_val);
++
++	/*
++	 * Wait for link lock.
++	 * [XML] Uses 1000ms regardless of link speed.
++	 * I2C pass-through CC requires fully trained link, not just PHY lock.
++	 */
++	msleep(1000);
++
++	/* Check link lock status on ALL ports for diagnostics */
++	{
++		unsigned int lock_a = 0, lock_b = 0, lock_c = 0, lock_d = 0;
++		unsigned int link_en = 0;
++		unsigned int reg10 = 0, reg11 = 0;
++
++		regmap_read(priv->regmap, 0x001A, &lock_a);
++		regmap_read(priv->regmap, 0x001B, &lock_b);
++		regmap_read(priv->regmap, 0x001C, &lock_c);
++		regmap_read(priv->regmap, 0x001D, &lock_d);
++		regmap_read(priv->regmap, MAX96724_LINK_EN_ADDR, &link_en);
++		regmap_read(priv->regmap, 0x0010, &reg10);
++		regmap_read(priv->regmap, 0x0011, &reg11);
++		dev_info(dev,
++			 "GMSL link status: EN=0x%02x A=0x%02x(%s) B=0x%02x(%s) C=0x%02x(%s) D=0x%02x(%s) REG10=0x%02x REG11=0x%02x\n",
++			 link_en,
++			 lock_a, (lock_a & 0x08) ? "LOCK" : "noLk",
++			 lock_b, (lock_b & 0x08) ? "LOCK" : "noLk",
++			 lock_c, (lock_c & 0x08) ? "LOCK" : "noLk",
++			 lock_d, (lock_d & 0x08) ? "LOCK" : "noLk",
++			 reg10, reg11);
++	}
++
++	return 0;
++}
++
++int max96724_setup_link(struct device *dev, struct device *s_dev)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++	int err = 0;
++	unsigned int i = 0;
++
++	err = max96724_get_sdev_idx(dev, s_dev, &i);
++	if (err)
++		return err;
++
++	/*
++	 * [FG24-4CH] Enable board POC / MFP8 output path BEFORE the GMSL
++	 * link is brought up.  The camera draws power over coax (PoC), so
++	 * without this the remote camera never powers on and the link can
++	 * never lock.  NOTE: this must live here (a path d5xx actually
++	 * invokes via dser_ops->setup_link) and NOT in max96724_power_on(),
++	 * which ds5_gmsl_serdes_setup() deliberately skips.  Run once.
++	 */
++	if (!priv->poc_enabled) {
++		max96724_board_poc_enable(dev);
++		priv->poc_enabled = true;
++	}
++
++	mutex_lock(&priv->lock);
++
++	if (!priv->splitter_enabled) {
++		err = max96724_write_link(dev,
++					  priv->sources[i].g_ctx->serdes_csi_link);
++		if (err)
++			goto ret;
++
++		priv->link_setup = true;
++	}
++
++ret:
++	mutex_unlock(&priv->lock);
++	return err;
++}
++EXPORT_SYMBOL(max96724_setup_link);
++
++/* ================================================================
++ * Control Setup
++ * ================================================================ */
++
++/*
++ * max96724_setup_control - Configure deserializer control pipeline
++ *
++ * Enables splitter mode when multiple sources are present,
++ * configures tunnel mode on all active pipes, and sets up
++ * the MIPI CSI-2 output.
++ */
++int max96724_setup_control(struct device *dev, struct device *s_dev)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++	int err = 0;
++	unsigned int i = 0;
++
++	static const u16 tun_en_addrs[] = {
++		MAX96724_PIPE0_TUN_EN_ADDR,
++		MAX96724_PIPE1_TUN_EN_ADDR,
++		MAX96724_PIPE2_TUN_EN_ADDR,
++		MAX96724_PIPE3_TUN_EN_ADDR,
++	};
++
++	static const u16 tun_dest_addrs[] = {
++		MAX96724_PIPE0_TUN_DEST_ADDR,
++		MAX96724_PIPE1_TUN_DEST_ADDR,
++		MAX96724_PIPE2_TUN_DEST_ADDR,
++		MAX96724_PIPE3_TUN_DEST_ADDR,
++	};
++
++	err = max96724_get_sdev_idx(dev, s_dev, &i);
++	if (err)
++		return err;
++
++	mutex_lock(&priv->lock);
++
++	if (!priv->link_setup) {
++		dev_err(dev, "%s: invalid state\n", __func__);
++		err = -EINVAL;
++		goto error;
++	}
++
++	if (priv->sources[i].g_ctx->serdev_found) {
++		priv->num_src_found++;
++		priv->src_link = priv->sources[i].g_ctx->serdes_csi_link;
++	}
++
++	/* Enable splitter mode for multi-camera configurations */
++	if ((priv->max_src > 1U) &&
++	    (priv->num_src_found > 0U) &&
++	    (priv->splitter_enabled == false)) {
++		/*
++		 * [UG Table 3] Multi-camera: set link rates and enable all links
++		 */
++		u8 link_rate = (priv->link_speed == 6) ? 0x22 : 0x11;
++
++		max96724_write_reg(dev, MAX96724_LINK_RATE_AB_ADDR,
++				   link_rate);
++		max96724_write_reg(dev, MAX96724_LINK_RATE_CD_ADDR,
++				   link_rate);
++		max96724_write_reg(dev, MAX96724_LINK_EN_ADDR,
++				   MAX96724_LINK_EN_ALL);
++
++		/* [Errata #5] For 6Gbps: force Error Channel power-up */
++		if (priv->link_speed == 6) {
++			max96724_write_reg(dev, MAX96724_ERRCH_A_ADDR,
++					   MAX96724_ERRCH_FORCE_ON);
++			max96724_write_reg(dev, MAX96724_ERRCH_B_ADDR,
++					   MAX96724_ERRCH_FORCE_ON);
++			max96724_write_reg(dev, MAX96724_ERRCH_C_ADDR,
++					   MAX96724_ERRCH_FORCE_ON);
++			max96724_write_reg(dev, MAX96724_ERRCH_D_ADDR,
++					   MAX96724_ERRCH_FORCE_ON);
++		}
++
++		priv->splitter_enabled = true;
++
++		msleep(100);
++	}
++
++	if (max96724_is_pixel_mode(priv)) {
++		for (i = 0; i < MAX96724_MAX_PIPES; i++) {
++			max96724_write_reg(dev, tun_en_addrs[i],
++					   MAX96724_TUN_DISABLED);
++		}
++		max96724_write_reg(dev, MAX96724_MIPI_CTRL_SEL_ADDR,
++				   MAX96724_MIPI_CTRL_SEL_PIXEL);
++		max96724_write_reg(dev, MAX96724_ONESHOT_ADDR,
++				   MAX96724_ONESHOT_ALL);
++		priv->sdev_ref++;
++		goto maybe_reset_splitter;
++	}
++
++	/*
++	 * [SC20190112] Enable tunnel mode and route to Controller 1.
++	 *   - TUN_EN   (0x0936): 0x01 (TUN_EN=1)
++	 *   - TUN_DEST (0x0939): 0x10 = Controller 1
++	 *   CSI_OUT_CFG=0x04 (2x4 mode): Controller 1 -> PHY0+1 -> Port A -> Orin
++	 */
++	{
++		for (i = 0; i < MAX96724_MAX_PIPES; i++) {
++			max96724_write_reg(dev, tun_en_addrs[i],
++					   MAX96724_TUN_EN);
++			max96724_write_reg(dev, tun_dest_addrs[i],
++					   MAX96724_TUN_DEST_CTRL1);
++		}
++	}
++
++	/*
++	 * [Errata #2] Tunnel Mode SRAM LCRC: disable ERRB for SRAM LCRC
++	 * errors in tunnel mode when frame/line counters are non-zero.
++	 * This prevents spurious ERRB assertions (no video corruption).
++	 */
++	max96724_write_reg(dev, MAX96724_SRAM_LCRC_ERR_ADDR, 0x00);
++
++	max96724_write_reg(dev, MAX96724_ONESHOT_ADDR,
++			   MAX96724_ONESHOT_ALL);
++
++	priv->sdev_ref++;
++
++maybe_reset_splitter:
++
++	/* Reset splitter mode if not all devices found */
++	if ((priv->sdev_ref == priv->max_src) &&
++	    (priv->splitter_enabled == true) &&
++	    (priv->num_src_found > 0U) &&
++	    (priv->num_src_found < priv->max_src)) {
++		err = max96724_write_link(dev, priv->src_link);
++		if (err)
++			goto error;
++
++		priv->splitter_enabled = false;
++	}
++
++error:
++	mutex_unlock(&priv->lock);
++	return err;
++}
++EXPORT_SYMBOL(max96724_setup_control);
++
++int max96724_reset_control(struct device *dev, struct device *s_dev)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++	int err = 0;
++
++	mutex_lock(&priv->lock);
++	if (!priv->sdev_ref) {
++		dev_info(dev, "%s: dev is already in reset state\n", __func__);
++		goto ret;
++	}
++
++	priv->sdev_ref--;
++	if (priv->sdev_ref == 0) {
++		max96724_reset_ctx(priv);
++		max96724_write_reg(dev, MAX96724_REG13_ADDR,
++				   MAX96724_SOFT_RESET);
++
++		msleep(100);
++	}
++
++ret:
++	mutex_unlock(&priv->lock);
++	return err;
++}
++EXPORT_SYMBOL(max96724_reset_control);
++
++/* ================================================================
++ * Device Registration
++ * ================================================================ */
++
++int max96724_sdev_register(struct device *dev, struct gmsl_link_ctx *g_ctx)
++{
++	struct max96724 *priv = NULL;
++	unsigned int i;
++	int err = 0;
++
++	if (!dev || !g_ctx || !g_ctx->s_dev) {
++		dev_err(dev, "%s: invalid input params\n", __func__);
++		return -EINVAL;
++	}
++
++	priv = dev_get_drvdata(dev);
++
++	mutex_lock(&priv->lock);
++
++	if (priv->num_src > priv->max_src) {
++		dev_err(dev,
++			"%s: MAX96724 inputs size exhausted\n", __func__);
++		err = -ENOMEM;
++		goto error;
++	}
++
++	if (priv->csi_mode == MAX96724_CSI_MODE_2X4) {
++		if (!((g_ctx->csi_mode == GMSL_CSI_1X4_MODE) ||
++		      (g_ctx->csi_mode == GMSL_CSI_2X4_MODE))) {
++			dev_err(dev, "%s: csi mode not supported\n", __func__);
++			err = -EINVAL;
++			goto error;
++		}
++	} else {
++		dev_err(dev, "%s: only csi 2x4 mode is supported\n", __func__);
++		err = -EINVAL;
++		goto error;
++	}
++
++	for (i = 0; i < priv->num_src; i++) {
++		if (g_ctx->serdes_csi_link ==
++		    priv->sources[i].g_ctx->serdes_csi_link) {
++			dev_err(dev,
++				"%s: serdes csi link is in use\n", __func__);
++			err = -EINVAL;
++			goto error;
++		}
++		if (g_ctx->num_csi_lanes !=
++		    priv->sources[i].g_ctx->num_csi_lanes) {
++			dev_err(dev,
++				"%s: csi num lanes mismatch\n", __func__);
++			err = -EINVAL;
++			goto error;
++		}
++	}
++
++	priv->sources[priv->num_src].g_ctx = g_ctx;
++	priv->sources[priv->num_src].st_enabled = false;
++
++	priv->num_src++;
++
++error:
++	mutex_unlock(&priv->lock);
++	return err;
++}
++EXPORT_SYMBOL(max96724_sdev_register);
++
++int max96724_sdev_unregister(struct device *dev, struct device *s_dev)
++{
++	struct max96724 *priv = NULL;
++	int err = 0;
++	unsigned int i = 0;
++
++	if (!dev || !s_dev) {
++		dev_err(dev, "%s: invalid input params\n", __func__);
++		return -EINVAL;
++	}
++
++	priv = dev_get_drvdata(dev);
++	mutex_lock(&priv->lock);
++
++	if (priv->num_src == 0) {
++		dev_err(dev, "%s: no source found\n", __func__);
++		err = -ENODATA;
++		goto error;
++	}
++
++	for (i = 0; i < priv->num_src; i++) {
++		if (s_dev == priv->sources[i].g_ctx->s_dev) {
++			priv->sources[i].g_ctx = NULL;
++			break;
++		}
++	}
++
++	if (i == priv->num_src) {
++		dev_err(dev,
++			"%s: requested device not found\n", __func__);
++		err = -EINVAL;
++		goto error;
++	}
++	priv->num_src--;
++
++error:
++	mutex_unlock(&priv->lock);
++	return err;
++}
++EXPORT_SYMBOL(max96724_sdev_unregister);
++
++/* ================================================================
++ * Streaming Setup
++ * ================================================================ */
++
++/*
++ * max96724_setup_streaming - Configure CSI-2 output pipeline
++ *
++ * In Tunnel Mode, the MAX96724 outputs the reconstructed CSI-2 stream
++ * with all VCs and DTs preserved from the serializer.
++ *
++ * The pipeline configuration:
++ *   1. Configure pipe-to-link routing
++ *   2. Enable tunnel mode on active pipes
++ *   3. Configure MIPI CSI-2 output lanes and PHY
++ *   4. Enable BACKTOP output port
++ *
++ */
++int max96724_setup_streaming(struct device *dev, struct device *s_dev)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++	struct gmsl_link_ctx *g_ctx;
++	int err = 0;
++	unsigned int i = 0;
++	unsigned int src_idx;
++	u8 vid_rx0_cfg;
++	u8 vid_rx6_cfg;
++	u8 st_sel_cfg;
++	u8 pipe_sel0;
++	u8 pipe_sel1;
++	u8 dpll_cfg;
++
++	err = max96724_get_sdev_idx(dev, s_dev, &i);
++	if (err)
++		return err;
++
++	mutex_lock(&priv->lock);
++
++	dev_info(dev, "=== setup_streaming ENTER src=%u st_enabled=%d ===\n",
++		 i, priv->sources[i].st_enabled);
++
++	if (priv->sources[i].st_enabled)
++		goto ret;
++
++	src_idx = i;
++	g_ctx = priv->sources[src_idx].g_ctx;
++	if (max96724_is_pixel_mode(priv)) {
++		pipe_sel0 = MAX96724_PIPE_SEL0_PIXEL;
++		pipe_sel1 = MAX96724_PIPE_SEL1_PIXEL;
++		vid_rx0_cfg = MAX96724_VID_RX0_PIXEL_VAL;
++		vid_rx6_cfg = MAX96724_VID_RX6_PIXEL_VAL;
++		st_sel_cfg = 0x00;
++		dpll_cfg = MAX96724_DPLL_1300MBPS;
++	} else {
++		pipe_sel0 = MAX96724_PIPE_SEL0_PIXEL;
++		pipe_sel1 = MAX96724_PIPE_SEL1_PIXEL;
++		vid_rx0_cfg = MAX96724_VID_RX0_CFG_VAL;
++		vid_rx6_cfg = MAX96724_VID_RX6_CFG_VAL;
++		st_sel_cfg = 0x10;
++		dpll_cfg = MAX96724_DPLL_1300MBPS;
++	}
++
++	/*
++	 * Pipe source routing
++	 * Single cam: all pipes from Link A (0x22/0x22)
++	 * Disable pipes before configuration, enable at the end
++	 */
++	max96724_write_reg(dev, MAX96724_PIPE_SEL0_ADDR, pipe_sel0);
++	max96724_write_reg(dev, MAX96724_PIPE_SEL1_ADDR, pipe_sel1);
++	/* Disable all pipes during configuration */
++	max96724_write_reg(dev, MAX96724_PIPE_EN_ADDR, 0x00);
++
++	/*
++	 * Keep 0x08 mode so PHY1 remains the Port A clock master,
++	 * but restore the live 2-lane subset used by the bridge board.
++	 */
++	max96724_apply_porta_subset(dev, priv);
++
++	/*
++	 * CSI-output DPLL data rate = 1300 Mbps
++	 * on ALL FOUR controller freq registers
++	 */
++	if (!priv->lane_setup) {
++		max96724_write_reg(dev, MAX96724_DPLL_FREQ0_ADDR,
++				   dpll_cfg);
++		max96724_write_reg(dev, MAX96724_DPLL_FREQ1_ADDR,
++				   dpll_cfg);
++		max96724_write_reg(dev, MAX96724_DPLL_FREQ2_ADDR,
++				   dpll_cfg);
++		max96724_write_reg(dev, MAX96724_DPLL_FREQ3_ADDR,
++				   dpll_cfg);
++
++		priv->lane_setup = true;
++	}
++
++	max96724_write_reg(dev, MAX96724_MIPI_CTRL_SEL_ADDR,
++			   MAX96724_MIPI_CTRL_SEL_PIXEL);
++
++	/*
++	 * Stream ID select for all pipes
++	 * 0x0933 + 0x40*pipe = stream select register
++	 * Value 0x10 selects the appropriate stream for tunnel mode
++	 */
++	for (i = 0; i < MAX96724_MAX_PIPES; i++) {
++		max96724_write_reg(dev,
++				   MAX96724_PIPE_X_ST_SEL_ADDR + (0x40 * i),
++				   st_sel_cfg);
++	}
++
++	/* 
++	 * BACKTOP: enable Controller 1 / CSI-B (0x02).
++	 * In 2x4 mode, Controller 1 is master for Port A -> Orin CSI.
++	 */
++	max96724_write_reg(dev, MAX96724_BACKTOP_EN_ADDR,
++			   MAX96724_BACKTOP_CSIB_EN);
++
++	dev_info(dev, "=== setup_streaming: writing 0x84 (force all MIPI clocks) ===\n");
++
++	/*
++	 * Assert 0x08A0=0x84 LAST: 2x4 mode + bit[7] "force all MIPI clocks running".  
++	 * The clock-force keeps the D-PHY clock lane continuous so the Orin CIL can lock;
++	 * written only after the full pipeline is configured.
++	 */
++	max96724_write_reg(dev, MAX96724_CSI_OUT_CFG_ADDR,
++			   MAX96724_CSI_OUT_EN_VAL);
++
++	/* Keep all video receivers aligned with serializer heartbeat mode. */
++	for (i = 0; i < MAX96724_MAX_PIPES; i++) {
++		max96724_write_reg(dev,
++				   MAX96724_VID_RX0_P0_ADDR +
++				   (MAX96724_VID_RX_STRIDE * i),
++				   vid_rx0_cfg);
++		max96724_write_reg(dev,
++				   MAX96724_VID_RX6_P0_ADDR +
++				   (MAX96724_VID_RX_STRIDE * i),
++				   vid_rx6_cfg);
++		if (max96724_is_pixel_mode(priv)) {
++			max96724_write_reg(dev,
++					   MAX96724_PIPE0_TUN_EN_ADDR + (0x40 * i),
++					   MAX96724_TUN_DISABLED);
++		}
++	}
++
++	max96724_write_reg(dev, MAX96724_ONESHOT_ADDR,
++			   MAX96724_ONESHOT_ALL);
++
++	/* Enable all 4 pipes */
++	max96724_write_reg(dev, MAX96724_PIPE_EN_ADDR, MAX96724_PIPE_EN_4);
++
++	priv->sources[src_idx].st_enabled = true;
++
++ret:
++	mutex_unlock(&priv->lock);
++	return err;
++}
++EXPORT_SYMBOL(max96724_setup_streaming);
++
++/* ================================================================
++ * Start / Stop Streaming
++ * ================================================================ */
++
++int max96724_start_streaming(struct device *dev, struct device *s_dev)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++	struct gmsl_link_ctx *g_ctx;
++	struct gmsl_stream *g_stream;
++	int err = 0;
++	unsigned int i = 0;
++
++	err = max96724_get_sdev_idx(dev, s_dev, &i);
++	if (err)
++		return err;
++
++	mutex_lock(&priv->lock);
++	g_ctx = priv->sources[i].g_ctx;
++
++	for (i = 0; i < g_ctx->num_streams; i++) {
++		g_stream = &g_ctx->streams[i];
++
++		if (g_stream->des_pipe != MAX96724_PIPE_INVALID)
++			max96724_write_reg(dev, g_stream->des_pipe,
++					   g_stream->st_id_sel);
++	}
++	mutex_unlock(&priv->lock);
++
++	return 0;
++}
++EXPORT_SYMBOL(max96724_start_streaming);
++
++int max96724_stop_streaming(struct device *dev, struct device *s_dev)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++	struct gmsl_link_ctx *g_ctx;
++	struct gmsl_stream *g_stream;
++	int err = 0;
++	unsigned int i = 0;
++
++	err = max96724_get_sdev_idx(dev, s_dev, &i);
++	if (err)
++		return err;
++
++	mutex_lock(&priv->lock);
++	g_ctx = priv->sources[i].g_ctx;
++
++	for (i = 0; i < g_ctx->num_streams; i++) {
++		g_stream = &g_ctx->streams[i];
++
++		if (g_stream->des_pipe != MAX96724_PIPE_INVALID)
++			max96724_write_reg(dev, g_stream->des_pipe,
++					   MAX96724_RESET_ST_ID);
++	}
++
++	mutex_unlock(&priv->lock);
++
++	return 0;
++}
++EXPORT_SYMBOL(max96724_stop_streaming);
++
++/* ================================================================
++ * Pipe Management
++ * ================================================================ */
++
++int max96724_get_available_pipe_id(struct device *dev, int vc_id)
++{
++	int i;
++	int pipe_id = -ENOMEM;
++	struct max96724 *priv = dev_get_drvdata(dev);
++
++	mutex_lock(&priv->lock);
++	for (i = 0; i < MAX96724_MAX_PIPES; i++) {
++		if (i == vc_id && !priv->pipe[i].st_count) {
++			priv->pipe[i].st_count++;
++			pipe_id = i;
++			break;
++		}
++	}
++	mutex_unlock(&priv->lock);
++
++	return pipe_id;
++}
++EXPORT_SYMBOL(max96724_get_available_pipe_id);
++
++int max96724_release_pipe(struct device *dev, int pipe_id)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++
++	if (pipe_id < 0 || pipe_id >= MAX96724_MAX_PIPES)
++		return -EINVAL;
++
++	mutex_lock(&priv->lock);
++	priv->pipe[pipe_id].st_count = 0;
++	mutex_unlock(&priv->lock);
++
++	return 0;
++}
++EXPORT_SYMBOL(max96724_release_pipe);
++
++int max96724_get_ser_pipe_id(struct device *dev, int dser_pipe_id, int vc_id)
++{
++	/* In Tunnel Mode with MAX96717, all VCs are carried in a single tunnel pipe. */
++	return dser_pipe_id;
++}
++EXPORT_SYMBOL(max96724_get_ser_pipe_id);
++
++void max96724_reset_oneshot(struct device *dev)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++	unsigned int i;
++	u8 pipe_sel0;
++	u8 pipe_sel1;
++	u8 vid_rx0_cfg;
++	u8 vid_rx6_cfg;
++	u8 st_sel_cfg;
++	u8 dpll_cfg;
++
++	mutex_lock(&priv->lock);
++	if (priv->splitter_enabled) {
++		/* Multi-camera: reset all links */
++		u8 link_rate = (priv->link_speed == 6) ? 0x22 : 0x11;
++
++		max96724_write_reg(dev, MAX96724_LINK_RATE_AB_ADDR,
++				   link_rate);
++		max96724_write_reg(dev, MAX96724_LINK_RATE_CD_ADDR,
++				   link_rate);
++		max96724_write_reg(dev, MAX96724_LINK_EN_ADDR,
++				   MAX96724_LINK_EN_ALL);
++	} else {
++		max96724_write_reg(dev, MAX96724_ONESHOT_ADDR,
++				   MAX96724_ONESHOT_ALL);
++	}
++	msleep(100);
++
++	if (max96724_is_pixel_mode(priv)) {
++		pipe_sel0 = MAX96724_PIPE_SEL0_PIXEL;
++		pipe_sel1 = MAX96724_PIPE_SEL1_PIXEL;
++		vid_rx0_cfg = MAX96724_VID_RX0_PIXEL_VAL;
++		vid_rx6_cfg = MAX96724_VID_RX6_PIXEL_VAL;
++		st_sel_cfg = 0x00;
++		dpll_cfg = MAX96724_DPLL_1300MBPS;
++	} else {
++		pipe_sel0 = MAX96724_PIPE_SEL0_PIXEL;
++		pipe_sel1 = MAX96724_PIPE_SEL1_PIXEL;
++		vid_rx0_cfg = MAX96724_VID_RX0_CFG_VAL;
++		vid_rx6_cfg = MAX96724_VID_RX6_CFG_VAL;
++		st_sel_cfg = 0x10;
++		dpll_cfg = MAX96724_DPLL_1300MBPS;
++	}
++
++	/* 
++	 * ONESHOT resets CSI/tunnel state. Restore the full pipeline config.
++	 * Mirror setup_streaming() order: disable pipes -> restore everything ->
++	 * BACKTOP/0x84 -> VID_RX -> final ONESHOT to latch -> enable pipes.
++	 */
++	max96724_write_reg(dev, MAX96724_PIPE_EN_ADDR, 0x00);
++
++	/* Pipe source routing: all pipes from Link A */
++	max96724_write_reg(dev, MAX96724_PIPE_SEL0_ADDR, pipe_sel0);
++	max96724_write_reg(dev, MAX96724_PIPE_SEL1_ADDR, pipe_sel1);
++
++	max96724_apply_porta_subset(dev, priv);
++
++	/*
++	 * CSI-output DPLL data rate = 1300 Mbps on ALL
++	 * FOUR controllers, matching the device-tree serdes_pix_clk_hz (325 MHz).
++	 * reset_oneshot is called by the sensor after setup_streaming, so it must
++	 * mirror the same DPLL values.
++	 */
++	max96724_write_reg(dev, MAX96724_DPLL_FREQ0_ADDR,
++			   dpll_cfg);
++	max96724_write_reg(dev, MAX96724_DPLL_FREQ1_ADDR,
++			   dpll_cfg);
++	max96724_write_reg(dev, MAX96724_DPLL_FREQ2_ADDR,
++			   dpll_cfg);
++	max96724_write_reg(dev, MAX96724_DPLL_FREQ3_ADDR,
++			   dpll_cfg);
++
++	max96724_write_reg(dev, MAX96724_MIPI_CTRL_SEL_ADDR,
++			   MAX96724_MIPI_CTRL_SEL_PIXEL);
++
++	max96724_write_reg(dev, MAX96724_BACKTOP_EN_ADDR,
++			   MAX96724_BACKTOP_CSIB_EN);
++	for (i = 0; i < MAX96724_MAX_PIPES; i++) {
++		max96724_write_reg(dev,
++				   MAX96724_PIPE_X_ST_SEL_ADDR + (0x40 * i),
++				   st_sel_cfg);
++		max96724_write_reg(dev,
++				   MAX96724_VID_RX0_P0_ADDR +
++				   (MAX96724_VID_RX_STRIDE * i),
++				   vid_rx0_cfg);
++		max96724_write_reg(dev,
++				   MAX96724_VID_RX6_P0_ADDR +
++				   (MAX96724_VID_RX_STRIDE * i),
++				   vid_rx6_cfg);
++		max96724_write_reg(dev,
++				   MAX96724_TX49_PIPE_X_ADDR + (0x40 * i),
++				   0x00);
++	}
++	if (max96724_is_pixel_mode(priv)) {
++		max96724_write_reg(dev, MAX96724_PIPE0_TUN_EN_ADDR, MAX96724_TUN_DISABLED);
++		max96724_write_reg(dev, MAX96724_PIPE1_TUN_EN_ADDR, MAX96724_TUN_DISABLED);
++		max96724_write_reg(dev, MAX96724_PIPE2_TUN_EN_ADDR, MAX96724_TUN_DISABLED);
++		max96724_write_reg(dev, MAX96724_PIPE3_TUN_EN_ADDR, MAX96724_TUN_DISABLED);
++	} else {
++		/* Re-enable tunnel on all pipes (ONESHOT resets TUN_EN to 0x08=disabled) */
++		max96724_write_reg(dev, MAX96724_PIPE0_TUN_EN_ADDR, MAX96724_TUN_EN);
++		max96724_write_reg(dev, MAX96724_PIPE1_TUN_EN_ADDR, MAX96724_TUN_EN);
++		max96724_write_reg(dev, MAX96724_PIPE2_TUN_EN_ADDR, MAX96724_TUN_EN);
++		max96724_write_reg(dev, MAX96724_PIPE3_TUN_EN_ADDR, MAX96724_TUN_EN);
++		/* TUN_DEST: set to Controller 1 (0x10) = Port A master in 2x4 mode */
++		max96724_write_reg(dev, MAX96724_PIPE0_TUN_DEST_ADDR,
++				   MAX96724_TUN_DEST_CTRL1);
++		max96724_write_reg(dev, MAX96724_PIPE1_TUN_DEST_ADDR,
++				   MAX96724_TUN_DEST_CTRL1);
++		max96724_write_reg(dev, MAX96724_PIPE2_TUN_DEST_ADDR,
++				   MAX96724_TUN_DEST_CTRL1);
++		max96724_write_reg(dev, MAX96724_PIPE3_TUN_DEST_ADDR,
++				   MAX96724_TUN_DEST_CTRL1);
++	}
++	max96724_write_reg(dev, MAX96724_PIPE_EN_ADDR,
++			   MAX96724_PIPE_EN_4);
++
++	/*
++	 * Assert 0x08A0=0x84 LAST:
++	 * 2x4 mode + bit[7] force all MIPI clocks running.  Must mirror
++	 * setup_streaming because the sensor's oneshot path overwrites it.
++	 */
++	max96724_write_reg(dev, MAX96724_CSI_OUT_CFG_ADDR,
++			   MAX96724_CSI_OUT_EN_VAL);
++
++	msleep(200);
++	mutex_unlock(&priv->lock);
++}
++EXPORT_SYMBOL(max96724_reset_oneshot);
++
++/* ================================================================
++ * Init Settings / Set Pipe
++ * ================================================================ */
++
++/*
++ * __max96724_set_pipe - Configure per-pipe mapping registers
++ */
++static int __max96724_set_pipe(struct device *dev, int pipe_id,
++			       u8 data_type1, u8 data_type2, u32 vc_id)
++{
++	int err = 0;
++	int i;
++	u8 en_mapping_num = 0x0F;
++	u8 all_mapping_phy = MAX96724_ALL_MAP_CTRL1;  /* Controller 1 = Port A master (2x4 mode) */
++	struct max96724 *priv = dev_get_drvdata(dev);
++
++	struct reg_pair map_pipe_control[] = {
++		/* Enable 4 mappings for Pipe X */
++		{MAX96724_TX11_PIPE_X_EN_ADDR, 0x0F},
++		/* Map data_type1 on vc_id */
++		{MAX96724_PIPE_X_SRC_0_MAP_ADDR, 0x1E},
++		{MAX96724_PIPE_X_DST_0_MAP_ADDR, 0x1E},
++		/* Map frame start on vc_id */
++		{MAX96724_PIPE_X_SRC_1_MAP_ADDR, 0x00},
++		{MAX96724_PIPE_X_DST_1_MAP_ADDR, 0x00},
++		/* Map frame end on vc_id */
++		{MAX96724_PIPE_X_SRC_2_MAP_ADDR, 0x01},
++		{MAX96724_PIPE_X_DST_2_MAP_ADDR, 0x01},
++		/* Map data_type2 on vc_id */
++		{MAX96724_PIPE_X_SRC_3_MAP_ADDR, 0x12},
++		{MAX96724_PIPE_X_DST_3_MAP_ADDR, 0x12},
++		/* All mappings to Controller 1 (2x4 mode: Ctrl1 drives Port A) */
++		{MAX96724_TX45_PIPE_X_DST_CTRL_ADDR, MAX96724_ALL_MAP_CTRL1},
++		{MAX96724_TX46_PIPE_X_ADDR, MAX96724_ALL_MAP_CTRL1},
++		{MAX96724_TX47_PIPE_X_ADDR, MAX96724_ALL_MAP_CTRL1},
++		{MAX96724_TX48_PIPE_X_ADDR, MAX96724_ALL_MAP_CTRL1},
++		/* TX49: concat disabled */
++		{MAX96724_TX49_PIPE_X_ADDR, 0x00},
++		/*
++		 * Keep DES heartbeat handling aligned with the serializer's
++		 * LIM_HEART-disabled tunnel mode to avoid persistent VID_SEQ_ERR.
++		 */
++		{0x0100, MAX96724_VID_RX0_CFG_VAL},
++		{0x0106, MAX96724_VID_RX6_CFG_VAL},
++		/*
++		 * Pipe stream control (offset 0x36 per pipe block).
++		 * TUN_EN = 0x01.
++		 */
++		{0x0936, MAX96724_TUN_EN},
++	};
++
++	/* 
++	 * Adjust addresses for pipe offset (stride 0x40 per pipe)
++	 * Entries 0-13: TX11, SRC/DST maps, TX45-TX49 (all stride 0x40)
++	 * Entries 14-15: VID_RX0/6 (stride 0x12)
++	 * Entry 16: Pipe stream control (stride 0x40)
++	 */
++	for (i = 0; i < 14; i++)
++		map_pipe_control[i].addr += 0x40 * pipe_id;
++
++	/* VID_RX offset: 0x12 per pipe */
++	map_pipe_control[14].addr += 0x12 * pipe_id;
++	map_pipe_control[15].addr += 0x12 * pipe_id;
++
++	/* Pipe stream control: stride 0x40 */
++	map_pipe_control[16].addr += 0x40 * pipe_id;
++
++	if (data_type2 == 0x0) {
++		en_mapping_num = 0x07;
++		all_mapping_phy = MAX96724_MAP3_CTRL1;
++	}
++
++	if (max96724_is_pixel_mode(priv)) {
++		map_pipe_control[10].val = 0x00;
++		map_pipe_control[11].val = 0x00;
++		map_pipe_control[12].val = 0x00;
++		map_pipe_control[13].val = 0x00;
++		map_pipe_control[14].val = MAX96724_VID_RX0_PIXEL_VAL;
++		map_pipe_control[15].val = MAX96724_VID_RX6_PIXEL_VAL;
++		map_pipe_control[16].val = MAX96724_TUN_DISABLED;
++	} else {
++		/* no concatenation needed */
++		map_pipe_control[13].val = 0x00;
++	}
++
++	map_pipe_control[0].val = en_mapping_num;
++	/* SRC: match incoming VC from camera (vc_id) */
++	map_pipe_control[1].val = (vc_id << 6) | data_type1;
++	/* DST: preserve VC — NVCSI/VI endpoints expect matching vc-id */
++	map_pipe_control[2].val = (vc_id << 6) | data_type1;
++	map_pipe_control[3].val = (vc_id << 6) | 0x00;
++	map_pipe_control[4].val = (vc_id << 6) | 0x00;
++	map_pipe_control[5].val = (vc_id << 6) | 0x01;
++	map_pipe_control[6].val = (vc_id << 6) | 0x01;
++	map_pipe_control[7].val = (vc_id << 6) | data_type2;
++	map_pipe_control[8].val = (vc_id << 6) | data_type2;
++	map_pipe_control[9].val = all_mapping_phy;
++	/* TX46-TX48 keep 0x55 (Ctrl1) from initializer */
++	/* TX49 set to 0x00 above — overridden per mode in pixel/tunnel branch */
++	/* VID_RX and pipe stream ctrl keep init values */
++
++	err = max96724_set_registers(dev, map_pipe_control,
++				     ARRAY_SIZE(map_pipe_control));
++
++	return err;
++}
++
++/*
++ * max96724_init_settings - Initialize default pipe and tunnel configuration
++ *
++ * Sets up all 4 pipes with default YUV422_8 + EMBED for VC0-3,
++ * matching the d4xx framework expectations.
++ *
++ */
++int max96724_init_settings(struct device *dev)
++{
++	int err = 0;
++	int i;
++	struct max96724 *priv = dev_get_drvdata(dev);
++
++	mutex_lock(&priv->lock);
++
++	for (i = 0; i < MAX96724_MAX_PIPES; i++)
++		err |= __max96724_set_pipe(dev, i, GMSL_CSI_DT_YUV422_8,
++					   GMSL_CSI_DT_EMBED, i);
++
++	mutex_unlock(&priv->lock);
++
++	return err;
++}
++EXPORT_SYMBOL(max96724_init_settings);
++
++int max96724_bind_ser_to_dser_pipe(struct device *dev, int dser_pipe_id,
++				   int ser_pipe_id, u32 vc_id)
++{
++	/* In Tunnel Mode, pipe mapping is 1:1 (each camera → one pipe) */
++	return 0;
++}
++EXPORT_SYMBOL(max96724_bind_ser_to_dser_pipe);
++
++int max96724_set_pipe(struct device *dev, int pipe_id,
++		      u8 data_type1, u8 data_type2, u32 vc_id)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++	int err = 0;
++
++	if (pipe_id > (MAX96724_MAX_PIPES - 1)) {
++		dev_info(dev, "%s: input pipe_id: %d exceeds max96724 max pipes\n",
++			 __func__, pipe_id);
++		return -EINVAL;
++	}
++
++	dev_dbg(dev, "%s pipe_id %d, data_type1 %u, data_type2 %u, vc_id %u\n",
++		__func__, pipe_id, data_type1, data_type2, vc_id);
++
++	mutex_lock(&priv->lock);
++
++	err = __max96724_set_pipe(dev, pipe_id, data_type1, data_type2, vc_id);
++
++	mutex_unlock(&priv->lock);
++
++	return err;
++}
++EXPORT_SYMBOL(max96724_set_pipe);
++
++/* ================================================================
++ * Device Tree Parsing
++ * ================================================================ */
++
++static const struct of_device_id max96724_of_match[] = {
++	{ .compatible = "adi,max96724", },
++	{ },
++};
++MODULE_DEVICE_TABLE(of, max96724_of_match);
++
++static int max96724_parse_dt(struct max96724 *priv,
++			     struct i2c_client *client)
++{
++	struct device_node *node = client->dev.of_node;
++	int err = 0;
++	const char *str_value;
++	int value;
++	const struct of_device_id *match;
++
++	if (!node)
++		return -EINVAL;
++
++	match = of_match_device(max96724_of_match, &client->dev);
++	if (!match) {
++		dev_err(&client->dev, "Failed to find matching dt id\n");
++		return -EFAULT;
++	}
++
++	/* CSI mode: "2x4" or "4x2" */
++	err = of_property_read_string(node, "csi-mode", &str_value);
++	if (err < 0) {
++		dev_err(&client->dev, "csi-mode property not found\n");
++		return err;
++	}
++
++	if (!strcmp(str_value, "2x4")) {
++		priv->csi_mode = MAX96724_CSI_MODE_2X4;
++		priv->lane_mp1 = MAX96724_LANE_MAP1_2X4;
++		priv->lane_mp2 = MAX96724_LANE_MAP2_2X4;
++	} else {
++		dev_err(&client->dev, "invalid csi mode\n");
++		return -EINVAL;
++	}
++
++	/* Max sources */
++	err = of_property_read_u32(node, "max-src", &value);
++	if (err < 0) {
++		dev_err(&client->dev, "No max-src info\n");
++		return err;
++	}
++	priv->max_src = value;
++
++	/* Reset GPIO */
++	priv->reset_gpio = of_get_named_gpio(node, "reset-gpios", 0);
++	if (priv->reset_gpio < 0) {
++		dev_info(&client->dev,
++			 "reset-gpios not found, continuing without external reset\n");
++		priv->reset_gpio = -1;
++	}
++
++	/* GMSL link speed from DT: 3 or 6 (Gbps) */
++	err = of_property_read_u32(node, "gmsl-link-speed", &value);
++	if (err < 0) {
++		/* Default to 3 Gbps if not specified */
++		priv->link_speed = 3;
++		dev_info(&client->dev,
++			 "gmsl-link-speed not specified, defaulting to 3 Gbps\n");
++	} else {
++		if (value != 3 && value != 6) {
++			dev_err(&client->dev,
++				"invalid gmsl-link-speed %d (must be 3 or 6)\n",
++				value);
++			return -EINVAL;
++		}
++		priv->link_speed = value;
++	}
++
++	priv->pixel_mode = of_property_read_bool(node, "adi,pixel-mode");
++
++	/* 1.2V regulator (optional) */
++	if (of_get_property(node, "vdd_cam_1v2-supply", NULL)) {
++		priv->vdd_cam_1v2 = regulator_get(&client->dev, "vdd_cam_1v2");
++		if (IS_ERR(priv->vdd_cam_1v2)) {
++			dev_err(&client->dev,
++				"vdd_cam_1v2 regulator get failed\n");
++			err = PTR_ERR(priv->vdd_cam_1v2);
++			priv->vdd_cam_1v2 = NULL;
++			return err;
++		}
++	} else {
++		priv->vdd_cam_1v2 = NULL;
++	}
++
++	return 0;
++}
++
++/* ================================================================
++ * Probe / Remove
++ * ================================================================ */
++
++static struct regmap_config max96724_regmap_config = {
++	.reg_bits = 16,
++	.val_bits = 8,
++	.cache_type = REGCACHE_NONE,
++};
++
++static int max96724_probe(struct i2c_client *client,
++			   const struct i2c_device_id *id)
++{
++	struct max96724 *priv;
++	int err = 0;
++
++	dev_info(&client->dev,
++		 "[MAX96724]: probing Quad GMSL2 Deserializer (Tunnel Mode)\n");
++
++	priv = devm_kzalloc(&client->dev, sizeof(*priv), GFP_KERNEL);
++	if (!priv)
++		return -ENOMEM;
++
++	priv->i2c_client = client;
++	priv->regmap = devm_regmap_init_i2c(priv->i2c_client,
++					     &max96724_regmap_config);
++	if (IS_ERR(priv->regmap)) {
++		dev_err(&client->dev,
++			"regmap init failed: %ld\n", PTR_ERR(priv->regmap));
++		return -ENODEV;
++	}
++
++	err = max96724_parse_dt(priv, client);
++	if (err) {
++		dev_err(&client->dev, "unable to parse dt\n");
++		return -EFAULT;
++	}
++
++	max96724_pipes_reset(priv);
++
++	if (priv->max_src > MAX96724_MAX_SOURCES) {
++		dev_err(&client->dev,
++			"max sources more than currently supported\n");
++		return -EINVAL;
++	}
++
++	mutex_init(&priv->lock);
++
++	dev_set_drvdata(&client->dev, priv);
++
++	dev_info(&client->dev, "%s: success (link_speed=%d Gbps, max_src=%d)\n",
++		 __func__, priv->link_speed, priv->max_src);
++
++	return err;
++}
++
++static int max96724_remove(struct i2c_client *client)
++{
++	struct max96724 *priv;
++
++	if (client != NULL) {
++		priv = dev_get_drvdata(&client->dev);
++		mutex_destroy(&priv->lock);
++		i2c_unregister_device(client);
++		client = NULL;
++	}
++
++	return 0;
++}
++
++static const struct i2c_device_id max96724_id[] = {
++	{ "max96724", 0 },
++	{ },
++};
++
++MODULE_DEVICE_TABLE(i2c, max96724_id);
++
++static struct i2c_driver max96724_i2c_driver = {
++	.driver = {
++		.name = "max96724",
++		.owner = THIS_MODULE,
++		.of_match_table = of_match_ptr(max96724_of_match),
++	},
++	.probe = max96724_probe,
++	.remove = max96724_remove,
++	.id_table = max96724_id,
++};
++
++static int __init max96724_init(void)
++{
++	return i2c_add_driver(&max96724_i2c_driver);
++}
++
++static void __exit max96724_exit(void)
++{
++	i2c_del_driver(&max96724_i2c_driver);
++}
++
++module_init(max96724_init);
++module_exit(max96724_exit);
++
++MODULE_DESCRIPTION("Quad GMSL2 Deserializer driver max96724 (Tunnel Mode)");
++MODULE_AUTHOR("RealSense AI");
++MODULE_LICENSE("GPL v2");
+diff --git a/include/media/max96717.h b/include/media/max96717.h
+new file mode 100644
+index 0000000..65bf930
+--- /dev/null
++++ b/include/media/max96717.h
+@@ -0,0 +1,151 @@
++/*
++ * max96717.c - MAX96717 GMSL2 Serializer driver (Tunnel Mode)
++ *
++ * Copyright (c) 2026, RealSense, Inc.  All rights reserved.
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms and conditions of the GNU General Public License,
++ * version 2, as published by the Free Software Foundation.
++ *
++ * This program is distributed in the hope it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
++ * more details.
++ *
++ * You should have received a copy of the GNU General Public License
++ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
++ */
++
++/**
++ * @file
++ * <b>MAX96717 API: For Analog Devices MAX96717 GMSL2 serializer</b>
++ *
++ * @b Description: Defines elements used to set up and use an
++ *  Analog Devices MAX96717 GMSL2 serializer in Tunnel Mode.
++ */
++
++#ifndef __MAX96717_H__
++#define __MAX96717_H__
++
++#include <linux/types.h>
++#include <media/gmsl-link.h>
++
++/**
++ * \defgroup max96717 MAX96717 serializer driver
++ *
++ * Controls the MAX96717 GMSL2 serializer module (Tunnel Mode).
++ *
++ * @ingroup serdes_group
++ * @{
++ */
++
++/**
++ * @brief  Configures a single pipe on the serializer.
++ *
++ * In Tunnel Mode, per-pipe DT/VC filtering is not active on the serializer
++ * side (all VCs are tunneled transparently). This function maintains API
++ * compatibility with the d4xx sensor driver framework.
++ *
++ * @param  [in]  dev          The serializer device handle.
++ * @param  [in]  pipe_id      Pipe index (0..3).
++ * @param  [in]  data_type1   Primary CSI-2 data type.
++ * @param  [in]  data_type2   Secondary CSI-2 data type (e.g. embedded).
++ * @param  [in]  vc_id        Virtual channel ID.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96717_set_pipe(struct device *dev, int pipe_id, u8 data_type1,
++		      u8 data_type2, u32 vc_id);
++
++/**
++ * @brief  Toggle SER TX to restore tunnel detection after DES ONESHOT.
++ *
++ * A DES ONESHOT resets the video data path. The serializer must cycle
++ * its TX enable (REG2 0x03→0x43) for the deserializer to re-acquire
++ * the tunnel stream.
++ *
++ * @param  [in]  dev          The serializer device handle.
++ */
++void max96717_retrigger_tx(struct device *dev);
++
++/**
++ * @brief  Powers on the serializer and performs I2C overrides
++ * for sensor and serializer devices.
++ *
++ * Must be called after the deserializer's max96724_setup_link().
++ *
++ * @param  [in]  dev          The serializer device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96717_setup_control(struct device *dev);
++
++/**
++ * @brief  Reverts I2C overrides and resets the serializer.
++ *
++ * @param  [in]  dev          The serializer device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96717_reset_control(struct device *dev);
++
++/**
++ * @brief  Pairs a sensor device with the serializer.
++ *
++ * To be called by the sensor client driver.
++ *
++ * @param  [in]  dev          The serializer device handle.
++ * @param  [in]  g_ctx        The gmsl_link_ctx structure handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96717_sdev_pair(struct device *dev, struct gmsl_link_ctx *g_ctx);
++
++/**
++ * @brief  Unpairs a sensor device from the serializer.
++ *
++ * @param  [in]  dev          The serializer device handle.
++ * @param  [in]  s_dev        The sensor device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96717_sdev_unpair(struct device *dev, struct device *s_dev);
++
++/**
++ * @brief  Sets up the serializer's internal streaming pipeline.
++ *
++ * Configures CSI-2 input mode, lane mapping, and enables Tunnel Mode
++ * (EXT11[7]=1 at register 0x0383).
++ *
++ * @param  [in]  dev          The serializer device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96717_setup_streaming(struct device *dev);
++
++/**
++ * @brief  Applies initial register settings for the serializer.
++ *
++ * Configures default pipe settings and Tunnel Mode registers.
++ *
++ * @param  [in]  dev          The serializer device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96717_init_settings(struct device *dev);
++
++/**
++ * @brief  No-op hook for GPIO-over-GMSL tunneling for FSIN/FOUT signals.
++ *
++ * The signal map is documented, but the concrete MFP_CFG values are
++ * not available yet. This hook currently logs and returns success.
++ *
++ * @param  [in]  dev          The serializer device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96717_setup_gpio_tunneling(struct device *dev);
++
++/** @} */
++
++#endif  /* __MAX96717_H__ */
+diff --git a/include/media/max96724.h b/include/media/max96724.h
+new file mode 100644
+index 0000000..dc5a8ea
+--- /dev/null
++++ b/include/media/max96724.h
+@@ -0,0 +1,183 @@
++/*
++ * max96717.c - MAX96717 GMSL2 Serializer driver (Tunnel Mode)
++ *
++ * Copyright (c) 2026, RealSense, Inc.  All rights reserved.
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms and conditions of the GNU General Public License,
++ * version 2, as published by the Free Software Foundation.
++ *
++ * This program is distributed in the hope it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
++ * more details.
++ *
++ * You should have received a copy of the GNU General Public License
++ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
++ */
++
++/**
++ * @file
++ * <b>MAX96724 API: For Analog Devices MAX96724 GMSL2 quad deserializer</b>
++ *
++ * @b Description: Defines elements used to set up and use an
++ *  Analog Devices MAX96724 quad GMSL2 deserializer in Tunnel Mode.
++ */
++
++#ifndef __MAX96724_H__
++#define __MAX96724_H__
++
++#include <linux/types.h>
++#include <media/gmsl-link.h>
++
++/**
++ * \defgroup max96724 MAX96724 deserializer driver
++ *
++ * Controls the MAX96724 quad GMSL2 deserializer module (Tunnel Mode).
++ *
++ * @ingroup serdes_group
++ * @{
++ */
++
++int max96724_get_available_pipe_id(struct device *dev, int vc_id);
++int max96724_get_ser_pipe_id(struct device *dev, int dser_pipe_id, int vc_id);
++int max96724_set_pipe(struct device *dev, int pipe_id, u8 data_type1,
++		      u8 data_type2, u32 vc_id);
++int max96724_release_pipe(struct device *dev, int pipe_id);
++void max96724_reset_oneshot(struct device *dev);
++
++/**
++ * @brief  Puts the deserializer in single exclusive link mode.
++ *
++ * @param  [in]  dev          The deserializer device handle.
++ * @param  [in]  s_dev        The sensor device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96724_setup_link(struct device *dev, struct device *s_dev);
++
++/**
++ * @brief  Sets up the deserializer link's control pipeline.
++ *
++ * Configures I2C pass-through, splitter mode if needed, and
++ * enables the tunnel mode pipe routing for the source.
++ *
++ * @param  [in]  dev          The deserializer device handle.
++ * @param  [in]  s_dev        The sensor device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96724_setup_control(struct device *dev, struct device *s_dev);
++
++/**
++ * @brief  Resets the deserializer link control pipeline.
++ *
++ * @param  [in]  dev          The deserializer device handle.
++ * @param  [in]  s_dev        The sensor device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96724_reset_control(struct device *dev, struct device *s_dev);
++
++/**
++ * @brief  Registers a source sensor device with the deserializer.
++ *
++ * @param  [in]  dev          The deserializer device handle.
++ * @param  [in]  g_ctx        The gmsl_link_ctx structure handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96724_sdev_register(struct device *dev, struct gmsl_link_ctx *g_ctx);
++
++/**
++ * @brief  Unregisters a source sensor device from the deserializer.
++ *
++ * @param  [in]  dev          The deserializer device handle.
++ * @param  [in]  s_dev        The sensor device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96724_sdev_unregister(struct device *dev, struct device *s_dev);
++
++/**
++ * @brief  Configures the internal streaming pipeline.
++ *
++ * Sets up tunnel mode pipe routing, CSI-2 output lane configuration,
++ * and MIPI PHY settings.
++ *
++ * @param  [in]  dev          The deserializer device handle.
++ * @param  [in]  s_dev        The sensor device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96724_setup_streaming(struct device *dev, struct device *s_dev);
++
++/**
++ * @brief  Enables streaming for a source sensor.
++ *
++ * @param  [in]  dev          The deserializer device handle.
++ * @param  [in]  s_dev        The sensor device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96724_start_streaming(struct device *dev, struct device *s_dev);
++
++/**
++ * @brief  Disables streaming for a source sensor.
++ *
++ * @param  [in]  dev          The deserializer device handle.
++ * @param  [in]  s_dev        The sensor device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96724_stop_streaming(struct device *dev, struct device *s_dev);
++
++/**
++ * @brief  Powers on the MAX96724 deserializer module.
++ *
++ * Asserts shared reset GPIO and powers on the regulator.
++ *
++ * @param  [in]  dev          The deserializer device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96724_power_on(struct device *dev);
++
++/**
++ * @brief  Powers off the MAX96724 deserializer module.
++ *
++ * @param  [in]  dev          The deserializer device handle.
++ */
++void max96724_power_off(struct device *dev);
++
++/**
++ * @brief  Applies initial register settings for the deserializer.
++ *
++ * Configures default pipe mappings, tunnel mode, and CSI output for
++ * the D5xx/SC1.2 use case.
++ *
++ * @param  [in]  dev          The deserializer device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96724_init_settings(struct device *dev);
++
++/**
++ * @brief  Maps deserializer pipe ID to serializer pipe ID.
++ *
++ * In tunnel mode with MAX96717, all data flows through a single pipe
++ * per camera, so the mapping is 1:1.
++ *
++ * @param  [in]  dev             The deserializer device handle.
++ * @param  [in]  dser_pipe_id    Deserializer pipe ID.
++ * @param  [in]  ser_pipe_id     Serializer pipe ID.
++ * @param  [in]  vc_id           VC ID associated with this pipe.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96724_bind_ser_to_dser_pipe(struct device *dev, int dser_pipe_id,
++				   int ser_pipe_id, u32 vc_id);
++
++/** @} */
++
++#endif  /* __MAX96724_H__ */
+-- 
+2.25.1
+

--- a/nvidia-oot/6.1/0011-Add-MAX96717-serializer-and-MAX96724-deserializer-dr.patch
+++ b/nvidia-oot/6.1/0011-Add-MAX96717-serializer-and-MAX96724-deserializer-dr.patch
@@ -1,0 +1,3147 @@
+From 40fac9b67ddea60055961d32fa89fe8f608396ff Mon Sep 17 00:00:00 2001
+From: RealSense AI <realsense@realsenseai.com>
+Date: Tue, 12 May 2026 17:06:23 +0800
+Subject: [PATCH] Add MAX96717 serializer and MAX96724 deserializer drivers for
+ tunnel mode
+
+Add MAX96717 GMSL2 serializer and MAX96724 GMSL2 quad deserializer
+drivers for Tunnel Mode operation with D5xx cameras.
+
+MAX96717 serializer features:
+- CSI-2 input with 2/4 lane support
+- Tunnel Mode encapsulation of full CSI-2 byte stream
+- I2C address translation for sensor passthrough
+- GPIO-over-GMSL tunneling hook for FSIN/FOUT signals
+
+MAX96724 quad deserializer features:
+- Up to 4 GMSL2 links (quad camera support)
+- Configurable link speed (3 Gbps / 6 Gbps via DT)
+- Tunnel Mode pipe routing and CSI-2 output
+- 2x4 and 4x2 CSI output mode support
+- Power management with GPIO reset and regulator control
+
+Signed-off-by: RealSense AI <realsense@realsenseai.com>
+---
+ drivers/media/i2c/Makefile   |    2 +
+ drivers/media/i2c/max96717.c |  835 ++++++++++++++
+ drivers/media/i2c/max96724.c | 1916 ++++++++++++++++++++++++++++++++++
+ include/media/max96717.h     |  151 ++
+ include/media/max96724.h     |  183 +++
+ 4 files changed, 3085 insertions(+)
+ create mode 100644 drivers/media/i2c/max96717.c
+ create mode 100644 drivers/media/i2c/max96724.c
+ create mode 100644 include/media/max96717.h
+ create mode 100644 include/media/max96724.h
+
+diff --git a/drivers/media/i2c/max96717.c b/drivers/media/i2c/max96717.c
+new file mode 100644
+index 0000000..70d25a3
+--- /dev/null
++++ b/drivers/media/i2c/max96717.c
+@@ -0,0 +1,835 @@
++/*
++ * max96717.c - MAX96717 GMSL2 Serializer driver (Tunnel Mode)
++ *
++ * Copyright (c) 2026, RealSense, Inc.  All rights reserved.
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms and conditions of the GNU General Public License,
++ * version 2, as published by the Free Software Foundation.
++ *
++ * This program is distributed in the hope it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
++ * more details.
++ *
++ * You should have received a copy of the GNU General Public License
++ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
++ */
++
++#include <media/camera_common.h>
++#include <linux/of.h>
++#include <linux/module.h>
++#include <media/max96717.h>
++
++/* ===== Register Addresses ===== */
++
++/* REG0: Device ID (read-only, returns 0x40) */
++#define MAX96717_DEV_ADDR		0x00
++
++/* 
++ *   REG1: Link Speed
++ *   bit[3]=1: 3 Gbps, bit[4]=1: 6 Gbps
++ */
++#define MAX96717_REG1_ADDR		0x01
++
++/* 
++ *   PIPE_EN: Pipe enable / soft reset
++ *   0x03 = soft reset, 0x43 = pipes enabled + video init
++ *   Matches MAX9295 PIPE_EN at 0x02
++ */
++#define MAX96717_PIPE_EN_ADDR		0x02
++
++/* 
++ *   CTRL0: GMSL2 TX Control
++ *   bit[5]=1: GMSL2 mode, bit[0]=1: enable transmitter
++ *   0x21 = GMSL2 mode + TX enable on Link A
++ */
++#define MAX96717_CTRL0_ADDR		0x10
++
++/* 
++ *   CTRL3: Start Video - final enable bit
++ *   bit[0]=1: activate video stream
++ */
++#define MAX96717_CTRL3_ADDR		0x13
++
++/* 
++ *   TX1: FEC Enable
++ *   bit[6]=1: Reed-Solomon FEC enabled
++ */
++#define MAX96717_TX1_ADDR		0x29
++
++/*
++ *   MAX96717 I2C address translation registers (GMSL2 standard):
++ *   SRC_A / DST_A (0x42/0x43): Translation pair A (SER broadcast addr)
++ *   SRC_B / DST_B (0x44/0x45): Translation pair B (sensor passthrough)
++ *
++ *   When host writes to SRC_B address, the MAX96717 translates it to
++ *   DST_B and forwards via GMSL back-channel to the remote sensor.
++ *
++ */
++#define MAX96717_SRC_A_ADDR		0x42
++#define MAX96717_DST_A_ADDR		0x43
++#define MAX96717_I2C4_ADDR		0x44
++#define MAX96717_I2C5_ADDR		0x45
++
++/* 
++ *   TX_STR_SEL: Stream ID select
++ *   bits[1:0]: stream ID for DES pipe routing
++ */
++#define MAX96717_TX_STR_SEL_ADDR	0x5B
++
++/* 
++ *   VIDEO_TX0/TX1: Video TX path config
++ *   0x0110=0xE9, 0x0111=0x10 for tunnel mode data path
++ */
++#define MAX96717_VIDEO_TX0_ADDR		0x110
++#define MAX96717_VIDEO_TX1_ADDR		0x111
++
++/* 
++ *   FRONTTOP_0: Front-end topology
++ *   0x12 = single CSI-2 port A, all VCs pass through
++ */
++#define MAX96717_FRONTTOP0_ADDR		0x308
++
++/* 
++ *   MIPI_RX0-RX3: CSI-2 receiver configuration
++ *   RX0 (0x330): CSI mode (0x00 = D-PHY controller A)
++ *   RX1 (0x331): Lane count - ctrl1_num_lanes bits[5:4]
++ *                0x30 = bits[5:4]=11 (4 lanes)
++ *   RX2 (0x332): Lane mapping - 0xE0 = default 1x4 map
++ *   RX3 (0x333): Lane mapping - 0x04 = default 1x4 map
++ */
++#define MAX96717_MIPI_RX0_ADDR		0x330
++#define MAX96717_MIPI_RX1_ADDR		0x331
++#define MAX96717_MIPI_RX2_ADDR		0x332
++#define MAX96717_MIPI_RX3_ADDR		0x333
++
++/* 
++ *   EXT11: TUNNEL MODE ENABLE
++ *   bit[7]=1: Tun_Mode = ON
++ *   0x383 = 0x80
++ */
++#define MAX96717_EXT11_ADDR		0x383
++
++/* PHY calibration stage-1 value */
++#define MAX96717_PHY_CAL_STAGE1		0x80
++/* PHY calibration stage-2 value */
++#define MAX96717_PHY_CAL_STAGE2		0x90
++/* CSI input timing / frequency config */
++#define MAX96717_CSI_TIMING_3F0		0x59
++#define MAX96717_CSI_TIMING_3F1		0x09
++
++/* ===== Register Values ===== */
++
++/* Soft reset value for PIPE_EN register */
++#define MAX96717_SOFT_RESET		0x03
++
++/* Final enable: pipes enabled + video init */
++#define MAX96717_PIPE_EN_ALL		0x43
++
++/* CTRL0: GMSL2 mode + TX enable (Link A) */
++#define MAX96717_CTRL0_LINK_A		0x21
++/* CTRL0: GMSL2 mode + TX enable (Link B) */
++#define MAX96717_CTRL0_LINK_B		0x22
++
++/* CTRL0 reset all */
++#define MAX96717_RESET_ALL		0x80
++
++/* EXT11 tunnel mode enable value */
++#define MAX96717_TUN_MODE_EN		0x80
++#define MAX96717_TUN_MODE_DIS		0x00
++
++/* VIDEO_TX0 tunnel mode data path enable */
++#define MAX96717_VIDEO_TX0_TUN		0xE9
++/* VIDEO_TX1 tunnel mode config */
++#define MAX96717_VIDEO_TX1_TUN		0x10
++#define MAX96717_VIDEO_TX0_BPP_MANUAL	0x60
++#define MAX96717_VIDEO_TX1_BPP16	0x50
++#define MAX96717_VIDEO_TX2_ADDR		0x112
++#define MAX96717_VIDEO_TX2_DRIFT_DIS	0x08
++
++/* 
++ *   MIPI RX1: 4-lane CSI-2.
++ *   bits[5:4]=11 (4 lanes).  bits[1:0]=11
++ */
++#define MAX96717_CSI_4_LANES		0x33
++/* 2-lane CSI-2, bits[5:4]=01 */
++#define MAX96717_CSI_2_LANES		0x10
++
++/* Lane mapping for 1x4 mode */
++#define MAX96717_CSI_1X4_LANE_MAP1	0xE0
++#define MAX96717_CSI_1X4_LANE_MAP2	0x04
++
++/* FRONTTOP_0: single port A, all VCs */
++#define MAX96717_FRONTTOP0_PORT_A	0x12
++/* Pixel mode from Port B into Pipe Z */
++#define MAX96717_FRONTTOP0_PIXEL_PORT_B	0x64
++#define MAX96717_FRONTTOP5_ADDR		0x30D
++#define MAX96717_FRONTTOP9_ADDR		0x311
++#define MAX96717_FRONTTOP16_ADDR	0x318
++#define MAX96717_FRONTTOP17_ADDR	0x319
++#define MAX96717_FRONTTOP9_START_VIDEO	0x40
++
++/* MIPI_RX0: CSI reset on + non-continuous clock */
++#define MAX96717_MIPI_RX0_RESET		0x08
++/* MIPI_RX0: Normal operation */
++#define MAX96717_MIPI_RX0_NORMAL	0x00
++
++/* REG1: 3 Gbps link speed, bit[3]=1 */
++#define MAX96717_LINK_SPEED_3GBPS	0x08
++/* REG1: 6 Gbps link speed, bit[4]=1 */
++#define MAX96717_LINK_SPEED_6GBPS	0x10
++
++/* EXT11 tunnel mode pre-config (0x0383=0x80) */
++#define MAX96717_EXT11_TUN_PRE		0x80
++
++#define MAX96717_MAX_PIPES		4
++
++/*
++ * MFP8 (GPIO8) high-impedance release.
++ *
++ * At power-up GPIO8 comes up with GPIO_OUT_DIS=0 (output driver enabled,
++ * GPIO8_A=0x9c observed live), so the serializer actively drives the M2_I2C
++ * line and wedges the bus: any IMU I2C access by the camera FW times out
++ * whenever the serializer is powered.  This was confirmed on hardware -
++ * tri-stating GPIO8 alone immediately restored IMU I2C reads.
++ *
++ * GPIO8 is the ONLY serializer pin left driving its net (all other GPIOs,
++ * including MFP3/MFP4 interrupt lines, are already high-Z).  Release GPIO8
++ * (output driver off, no link TX/RX, no pull) so only the M2_I2C bus
++ * masters own the line.
++ *
++ * GPIO_n registers are a 3-byte group (A/B/C) starting at 0x02BE:
++ *   GPIO_n_A = 0x02BE + 3*n
++ */
++#define MAX96717_GPIO8_A_ADDR		0x02D6	/* MFP8 / M2_I2C (pass-through SCL1) */
++#define MAX96717_GPIO8_B_ADDR		0x02D7
++/* GPIO_A: GPIO_OUT_DIS=1 (high-Z), GPIO_TX_EN=0, GPIO_RX_EN=0 */
++#define MAX96717_GPIO_A_HIGH_Z		0x01
++/* GPIO_B: PULL_UPDN_SEL=None, TX_ID=0 */
++#define MAX96717_GPIO_B_NO_PULL		0x00
++
++/* ===== Data Structures ===== */
++
++struct max96717_client_ctx {
++	struct gmsl_link_ctx *g_ctx;
++	bool st_done;
++};
++
++struct max96717 {
++	struct i2c_client *i2c_client;
++	struct regmap *regmap;
++	struct max96717_client_ctx g_client;
++	struct mutex lock;
++	bool pixel_mode;
++	/* primary serializer properties */
++	__u32 def_addr;
++	__u32 pst2_ref;
++};
++
++static struct max96717 *prim_priv__;
++
++struct reg_pair {
++	u16 addr;
++	u8 val;
++};
++
++/* ===== Low-level I2C ===== */
++
++static int max96717_write_reg(struct device *dev, u16 addr, u8 val)
++{
++	struct max96717 *priv = dev_get_drvdata(dev);
++	int err;
++
++	err = regmap_write(priv->regmap, addr, val);
++	if (err)
++		dev_err(dev, "%s:i2c write failed, 0x%x = %x\n",
++			__func__, addr, val);
++
++	/* delay before next i2c command as required for SERDES link */
++	usleep_range(100, 110);
++
++	return err;
++}
++
++static int max96717_set_registers(struct device *dev, struct reg_pair *map,
++				  u32 count)
++{
++	int err = 0;
++	u32 j;
++
++	for (j = 0; j < count; j++) {
++		err = max96717_write_reg(dev, map[j].addr, map[j].val);
++		if (err)
++			break;
++	}
++
++	return err;
++}
++
++/* ===== Streaming Setup ===== */
++
++/*
++ * max96717_setup_streaming - Configure CSI-2 input and enable Tunnel Mode
++ *
++ * In Tunnel Mode (unlike MAX9295 Pixel Mode), the serializer encapsulates
++ * the entire CSI-2 byte stream verbatim into a single GMSL2 tunnel.
++ * All VCs (VC0-VC3) are preserved end-to-end.
++ */
++int max96717_setup_streaming(struct device *dev)
++{
++	struct max96717 *priv = dev_get_drvdata(dev);
++	int err = 0;
++	struct gmsl_link_ctx *g_ctx;
++
++	mutex_lock(&priv->lock);
++
++	if (!priv->g_client.g_ctx) {
++		dev_err(dev, "%s: no sdev client found\n", __func__);
++		err = -EINVAL;
++		goto error;
++	}
++
++	if (priv->g_client.st_done) {
++		dev_dbg(dev, "%s: stream setup is already done\n", __func__);
++		goto error;
++	}
++
++	g_ctx = priv->g_client.g_ctx;
++
++	max96717_write_reg(dev, MAX96717_EXT11_ADDR, MAX96717_TUN_MODE_EN);
++	max96717_write_reg(dev, MAX96717_MIPI_RX1_ADDR, MAX96717_CSI_4_LANES);
++	max96717_write_reg(dev, MAX96717_MIPI_RX2_ADDR, MAX96717_CSI_1X4_LANE_MAP1);
++	max96717_write_reg(dev, MAX96717_MIPI_RX3_ADDR, MAX96717_CSI_1X4_LANE_MAP2);
++	max96717_write_reg(dev, MAX96717_VIDEO_TX0_ADDR, MAX96717_VIDEO_TX0_TUN);
++	max96717_write_reg(dev, MAX96717_VIDEO_TX1_ADDR, MAX96717_VIDEO_TX1_TUN);
++
++	max96717_write_reg(dev, MAX96717_MIPI_RX0_ADDR, MAX96717_MIPI_RX0_RESET);
++	usleep_range(2000, 2100);
++	max96717_write_reg(dev, MAX96717_MIPI_RX0_ADDR, MAX96717_MIPI_RX0_NORMAL);
++
++	/* pipes on + video init */
++	max96717_write_reg(dev, MAX96717_PIPE_EN_ADDR, MAX96717_PIPE_EN_ALL);
++
++	priv->g_client.st_done = true;
++
++error:
++	mutex_unlock(&priv->lock);
++	return err;
++}
++EXPORT_SYMBOL(max96717_setup_streaming);
++
++/* ===== Control Setup ===== */
++
++/*
++ * max96717_setup_control - Set up I2C address translation and link control
++ *
++ * Steps:
++ *   1. Reassign serializer I2C address via DEV_ADDR (reg 0x00)
++ *   2. Configure GMSL2 link mode via CTRL0 (reg 0x10)
++ *   3. Set I2C address translation for sensor passthrough:
++ *      I2C4/SRC_B (0x44) <- (sdev_reg << 1): proxy addr visible to host
++ *      I2C5/DST_B (0x45) <- (sdev_def << 1): real addr on back-channel
++ *
++ */
++int max96717_setup_control(struct device *dev)
++{
++	struct max96717 *priv = dev_get_drvdata(dev);
++	int err = 0;
++	struct gmsl_link_ctx *g_ctx;
++
++	mutex_lock(&priv->lock);
++
++	if (!priv->g_client.g_ctx) {
++		dev_err(dev, "%s: no sensor dev client found\n", __func__);
++		err = -EINVAL;
++		goto error;
++	}
++
++	g_ctx = priv->g_client.g_ctx;
++
++	if (prim_priv__) {
++		unsigned int dev_id;
++		int probe_ret;
++
++		probe_ret = regmap_read(prim_priv__->regmap,
++					MAX96717_DEV_ADDR, &dev_id);
++		if (probe_ret == 0) {
++			/* Primary address (0x40) still responsive — do reassign */
++			max96717_write_reg(&prim_priv__->i2c_client->dev,
++					   MAX96717_DEV_ADDR,
++					   (g_ctx->ser_reg << 1));
++		} else {
++			dev_info(&prim_priv__->i2c_client->dev,
++				 "%s: SER already reassigned (addr 0x40 NACK), skipping DEV_ADDR write\n",
++				 __func__);
++		}
++	}
++
++	/* CTRL0: GMSL2 mode + TX enable */
++	if (g_ctx->serdes_csi_link == GMSL_SERDES_CSI_LINK_A)
++		err = max96717_write_reg(dev, MAX96717_CTRL0_ADDR,
++					 MAX96717_CTRL0_LINK_A);
++	else
++		err = max96717_write_reg(dev, MAX96717_CTRL0_ADDR,
++					 MAX96717_CTRL0_LINK_B);
++
++	if (err) {
++		dev_err(dev, "%s: ERROR: ser device not found\n", __func__);
++		goto error;
++	}
++
++	/* delay to settle link */
++	msleep(100);
++
++	/*
++	 * I2C address translation for sensor passthrough.
++	 *
++	 * I2C4 / SRC_B (0x44): sensor proxy addr visible to Orin host
++	 * I2C5 / DST_B (0x45): sensor real addr on GMSL back-channel
++	 *
++	 * When host sends I2C to sdev_reg (e.g., 0x1a), the MAX96717
++	 * translates it to sdev_def (e.g., 0x42) and forwards via GMSL
++	 * back-channel to the HKR sensor.
++	 */
++	max96717_write_reg(dev, MAX96717_I2C4_ADDR,
++			   (g_ctx->sdev_reg << 1));
++	max96717_write_reg(dev, MAX96717_I2C5_ADDR,
++			   (g_ctx->sdev_def << 1));
++
++	/* dev addr pass-through ref */
++	if (prim_priv__)
++		prim_priv__->pst2_ref++;
++
++	g_ctx->serdev_found = true;
++
++error:
++	mutex_unlock(&priv->lock);
++	return err;
++}
++EXPORT_SYMBOL(max96717_setup_control);
++
++/* ===== GPIO Tunneling ===== */
++
++/*
++ * max96717_setup_gpio_tunneling - GPIO-over-GMSL no-op hook
++ *
++ *   GPIO Signal Mapping:
++ *   MFP0 → GPIO0: FSIN (DES→SER, frame sync in)
++ *   MFP1 → GPIO1: FOUT/STROBE (SER→DES, frame sync out)
++ *   MFP4 → GPIO4: RESET_N (DES→SER, hard reset)
++ *   MFP5 → GPIO5: IRQ (SER→DES, interrupt request)
++ *   MFP6 → GPIO6: ZV_SYNC (DES→SER, IR stereo sync)
++ *
++ */
++int max96717_setup_gpio_tunneling(struct device *dev)
++{
++	struct max96717 *priv = dev_get_drvdata(dev);
++	int err = 0;
++
++	mutex_lock(&priv->lock);
++
++	dev_info(dev, "%s: GPIO tunneling hook is a no-op; MFP_CFG values are not defined yet\n",
++		 __func__);
++
++	mutex_unlock(&priv->lock);
++
++	return err;
++}
++EXPORT_SYMBOL(max96717_setup_gpio_tunneling);
++
++/* ===== Reset Control ===== */
++
++int max96717_reset_control(struct device *dev)
++{
++	struct max96717 *priv = dev_get_drvdata(dev);
++	int err = 0;
++
++	mutex_lock(&priv->lock);
++	if (!priv->g_client.g_ctx) {
++		dev_err(dev, "%s: no sdev client found\n", __func__);
++		err = -EINVAL;
++		goto error;
++	}
++
++	priv->g_client.st_done = false;
++
++	if (prim_priv__) {
++		prim_priv__->pst2_ref--;
++
++		max96717_write_reg(dev, MAX96717_DEV_ADDR,
++				   (prim_priv__->def_addr << 1));
++		if (prim_priv__->pst2_ref == 0)
++			max96717_write_reg(&prim_priv__->i2c_client->dev,
++					   MAX96717_CTRL0_ADDR,
++					   MAX96717_RESET_ALL);
++	}
++
++error:
++	mutex_unlock(&priv->lock);
++	return err;
++}
++EXPORT_SYMBOL(max96717_reset_control);
++
++/* ===== Device Pairing ===== */
++
++int max96717_sdev_pair(struct device *dev, struct gmsl_link_ctx *g_ctx)
++{
++	struct max96717 *priv;
++	int err = 0;
++
++	if (!dev || !g_ctx || !g_ctx->s_dev) {
++		dev_err(dev, "%s: invalid input params\n", __func__);
++		return -EINVAL;
++	}
++
++	priv = dev_get_drvdata(dev);
++	mutex_lock(&priv->lock);
++	if (priv->g_client.g_ctx) {
++		/* 
++		 * Already paired — tolerate if this is a re-probe of
++		 * the same camera after a failed first attempt.
++		 * Simply overwrite with the new g_ctx.
++		 */
++		dev_warn(dev, "%s: re-pairing (previous probe may have failed)\n",
++			 __func__);
++	}
++
++	priv->g_client.st_done = false;
++	priv->g_client.g_ctx = g_ctx;
++
++	/* mutex_unlock in error path, but we have none — inline the unlock */
++	mutex_unlock(&priv->lock);
++	return err;
++}
++EXPORT_SYMBOL(max96717_sdev_pair);
++
++int max96717_sdev_unpair(struct device *dev, struct device *s_dev)
++{
++	struct max96717 *priv = NULL;
++	int err = 0;
++
++	if (!dev || !s_dev) {
++		dev_err(dev, "%s: invalid input params\n", __func__);
++		return -EINVAL;
++	}
++
++	priv = dev_get_drvdata(dev);
++
++	mutex_lock(&priv->lock);
++
++	if (!priv->g_client.g_ctx) {
++		dev_dbg(dev, "%s: device is not paired\n", __func__);
++		err = 0; /* Not an error — already unpaired */
++		goto error;
++	}
++
++	if (priv->g_client.g_ctx->s_dev != s_dev) {
++		dev_warn(dev, "%s: s_dev mismatch, clearing anyway\n", __func__);
++	}
++
++	priv->g_client.g_ctx = NULL;
++	priv->g_client.st_done = false;
++
++error:
++	mutex_unlock(&priv->lock);
++	return err;
++}
++EXPORT_SYMBOL(max96717_sdev_unpair);
++
++/* ===== Pipe Configuration ===== */
++
++/*
++ * __max96717_set_pipe - Configure a single pipe's DT/VC mapping
++ *
++ * In Tunnel Mode, per-pipe DT/VC filtering is bypassed on the serializer。
++ * However, we still write the registers for d4xx framework compatibility.
++ *
++ */
++static int __max96717_set_pipe(struct device *dev, int pipe_id, u8 data_type1,
++			       u8 data_type2, u32 vc_id)
++{
++	int err = 0;
++	u8 bpp = 0x30;
++	struct max96717 *priv = dev_get_drvdata(dev);
++
++	if (priv->pixel_mode) {
++		struct reg_pair pixel_pipe_control[] = {
++			{MAX96717_FRONTTOP16_ADDR, 0x5E},
++			{MAX96717_FRONTTOP17_ADDR, 0x52},
++			{MAX96717_FRONTTOP5_ADDR, 0x01},
++		};
++
++		pixel_pipe_control[0].val = 0x40 | data_type1;
++		pixel_pipe_control[1].val = data_type2 ? (0x40 | data_type2) : 0x00;
++		pixel_pipe_control[2].val = 1 << vc_id;
++
++		return max96717_set_registers(dev, pixel_pipe_control,
++					     ARRAY_SIZE(pixel_pipe_control));
++	} else {
++		struct reg_pair map_pipe_control[] = {
++			/* Pipe X DT addr + 0x2*pipe_id */
++			{0x0314, 0x5E},  /* data_type1 */
++			{0x0315, 0x52},  /* data_type2 */
++			{0x0309, 0x01},  /* VC select */
++			{0x030A, 0x00},
++			{0x031C, 0x30},  /* BPP */
++			{0x0102, 0x0E},  /* LIM_HEART: Disabled */
++		};
++
++		if (data_type1 == GMSL_CSI_DT_RGB_888)
++			bpp = 0x18;
++
++		map_pipe_control[0].addr += 0x2 * pipe_id;
++		map_pipe_control[1].addr += 0x2 * pipe_id;
++		map_pipe_control[2].addr += 0x2 * pipe_id;
++		map_pipe_control[3].addr += 0x2 * pipe_id;
++		map_pipe_control[4].addr += 0x1 * pipe_id;
++		map_pipe_control[5].addr += 0x8 * pipe_id;
++
++		map_pipe_control[0].val = 0x40 | data_type1;
++		map_pipe_control[1].val = 0x40 | data_type2;
++		if (pipe_id == 0)
++			map_pipe_control[1].val |= 0x80;
++		map_pipe_control[2].val = 1 << vc_id;
++		map_pipe_control[3].val = 0x00;
++		map_pipe_control[4].val = bpp;
++		map_pipe_control[5].val = 0x0E;
++
++		err = max96717_set_registers(dev, map_pipe_control,
++					     ARRAY_SIZE(map_pipe_control));
++	}
++
++	return err;
++}
++
++/*
++ * max96717_init_settings - Initialize default pipe/streaming settings
++ *
++ * In Tunnel Mode, per-pipe DT config is not functionally needed
++ * but we configure pipes for d4xx compatibility.
++ * Default: 4 pipes with YUV422_8 + EMBED, VC0-3.
++ */
++int max96717_init_settings(struct device *dev)
++{
++	int err = 0;
++	int i;
++	struct max96717 *priv = dev_get_drvdata(dev);
++
++	struct reg_pair map_init[] = {
++		/* 
++		 * PIPE_EN soft reset first, then enable tunnel mode.
++		 * Note: FRONTTOP0 is bypassed in tunnel mode (per UG) —
++		 * CSI-2 input goes directly into the tunnel, no port config needed.
++		 */
++		{MAX96717_PIPE_EN_ADDR, MAX96717_SOFT_RESET},
++		{MAX96717_EXT11_ADDR, MAX96717_TUN_MODE_EN},
++		{MAX96717_PIPE_EN_ADDR, MAX96717_PIPE_EN_ALL},
++	};
++	struct reg_pair pixel_init[] = {
++		{MAX96717_PIPE_EN_ADDR, MAX96717_SOFT_RESET},
++		{MAX96717_EXT11_ADDR, MAX96717_TUN_MODE_DIS},
++		{MAX96717_FRONTTOP0_ADDR, MAX96717_FRONTTOP0_PIXEL_PORT_B},
++		{MAX96717_FRONTTOP9_ADDR, MAX96717_FRONTTOP9_START_VIDEO},
++		{MAX96717_VIDEO_TX0_ADDR, MAX96717_VIDEO_TX0_BPP_MANUAL},
++		{MAX96717_VIDEO_TX1_ADDR, MAX96717_VIDEO_TX1_BPP16},
++		{MAX96717_VIDEO_TX2_ADDR, MAX96717_VIDEO_TX2_DRIFT_DIS},
++		{MAX96717_PIPE_EN_ADDR, MAX96717_PIPE_EN_ALL},
++	};
++	/*
++	 * Release MFP8 (GPIO8) before any other config so the serializer
++	 * stops driving the camera-side M2_I2C bus shared with the BMI088
++	 * IMU. Confirmed on HW: tri-stating GPIO8 restores IMU I2C access.
++	 */
++	struct reg_pair gpio_release[] = {
++		{MAX96717_GPIO8_A_ADDR, MAX96717_GPIO_A_HIGH_Z},
++		{MAX96717_GPIO8_B_ADDR, MAX96717_GPIO_B_NO_PULL},
++	};
++
++	mutex_lock(&priv->lock);
++
++	/*
++	 * After CTRL0 + I2C translation writes in
++	 * setup_control, the MAX96717 needs settling time before
++	 * accepting writes to PIPE_EN (0x02) and FRONTTOP registers.
++	 */
++	usleep_range(5000, 6000);
++
++	/*
++	 * Tri-state MFP8 (GPIO8) first to release the camera-side M2_I2C
++	 * bus shared with the BMI088 IMU before configuring the rest of
++	 * the SER.
++	 */
++	err = max96717_set_registers(dev, gpio_release,
++				    ARRAY_SIZE(gpio_release));
++	if (err)
++		dev_warn(dev, "%s: failed to release MFP8 (IMU M2_I2C bus)\n",
++			 __func__);
++
++	if (priv->pixel_mode) {
++		err = max96717_set_registers(dev, pixel_init,
++					 ARRAY_SIZE(pixel_init));
++		err |= __max96717_set_pipe(dev, 0, GMSL_CSI_DT_YUV422_8,
++				   0, 0);
++	} else {
++		err = max96717_set_registers(dev, map_init, ARRAY_SIZE(map_init));
++
++		for (i = 0; i < MAX96717_MAX_PIPES; i++)
++			err |= __max96717_set_pipe(dev, i, GMSL_CSI_DT_YUV422_8,
++					   GMSL_CSI_DT_EMBED, i);
++	}
++
++	mutex_unlock(&priv->lock);
++
++	return err;
++}
++EXPORT_SYMBOL(max96717_init_settings);
++
++int max96717_set_pipe(struct device *dev, int pipe_id,
++		      u8 data_type1, u8 data_type2, u32 vc_id)
++{
++	struct max96717 *priv = dev_get_drvdata(dev);
++	int err = 0;
++
++	if (pipe_id > (MAX96717_MAX_PIPES - 1)) {
++		dev_info(dev, "%s: input pipe_id: %d exceeds max96717 max pipes\n",
++			 __func__, pipe_id);
++		return -EINVAL;
++	}
++
++	dev_dbg(dev, "%s pipe_id %d, data_type1 %u, data_type2 %u, vc_id %u\n",
++		__func__, pipe_id, data_type1, data_type2, vc_id);
++
++	mutex_lock(&priv->lock);
++
++	err = __max96717_set_pipe(dev, pipe_id, data_type1, data_type2, vc_id);
++
++	mutex_unlock(&priv->lock);
++
++	return err;
++}
++EXPORT_SYMBOL(max96717_set_pipe);
++
++/*
++ * max96717_retrigger_tx - Toggle SER TX to restore tunnel detection after
++ * a DES ONESHOT.  DES ONESHOT resets the data path; the SER must cycle
++ * its TX enable for the DES to re-acquire the tunnel stream.
++ */
++void max96717_retrigger_tx(struct device *dev)
++{
++	max96717_write_reg(dev, MAX96717_PIPE_EN_ADDR, MAX96717_SOFT_RESET);
++	msleep(30);
++	max96717_write_reg(dev, MAX96717_PIPE_EN_ADDR, MAX96717_PIPE_EN_ALL);
++}
++EXPORT_SYMBOL(max96717_retrigger_tx);
++
++/* ===== Probe / Remove ===== */
++
++static struct regmap_config max96717_regmap_config = {
++	.reg_bits = 16,
++	.val_bits = 8,
++	.cache_type = REGCACHE_RBTREE,
++};
++
++static int max96717_probe(struct i2c_client *client,
++			   const struct i2c_device_id *id)
++{
++	struct max96717 *priv;
++	int err = 0;
++	struct device_node *node = client->dev.of_node;
++
++	dev_info(&client->dev, "[MAX96717]: probing GMSL2 Serializer (Tunnel Mode)\n");
++
++	priv = devm_kzalloc(&client->dev, sizeof(*priv), GFP_KERNEL);
++	if (!priv)
++		return -ENOMEM;
++
++	priv->i2c_client = client;
++	priv->regmap = devm_regmap_init_i2c(priv->i2c_client,
++					     &max96717_regmap_config);
++	if (IS_ERR(priv->regmap)) {
++		dev_err(&client->dev,
++			"regmap init failed: %ld\n", PTR_ERR(priv->regmap));
++		return -ENODEV;
++	}
++
++	mutex_init(&priv->lock);
++	priv->pixel_mode = of_property_read_bool(node, "adi,pixel-mode");
++
++	if (of_get_property(node, "is-prim-ser", NULL)) {
++		if (prim_priv__) {
++			dev_err(&client->dev,
++				"prim-ser already exists\n");
++			return -EEXIST;
++		}
++
++		err = of_property_read_u32(node, "reg", &priv->def_addr);
++		if (err < 0) {
++			dev_err(&client->dev, "reg not found\n");
++			return -EINVAL;
++		}
++
++		prim_priv__ = priv;
++	}
++
++	dev_set_drvdata(&client->dev, priv);
++
++	dev_info(&client->dev, "%s: success\n", __func__);
++
++	return err;
++}
++
++static int max96717_remove(struct i2c_client *client)
++{
++	struct max96717 *priv;
++
++	if (client != NULL) {
++		priv = dev_get_drvdata(&client->dev);
++		mutex_destroy(&priv->lock);
++		i2c_unregister_device(client);
++		client = NULL;
++	}
++
++	return 0;
++}
++
++static const struct i2c_device_id max96717_id[] = {
++	{ "max96717", 0 },
++	{ },
++};
++
++static const struct of_device_id max96717_of_match[] = {
++	{ .compatible = "adi,max96717", },
++	{ .compatible = "maxim,max96717", },
++	{ },
++};
++MODULE_DEVICE_TABLE(of, max96717_of_match);
++MODULE_DEVICE_TABLE(i2c, max96717_id);
++
++static struct i2c_driver max96717_i2c_driver = {
++	.driver = {
++		.name = "max96717",
++		.owner = THIS_MODULE,
++		.of_match_table = of_match_ptr(max96717_of_match),
++	},
++	.probe = max96717_probe,
++	.remove = max96717_remove,
++	.id_table = max96717_id,
++};
++
++static int __init max96717_init(void)
++{
++	return i2c_add_driver(&max96717_i2c_driver);
++}
++
++static void __exit max96717_exit(void)
++{
++	i2c_del_driver(&max96717_i2c_driver);
++}
++
++module_init(max96717_init);
++module_exit(max96717_exit);
++
++MODULE_DESCRIPTION("GMSL2 Serializer driver max96717 (Tunnel Mode)");
++MODULE_AUTHOR("RealSense AI");
++MODULE_LICENSE("GPL v2");
+diff --git a/drivers/media/i2c/max96724.c b/drivers/media/i2c/max96724.c
+new file mode 100644
+index 0000000..22bfb47
+--- /dev/null
++++ b/drivers/media/i2c/max96724.c
+@@ -0,0 +1,1916 @@
++/*
++ * max96724.c - MAX96724 GMSL2 Quad Deserializer driver (Tunnel Mode)
++ *
++ * Copyright (c) 2026, RealSense, Inc.  All rights reserved.
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms and conditions of the GNU General Public License,
++ * version 2, as published by the Free Software Foundation.
++ *
++ * This program is distributed in the hope it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
++ * more details.
++ *
++ * You should have received a copy of the GNU General Public License
++ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
++ */
++
++
++#include <linux/gpio.h>
++#include <linux/types.h>
++#include <linux/module.h>
++#include <linux/of.h>
++#include <linux/of_device.h>
++#include <linux/of_gpio.h>
++#include <media/camera_common.h>
++#include <linux/module.h>
++#include <media/max96724.h>
++
++/* ================================================================
++ * Register Addresses
++ * ================================================================ */
++
++/* --- Device ID / Configuration --- */
++
++/* REG0: Device ID (read-only, returns 0xA2) */
++#define MAX96724_DEV_ID_ADDR		0x00
++
++/* ERRB master reset register */
++#define MAX96724_ERRB_MST_RST_ADDR	0x05
++
++/* 
++ *   GMSL Link/PHY Enable and Mode Select
++ *   bits[7:4]: PHY mode (0=GMSL1, 1=GMSL2) per link D/C/B/A
++ *   bits[3:0]: Link Enable per link D/C/B/A
++ */
++#define MAX96724_LINK_EN_ADDR		0x0006
++
++/* 
++ *   GMSL Link/PHY Rate Select (Links A&B)
++ *   bits[7:6]: Tx Rate Link B, bits[5:4]: Rx Rate Link B
++ *   bits[3:2]: Tx Rate Link A, bits[1:0]: Rx Rate Link A
++ *   Tx: 00=187.5Mbps, Rx: 01=3Gbps, 10=6Gbps
++ */
++#define MAX96724_LINK_RATE_AB_ADDR	0x0010
++
++/* GMSL Link/PHY Rate Select (Links C&D) */
++#define MAX96724_LINK_RATE_CD_ADDR	0x0011
++
++/* Link A lock status (bit[3]=LOCK) */
++#define MAX96724_LINK_A_LOCK_ADDR	0x001A
++
++/* 
++ *   GMSL Link Reset
++ *   bits[7:4]: Link reset D/C/B/A, bits[3:0]: One-shot reset D/C/B/A
++ */
++#define MAX96724_ONESHOT_ADDR		0x0018
++
++/* Soft Reset (write 0x40, wait 5ms) */
++#define MAX96724_REG13_ADDR		0x000D
++
++/* 
++ *   Error Channel Power Up registers (required for 6Gbps)
++ *   Write 0x75 immediately after power-up for robust 6Gbps operation
++ */
++#define MAX96724_ERRCH_A_ADDR		0x1449
++#define MAX96724_ERRCH_B_ADDR		0x1549
++#define MAX96724_ERRCH_C_ADDR		0x1649
++#define MAX96724_ERRCH_D_ADDR		0x1749
++#define MAX96724_ERRCH_FORCE_ON		0x75
++
++/* --- I2C Control Channel / Errata --- */
++
++/* 
++ *   Tunnel Mode SRAM LCRC error suppression
++ *   Set 0x458[7:4] = 0x0 to suppress spurious ERRB in tunnel mode
++ */
++#define MAX96724_SRAM_LCRC_ERR_ADDR	0x0458
++
++/* --- Video Pipe Selection --- */
++
++/*
++ *   bits[3:0] = Pipe 0 source (0x0=SIOA)
++ *   bits[7:4] = Pipe 1 source (0x1=SIOB)
++ */
++#define MAX96724_PIPE_SEL0_ADDR		0xF0
++
++/*
++ *   bits[3:0] = Pipe 2 source (0x2=SIOC)
++ *   bits[7:4] = Pipe 3 source (0x3=SIOD)
++ */
++#define MAX96724_PIPE_SEL1_ADDR		0xF1
++
++#define MAX96724_PIPE_EN_ADDR		0xF4
++
++/* --- Pipe Receiver / Tunnel Mode --- */
++
++/*
++ *   bit[5]=1: Tunnel Mode, bits[1:0]=11: 4-lane MIPI out
++ *   Stride: 0x12 per pipe (P0=0x100, P1=0x112, P2=0x124, P3=0x136)
++ */
++#define MAX96724_VID_RX0_P0_ADDR	0x100
++#define MAX96724_VID_RX6_P0_ADDR	0x106
++#define MAX96724_VID_RX_STRIDE		0x12
++
++#define MAX96724_VID_RX1_P0_ADDR	0x101
++
++/* --- CSI-2 Output (BACKTOP) --- */
++
++/* BACKTOP: CSI-2 output port enable
++ *   0x040B bit[1]=CSIB_EN, bit[0]=CSIA_EN
++ */
++#define MAX96724_BACKTOP_EN_ADDR	0x040B
++
++/* --- MIPI DPLL (Data Rate) --- */
++
++/* 
++ *   MIPI PHY DPLL Freq registers
++ *   bits[4:0] = frequency in multiples of 100MHz
++ *   bit[5]    = DPLL enable (must be set for DPLL to lock)
++ *   E.g., 0x27 = 700MHz + enable = 700Mbps/lane D-PHY
++ *   E.g., 0x2F = 1500MHz + enable = 1.5Gbps/lane
++ */
++#define MAX96724_DPLL_FREQ0_ADDR	0x0415
++#define MAX96724_DPLL_FREQ1_ADDR	0x0418
++#define MAX96724_DPLL_FREQ2_ADDR	0x041B
++#define MAX96724_DPLL_FREQ3_ADDR	0x041E
++
++/* 
++ *   DPLL PHY reset control
++ *   0x1D00 = DPLL CSI PHY1 control
++ *   Write 0xF4 to disable/reset, 0xF5 to enable
++ */
++#define MAX96724_DPLL_CSI2_ADDR		0x1D00
++#define MAX96724_DPLL_DISABLE		0xF4
++#define MAX96724_DPLL_ENABLE		0xF5
++
++/* --- CSI-2 Output PHY Configuration --- */
++
++/* 
++ * CSI output mode/config register.
++ * Mode bits (set exactly one of [4:0]):
++ *   bit[0]=0x01: 4x2 mode
++ *   bit[2]=0x04: 2x4 mode        (Ctrl 1 = master for Port A, Ctrl 2 = Port B)
++ *   bit[3]=0x08: 1x4a + 2x2 mode (Ctrl 1 = master for Port A)
++ *   bit[4]=0x10: 1x4b + 2x2 mode (Ctrl 2 = master for Port B)
++ *
++ * Clock-force bits:
++ *   bit[7]=0x80: force ALL MIPI clocks running (continuous HS clock)
++ *   bit[6]=0x40: force PHY 3 MIPI clock running
++ *   bit[5]=0x20: force PHY 0 MIPI clock running
++ */
++#define MAX96724_CSI_OUT_CFG_ADDR	0x08A0
++
++/* 
++ *   MIPI PHY Enable register
++ *   bits[7:4]: Enable PHY 3/2/1/0 (1=enabled, 0=standby)
++ */
++#define MAX96724_CSI_PHY_EN_ADDR	0x08A2
++
++/* MIPI PHY 0 and 1 Lane Mapping */
++#define MAX96724_CSI_LANE_MAP1_ADDR	0x08A3
++
++/* MIPI PHY 2 and 3 Lane Mapping */
++#define MAX96724_CSI_LANE_MAP2_ADDR	0x08A4
++
++/* 
++ *   MIPI output lane polarity (P/N swap) registers.
++ *   0x08A5 = PHY0/PHY1 lane polarity, 0x08A6 = PHY2/PHY3 lane polarity.
++ *   The FangZhu FG24-4CH PCB swaps the differential P/N pairs on the
++ *   MAX96724 CSI output, so the deserializer must invert lane polarity
++ */
++#define MAX96724_CSI_PHY_POL0_ADDR	0x08A5
++#define MAX96724_CSI_PHY_POL1_ADDR	0x08A6
++#define MAX96724_CSI_PHY_POL_SWAP	0x3F
++
++/* Pipe-to-controller mapping */
++#define MAX96724_MIPI_CTRL_SEL_ADDR	0x08CA
++
++/* Method-1 controller mapping */
++#define MAX96724_MIPI_CTRL_SEL_PIXEL	0xE4
++
++/* --- Lane Control per pipe (stride 0x40) --- */
++
++/*
++ *   0xC0 = 4-lane enabled
++ */
++#define MAX96724_LANE_CTRL0_ADDR	0x090A
++#define MAX96724_LANE_CTRL1_ADDR	0x094A
++#define MAX96724_LANE_CTRL2_ADDR	0x098A
++#define MAX96724_LANE_CTRL3_ADDR	0x09CA
++
++/* --- Pipe Mapping Registers (stride 0x40 per pipe) --- */
++
++/*
++ *   Base addresses for Pipe X (Pipe 0)
++ *   Stride: 0x40 per pipe
++ */
++#define MAX96724_TX11_PIPE_X_EN_ADDR		0x090B
++#define MAX96724_TX45_PIPE_X_DST_CTRL_ADDR	0x092D
++#define MAX96724_PIPE_X_SRC_0_MAP_ADDR		0x090D
++#define MAX96724_PIPE_X_DST_0_MAP_ADDR		0x090E
++#define MAX96724_PIPE_X_SRC_1_MAP_ADDR		0x090F
++#define MAX96724_PIPE_X_DST_1_MAP_ADDR		0x0910
++#define MAX96724_PIPE_X_SRC_2_MAP_ADDR		0x0911
++#define MAX96724_PIPE_X_DST_2_MAP_ADDR		0x0912
++#define MAX96724_PIPE_X_SRC_3_MAP_ADDR		0x0913
++#define MAX96724_PIPE_X_DST_3_MAP_ADDR		0x0914
++
++/* --- Stream Select --- */
++
++/*
++ *   Pipe X=0x0933, stride 0x40 per pipe
++ */
++#define MAX96724_PIPE_X_ST_SEL_ADDR	0x0933
++
++/* --- Extended Pipe Mapping (DST_CTRL2-4 / TX49) --- */
++
++/* 
++ *   Extended DST_CTRL for additional mapping pairs
++ *   All to PHY1 (0x55), same as TX45
++ *   Stride: 0x40 per pipe (base = Pipe X)
++ */
++#define MAX96724_TX46_PIPE_X_ADDR	0x092E
++#define MAX96724_TX47_PIPE_X_ADDR	0x092F
++#define MAX96724_TX48_PIPE_X_ADDR	0x0930
++
++/* 
++ *   MIPI_TX49 synchronous concatenation control
++ *   Set to 0x00 (no concat) for single-camera tunnel mode.
++ *   For 4W concat use 0x87.
++ *   Stride: 0x40 per pipe (base = Pipe X)
++ */
++#define MAX96724_TX49_PIPE_X_ADDR	0x0931
++#define MAX96724_TX49_CONCAT_4W		0x87
++
++/* --- Tunnel Mode per-pipe --- */
++
++/*
++ *   bit[0] = TUN_EN, Default=0x08, write 0x01 to enable
++ */
++#define MAX96724_PIPE0_TUN_EN_ADDR	0x0936
++#define MAX96724_PIPE1_TUN_EN_ADDR	0x0976
++#define MAX96724_PIPE2_TUN_EN_ADDR	0x09B6
++#define MAX96724_PIPE3_TUN_EN_ADDR	0x09F6
++
++/*
++ *   bit[6]: disable auto-tunnel-detect
++ *   bits[5:4]: TUN_DEST (00=PHY0, 01=PHY1, 10=PHY2, 11=PHY3)
++ */
++#define MAX96724_PIPE0_TUN_DEST_ADDR	0x0939
++#define MAX96724_PIPE1_TUN_DEST_ADDR	0x0979
++#define MAX96724_PIPE2_TUN_DEST_ADDR	0x09B9
++#define MAX96724_PIPE3_TUN_DEST_ADDR	0x09F9
++
++/* ================================================================
++ * Register Values
++ * ================================================================ */
++
++/* Soft reset value (write to 0x000D) */
++#define MAX96724_SOFT_RESET		0x40
++
++/* 
++ * Link Rate values for 0x0010/0x0011
++ *   Per link pair: bits[1:0]=RxA, [3:2]=TxA, [5:4]=RxB, [7:6]=TxB
++ *   Tx = 00 (187.5Mbps), Rx = 01 (3Gbps) or 10 (6Gbps)
++ *   3Gbps: Tx=00, Rx=01 → per pair 0x01, both pairs = 0x01 in low nibble
++ */
++#define MAX96724_LINK_RATE_3GBPS	0x01  /* Rx=3G, Tx=187.5M for one link pair */
++#define MAX96724_LINK_RATE_6GBPS	0x02  /* Rx=6G, Tx=187.5M for one link pair */
++
++/* 
++ * 0x0006: Link enable / mode values
++ *   bits[7:4] = PHY mode (1=GMSL2 per link)
++ *   bits[3:0] = Link enable per link
++ *   0xF1 = all GMSL2-mode, only Link A enabled
++ *   0xFF = all GMSL2-mode, all 4 links enabled
++ */
++#define MAX96724_LINK_EN_SIOA		0xF1  /* GMSL2 all, enable Link A only */
++#define MAX96724_LINK_EN_ALL		0xFF  /* GMSL2 all, enable all links */
++
++/* BACKTOP_EN (0x040B): CSI output port enable */
++#define MAX96724_BACKTOP_CSIB_EN	0x02
++#define MAX96724_BACKTOP_CSIA_EN	0x01
++
++/* 
++ *   VIDEO_RX0: DIS_PKT_DET=1 (bit0) required for tunnel mode.
++ *   Without it, DES rejects tunnel data as invalid GMSL2 video packets.
++ *   SEQ_MISS_EN=1 (bit4), LINE_CRC_EN=1 (bit1).  XML value: 0x33.
++ */
++#define MAX96724_VID_RX0_CFG_VAL	0x33
++#define MAX96724_VID_RX6_CFG_VAL	0x0A
++
++/* Pixel-mode receiver settings */
++#define MAX96724_VID_RX0_PIXEL_VAL	0x32
++#define MAX96724_VID_RX6_PIXEL_VAL	0x12
++
++/* 
++ *   Tunnel mode enable (MIPI_TX54, 0x0936):
++ *   bit[0] = TUN_EN = 1
++ *   Verified value: 0x01
++ */
++#define MAX96724_TUN_EN			0x01
++
++/* Default/reset state when tunnel is disabled */
++#define MAX96724_TUN_DISABLED		0x08
++
++/* 
++ *   Tunnel controller destination (MIPI_TX57, 0x0939):
++ *   bits[5:4]: TUN_DEST (00=PHY0, 01=PHY1, 10=PHY2, 11=PHY3)
++ *   Verified value: 0x10 = PHY1 destination with auto-detect enabled
++ */
++#define MAX96724_TUN_DEST_CTRL0		0x00  /* Auto-detect + PHY0 */
++#define MAX96724_TUN_DEST_CTRL1		0x10  /* Auto-detect + PHY1 (Port A master) */
++
++#define MAX96724_CSI_MODE_2X4_VAL	0x04  /* bit[2] = clean 2x4: Port A = PHY0+PHY1 */
++
++/* 
++ *   0x84 = 2x4 mode (bit2) + bit[7] "force ALL MIPI clocks running".  The bit[7]
++ *   clock-force is the key part: it keeps the D-PHY clock lane in continuous HS
++ *   mode so the Orin NVCSI/CIL can lock.
++ */
++#define MAX96724_CSI_OUT_EN_VAL		0x84  /* 2x4 + bit[7] force all MIPI clocks running */
++
++#define MAX96724_CSI_PHY_EN_ALL		0xF0
++#define MAX96724_CSI_PHY_EN_01		0x30  /* PHY0+PHY1 only (Port A) */
++#define MAX96724_CSI_PHY_EN_23		0xC0  /* PHY2+PHY3 only (Port B) */
++
++/* Lane mapping default */
++#define MAX96724_CSI_LANE_MAP_DEFAULT	0xE4
++
++/* Lane control: 4-lane enabled */
++#define MAX96724_LANE_CTRL_4LANE	0xC0
++
++/*
++ *   Lane control: 2-lane enabled.
++ *   bits[7:6] = (num_lanes - 1): 01=2-lane(0x40), 11=4-lane(0xC0)
++ *   Ref: gmsl_ser_des_guide §8.2, E2E_enable_guide §5.6.4 
++ */
++#define MAX96724_LANE_CTRL_2LANE	0x40
++
++/* 
++ *   CSI PHY enable: all PHYs powered for DPLL lock.
++ */
++#define MAX96724_CSI_PHY_EN_2LANE	0xF0
++
++/* 
++ *   DPLL for Controller 0 (drives PHY0, 2 lanes).
++ *   bits[4:0] = data-rate / 100 MHz.  700 Mbps / 100 = 7 = 0x07.
++ *   bit[5]    = DPLL enable = 1.
++ *   Result: 0x27 = 700 Mbps/lane D-PHY.
++ */
++#define MAX96724_DPLL_700MBPS_CTRL0	0x27
++
++/* 
++ *   CSI-output DPLL data rate = 1300 Mbps.
++ *   bits[4:0] = data-rate / 100 MHz -> 1300/100 = 13 = 0x0D. bit[5] = DPLL en.
++ */
++#define MAX96724_DPLL_1300MBPS		0x2D
++
++/* One-shot reset: all links */
++#define MAX96724_ONESHOT_ALL		0x0F
++
++/* 
++ *   Pipe source selection values
++ *   Encoding per pipe nibble in tunnel mode:
++ *   0x22 routes all pipes from Link A in tunnel mode.
++ */
++#define MAX96724_PIPE_SEL0_SINGLE	0x22  /* All pipes from Link A */
++#define MAX96724_PIPE_SEL1_SINGLE	0x22  /* All pipes from Link A */
++#define MAX96724_PIPE_SEL0_PIXEL	0x62  /* pixel-mode reference */
++#define MAX96724_PIPE_SEL1_PIXEL	0xEA  /* pixel-mode reference */
++#define MAX96724_PIPE_SEL0_DUAL		0x40  /* Pipe 0 ← A/X, Pipe 1 ← B/X */
++#define MAX96724_PIPE_SEL0_QUAD_LO	0x40  /* Pipe 0 ← A/X, Pipe 1 ← B/X */
++#define MAX96724_PIPE_SEL1_QUAD_HI	0xC8  /* Pipe 2 ← C/X, Pipe 3 ← D/X */
++
++/* Pipe enable values */
++#define MAX96724_PIPE_EN_1		0x01
++#define MAX96724_PIPE_EN_2		0x03
++#define MAX96724_PIPE_EN_4		0x0F
++
++/* Lane control map: bits[7:6] = (num_lanes - 1) */
++#define MAX96724_LANE_CTRL_MAP(num_lanes) \
++	((((num_lanes) - 1) << 6) & 0xC0)
++
++/* Reset all */
++#define MAX96724_RESET_ALL		0x80
++
++/* Stream ID invalid */
++#define MAX96724_INVAL_ST_ID		0xFF
++#define MAX96724_RESET_ST_ID		0x00
++#define MAX96724_ST_ID_SEL_INVALID	0xF
++
++/* Controller mapping: all mappings → Controller 0 */
++#define MAX96724_ALL_MAP_CTRL0		0x00
++/* Controller mapping: all mappings → Controller 1 */
++#define MAX96724_ALL_MAP_CTRL1		0x55
++
++/* Three mappings to controller 1 */
++#define MAX96724_MAP3_CTRL1		0x15
++
++/* ================================================================
++ * Data Structures
++ * ================================================================ */
++
++/* Quad GMSL: up to 4 sources */
++#define MAX96724_MAX_SOURCES		4
++#define MAX96724_MAX_PIPES		4
++
++#define MAX96724_PIPE_X			0
++#define MAX96724_PIPE_Y			1
++#define MAX96724_PIPE_Z			2
++#define MAX96724_PIPE_U			3
++#define MAX96724_PIPE_INVALID		0xF
++
++#define MAX96724_CSI_CTRL_0		0
++#define MAX96724_CSI_CTRL_1		1
++#define MAX96724_CSI_CTRL_2		2
++#define MAX96724_CSI_CTRL_3		3
++
++#define MAX96724_CSI_MODE_2X4		0x08  /* enum tag for the 4-lane Port A (Ctrl1) path */
++
++/* Lane map presets */
++#define MAX96724_LANE_MAP1_2X4		0xE4  /* SC20190112 subset: PHY0 data + PHY1 clock */
++#define MAX96724_LANE_MAP2_2X4		0x44  /* keep unused PHY2/3 straight in 0x08 mode */
++
++struct max96724_source_ctx {
++	struct gmsl_link_ctx *g_ctx;
++	bool st_enabled;
++};
++
++struct pipe_ctx {
++	u32 id;
++	u32 dt_type;
++	u32 dst_csi_ctrl;
++	u32 st_count;
++	u32 st_id_sel;
++};
++
++struct max96724 {
++	struct i2c_client *i2c_client;
++	struct regmap *regmap;
++	u32 num_src;
++	u32 max_src;
++	u32 num_src_found;
++	u32 src_link;
++	bool splitter_enabled;
++	struct max96724_source_ctx sources[MAX96724_MAX_SOURCES];
++	struct mutex lock;
++	u32 sdev_ref;
++	bool lane_setup;
++	bool link_setup;
++	struct pipe_ctx pipe[MAX96724_MAX_PIPES];
++	u8 csi_mode;
++	u8 lane_mp1;
++	u8 lane_mp2;
++	int reset_gpio;
++	int pw_ref;
++	struct regulator *vdd_cam_1v2;
++	u8 link_speed;  /* DT-configurable: 3 or 6 Gbps */
++	bool pixel_mode;
++	bool poc_enabled; /* FG24-4CH board POC/IO enable applied once */
++};
++
++struct reg_pair {
++	u16 addr;
++	u8 val;
++};
++
++/* ================================================================
++ * Low-level I2C
++ * ================================================================ */
++
++static int max96724_write_reg(struct device *dev, u16 addr, u8 val)
++{
++	struct max96724 *priv;
++	int err;
++
++	priv = dev_get_drvdata(dev);
++
++	err = regmap_write(priv->regmap, addr, val);
++	if (err)
++		dev_err(dev, "%s:i2c write failed, 0x%x = %x\n",
++			__func__, addr, val);
++
++	/* delay before next i2c command as required for SERDES link */
++	usleep_range(100, 110);
++
++	return err;
++}
++
++static int max96724_set_registers(struct device *dev, struct reg_pair *map,
++				  u32 count)
++{
++	int err = 0;
++	u32 j;
++
++	for (j = 0; j < count; j++) {
++		err = max96724_write_reg(dev, map[j].addr, map[j].val);
++		if (err)
++			break;
++	}
++
++	return err;
++}
++
++/* ================================================================
++ * Internal Helpers
++ * ================================================================ */
++
++static int max96724_get_sdev_idx(struct device *dev,
++				 struct device *s_dev, unsigned int *idx)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++	unsigned int i;
++	int err = 0;
++
++	mutex_lock(&priv->lock);
++	for (i = 0; i < priv->max_src; i++) {
++		if (priv->sources[i].g_ctx->s_dev == s_dev)
++			break;
++	}
++	if (i == priv->max_src) {
++		dev_err(dev, "no sdev found\n");
++		err = -EINVAL;
++		goto ret;
++	}
++
++	if (idx)
++		*idx = i;
++
++ret:
++	mutex_unlock(&priv->lock);
++	return err;
++}
++
++static void max96724_pipes_reset(struct max96724 *priv)
++{
++	/*
++	 * Default pipe configuration for D5xx/SC1.2:
++	 * In tunnel mode, DT types are not used for filtering
++	 * but we initialize them for d4xx framework compatibility.
++	 */
++	struct pipe_ctx pipe_defaults[] = {
++		{MAX96724_PIPE_X, GMSL_CSI_DT_RAW_12,
++			MAX96724_CSI_CTRL_1, 0, MAX96724_INVAL_ST_ID},
++		{MAX96724_PIPE_Y, GMSL_CSI_DT_RAW_12,
++			MAX96724_CSI_CTRL_1, 0, MAX96724_INVAL_ST_ID},
++		{MAX96724_PIPE_Z, GMSL_CSI_DT_EMBED,
++			MAX96724_CSI_CTRL_1, 0, MAX96724_INVAL_ST_ID},
++		{MAX96724_PIPE_U, GMSL_CSI_DT_EMBED,
++			MAX96724_CSI_CTRL_1, 0, MAX96724_INVAL_ST_ID}
++	};
++
++	memcpy(priv->pipe, pipe_defaults, sizeof(pipe_defaults));
++}
++
++static void max96724_reset_ctx(struct max96724 *priv)
++{
++	unsigned int i;
++
++	priv->link_setup = false;
++	priv->lane_setup = false;
++	priv->num_src_found = 0;
++	priv->src_link = 0;
++	priv->splitter_enabled = false;
++	max96724_pipes_reset(priv);
++	for (i = 0; i < priv->num_src; i++)
++		priv->sources[i].st_enabled = false;
++}
++
++static void max96724_apply_porta_subset(struct device *dev,
++						 struct max96724 *priv)
++{
++	/*
++	 * [XML-verified 4-lane] D-PHY Port A output, 4 data lanes.
++	 * [FG24-4CH working-config verified] 0x04 = 2x4 mode so Port A
++	 * maps to PHY0+PHY1 (the lanes the FG24 PCB wires to Orin).  Output is
++	 * not yet enabled here (bit7 = 0); setup_streaming() asserts 0x84 after
++	 * the full pipeline is configured.
++	 */
++	max96724_write_reg(dev, MAX96724_CSI_OUT_CFG_ADDR,
++			   MAX96724_CSI_MODE_2X4_VAL);
++	/*
++	 * [FG24-4CH working dump] Enable ALL four CSI PHYs (0x08A2=0xF0).
++	 * The working FangZhu config powers every PHY; the MAX96724 DPLL
++	 * needs all PHYs powered to lock reliably (single-PHY enable was
++	 * observed to never lock the output clock). Port A data still
++	 * leaves on PHY0/1 in 2x4 mode; PHY2/3 are just powered.
++	 */
++	max96724_write_reg(dev, MAX96724_CSI_PHY_EN_ADDR,
++			   MAX96724_CSI_PHY_EN_ALL);
++	max96724_write_reg(dev, MAX96724_CSI_LANE_MAP1_ADDR,
++			   priv->lane_mp1);
++	/*
++	 * [FG24-4CH working dump] LANE_MAP2 (PHY2/3) = 0xE4 straight mapping.
++	 * The working config writes 0x08A4=0xE4 (not the chip default 0x44).
++	 */
++	max96724_write_reg(dev, MAX96724_CSI_LANE_MAP2_ADDR,
++			   MAX96724_CSI_LANE_MAP_DEFAULT);
++	/*
++	 * [FG24-4CH board] Switch MIPI output lane polarity (P/N swap).
++	 * The FG24-4CH PCB inverts the differential pairs on the DES->Orin
++	 * output; without this the Orin CIL never locks the HS clock.
++	 * Per FangZhu MAX4CH_FG24_POC_Enable table: 0x08A5/0x08A6 = 0x3F.
++	 */
++	max96724_write_reg(dev, MAX96724_CSI_PHY_POL0_ADDR,
++			   MAX96724_CSI_PHY_POL_SWAP);
++	max96724_write_reg(dev, MAX96724_CSI_PHY_POL1_ADDR,
++			   MAX96724_CSI_PHY_POL_SWAP);
++	max96724_write_reg(dev, MAX96724_LANE_CTRL0_ADDR,
++			   MAX96724_LANE_CTRL_4LANE);
++	max96724_write_reg(dev, MAX96724_LANE_CTRL1_ADDR,
++			   MAX96724_LANE_CTRL_4LANE);
++	max96724_write_reg(dev, MAX96724_LANE_CTRL2_ADDR,
++			   MAX96724_LANE_CTRL_4LANE);
++	max96724_write_reg(dev, MAX96724_LANE_CTRL3_ADDR,
++			   MAX96724_LANE_CTRL_4LANE);
++}
++
++static inline bool max96724_is_pixel_mode(struct max96724 *priv)
++{
++	return priv->pixel_mode;
++}
++
++/* ================================================================
++ * Power Management
++ * ================================================================ */
++
++/* [FG24-4CH board] POC (Power-over-Coax) / IO enable sequence.
++ *   Per FangZhu MAX4CH_FG24_POC_Enable table. On the FG24-4CH board the
++ *   MFP8 line (0x0319 bit4) and the POC IO enable (0x0001 bit5) gate the
++ *   board-level output / POC path. Without these the DES PLL still locks
++ *   and shows internal activity, but no clock reaches the Orin connector.
++ */
++#define MAX96724_POC_IO_EN_ADDR		0x0001
++#define MAX96724_POC_IO_EN_VAL		0xE0  /* Enable POC IO (working dump: 0xE0) */
++#define MAX96724_POC_MFP8_ADDR		0x0319
++#define MAX96724_POC_MFP8_PRE		0x80  /* MFP8 pre-enable */
++#define MAX96724_POC_MFP8_HIGH		0x98  /* Enable POC MFP8 High (working dump: 0x98) */
++
++/*
++ * max96724_board_poc_enable - Apply FG24-4CH POC/IO enable (one-time).
++ * Mirrors the vendor MAX4CH_FG24_POC_Enable table.
++ */
++static void max96724_board_poc_enable(struct device *dev)
++{
++	max96724_write_reg(dev, MAX96724_POC_IO_EN_ADDR,
++			   MAX96724_POC_IO_EN_VAL);
++	max96724_write_reg(dev, MAX96724_POC_MFP8_ADDR,
++			   MAX96724_POC_MFP8_PRE);
++	msleep(100);
++	max96724_write_reg(dev, MAX96724_POC_MFP8_ADDR,
++			   MAX96724_POC_MFP8_HIGH);
++	msleep(500);
++}
++
++/*
++ * max96724_power_on - Power on the MAX96724 deserializer
++ */
++int max96724_power_on(struct device *dev)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++	int err = 0;
++
++	mutex_lock(&priv->lock);
++	if (priv->pw_ref == 0) {
++		usleep_range(1, 2);
++		if (gpio_is_valid(priv->reset_gpio))
++			gpio_set_value(priv->reset_gpio, 0);
++
++		usleep_range(30, 50);
++
++		if (priv->vdd_cam_1v2) {
++			err = regulator_enable(priv->vdd_cam_1v2);
++			if (unlikely(err))
++				goto ret;
++		}
++
++		usleep_range(30, 50);
++
++		/* exit reset mode: XCLR */
++		if (gpio_is_valid(priv->reset_gpio)) {
++			gpio_set_value(priv->reset_gpio, 0);
++			usleep_range(30, 50);
++			gpio_set_value(priv->reset_gpio, 1);
++			usleep_range(30, 50);
++		}
++
++		msleep(20);
++	}
++
++	priv->pw_ref++;
++
++ret:
++	mutex_unlock(&priv->lock);
++	return err;
++}
++EXPORT_SYMBOL(max96724_power_on);
++
++void max96724_power_off(struct device *dev)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++
++	mutex_lock(&priv->lock);
++	priv->pw_ref--;
++
++	if (priv->pw_ref < 0)
++		priv->pw_ref = 0;
++
++	if (priv->pw_ref == 0) {
++		usleep_range(1, 2);
++		if (gpio_is_valid(priv->reset_gpio))
++			gpio_set_value(priv->reset_gpio, 0);
++
++		if (priv->vdd_cam_1v2)
++			regulator_disable(priv->vdd_cam_1v2);
++	}
++
++	mutex_unlock(&priv->lock);
++}
++EXPORT_SYMBOL(max96724_power_off);
++
++/* ================================================================
++ * Link Setup
++ * ================================================================ */
++
++/*
++ * max96724_write_link - Configure a specific GMSL link
++ *
++ * [Users Guide, Link Initialization, p11-12]
++ *   Register 0x0006: Link Enable and Mode Select
++ *   Register 0x0010: Link Rate (Links A/B)
++ *
++ * The link speed is DT-configurable via the "gmsl-link-speed" property.
++ */
++static int max96724_write_link(struct device *dev, u32 link)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++	u8 link_rate_ab, link_rate_cd;
++	u8 link_en_val;
++
++	/*
++	 * [Aardvark-verified] Disable CSI output before link configuration
++	 * This prevents glitches on CSI bus during GMSL link setup.
++	 * Re-enabled in max96724_setup_streaming() after full pipeline config.
++	 */
++	max96724_write_reg(dev, MAX96724_BACKTOP_EN_ADDR, 0x00);
++
++	/* [UG Table 3 + Tech Overview REG26]
++	 * Register 0x0010:
++	 *   bits[7:2] = Link rate configuration
++	 *   bits[1:0] = I2C CC pass-through link select
++	 *     10 = route CC via SIOA (Link A)  [tech overview: 0x02 → SIOA]
++	 *     01 = route CC via SIOB (Link B)
++	 *
++	 * For 6G + Link A: bits[7:2]=001000, bits[1:0]=10 → 0x22
++	 * For 6G + Link B: bits[7:2]=001000, bits[1:0]=01 → 0x21
++	 * For 3G + Link A: bits[7:2]=000100, bits[1:0]=10 → 0x12 (? or 0x11)
++	 * For 3G + Link B: bits[7:2]=000100, bits[1:0]=01 → 0x11 (? or 0x09)
++	 */
++	if (priv->link_speed == 6) {
++		if (link == GMSL_SERDES_CSI_LINK_B) {
++			link_rate_ab = 0x21; /* 6G rate + CC via Link B */
++		} else {
++			link_rate_ab = 0x22; /* 6G rate + CC via Link A */
++		}
++		link_rate_cd = 0x22; /* C/D: 6G rate (CC routing don't care) */
++	} else {
++		if (link == GMSL_SERDES_CSI_LINK_B) {
++			link_rate_ab = 0x09; /* 3G rate + CC via Link B */
++		} else {
++			link_rate_ab = 0x12; /* 3G rate + CC via Link A */
++		}
++		link_rate_cd = 0x11; /* C/D: 3G rate */
++	}
++
++	if (link == GMSL_SERDES_CSI_LINK_A) {
++		link_en_val = MAX96724_LINK_EN_SIOA;
++	} else if (link == GMSL_SERDES_CSI_LINK_B) {
++		link_en_val = 0xF2; /* GMSL2 all, enable Link B only */
++	} else {
++		dev_err(dev, "%s: invalid gmsl link\n", __func__);
++		return -EINVAL;
++	}
++
++	/* [UG Table 3] Set link rates + CC routing */
++	max96724_write_reg(dev, MAX96724_LINK_RATE_AB_ADDR, link_rate_ab);
++	max96724_write_reg(dev, MAX96724_LINK_RATE_CD_ADDR, link_rate_cd);
++
++	/*
++	 * [XML-verified sequence] One-shot reset applies rate configuration
++	 * to the link state machine, then link enable starts training.
++	 * XML order: rate → ONE-SHOT → LINK_EN → wait 1000ms.
++	 * Note: Error channel registers omitted (not in reference XML).
++	 */
++	max96724_write_reg(dev, MAX96724_ONESHOT_ADDR,
++			   MAX96724_ONESHOT_ALL);
++	max96724_write_reg(dev, MAX96724_LINK_EN_ADDR, link_en_val);
++
++	/*
++	 * Wait for link lock.
++	 * [XML] Uses 1000ms regardless of link speed.
++	 * I2C pass-through CC requires fully trained link, not just PHY lock.
++	 */
++	msleep(1000);
++
++	/* Check link lock status on ALL ports for diagnostics */
++	{
++		unsigned int lock_a = 0, lock_b = 0, lock_c = 0, lock_d = 0;
++		unsigned int link_en = 0;
++		unsigned int reg10 = 0, reg11 = 0;
++
++		regmap_read(priv->regmap, 0x001A, &lock_a);
++		regmap_read(priv->regmap, 0x001B, &lock_b);
++		regmap_read(priv->regmap, 0x001C, &lock_c);
++		regmap_read(priv->regmap, 0x001D, &lock_d);
++		regmap_read(priv->regmap, MAX96724_LINK_EN_ADDR, &link_en);
++		regmap_read(priv->regmap, 0x0010, &reg10);
++		regmap_read(priv->regmap, 0x0011, &reg11);
++		dev_info(dev,
++			 "GMSL link status: EN=0x%02x A=0x%02x(%s) B=0x%02x(%s) C=0x%02x(%s) D=0x%02x(%s) REG10=0x%02x REG11=0x%02x\n",
++			 link_en,
++			 lock_a, (lock_a & 0x08) ? "LOCK" : "noLk",
++			 lock_b, (lock_b & 0x08) ? "LOCK" : "noLk",
++			 lock_c, (lock_c & 0x08) ? "LOCK" : "noLk",
++			 lock_d, (lock_d & 0x08) ? "LOCK" : "noLk",
++			 reg10, reg11);
++	}
++
++	return 0;
++}
++
++int max96724_setup_link(struct device *dev, struct device *s_dev)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++	int err = 0;
++	unsigned int i = 0;
++
++	err = max96724_get_sdev_idx(dev, s_dev, &i);
++	if (err)
++		return err;
++
++	/*
++	 * [FG24-4CH] Enable board POC / MFP8 output path BEFORE the GMSL
++	 * link is brought up.  The camera draws power over coax (PoC), so
++	 * without this the remote camera never powers on and the link can
++	 * never lock.  NOTE: this must live here (a path d5xx actually
++	 * invokes via dser_ops->setup_link) and NOT in max96724_power_on(),
++	 * which ds5_gmsl_serdes_setup() deliberately skips.  Run once.
++	 */
++	if (!priv->poc_enabled) {
++		max96724_board_poc_enable(dev);
++		priv->poc_enabled = true;
++	}
++
++	mutex_lock(&priv->lock);
++
++	if (!priv->splitter_enabled) {
++		err = max96724_write_link(dev,
++					  priv->sources[i].g_ctx->serdes_csi_link);
++		if (err)
++			goto ret;
++
++		priv->link_setup = true;
++	}
++
++ret:
++	mutex_unlock(&priv->lock);
++	return err;
++}
++EXPORT_SYMBOL(max96724_setup_link);
++
++/* ================================================================
++ * Control Setup
++ * ================================================================ */
++
++/*
++ * max96724_setup_control - Configure deserializer control pipeline
++ *
++ * Enables splitter mode when multiple sources are present,
++ * configures tunnel mode on all active pipes, and sets up
++ * the MIPI CSI-2 output.
++ */
++int max96724_setup_control(struct device *dev, struct device *s_dev)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++	int err = 0;
++	unsigned int i = 0;
++
++	static const u16 tun_en_addrs[] = {
++		MAX96724_PIPE0_TUN_EN_ADDR,
++		MAX96724_PIPE1_TUN_EN_ADDR,
++		MAX96724_PIPE2_TUN_EN_ADDR,
++		MAX96724_PIPE3_TUN_EN_ADDR,
++	};
++
++	static const u16 tun_dest_addrs[] = {
++		MAX96724_PIPE0_TUN_DEST_ADDR,
++		MAX96724_PIPE1_TUN_DEST_ADDR,
++		MAX96724_PIPE2_TUN_DEST_ADDR,
++		MAX96724_PIPE3_TUN_DEST_ADDR,
++	};
++
++	err = max96724_get_sdev_idx(dev, s_dev, &i);
++	if (err)
++		return err;
++
++	mutex_lock(&priv->lock);
++
++	if (!priv->link_setup) {
++		dev_err(dev, "%s: invalid state\n", __func__);
++		err = -EINVAL;
++		goto error;
++	}
++
++	if (priv->sources[i].g_ctx->serdev_found) {
++		priv->num_src_found++;
++		priv->src_link = priv->sources[i].g_ctx->serdes_csi_link;
++	}
++
++	/* Enable splitter mode for multi-camera configurations */
++	if ((priv->max_src > 1U) &&
++	    (priv->num_src_found > 0U) &&
++	    (priv->splitter_enabled == false)) {
++		/*
++		 * [UG Table 3] Multi-camera: set link rates and enable all links
++		 */
++		u8 link_rate = (priv->link_speed == 6) ? 0x22 : 0x11;
++
++		max96724_write_reg(dev, MAX96724_LINK_RATE_AB_ADDR,
++				   link_rate);
++		max96724_write_reg(dev, MAX96724_LINK_RATE_CD_ADDR,
++				   link_rate);
++		max96724_write_reg(dev, MAX96724_LINK_EN_ADDR,
++				   MAX96724_LINK_EN_ALL);
++
++		/* [Errata #5] For 6Gbps: force Error Channel power-up */
++		if (priv->link_speed == 6) {
++			max96724_write_reg(dev, MAX96724_ERRCH_A_ADDR,
++					   MAX96724_ERRCH_FORCE_ON);
++			max96724_write_reg(dev, MAX96724_ERRCH_B_ADDR,
++					   MAX96724_ERRCH_FORCE_ON);
++			max96724_write_reg(dev, MAX96724_ERRCH_C_ADDR,
++					   MAX96724_ERRCH_FORCE_ON);
++			max96724_write_reg(dev, MAX96724_ERRCH_D_ADDR,
++					   MAX96724_ERRCH_FORCE_ON);
++		}
++
++		priv->splitter_enabled = true;
++
++		msleep(100);
++	}
++
++	if (max96724_is_pixel_mode(priv)) {
++		for (i = 0; i < MAX96724_MAX_PIPES; i++) {
++			max96724_write_reg(dev, tun_en_addrs[i],
++					   MAX96724_TUN_DISABLED);
++		}
++		max96724_write_reg(dev, MAX96724_MIPI_CTRL_SEL_ADDR,
++				   MAX96724_MIPI_CTRL_SEL_PIXEL);
++		max96724_write_reg(dev, MAX96724_ONESHOT_ADDR,
++				   MAX96724_ONESHOT_ALL);
++		priv->sdev_ref++;
++		goto maybe_reset_splitter;
++	}
++
++	/*
++	 * [SC20190112] Enable tunnel mode and route to Controller 1.
++	 *   - TUN_EN   (0x0936): 0x01 (TUN_EN=1)
++	 *   - TUN_DEST (0x0939): 0x10 = Controller 1
++	 *   CSI_OUT_CFG=0x04 (2x4 mode): Controller 1 -> PHY0+1 -> Port A -> Orin
++	 */
++	{
++		for (i = 0; i < MAX96724_MAX_PIPES; i++) {
++			max96724_write_reg(dev, tun_en_addrs[i],
++					   MAX96724_TUN_EN);
++			max96724_write_reg(dev, tun_dest_addrs[i],
++					   MAX96724_TUN_DEST_CTRL1);
++		}
++	}
++
++	/*
++	 * [Errata #2] Tunnel Mode SRAM LCRC: disable ERRB for SRAM LCRC
++	 * errors in tunnel mode when frame/line counters are non-zero.
++	 * This prevents spurious ERRB assertions (no video corruption).
++	 */
++	max96724_write_reg(dev, MAX96724_SRAM_LCRC_ERR_ADDR, 0x00);
++
++	max96724_write_reg(dev, MAX96724_ONESHOT_ADDR,
++			   MAX96724_ONESHOT_ALL);
++
++	priv->sdev_ref++;
++
++maybe_reset_splitter:
++
++	/* Reset splitter mode if not all devices found */
++	if ((priv->sdev_ref == priv->max_src) &&
++	    (priv->splitter_enabled == true) &&
++	    (priv->num_src_found > 0U) &&
++	    (priv->num_src_found < priv->max_src)) {
++		err = max96724_write_link(dev, priv->src_link);
++		if (err)
++			goto error;
++
++		priv->splitter_enabled = false;
++	}
++
++error:
++	mutex_unlock(&priv->lock);
++	return err;
++}
++EXPORT_SYMBOL(max96724_setup_control);
++
++int max96724_reset_control(struct device *dev, struct device *s_dev)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++	int err = 0;
++
++	mutex_lock(&priv->lock);
++	if (!priv->sdev_ref) {
++		dev_info(dev, "%s: dev is already in reset state\n", __func__);
++		goto ret;
++	}
++
++	priv->sdev_ref--;
++	if (priv->sdev_ref == 0) {
++		max96724_reset_ctx(priv);
++		max96724_write_reg(dev, MAX96724_REG13_ADDR,
++				   MAX96724_SOFT_RESET);
++
++		msleep(100);
++	}
++
++ret:
++	mutex_unlock(&priv->lock);
++	return err;
++}
++EXPORT_SYMBOL(max96724_reset_control);
++
++/* ================================================================
++ * Device Registration
++ * ================================================================ */
++
++int max96724_sdev_register(struct device *dev, struct gmsl_link_ctx *g_ctx)
++{
++	struct max96724 *priv = NULL;
++	unsigned int i;
++	int err = 0;
++
++	if (!dev || !g_ctx || !g_ctx->s_dev) {
++		dev_err(dev, "%s: invalid input params\n", __func__);
++		return -EINVAL;
++	}
++
++	priv = dev_get_drvdata(dev);
++
++	mutex_lock(&priv->lock);
++
++	if (priv->num_src > priv->max_src) {
++		dev_err(dev,
++			"%s: MAX96724 inputs size exhausted\n", __func__);
++		err = -ENOMEM;
++		goto error;
++	}
++
++	if (priv->csi_mode == MAX96724_CSI_MODE_2X4) {
++		if (!((g_ctx->csi_mode == GMSL_CSI_1X4_MODE) ||
++		      (g_ctx->csi_mode == GMSL_CSI_2X4_MODE))) {
++			dev_err(dev, "%s: csi mode not supported\n", __func__);
++			err = -EINVAL;
++			goto error;
++		}
++	} else {
++		dev_err(dev, "%s: only csi 2x4 mode is supported\n", __func__);
++		err = -EINVAL;
++		goto error;
++	}
++
++	for (i = 0; i < priv->num_src; i++) {
++		if (g_ctx->serdes_csi_link ==
++		    priv->sources[i].g_ctx->serdes_csi_link) {
++			dev_err(dev,
++				"%s: serdes csi link is in use\n", __func__);
++			err = -EINVAL;
++			goto error;
++		}
++		if (g_ctx->num_csi_lanes !=
++		    priv->sources[i].g_ctx->num_csi_lanes) {
++			dev_err(dev,
++				"%s: csi num lanes mismatch\n", __func__);
++			err = -EINVAL;
++			goto error;
++		}
++	}
++
++	priv->sources[priv->num_src].g_ctx = g_ctx;
++	priv->sources[priv->num_src].st_enabled = false;
++
++	priv->num_src++;
++
++error:
++	mutex_unlock(&priv->lock);
++	return err;
++}
++EXPORT_SYMBOL(max96724_sdev_register);
++
++int max96724_sdev_unregister(struct device *dev, struct device *s_dev)
++{
++	struct max96724 *priv = NULL;
++	int err = 0;
++	unsigned int i = 0;
++
++	if (!dev || !s_dev) {
++		dev_err(dev, "%s: invalid input params\n", __func__);
++		return -EINVAL;
++	}
++
++	priv = dev_get_drvdata(dev);
++	mutex_lock(&priv->lock);
++
++	if (priv->num_src == 0) {
++		dev_err(dev, "%s: no source found\n", __func__);
++		err = -ENODATA;
++		goto error;
++	}
++
++	for (i = 0; i < priv->num_src; i++) {
++		if (s_dev == priv->sources[i].g_ctx->s_dev) {
++			priv->sources[i].g_ctx = NULL;
++			break;
++		}
++	}
++
++	if (i == priv->num_src) {
++		dev_err(dev,
++			"%s: requested device not found\n", __func__);
++		err = -EINVAL;
++		goto error;
++	}
++	priv->num_src--;
++
++error:
++	mutex_unlock(&priv->lock);
++	return err;
++}
++EXPORT_SYMBOL(max96724_sdev_unregister);
++
++/* ================================================================
++ * Streaming Setup
++ * ================================================================ */
++
++/*
++ * max96724_setup_streaming - Configure CSI-2 output pipeline
++ *
++ * In Tunnel Mode, the MAX96724 outputs the reconstructed CSI-2 stream
++ * with all VCs and DTs preserved from the serializer.
++ *
++ * The pipeline configuration:
++ *   1. Configure pipe-to-link routing
++ *   2. Enable tunnel mode on active pipes
++ *   3. Configure MIPI CSI-2 output lanes and PHY
++ *   4. Enable BACKTOP output port
++ *
++ */
++int max96724_setup_streaming(struct device *dev, struct device *s_dev)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++	struct gmsl_link_ctx *g_ctx;
++	int err = 0;
++	unsigned int i = 0;
++	unsigned int src_idx;
++	u8 vid_rx0_cfg;
++	u8 vid_rx6_cfg;
++	u8 st_sel_cfg;
++	u8 pipe_sel0;
++	u8 pipe_sel1;
++	u8 dpll_cfg;
++
++	err = max96724_get_sdev_idx(dev, s_dev, &i);
++	if (err)
++		return err;
++
++	mutex_lock(&priv->lock);
++
++	dev_info(dev, "=== setup_streaming ENTER src=%u st_enabled=%d ===\n",
++		 i, priv->sources[i].st_enabled);
++
++	if (priv->sources[i].st_enabled)
++		goto ret;
++
++	src_idx = i;
++	g_ctx = priv->sources[src_idx].g_ctx;
++	if (max96724_is_pixel_mode(priv)) {
++		pipe_sel0 = MAX96724_PIPE_SEL0_PIXEL;
++		pipe_sel1 = MAX96724_PIPE_SEL1_PIXEL;
++		vid_rx0_cfg = MAX96724_VID_RX0_PIXEL_VAL;
++		vid_rx6_cfg = MAX96724_VID_RX6_PIXEL_VAL;
++		st_sel_cfg = 0x00;
++		dpll_cfg = MAX96724_DPLL_1300MBPS;
++	} else {
++		pipe_sel0 = MAX96724_PIPE_SEL0_PIXEL;
++		pipe_sel1 = MAX96724_PIPE_SEL1_PIXEL;
++		vid_rx0_cfg = MAX96724_VID_RX0_CFG_VAL;
++		vid_rx6_cfg = MAX96724_VID_RX6_CFG_VAL;
++		st_sel_cfg = 0x10;
++		dpll_cfg = MAX96724_DPLL_1300MBPS;
++	}
++
++	/*
++	 * Pipe source routing
++	 * Single cam: all pipes from Link A (0x22/0x22)
++	 * Disable pipes before configuration, enable at the end
++	 */
++	max96724_write_reg(dev, MAX96724_PIPE_SEL0_ADDR, pipe_sel0);
++	max96724_write_reg(dev, MAX96724_PIPE_SEL1_ADDR, pipe_sel1);
++	/* Disable all pipes during configuration */
++	max96724_write_reg(dev, MAX96724_PIPE_EN_ADDR, 0x00);
++
++	/*
++	 * Keep 0x08 mode so PHY1 remains the Port A clock master,
++	 * but restore the live 2-lane subset used by the bridge board.
++	 */
++	max96724_apply_porta_subset(dev, priv);
++
++	/*
++	 * CSI-output DPLL data rate = 1300 Mbps
++	 * on ALL FOUR controller freq registers
++	 */
++	if (!priv->lane_setup) {
++		max96724_write_reg(dev, MAX96724_DPLL_FREQ0_ADDR,
++				   dpll_cfg);
++		max96724_write_reg(dev, MAX96724_DPLL_FREQ1_ADDR,
++				   dpll_cfg);
++		max96724_write_reg(dev, MAX96724_DPLL_FREQ2_ADDR,
++				   dpll_cfg);
++		max96724_write_reg(dev, MAX96724_DPLL_FREQ3_ADDR,
++				   dpll_cfg);
++
++		priv->lane_setup = true;
++	}
++
++	max96724_write_reg(dev, MAX96724_MIPI_CTRL_SEL_ADDR,
++			   MAX96724_MIPI_CTRL_SEL_PIXEL);
++
++	/*
++	 * Stream ID select for all pipes
++	 * 0x0933 + 0x40*pipe = stream select register
++	 * Value 0x10 selects the appropriate stream for tunnel mode
++	 */
++	for (i = 0; i < MAX96724_MAX_PIPES; i++) {
++		max96724_write_reg(dev,
++				   MAX96724_PIPE_X_ST_SEL_ADDR + (0x40 * i),
++				   st_sel_cfg);
++	}
++
++	/* 
++	 * BACKTOP: enable Controller 1 / CSI-B (0x02).
++	 * In 2x4 mode, Controller 1 is master for Port A -> Orin CSI.
++	 */
++	max96724_write_reg(dev, MAX96724_BACKTOP_EN_ADDR,
++			   MAX96724_BACKTOP_CSIB_EN);
++
++	dev_info(dev, "=== setup_streaming: writing 0x84 (force all MIPI clocks) ===\n");
++
++	/*
++	 * Assert 0x08A0=0x84 LAST: 2x4 mode + bit[7] "force all MIPI clocks running".  
++	 * The clock-force keeps the D-PHY clock lane continuous so the Orin CIL can lock;
++	 * written only after the full pipeline is configured.
++	 */
++	max96724_write_reg(dev, MAX96724_CSI_OUT_CFG_ADDR,
++			   MAX96724_CSI_OUT_EN_VAL);
++
++	/* Keep all video receivers aligned with serializer heartbeat mode. */
++	for (i = 0; i < MAX96724_MAX_PIPES; i++) {
++		max96724_write_reg(dev,
++				   MAX96724_VID_RX0_P0_ADDR +
++				   (MAX96724_VID_RX_STRIDE * i),
++				   vid_rx0_cfg);
++		max96724_write_reg(dev,
++				   MAX96724_VID_RX6_P0_ADDR +
++				   (MAX96724_VID_RX_STRIDE * i),
++				   vid_rx6_cfg);
++		if (max96724_is_pixel_mode(priv)) {
++			max96724_write_reg(dev,
++					   MAX96724_PIPE0_TUN_EN_ADDR + (0x40 * i),
++					   MAX96724_TUN_DISABLED);
++		}
++	}
++
++	max96724_write_reg(dev, MAX96724_ONESHOT_ADDR,
++			   MAX96724_ONESHOT_ALL);
++
++	/* Enable all 4 pipes */
++	max96724_write_reg(dev, MAX96724_PIPE_EN_ADDR, MAX96724_PIPE_EN_4);
++
++	priv->sources[src_idx].st_enabled = true;
++
++ret:
++	mutex_unlock(&priv->lock);
++	return err;
++}
++EXPORT_SYMBOL(max96724_setup_streaming);
++
++/* ================================================================
++ * Start / Stop Streaming
++ * ================================================================ */
++
++int max96724_start_streaming(struct device *dev, struct device *s_dev)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++	struct gmsl_link_ctx *g_ctx;
++	struct gmsl_stream *g_stream;
++	int err = 0;
++	unsigned int i = 0;
++
++	err = max96724_get_sdev_idx(dev, s_dev, &i);
++	if (err)
++		return err;
++
++	mutex_lock(&priv->lock);
++	g_ctx = priv->sources[i].g_ctx;
++
++	for (i = 0; i < g_ctx->num_streams; i++) {
++		g_stream = &g_ctx->streams[i];
++
++		if (g_stream->des_pipe != MAX96724_PIPE_INVALID)
++			max96724_write_reg(dev, g_stream->des_pipe,
++					   g_stream->st_id_sel);
++	}
++	mutex_unlock(&priv->lock);
++
++	return 0;
++}
++EXPORT_SYMBOL(max96724_start_streaming);
++
++int max96724_stop_streaming(struct device *dev, struct device *s_dev)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++	struct gmsl_link_ctx *g_ctx;
++	struct gmsl_stream *g_stream;
++	int err = 0;
++	unsigned int i = 0;
++
++	err = max96724_get_sdev_idx(dev, s_dev, &i);
++	if (err)
++		return err;
++
++	mutex_lock(&priv->lock);
++	g_ctx = priv->sources[i].g_ctx;
++
++	for (i = 0; i < g_ctx->num_streams; i++) {
++		g_stream = &g_ctx->streams[i];
++
++		if (g_stream->des_pipe != MAX96724_PIPE_INVALID)
++			max96724_write_reg(dev, g_stream->des_pipe,
++					   MAX96724_RESET_ST_ID);
++	}
++
++	mutex_unlock(&priv->lock);
++
++	return 0;
++}
++EXPORT_SYMBOL(max96724_stop_streaming);
++
++/* ================================================================
++ * Pipe Management
++ * ================================================================ */
++
++int max96724_get_available_pipe_id(struct device *dev, int vc_id)
++{
++	int i;
++	int pipe_id = -ENOMEM;
++	struct max96724 *priv = dev_get_drvdata(dev);
++
++	mutex_lock(&priv->lock);
++	for (i = 0; i < MAX96724_MAX_PIPES; i++) {
++		if (i == vc_id && !priv->pipe[i].st_count) {
++			priv->pipe[i].st_count++;
++			pipe_id = i;
++			break;
++		}
++	}
++	mutex_unlock(&priv->lock);
++
++	return pipe_id;
++}
++EXPORT_SYMBOL(max96724_get_available_pipe_id);
++
++int max96724_release_pipe(struct device *dev, int pipe_id)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++
++	if (pipe_id < 0 || pipe_id >= MAX96724_MAX_PIPES)
++		return -EINVAL;
++
++	mutex_lock(&priv->lock);
++	priv->pipe[pipe_id].st_count = 0;
++	mutex_unlock(&priv->lock);
++
++	return 0;
++}
++EXPORT_SYMBOL(max96724_release_pipe);
++
++int max96724_get_ser_pipe_id(struct device *dev, int dser_pipe_id, int vc_id)
++{
++	/* In Tunnel Mode with MAX96717, all VCs are carried in a single tunnel pipe. */
++	return dser_pipe_id;
++}
++EXPORT_SYMBOL(max96724_get_ser_pipe_id);
++
++void max96724_reset_oneshot(struct device *dev)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++	unsigned int i;
++	u8 pipe_sel0;
++	u8 pipe_sel1;
++	u8 vid_rx0_cfg;
++	u8 vid_rx6_cfg;
++	u8 st_sel_cfg;
++	u8 dpll_cfg;
++
++	mutex_lock(&priv->lock);
++	if (priv->splitter_enabled) {
++		/* Multi-camera: reset all links */
++		u8 link_rate = (priv->link_speed == 6) ? 0x22 : 0x11;
++
++		max96724_write_reg(dev, MAX96724_LINK_RATE_AB_ADDR,
++				   link_rate);
++		max96724_write_reg(dev, MAX96724_LINK_RATE_CD_ADDR,
++				   link_rate);
++		max96724_write_reg(dev, MAX96724_LINK_EN_ADDR,
++				   MAX96724_LINK_EN_ALL);
++	} else {
++		max96724_write_reg(dev, MAX96724_ONESHOT_ADDR,
++				   MAX96724_ONESHOT_ALL);
++	}
++	msleep(100);
++
++	if (max96724_is_pixel_mode(priv)) {
++		pipe_sel0 = MAX96724_PIPE_SEL0_PIXEL;
++		pipe_sel1 = MAX96724_PIPE_SEL1_PIXEL;
++		vid_rx0_cfg = MAX96724_VID_RX0_PIXEL_VAL;
++		vid_rx6_cfg = MAX96724_VID_RX6_PIXEL_VAL;
++		st_sel_cfg = 0x00;
++		dpll_cfg = MAX96724_DPLL_1300MBPS;
++	} else {
++		pipe_sel0 = MAX96724_PIPE_SEL0_PIXEL;
++		pipe_sel1 = MAX96724_PIPE_SEL1_PIXEL;
++		vid_rx0_cfg = MAX96724_VID_RX0_CFG_VAL;
++		vid_rx6_cfg = MAX96724_VID_RX6_CFG_VAL;
++		st_sel_cfg = 0x10;
++		dpll_cfg = MAX96724_DPLL_1300MBPS;
++	}
++
++	/* 
++	 * ONESHOT resets CSI/tunnel state. Restore the full pipeline config.
++	 * Mirror setup_streaming() order: disable pipes -> restore everything ->
++	 * BACKTOP/0x84 -> VID_RX -> final ONESHOT to latch -> enable pipes.
++	 */
++	max96724_write_reg(dev, MAX96724_PIPE_EN_ADDR, 0x00);
++
++	/* Pipe source routing: all pipes from Link A */
++	max96724_write_reg(dev, MAX96724_PIPE_SEL0_ADDR, pipe_sel0);
++	max96724_write_reg(dev, MAX96724_PIPE_SEL1_ADDR, pipe_sel1);
++
++	max96724_apply_porta_subset(dev, priv);
++
++	/*
++	 * CSI-output DPLL data rate = 1300 Mbps on ALL
++	 * FOUR controllers, matching the device-tree serdes_pix_clk_hz (325 MHz).
++	 * reset_oneshot is called by the sensor after setup_streaming, so it must
++	 * mirror the same DPLL values.
++	 */
++	max96724_write_reg(dev, MAX96724_DPLL_FREQ0_ADDR,
++			   dpll_cfg);
++	max96724_write_reg(dev, MAX96724_DPLL_FREQ1_ADDR,
++			   dpll_cfg);
++	max96724_write_reg(dev, MAX96724_DPLL_FREQ2_ADDR,
++			   dpll_cfg);
++	max96724_write_reg(dev, MAX96724_DPLL_FREQ3_ADDR,
++			   dpll_cfg);
++
++	max96724_write_reg(dev, MAX96724_MIPI_CTRL_SEL_ADDR,
++			   MAX96724_MIPI_CTRL_SEL_PIXEL);
++
++	max96724_write_reg(dev, MAX96724_BACKTOP_EN_ADDR,
++			   MAX96724_BACKTOP_CSIB_EN);
++	for (i = 0; i < MAX96724_MAX_PIPES; i++) {
++		max96724_write_reg(dev,
++				   MAX96724_PIPE_X_ST_SEL_ADDR + (0x40 * i),
++				   st_sel_cfg);
++		max96724_write_reg(dev,
++				   MAX96724_VID_RX0_P0_ADDR +
++				   (MAX96724_VID_RX_STRIDE * i),
++				   vid_rx0_cfg);
++		max96724_write_reg(dev,
++				   MAX96724_VID_RX6_P0_ADDR +
++				   (MAX96724_VID_RX_STRIDE * i),
++				   vid_rx6_cfg);
++		max96724_write_reg(dev,
++				   MAX96724_TX49_PIPE_X_ADDR + (0x40 * i),
++				   0x00);
++	}
++	if (max96724_is_pixel_mode(priv)) {
++		max96724_write_reg(dev, MAX96724_PIPE0_TUN_EN_ADDR, MAX96724_TUN_DISABLED);
++		max96724_write_reg(dev, MAX96724_PIPE1_TUN_EN_ADDR, MAX96724_TUN_DISABLED);
++		max96724_write_reg(dev, MAX96724_PIPE2_TUN_EN_ADDR, MAX96724_TUN_DISABLED);
++		max96724_write_reg(dev, MAX96724_PIPE3_TUN_EN_ADDR, MAX96724_TUN_DISABLED);
++	} else {
++		/* Re-enable tunnel on all pipes (ONESHOT resets TUN_EN to 0x08=disabled) */
++		max96724_write_reg(dev, MAX96724_PIPE0_TUN_EN_ADDR, MAX96724_TUN_EN);
++		max96724_write_reg(dev, MAX96724_PIPE1_TUN_EN_ADDR, MAX96724_TUN_EN);
++		max96724_write_reg(dev, MAX96724_PIPE2_TUN_EN_ADDR, MAX96724_TUN_EN);
++		max96724_write_reg(dev, MAX96724_PIPE3_TUN_EN_ADDR, MAX96724_TUN_EN);
++		/* TUN_DEST: set to Controller 1 (0x10) = Port A master in 2x4 mode */
++		max96724_write_reg(dev, MAX96724_PIPE0_TUN_DEST_ADDR,
++				   MAX96724_TUN_DEST_CTRL1);
++		max96724_write_reg(dev, MAX96724_PIPE1_TUN_DEST_ADDR,
++				   MAX96724_TUN_DEST_CTRL1);
++		max96724_write_reg(dev, MAX96724_PIPE2_TUN_DEST_ADDR,
++				   MAX96724_TUN_DEST_CTRL1);
++		max96724_write_reg(dev, MAX96724_PIPE3_TUN_DEST_ADDR,
++				   MAX96724_TUN_DEST_CTRL1);
++	}
++	max96724_write_reg(dev, MAX96724_PIPE_EN_ADDR,
++			   MAX96724_PIPE_EN_4);
++
++	/*
++	 * Assert 0x08A0=0x84 LAST:
++	 * 2x4 mode + bit[7] force all MIPI clocks running.  Must mirror
++	 * setup_streaming because the sensor's oneshot path overwrites it.
++	 */
++	max96724_write_reg(dev, MAX96724_CSI_OUT_CFG_ADDR,
++			   MAX96724_CSI_OUT_EN_VAL);
++
++	msleep(200);
++	mutex_unlock(&priv->lock);
++}
++EXPORT_SYMBOL(max96724_reset_oneshot);
++
++/* ================================================================
++ * Init Settings / Set Pipe
++ * ================================================================ */
++
++/*
++ * __max96724_set_pipe - Configure per-pipe mapping registers
++ */
++static int __max96724_set_pipe(struct device *dev, int pipe_id,
++			       u8 data_type1, u8 data_type2, u32 vc_id)
++{
++	int err = 0;
++	int i;
++	u8 en_mapping_num = 0x0F;
++	u8 all_mapping_phy = MAX96724_ALL_MAP_CTRL1;  /* Controller 1 = Port A master (2x4 mode) */
++	struct max96724 *priv = dev_get_drvdata(dev);
++
++	struct reg_pair map_pipe_control[] = {
++		/* Enable 4 mappings for Pipe X */
++		{MAX96724_TX11_PIPE_X_EN_ADDR, 0x0F},
++		/* Map data_type1 on vc_id */
++		{MAX96724_PIPE_X_SRC_0_MAP_ADDR, 0x1E},
++		{MAX96724_PIPE_X_DST_0_MAP_ADDR, 0x1E},
++		/* Map frame start on vc_id */
++		{MAX96724_PIPE_X_SRC_1_MAP_ADDR, 0x00},
++		{MAX96724_PIPE_X_DST_1_MAP_ADDR, 0x00},
++		/* Map frame end on vc_id */
++		{MAX96724_PIPE_X_SRC_2_MAP_ADDR, 0x01},
++		{MAX96724_PIPE_X_DST_2_MAP_ADDR, 0x01},
++		/* Map data_type2 on vc_id */
++		{MAX96724_PIPE_X_SRC_3_MAP_ADDR, 0x12},
++		{MAX96724_PIPE_X_DST_3_MAP_ADDR, 0x12},
++		/* All mappings to Controller 1 (2x4 mode: Ctrl1 drives Port A) */
++		{MAX96724_TX45_PIPE_X_DST_CTRL_ADDR, MAX96724_ALL_MAP_CTRL1},
++		{MAX96724_TX46_PIPE_X_ADDR, MAX96724_ALL_MAP_CTRL1},
++		{MAX96724_TX47_PIPE_X_ADDR, MAX96724_ALL_MAP_CTRL1},
++		{MAX96724_TX48_PIPE_X_ADDR, MAX96724_ALL_MAP_CTRL1},
++		/* TX49: concat disabled */
++		{MAX96724_TX49_PIPE_X_ADDR, 0x00},
++		/*
++		 * Keep DES heartbeat handling aligned with the serializer's
++		 * LIM_HEART-disabled tunnel mode to avoid persistent VID_SEQ_ERR.
++		 */
++		{0x0100, MAX96724_VID_RX0_CFG_VAL},
++		{0x0106, MAX96724_VID_RX6_CFG_VAL},
++		/*
++		 * Pipe stream control (offset 0x36 per pipe block).
++		 * TUN_EN = 0x01.
++		 */
++		{0x0936, MAX96724_TUN_EN},
++	};
++
++	/* 
++	 * Adjust addresses for pipe offset (stride 0x40 per pipe)
++	 * Entries 0-13: TX11, SRC/DST maps, TX45-TX49 (all stride 0x40)
++	 * Entries 14-15: VID_RX0/6 (stride 0x12)
++	 * Entry 16: Pipe stream control (stride 0x40)
++	 */
++	for (i = 0; i < 14; i++)
++		map_pipe_control[i].addr += 0x40 * pipe_id;
++
++	/* VID_RX offset: 0x12 per pipe */
++	map_pipe_control[14].addr += 0x12 * pipe_id;
++	map_pipe_control[15].addr += 0x12 * pipe_id;
++
++	/* Pipe stream control: stride 0x40 */
++	map_pipe_control[16].addr += 0x40 * pipe_id;
++
++	if (data_type2 == 0x0) {
++		en_mapping_num = 0x07;
++		all_mapping_phy = MAX96724_MAP3_CTRL1;
++	}
++
++	if (max96724_is_pixel_mode(priv)) {
++		map_pipe_control[10].val = 0x00;
++		map_pipe_control[11].val = 0x00;
++		map_pipe_control[12].val = 0x00;
++		map_pipe_control[13].val = 0x00;
++		map_pipe_control[14].val = MAX96724_VID_RX0_PIXEL_VAL;
++		map_pipe_control[15].val = MAX96724_VID_RX6_PIXEL_VAL;
++		map_pipe_control[16].val = MAX96724_TUN_DISABLED;
++	} else {
++		/* no concatenation needed */
++		map_pipe_control[13].val = 0x00;
++	}
++
++	map_pipe_control[0].val = en_mapping_num;
++	/* SRC: match incoming VC from camera (vc_id) */
++	map_pipe_control[1].val = (vc_id << 6) | data_type1;
++	/* DST: preserve VC — NVCSI/VI endpoints expect matching vc-id */
++	map_pipe_control[2].val = (vc_id << 6) | data_type1;
++	map_pipe_control[3].val = (vc_id << 6) | 0x00;
++	map_pipe_control[4].val = (vc_id << 6) | 0x00;
++	map_pipe_control[5].val = (vc_id << 6) | 0x01;
++	map_pipe_control[6].val = (vc_id << 6) | 0x01;
++	map_pipe_control[7].val = (vc_id << 6) | data_type2;
++	map_pipe_control[8].val = (vc_id << 6) | data_type2;
++	map_pipe_control[9].val = all_mapping_phy;
++	/* TX46-TX48 keep 0x55 (Ctrl1) from initializer */
++	/* TX49 set to 0x00 above — overridden per mode in pixel/tunnel branch */
++	/* VID_RX and pipe stream ctrl keep init values */
++
++	err = max96724_set_registers(dev, map_pipe_control,
++				     ARRAY_SIZE(map_pipe_control));
++
++	return err;
++}
++
++/*
++ * max96724_init_settings - Initialize default pipe and tunnel configuration
++ *
++ * Sets up all 4 pipes with default YUV422_8 + EMBED for VC0-3,
++ * matching the d4xx framework expectations.
++ *
++ */
++int max96724_init_settings(struct device *dev)
++{
++	int err = 0;
++	int i;
++	struct max96724 *priv = dev_get_drvdata(dev);
++
++	mutex_lock(&priv->lock);
++
++	for (i = 0; i < MAX96724_MAX_PIPES; i++)
++		err |= __max96724_set_pipe(dev, i, GMSL_CSI_DT_YUV422_8,
++					   GMSL_CSI_DT_EMBED, i);
++
++	mutex_unlock(&priv->lock);
++
++	return err;
++}
++EXPORT_SYMBOL(max96724_init_settings);
++
++int max96724_bind_ser_to_dser_pipe(struct device *dev, int dser_pipe_id,
++				   int ser_pipe_id, u32 vc_id)
++{
++	/* In Tunnel Mode, pipe mapping is 1:1 (each camera → one pipe) */
++	return 0;
++}
++EXPORT_SYMBOL(max96724_bind_ser_to_dser_pipe);
++
++int max96724_set_pipe(struct device *dev, int pipe_id,
++		      u8 data_type1, u8 data_type2, u32 vc_id)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++	int err = 0;
++
++	if (pipe_id > (MAX96724_MAX_PIPES - 1)) {
++		dev_info(dev, "%s: input pipe_id: %d exceeds max96724 max pipes\n",
++			 __func__, pipe_id);
++		return -EINVAL;
++	}
++
++	dev_dbg(dev, "%s pipe_id %d, data_type1 %u, data_type2 %u, vc_id %u\n",
++		__func__, pipe_id, data_type1, data_type2, vc_id);
++
++	mutex_lock(&priv->lock);
++
++	err = __max96724_set_pipe(dev, pipe_id, data_type1, data_type2, vc_id);
++
++	mutex_unlock(&priv->lock);
++
++	return err;
++}
++EXPORT_SYMBOL(max96724_set_pipe);
++
++/* ================================================================
++ * Device Tree Parsing
++ * ================================================================ */
++
++static const struct of_device_id max96724_of_match[] = {
++	{ .compatible = "adi,max96724", },
++	{ },
++};
++MODULE_DEVICE_TABLE(of, max96724_of_match);
++
++static int max96724_parse_dt(struct max96724 *priv,
++			     struct i2c_client *client)
++{
++	struct device_node *node = client->dev.of_node;
++	int err = 0;
++	const char *str_value;
++	int value;
++	const struct of_device_id *match;
++
++	if (!node)
++		return -EINVAL;
++
++	match = of_match_device(max96724_of_match, &client->dev);
++	if (!match) {
++		dev_err(&client->dev, "Failed to find matching dt id\n");
++		return -EFAULT;
++	}
++
++	/* CSI mode: "2x4" or "4x2" */
++	err = of_property_read_string(node, "csi-mode", &str_value);
++	if (err < 0) {
++		dev_err(&client->dev, "csi-mode property not found\n");
++		return err;
++	}
++
++	if (!strcmp(str_value, "2x4")) {
++		priv->csi_mode = MAX96724_CSI_MODE_2X4;
++		priv->lane_mp1 = MAX96724_LANE_MAP1_2X4;
++		priv->lane_mp2 = MAX96724_LANE_MAP2_2X4;
++	} else {
++		dev_err(&client->dev, "invalid csi mode\n");
++		return -EINVAL;
++	}
++
++	/* Max sources */
++	err = of_property_read_u32(node, "max-src", &value);
++	if (err < 0) {
++		dev_err(&client->dev, "No max-src info\n");
++		return err;
++	}
++	priv->max_src = value;
++
++	/* Reset GPIO */
++	priv->reset_gpio = of_get_named_gpio(node, "reset-gpios", 0);
++	if (priv->reset_gpio < 0) {
++		dev_info(&client->dev,
++			 "reset-gpios not found, continuing without external reset\n");
++		priv->reset_gpio = -1;
++	}
++
++	/* GMSL link speed from DT: 3 or 6 (Gbps) */
++	err = of_property_read_u32(node, "gmsl-link-speed", &value);
++	if (err < 0) {
++		/* Default to 3 Gbps if not specified */
++		priv->link_speed = 3;
++		dev_info(&client->dev,
++			 "gmsl-link-speed not specified, defaulting to 3 Gbps\n");
++	} else {
++		if (value != 3 && value != 6) {
++			dev_err(&client->dev,
++				"invalid gmsl-link-speed %d (must be 3 or 6)\n",
++				value);
++			return -EINVAL;
++		}
++		priv->link_speed = value;
++	}
++
++	priv->pixel_mode = of_property_read_bool(node, "adi,pixel-mode");
++
++	/* 1.2V regulator (optional) */
++	if (of_get_property(node, "vdd_cam_1v2-supply", NULL)) {
++		priv->vdd_cam_1v2 = regulator_get(&client->dev, "vdd_cam_1v2");
++		if (IS_ERR(priv->vdd_cam_1v2)) {
++			dev_err(&client->dev,
++				"vdd_cam_1v2 regulator get failed\n");
++			err = PTR_ERR(priv->vdd_cam_1v2);
++			priv->vdd_cam_1v2 = NULL;
++			return err;
++		}
++	} else {
++		priv->vdd_cam_1v2 = NULL;
++	}
++
++	return 0;
++}
++
++/* ================================================================
++ * Probe / Remove
++ * ================================================================ */
++
++static struct regmap_config max96724_regmap_config = {
++	.reg_bits = 16,
++	.val_bits = 8,
++	.cache_type = REGCACHE_NONE,
++};
++
++static int max96724_probe(struct i2c_client *client,
++			   const struct i2c_device_id *id)
++{
++	struct max96724 *priv;
++	int err = 0;
++
++	dev_info(&client->dev,
++		 "[MAX96724]: probing Quad GMSL2 Deserializer (Tunnel Mode)\n");
++
++	priv = devm_kzalloc(&client->dev, sizeof(*priv), GFP_KERNEL);
++	if (!priv)
++		return -ENOMEM;
++
++	priv->i2c_client = client;
++	priv->regmap = devm_regmap_init_i2c(priv->i2c_client,
++					     &max96724_regmap_config);
++	if (IS_ERR(priv->regmap)) {
++		dev_err(&client->dev,
++			"regmap init failed: %ld\n", PTR_ERR(priv->regmap));
++		return -ENODEV;
++	}
++
++	err = max96724_parse_dt(priv, client);
++	if (err) {
++		dev_err(&client->dev, "unable to parse dt\n");
++		return -EFAULT;
++	}
++
++	max96724_pipes_reset(priv);
++
++	if (priv->max_src > MAX96724_MAX_SOURCES) {
++		dev_err(&client->dev,
++			"max sources more than currently supported\n");
++		return -EINVAL;
++	}
++
++	mutex_init(&priv->lock);
++
++	dev_set_drvdata(&client->dev, priv);
++
++	dev_info(&client->dev, "%s: success (link_speed=%d Gbps, max_src=%d)\n",
++		 __func__, priv->link_speed, priv->max_src);
++
++	return err;
++}
++
++static int max96724_remove(struct i2c_client *client)
++{
++	struct max96724 *priv;
++
++	if (client != NULL) {
++		priv = dev_get_drvdata(&client->dev);
++		mutex_destroy(&priv->lock);
++		i2c_unregister_device(client);
++		client = NULL;
++	}
++
++	return 0;
++}
++
++static const struct i2c_device_id max96724_id[] = {
++	{ "max96724", 0 },
++	{ },
++};
++
++MODULE_DEVICE_TABLE(i2c, max96724_id);
++
++static struct i2c_driver max96724_i2c_driver = {
++	.driver = {
++		.name = "max96724",
++		.owner = THIS_MODULE,
++		.of_match_table = of_match_ptr(max96724_of_match),
++	},
++	.probe = max96724_probe,
++	.remove = max96724_remove,
++	.id_table = max96724_id,
++};
++
++static int __init max96724_init(void)
++{
++	return i2c_add_driver(&max96724_i2c_driver);
++}
++
++static void __exit max96724_exit(void)
++{
++	i2c_del_driver(&max96724_i2c_driver);
++}
++
++module_init(max96724_init);
++module_exit(max96724_exit);
++
++MODULE_DESCRIPTION("Quad GMSL2 Deserializer driver max96724 (Tunnel Mode)");
++MODULE_AUTHOR("RealSense AI");
++MODULE_LICENSE("GPL v2");
+diff --git a/include/media/max96717.h b/include/media/max96717.h
+new file mode 100644
+index 0000000..65bf930
+--- /dev/null
++++ b/include/media/max96717.h
+@@ -0,0 +1,151 @@
++/*
++ * max96717.c - MAX96717 GMSL2 Serializer driver (Tunnel Mode)
++ *
++ * Copyright (c) 2026, RealSense, Inc.  All rights reserved.
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms and conditions of the GNU General Public License,
++ * version 2, as published by the Free Software Foundation.
++ *
++ * This program is distributed in the hope it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
++ * more details.
++ *
++ * You should have received a copy of the GNU General Public License
++ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
++ */
++
++/**
++ * @file
++ * <b>MAX96717 API: For Analog Devices MAX96717 GMSL2 serializer</b>
++ *
++ * @b Description: Defines elements used to set up and use an
++ *  Analog Devices MAX96717 GMSL2 serializer in Tunnel Mode.
++ */
++
++#ifndef __MAX96717_H__
++#define __MAX96717_H__
++
++#include <linux/types.h>
++#include <media/gmsl-link.h>
++
++/**
++ * \defgroup max96717 MAX96717 serializer driver
++ *
++ * Controls the MAX96717 GMSL2 serializer module (Tunnel Mode).
++ *
++ * @ingroup serdes_group
++ * @{
++ */
++
++/**
++ * @brief  Configures a single pipe on the serializer.
++ *
++ * In Tunnel Mode, per-pipe DT/VC filtering is not active on the serializer
++ * side (all VCs are tunneled transparently). This function maintains API
++ * compatibility with the d4xx sensor driver framework.
++ *
++ * @param  [in]  dev          The serializer device handle.
++ * @param  [in]  pipe_id      Pipe index (0..3).
++ * @param  [in]  data_type1   Primary CSI-2 data type.
++ * @param  [in]  data_type2   Secondary CSI-2 data type (e.g. embedded).
++ * @param  [in]  vc_id        Virtual channel ID.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96717_set_pipe(struct device *dev, int pipe_id, u8 data_type1,
++		      u8 data_type2, u32 vc_id);
++
++/**
++ * @brief  Toggle SER TX to restore tunnel detection after DES ONESHOT.
++ *
++ * A DES ONESHOT resets the video data path. The serializer must cycle
++ * its TX enable (REG2 0x03→0x43) for the deserializer to re-acquire
++ * the tunnel stream.
++ *
++ * @param  [in]  dev          The serializer device handle.
++ */
++void max96717_retrigger_tx(struct device *dev);
++
++/**
++ * @brief  Powers on the serializer and performs I2C overrides
++ * for sensor and serializer devices.
++ *
++ * Must be called after the deserializer's max96724_setup_link().
++ *
++ * @param  [in]  dev          The serializer device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96717_setup_control(struct device *dev);
++
++/**
++ * @brief  Reverts I2C overrides and resets the serializer.
++ *
++ * @param  [in]  dev          The serializer device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96717_reset_control(struct device *dev);
++
++/**
++ * @brief  Pairs a sensor device with the serializer.
++ *
++ * To be called by the sensor client driver.
++ *
++ * @param  [in]  dev          The serializer device handle.
++ * @param  [in]  g_ctx        The gmsl_link_ctx structure handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96717_sdev_pair(struct device *dev, struct gmsl_link_ctx *g_ctx);
++
++/**
++ * @brief  Unpairs a sensor device from the serializer.
++ *
++ * @param  [in]  dev          The serializer device handle.
++ * @param  [in]  s_dev        The sensor device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96717_sdev_unpair(struct device *dev, struct device *s_dev);
++
++/**
++ * @brief  Sets up the serializer's internal streaming pipeline.
++ *
++ * Configures CSI-2 input mode, lane mapping, and enables Tunnel Mode
++ * (EXT11[7]=1 at register 0x0383).
++ *
++ * @param  [in]  dev          The serializer device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96717_setup_streaming(struct device *dev);
++
++/**
++ * @brief  Applies initial register settings for the serializer.
++ *
++ * Configures default pipe settings and Tunnel Mode registers.
++ *
++ * @param  [in]  dev          The serializer device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96717_init_settings(struct device *dev);
++
++/**
++ * @brief  No-op hook for GPIO-over-GMSL tunneling for FSIN/FOUT signals.
++ *
++ * The signal map is documented, but the concrete MFP_CFG values are
++ * not available yet. This hook currently logs and returns success.
++ *
++ * @param  [in]  dev          The serializer device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96717_setup_gpio_tunneling(struct device *dev);
++
++/** @} */
++
++#endif  /* __MAX96717_H__ */
+diff --git a/include/media/max96724.h b/include/media/max96724.h
+new file mode 100644
+index 0000000..dc5a8ea
+--- /dev/null
++++ b/include/media/max96724.h
+@@ -0,0 +1,183 @@
++/*
++ * max96717.c - MAX96717 GMSL2 Serializer driver (Tunnel Mode)
++ *
++ * Copyright (c) 2026, RealSense, Inc.  All rights reserved.
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms and conditions of the GNU General Public License,
++ * version 2, as published by the Free Software Foundation.
++ *
++ * This program is distributed in the hope it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
++ * more details.
++ *
++ * You should have received a copy of the GNU General Public License
++ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
++ */
++
++/**
++ * @file
++ * <b>MAX96724 API: For Analog Devices MAX96724 GMSL2 quad deserializer</b>
++ *
++ * @b Description: Defines elements used to set up and use an
++ *  Analog Devices MAX96724 quad GMSL2 deserializer in Tunnel Mode.
++ */
++
++#ifndef __MAX96724_H__
++#define __MAX96724_H__
++
++#include <linux/types.h>
++#include <media/gmsl-link.h>
++
++/**
++ * \defgroup max96724 MAX96724 deserializer driver
++ *
++ * Controls the MAX96724 quad GMSL2 deserializer module (Tunnel Mode).
++ *
++ * @ingroup serdes_group
++ * @{
++ */
++
++int max96724_get_available_pipe_id(struct device *dev, int vc_id);
++int max96724_get_ser_pipe_id(struct device *dev, int dser_pipe_id, int vc_id);
++int max96724_set_pipe(struct device *dev, int pipe_id, u8 data_type1,
++		      u8 data_type2, u32 vc_id);
++int max96724_release_pipe(struct device *dev, int pipe_id);
++void max96724_reset_oneshot(struct device *dev);
++
++/**
++ * @brief  Puts the deserializer in single exclusive link mode.
++ *
++ * @param  [in]  dev          The deserializer device handle.
++ * @param  [in]  s_dev        The sensor device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96724_setup_link(struct device *dev, struct device *s_dev);
++
++/**
++ * @brief  Sets up the deserializer link's control pipeline.
++ *
++ * Configures I2C pass-through, splitter mode if needed, and
++ * enables the tunnel mode pipe routing for the source.
++ *
++ * @param  [in]  dev          The deserializer device handle.
++ * @param  [in]  s_dev        The sensor device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96724_setup_control(struct device *dev, struct device *s_dev);
++
++/**
++ * @brief  Resets the deserializer link control pipeline.
++ *
++ * @param  [in]  dev          The deserializer device handle.
++ * @param  [in]  s_dev        The sensor device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96724_reset_control(struct device *dev, struct device *s_dev);
++
++/**
++ * @brief  Registers a source sensor device with the deserializer.
++ *
++ * @param  [in]  dev          The deserializer device handle.
++ * @param  [in]  g_ctx        The gmsl_link_ctx structure handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96724_sdev_register(struct device *dev, struct gmsl_link_ctx *g_ctx);
++
++/**
++ * @brief  Unregisters a source sensor device from the deserializer.
++ *
++ * @param  [in]  dev          The deserializer device handle.
++ * @param  [in]  s_dev        The sensor device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96724_sdev_unregister(struct device *dev, struct device *s_dev);
++
++/**
++ * @brief  Configures the internal streaming pipeline.
++ *
++ * Sets up tunnel mode pipe routing, CSI-2 output lane configuration,
++ * and MIPI PHY settings.
++ *
++ * @param  [in]  dev          The deserializer device handle.
++ * @param  [in]  s_dev        The sensor device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96724_setup_streaming(struct device *dev, struct device *s_dev);
++
++/**
++ * @brief  Enables streaming for a source sensor.
++ *
++ * @param  [in]  dev          The deserializer device handle.
++ * @param  [in]  s_dev        The sensor device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96724_start_streaming(struct device *dev, struct device *s_dev);
++
++/**
++ * @brief  Disables streaming for a source sensor.
++ *
++ * @param  [in]  dev          The deserializer device handle.
++ * @param  [in]  s_dev        The sensor device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96724_stop_streaming(struct device *dev, struct device *s_dev);
++
++/**
++ * @brief  Powers on the MAX96724 deserializer module.
++ *
++ * Asserts shared reset GPIO and powers on the regulator.
++ *
++ * @param  [in]  dev          The deserializer device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96724_power_on(struct device *dev);
++
++/**
++ * @brief  Powers off the MAX96724 deserializer module.
++ *
++ * @param  [in]  dev          The deserializer device handle.
++ */
++void max96724_power_off(struct device *dev);
++
++/**
++ * @brief  Applies initial register settings for the deserializer.
++ *
++ * Configures default pipe mappings, tunnel mode, and CSI output for
++ * the D5xx/SC1.2 use case.
++ *
++ * @param  [in]  dev          The deserializer device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96724_init_settings(struct device *dev);
++
++/**
++ * @brief  Maps deserializer pipe ID to serializer pipe ID.
++ *
++ * In tunnel mode with MAX96717, all data flows through a single pipe
++ * per camera, so the mapping is 1:1.
++ *
++ * @param  [in]  dev             The deserializer device handle.
++ * @param  [in]  dser_pipe_id    Deserializer pipe ID.
++ * @param  [in]  ser_pipe_id     Serializer pipe ID.
++ * @param  [in]  vc_id           VC ID associated with this pipe.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96724_bind_ser_to_dser_pipe(struct device *dev, int dser_pipe_id,
++				   int ser_pipe_id, u32 vc_id);
++
++/** @} */
++
++#endif  /* __MAX96724_H__ */
+-- 
+2.25.1
+

--- a/nvidia-oot/6.2/0001-Porting-nvidia-driver-patches-to-jetpack-6.0.patch
+++ b/nvidia-oot/6.2/0001-Porting-nvidia-driver-patches-to-jetpack-6.0.patch
@@ -25,13 +25,15 @@ diff --git a/drivers/media/i2c/Makefile b/drivers/media/i2c/Makefile
 index 7c5913c6..396b9bc3 100644
 --- a/drivers/media/i2c/Makefile
 +++ b/drivers/media/i2c/Makefile
-@@ -5,6 +5,9 @@ subdir-ccflags-y += -Werror
+@@ -5,6 +5,11 @@ subdir-ccflags-y += -Werror
  
  obj-m += max9295.o
  obj-m += max9296.o
 +subdir-ccflags-y += -DCONFIG_VIDEO_D4XX_SERDES
 +subdir-ccflags-y += -DCONFIG_TEGRA_CAMERA_PLATFORM
 +obj-m += d4xx.o
++obj-m += max96717.o
++obj-m += max96724.o
  ifeq ($(findstring ack_src,$(NV_BUILD_KERNEL_OPTIONS)),)
  obj-m += max96712.o
  

--- a/nvidia-oot/6.2/0011-Add-MAX96717-serializer-and-MAX96724-deserializer-dr.patch
+++ b/nvidia-oot/6.2/0011-Add-MAX96717-serializer-and-MAX96724-deserializer-dr.patch
@@ -1,0 +1,3147 @@
+From 40fac9b67ddea60055961d32fa89fe8f608396ff Mon Sep 17 00:00:00 2001
+From: RealSense AI <realsense@realsenseai.com>
+Date: Tue, 12 May 2026 17:06:23 +0800
+Subject: [PATCH] Add MAX96717 serializer and MAX96724 deserializer drivers for
+ tunnel mode
+
+Add MAX96717 GMSL2 serializer and MAX96724 GMSL2 quad deserializer
+drivers for Tunnel Mode operation with D5xx cameras.
+
+MAX96717 serializer features:
+- CSI-2 input with 2/4 lane support
+- Tunnel Mode encapsulation of full CSI-2 byte stream
+- I2C address translation for sensor passthrough
+- GPIO-over-GMSL tunneling hook for FSIN/FOUT signals
+
+MAX96724 quad deserializer features:
+- Up to 4 GMSL2 links (quad camera support)
+- Configurable link speed (3 Gbps / 6 Gbps via DT)
+- Tunnel Mode pipe routing and CSI-2 output
+- 2x4 and 4x2 CSI output mode support
+- Power management with GPIO reset and regulator control
+
+Signed-off-by: RealSense AI <realsense@realsenseai.com>
+---
+ drivers/media/i2c/Makefile   |    2 +
+ drivers/media/i2c/max96717.c |  835 ++++++++++++++
+ drivers/media/i2c/max96724.c | 1916 ++++++++++++++++++++++++++++++++++
+ include/media/max96717.h     |  151 ++
+ include/media/max96724.h     |  183 +++
+ 4 files changed, 3085 insertions(+)
+ create mode 100644 drivers/media/i2c/max96717.c
+ create mode 100644 drivers/media/i2c/max96724.c
+ create mode 100644 include/media/max96717.h
+ create mode 100644 include/media/max96724.h
+
+diff --git a/drivers/media/i2c/max96717.c b/drivers/media/i2c/max96717.c
+new file mode 100644
+index 0000000..70d25a3
+--- /dev/null
++++ b/drivers/media/i2c/max96717.c
+@@ -0,0 +1,835 @@
++/*
++ * max96717.c - MAX96717 GMSL2 Serializer driver (Tunnel Mode)
++ *
++ * Copyright (c) 2026, RealSense, Inc.  All rights reserved.
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms and conditions of the GNU General Public License,
++ * version 2, as published by the Free Software Foundation.
++ *
++ * This program is distributed in the hope it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
++ * more details.
++ *
++ * You should have received a copy of the GNU General Public License
++ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
++ */
++
++#include <media/camera_common.h>
++#include <linux/of.h>
++#include <linux/module.h>
++#include <media/max96717.h>
++
++/* ===== Register Addresses ===== */
++
++/* REG0: Device ID (read-only, returns 0x40) */
++#define MAX96717_DEV_ADDR		0x00
++
++/* 
++ *   REG1: Link Speed
++ *   bit[3]=1: 3 Gbps, bit[4]=1: 6 Gbps
++ */
++#define MAX96717_REG1_ADDR		0x01
++
++/* 
++ *   PIPE_EN: Pipe enable / soft reset
++ *   0x03 = soft reset, 0x43 = pipes enabled + video init
++ *   Matches MAX9295 PIPE_EN at 0x02
++ */
++#define MAX96717_PIPE_EN_ADDR		0x02
++
++/* 
++ *   CTRL0: GMSL2 TX Control
++ *   bit[5]=1: GMSL2 mode, bit[0]=1: enable transmitter
++ *   0x21 = GMSL2 mode + TX enable on Link A
++ */
++#define MAX96717_CTRL0_ADDR		0x10
++
++/* 
++ *   CTRL3: Start Video - final enable bit
++ *   bit[0]=1: activate video stream
++ */
++#define MAX96717_CTRL3_ADDR		0x13
++
++/* 
++ *   TX1: FEC Enable
++ *   bit[6]=1: Reed-Solomon FEC enabled
++ */
++#define MAX96717_TX1_ADDR		0x29
++
++/*
++ *   MAX96717 I2C address translation registers (GMSL2 standard):
++ *   SRC_A / DST_A (0x42/0x43): Translation pair A (SER broadcast addr)
++ *   SRC_B / DST_B (0x44/0x45): Translation pair B (sensor passthrough)
++ *
++ *   When host writes to SRC_B address, the MAX96717 translates it to
++ *   DST_B and forwards via GMSL back-channel to the remote sensor.
++ *
++ */
++#define MAX96717_SRC_A_ADDR		0x42
++#define MAX96717_DST_A_ADDR		0x43
++#define MAX96717_I2C4_ADDR		0x44
++#define MAX96717_I2C5_ADDR		0x45
++
++/* 
++ *   TX_STR_SEL: Stream ID select
++ *   bits[1:0]: stream ID for DES pipe routing
++ */
++#define MAX96717_TX_STR_SEL_ADDR	0x5B
++
++/* 
++ *   VIDEO_TX0/TX1: Video TX path config
++ *   0x0110=0xE9, 0x0111=0x10 for tunnel mode data path
++ */
++#define MAX96717_VIDEO_TX0_ADDR		0x110
++#define MAX96717_VIDEO_TX1_ADDR		0x111
++
++/* 
++ *   FRONTTOP_0: Front-end topology
++ *   0x12 = single CSI-2 port A, all VCs pass through
++ */
++#define MAX96717_FRONTTOP0_ADDR		0x308
++
++/* 
++ *   MIPI_RX0-RX3: CSI-2 receiver configuration
++ *   RX0 (0x330): CSI mode (0x00 = D-PHY controller A)
++ *   RX1 (0x331): Lane count - ctrl1_num_lanes bits[5:4]
++ *                0x30 = bits[5:4]=11 (4 lanes)
++ *   RX2 (0x332): Lane mapping - 0xE0 = default 1x4 map
++ *   RX3 (0x333): Lane mapping - 0x04 = default 1x4 map
++ */
++#define MAX96717_MIPI_RX0_ADDR		0x330
++#define MAX96717_MIPI_RX1_ADDR		0x331
++#define MAX96717_MIPI_RX2_ADDR		0x332
++#define MAX96717_MIPI_RX3_ADDR		0x333
++
++/* 
++ *   EXT11: TUNNEL MODE ENABLE
++ *   bit[7]=1: Tun_Mode = ON
++ *   0x383 = 0x80
++ */
++#define MAX96717_EXT11_ADDR		0x383
++
++/* PHY calibration stage-1 value */
++#define MAX96717_PHY_CAL_STAGE1		0x80
++/* PHY calibration stage-2 value */
++#define MAX96717_PHY_CAL_STAGE2		0x90
++/* CSI input timing / frequency config */
++#define MAX96717_CSI_TIMING_3F0		0x59
++#define MAX96717_CSI_TIMING_3F1		0x09
++
++/* ===== Register Values ===== */
++
++/* Soft reset value for PIPE_EN register */
++#define MAX96717_SOFT_RESET		0x03
++
++/* Final enable: pipes enabled + video init */
++#define MAX96717_PIPE_EN_ALL		0x43
++
++/* CTRL0: GMSL2 mode + TX enable (Link A) */
++#define MAX96717_CTRL0_LINK_A		0x21
++/* CTRL0: GMSL2 mode + TX enable (Link B) */
++#define MAX96717_CTRL0_LINK_B		0x22
++
++/* CTRL0 reset all */
++#define MAX96717_RESET_ALL		0x80
++
++/* EXT11 tunnel mode enable value */
++#define MAX96717_TUN_MODE_EN		0x80
++#define MAX96717_TUN_MODE_DIS		0x00
++
++/* VIDEO_TX0 tunnel mode data path enable */
++#define MAX96717_VIDEO_TX0_TUN		0xE9
++/* VIDEO_TX1 tunnel mode config */
++#define MAX96717_VIDEO_TX1_TUN		0x10
++#define MAX96717_VIDEO_TX0_BPP_MANUAL	0x60
++#define MAX96717_VIDEO_TX1_BPP16	0x50
++#define MAX96717_VIDEO_TX2_ADDR		0x112
++#define MAX96717_VIDEO_TX2_DRIFT_DIS	0x08
++
++/* 
++ *   MIPI RX1: 4-lane CSI-2.
++ *   bits[5:4]=11 (4 lanes).  bits[1:0]=11
++ */
++#define MAX96717_CSI_4_LANES		0x33
++/* 2-lane CSI-2, bits[5:4]=01 */
++#define MAX96717_CSI_2_LANES		0x10
++
++/* Lane mapping for 1x4 mode */
++#define MAX96717_CSI_1X4_LANE_MAP1	0xE0
++#define MAX96717_CSI_1X4_LANE_MAP2	0x04
++
++/* FRONTTOP_0: single port A, all VCs */
++#define MAX96717_FRONTTOP0_PORT_A	0x12
++/* Pixel mode from Port B into Pipe Z */
++#define MAX96717_FRONTTOP0_PIXEL_PORT_B	0x64
++#define MAX96717_FRONTTOP5_ADDR		0x30D
++#define MAX96717_FRONTTOP9_ADDR		0x311
++#define MAX96717_FRONTTOP16_ADDR	0x318
++#define MAX96717_FRONTTOP17_ADDR	0x319
++#define MAX96717_FRONTTOP9_START_VIDEO	0x40
++
++/* MIPI_RX0: CSI reset on + non-continuous clock */
++#define MAX96717_MIPI_RX0_RESET		0x08
++/* MIPI_RX0: Normal operation */
++#define MAX96717_MIPI_RX0_NORMAL	0x00
++
++/* REG1: 3 Gbps link speed, bit[3]=1 */
++#define MAX96717_LINK_SPEED_3GBPS	0x08
++/* REG1: 6 Gbps link speed, bit[4]=1 */
++#define MAX96717_LINK_SPEED_6GBPS	0x10
++
++/* EXT11 tunnel mode pre-config (0x0383=0x80) */
++#define MAX96717_EXT11_TUN_PRE		0x80
++
++#define MAX96717_MAX_PIPES		4
++
++/*
++ * MFP8 (GPIO8) high-impedance release.
++ *
++ * At power-up GPIO8 comes up with GPIO_OUT_DIS=0 (output driver enabled,
++ * GPIO8_A=0x9c observed live), so the serializer actively drives the M2_I2C
++ * line and wedges the bus: any IMU I2C access by the camera FW times out
++ * whenever the serializer is powered.  This was confirmed on hardware -
++ * tri-stating GPIO8 alone immediately restored IMU I2C reads.
++ *
++ * GPIO8 is the ONLY serializer pin left driving its net (all other GPIOs,
++ * including MFP3/MFP4 interrupt lines, are already high-Z).  Release GPIO8
++ * (output driver off, no link TX/RX, no pull) so only the M2_I2C bus
++ * masters own the line.
++ *
++ * GPIO_n registers are a 3-byte group (A/B/C) starting at 0x02BE:
++ *   GPIO_n_A = 0x02BE + 3*n
++ */
++#define MAX96717_GPIO8_A_ADDR		0x02D6	/* MFP8 / M2_I2C (pass-through SCL1) */
++#define MAX96717_GPIO8_B_ADDR		0x02D7
++/* GPIO_A: GPIO_OUT_DIS=1 (high-Z), GPIO_TX_EN=0, GPIO_RX_EN=0 */
++#define MAX96717_GPIO_A_HIGH_Z		0x01
++/* GPIO_B: PULL_UPDN_SEL=None, TX_ID=0 */
++#define MAX96717_GPIO_B_NO_PULL		0x00
++
++/* ===== Data Structures ===== */
++
++struct max96717_client_ctx {
++	struct gmsl_link_ctx *g_ctx;
++	bool st_done;
++};
++
++struct max96717 {
++	struct i2c_client *i2c_client;
++	struct regmap *regmap;
++	struct max96717_client_ctx g_client;
++	struct mutex lock;
++	bool pixel_mode;
++	/* primary serializer properties */
++	__u32 def_addr;
++	__u32 pst2_ref;
++};
++
++static struct max96717 *prim_priv__;
++
++struct reg_pair {
++	u16 addr;
++	u8 val;
++};
++
++/* ===== Low-level I2C ===== */
++
++static int max96717_write_reg(struct device *dev, u16 addr, u8 val)
++{
++	struct max96717 *priv = dev_get_drvdata(dev);
++	int err;
++
++	err = regmap_write(priv->regmap, addr, val);
++	if (err)
++		dev_err(dev, "%s:i2c write failed, 0x%x = %x\n",
++			__func__, addr, val);
++
++	/* delay before next i2c command as required for SERDES link */
++	usleep_range(100, 110);
++
++	return err;
++}
++
++static int max96717_set_registers(struct device *dev, struct reg_pair *map,
++				  u32 count)
++{
++	int err = 0;
++	u32 j;
++
++	for (j = 0; j < count; j++) {
++		err = max96717_write_reg(dev, map[j].addr, map[j].val);
++		if (err)
++			break;
++	}
++
++	return err;
++}
++
++/* ===== Streaming Setup ===== */
++
++/*
++ * max96717_setup_streaming - Configure CSI-2 input and enable Tunnel Mode
++ *
++ * In Tunnel Mode (unlike MAX9295 Pixel Mode), the serializer encapsulates
++ * the entire CSI-2 byte stream verbatim into a single GMSL2 tunnel.
++ * All VCs (VC0-VC3) are preserved end-to-end.
++ */
++int max96717_setup_streaming(struct device *dev)
++{
++	struct max96717 *priv = dev_get_drvdata(dev);
++	int err = 0;
++	struct gmsl_link_ctx *g_ctx;
++
++	mutex_lock(&priv->lock);
++
++	if (!priv->g_client.g_ctx) {
++		dev_err(dev, "%s: no sdev client found\n", __func__);
++		err = -EINVAL;
++		goto error;
++	}
++
++	if (priv->g_client.st_done) {
++		dev_dbg(dev, "%s: stream setup is already done\n", __func__);
++		goto error;
++	}
++
++	g_ctx = priv->g_client.g_ctx;
++
++	max96717_write_reg(dev, MAX96717_EXT11_ADDR, MAX96717_TUN_MODE_EN);
++	max96717_write_reg(dev, MAX96717_MIPI_RX1_ADDR, MAX96717_CSI_4_LANES);
++	max96717_write_reg(dev, MAX96717_MIPI_RX2_ADDR, MAX96717_CSI_1X4_LANE_MAP1);
++	max96717_write_reg(dev, MAX96717_MIPI_RX3_ADDR, MAX96717_CSI_1X4_LANE_MAP2);
++	max96717_write_reg(dev, MAX96717_VIDEO_TX0_ADDR, MAX96717_VIDEO_TX0_TUN);
++	max96717_write_reg(dev, MAX96717_VIDEO_TX1_ADDR, MAX96717_VIDEO_TX1_TUN);
++
++	max96717_write_reg(dev, MAX96717_MIPI_RX0_ADDR, MAX96717_MIPI_RX0_RESET);
++	usleep_range(2000, 2100);
++	max96717_write_reg(dev, MAX96717_MIPI_RX0_ADDR, MAX96717_MIPI_RX0_NORMAL);
++
++	/* pipes on + video init */
++	max96717_write_reg(dev, MAX96717_PIPE_EN_ADDR, MAX96717_PIPE_EN_ALL);
++
++	priv->g_client.st_done = true;
++
++error:
++	mutex_unlock(&priv->lock);
++	return err;
++}
++EXPORT_SYMBOL(max96717_setup_streaming);
++
++/* ===== Control Setup ===== */
++
++/*
++ * max96717_setup_control - Set up I2C address translation and link control
++ *
++ * Steps:
++ *   1. Reassign serializer I2C address via DEV_ADDR (reg 0x00)
++ *   2. Configure GMSL2 link mode via CTRL0 (reg 0x10)
++ *   3. Set I2C address translation for sensor passthrough:
++ *      I2C4/SRC_B (0x44) <- (sdev_reg << 1): proxy addr visible to host
++ *      I2C5/DST_B (0x45) <- (sdev_def << 1): real addr on back-channel
++ *
++ */
++int max96717_setup_control(struct device *dev)
++{
++	struct max96717 *priv = dev_get_drvdata(dev);
++	int err = 0;
++	struct gmsl_link_ctx *g_ctx;
++
++	mutex_lock(&priv->lock);
++
++	if (!priv->g_client.g_ctx) {
++		dev_err(dev, "%s: no sensor dev client found\n", __func__);
++		err = -EINVAL;
++		goto error;
++	}
++
++	g_ctx = priv->g_client.g_ctx;
++
++	if (prim_priv__) {
++		unsigned int dev_id;
++		int probe_ret;
++
++		probe_ret = regmap_read(prim_priv__->regmap,
++					MAX96717_DEV_ADDR, &dev_id);
++		if (probe_ret == 0) {
++			/* Primary address (0x40) still responsive — do reassign */
++			max96717_write_reg(&prim_priv__->i2c_client->dev,
++					   MAX96717_DEV_ADDR,
++					   (g_ctx->ser_reg << 1));
++		} else {
++			dev_info(&prim_priv__->i2c_client->dev,
++				 "%s: SER already reassigned (addr 0x40 NACK), skipping DEV_ADDR write\n",
++				 __func__);
++		}
++	}
++
++	/* CTRL0: GMSL2 mode + TX enable */
++	if (g_ctx->serdes_csi_link == GMSL_SERDES_CSI_LINK_A)
++		err = max96717_write_reg(dev, MAX96717_CTRL0_ADDR,
++					 MAX96717_CTRL0_LINK_A);
++	else
++		err = max96717_write_reg(dev, MAX96717_CTRL0_ADDR,
++					 MAX96717_CTRL0_LINK_B);
++
++	if (err) {
++		dev_err(dev, "%s: ERROR: ser device not found\n", __func__);
++		goto error;
++	}
++
++	/* delay to settle link */
++	msleep(100);
++
++	/*
++	 * I2C address translation for sensor passthrough.
++	 *
++	 * I2C4 / SRC_B (0x44): sensor proxy addr visible to Orin host
++	 * I2C5 / DST_B (0x45): sensor real addr on GMSL back-channel
++	 *
++	 * When host sends I2C to sdev_reg (e.g., 0x1a), the MAX96717
++	 * translates it to sdev_def (e.g., 0x42) and forwards via GMSL
++	 * back-channel to the HKR sensor.
++	 */
++	max96717_write_reg(dev, MAX96717_I2C4_ADDR,
++			   (g_ctx->sdev_reg << 1));
++	max96717_write_reg(dev, MAX96717_I2C5_ADDR,
++			   (g_ctx->sdev_def << 1));
++
++	/* dev addr pass-through ref */
++	if (prim_priv__)
++		prim_priv__->pst2_ref++;
++
++	g_ctx->serdev_found = true;
++
++error:
++	mutex_unlock(&priv->lock);
++	return err;
++}
++EXPORT_SYMBOL(max96717_setup_control);
++
++/* ===== GPIO Tunneling ===== */
++
++/*
++ * max96717_setup_gpio_tunneling - GPIO-over-GMSL no-op hook
++ *
++ *   GPIO Signal Mapping:
++ *   MFP0 → GPIO0: FSIN (DES→SER, frame sync in)
++ *   MFP1 → GPIO1: FOUT/STROBE (SER→DES, frame sync out)
++ *   MFP4 → GPIO4: RESET_N (DES→SER, hard reset)
++ *   MFP5 → GPIO5: IRQ (SER→DES, interrupt request)
++ *   MFP6 → GPIO6: ZV_SYNC (DES→SER, IR stereo sync)
++ *
++ */
++int max96717_setup_gpio_tunneling(struct device *dev)
++{
++	struct max96717 *priv = dev_get_drvdata(dev);
++	int err = 0;
++
++	mutex_lock(&priv->lock);
++
++	dev_info(dev, "%s: GPIO tunneling hook is a no-op; MFP_CFG values are not defined yet\n",
++		 __func__);
++
++	mutex_unlock(&priv->lock);
++
++	return err;
++}
++EXPORT_SYMBOL(max96717_setup_gpio_tunneling);
++
++/* ===== Reset Control ===== */
++
++int max96717_reset_control(struct device *dev)
++{
++	struct max96717 *priv = dev_get_drvdata(dev);
++	int err = 0;
++
++	mutex_lock(&priv->lock);
++	if (!priv->g_client.g_ctx) {
++		dev_err(dev, "%s: no sdev client found\n", __func__);
++		err = -EINVAL;
++		goto error;
++	}
++
++	priv->g_client.st_done = false;
++
++	if (prim_priv__) {
++		prim_priv__->pst2_ref--;
++
++		max96717_write_reg(dev, MAX96717_DEV_ADDR,
++				   (prim_priv__->def_addr << 1));
++		if (prim_priv__->pst2_ref == 0)
++			max96717_write_reg(&prim_priv__->i2c_client->dev,
++					   MAX96717_CTRL0_ADDR,
++					   MAX96717_RESET_ALL);
++	}
++
++error:
++	mutex_unlock(&priv->lock);
++	return err;
++}
++EXPORT_SYMBOL(max96717_reset_control);
++
++/* ===== Device Pairing ===== */
++
++int max96717_sdev_pair(struct device *dev, struct gmsl_link_ctx *g_ctx)
++{
++	struct max96717 *priv;
++	int err = 0;
++
++	if (!dev || !g_ctx || !g_ctx->s_dev) {
++		dev_err(dev, "%s: invalid input params\n", __func__);
++		return -EINVAL;
++	}
++
++	priv = dev_get_drvdata(dev);
++	mutex_lock(&priv->lock);
++	if (priv->g_client.g_ctx) {
++		/* 
++		 * Already paired — tolerate if this is a re-probe of
++		 * the same camera after a failed first attempt.
++		 * Simply overwrite with the new g_ctx.
++		 */
++		dev_warn(dev, "%s: re-pairing (previous probe may have failed)\n",
++			 __func__);
++	}
++
++	priv->g_client.st_done = false;
++	priv->g_client.g_ctx = g_ctx;
++
++	/* mutex_unlock in error path, but we have none — inline the unlock */
++	mutex_unlock(&priv->lock);
++	return err;
++}
++EXPORT_SYMBOL(max96717_sdev_pair);
++
++int max96717_sdev_unpair(struct device *dev, struct device *s_dev)
++{
++	struct max96717 *priv = NULL;
++	int err = 0;
++
++	if (!dev || !s_dev) {
++		dev_err(dev, "%s: invalid input params\n", __func__);
++		return -EINVAL;
++	}
++
++	priv = dev_get_drvdata(dev);
++
++	mutex_lock(&priv->lock);
++
++	if (!priv->g_client.g_ctx) {
++		dev_dbg(dev, "%s: device is not paired\n", __func__);
++		err = 0; /* Not an error — already unpaired */
++		goto error;
++	}
++
++	if (priv->g_client.g_ctx->s_dev != s_dev) {
++		dev_warn(dev, "%s: s_dev mismatch, clearing anyway\n", __func__);
++	}
++
++	priv->g_client.g_ctx = NULL;
++	priv->g_client.st_done = false;
++
++error:
++	mutex_unlock(&priv->lock);
++	return err;
++}
++EXPORT_SYMBOL(max96717_sdev_unpair);
++
++/* ===== Pipe Configuration ===== */
++
++/*
++ * __max96717_set_pipe - Configure a single pipe's DT/VC mapping
++ *
++ * In Tunnel Mode, per-pipe DT/VC filtering is bypassed on the serializer。
++ * However, we still write the registers for d4xx framework compatibility.
++ *
++ */
++static int __max96717_set_pipe(struct device *dev, int pipe_id, u8 data_type1,
++			       u8 data_type2, u32 vc_id)
++{
++	int err = 0;
++	u8 bpp = 0x30;
++	struct max96717 *priv = dev_get_drvdata(dev);
++
++	if (priv->pixel_mode) {
++		struct reg_pair pixel_pipe_control[] = {
++			{MAX96717_FRONTTOP16_ADDR, 0x5E},
++			{MAX96717_FRONTTOP17_ADDR, 0x52},
++			{MAX96717_FRONTTOP5_ADDR, 0x01},
++		};
++
++		pixel_pipe_control[0].val = 0x40 | data_type1;
++		pixel_pipe_control[1].val = data_type2 ? (0x40 | data_type2) : 0x00;
++		pixel_pipe_control[2].val = 1 << vc_id;
++
++		return max96717_set_registers(dev, pixel_pipe_control,
++					     ARRAY_SIZE(pixel_pipe_control));
++	} else {
++		struct reg_pair map_pipe_control[] = {
++			/* Pipe X DT addr + 0x2*pipe_id */
++			{0x0314, 0x5E},  /* data_type1 */
++			{0x0315, 0x52},  /* data_type2 */
++			{0x0309, 0x01},  /* VC select */
++			{0x030A, 0x00},
++			{0x031C, 0x30},  /* BPP */
++			{0x0102, 0x0E},  /* LIM_HEART: Disabled */
++		};
++
++		if (data_type1 == GMSL_CSI_DT_RGB_888)
++			bpp = 0x18;
++
++		map_pipe_control[0].addr += 0x2 * pipe_id;
++		map_pipe_control[1].addr += 0x2 * pipe_id;
++		map_pipe_control[2].addr += 0x2 * pipe_id;
++		map_pipe_control[3].addr += 0x2 * pipe_id;
++		map_pipe_control[4].addr += 0x1 * pipe_id;
++		map_pipe_control[5].addr += 0x8 * pipe_id;
++
++		map_pipe_control[0].val = 0x40 | data_type1;
++		map_pipe_control[1].val = 0x40 | data_type2;
++		if (pipe_id == 0)
++			map_pipe_control[1].val |= 0x80;
++		map_pipe_control[2].val = 1 << vc_id;
++		map_pipe_control[3].val = 0x00;
++		map_pipe_control[4].val = bpp;
++		map_pipe_control[5].val = 0x0E;
++
++		err = max96717_set_registers(dev, map_pipe_control,
++					     ARRAY_SIZE(map_pipe_control));
++	}
++
++	return err;
++}
++
++/*
++ * max96717_init_settings - Initialize default pipe/streaming settings
++ *
++ * In Tunnel Mode, per-pipe DT config is not functionally needed
++ * but we configure pipes for d4xx compatibility.
++ * Default: 4 pipes with YUV422_8 + EMBED, VC0-3.
++ */
++int max96717_init_settings(struct device *dev)
++{
++	int err = 0;
++	int i;
++	struct max96717 *priv = dev_get_drvdata(dev);
++
++	struct reg_pair map_init[] = {
++		/* 
++		 * PIPE_EN soft reset first, then enable tunnel mode.
++		 * Note: FRONTTOP0 is bypassed in tunnel mode (per UG) —
++		 * CSI-2 input goes directly into the tunnel, no port config needed.
++		 */
++		{MAX96717_PIPE_EN_ADDR, MAX96717_SOFT_RESET},
++		{MAX96717_EXT11_ADDR, MAX96717_TUN_MODE_EN},
++		{MAX96717_PIPE_EN_ADDR, MAX96717_PIPE_EN_ALL},
++	};
++	struct reg_pair pixel_init[] = {
++		{MAX96717_PIPE_EN_ADDR, MAX96717_SOFT_RESET},
++		{MAX96717_EXT11_ADDR, MAX96717_TUN_MODE_DIS},
++		{MAX96717_FRONTTOP0_ADDR, MAX96717_FRONTTOP0_PIXEL_PORT_B},
++		{MAX96717_FRONTTOP9_ADDR, MAX96717_FRONTTOP9_START_VIDEO},
++		{MAX96717_VIDEO_TX0_ADDR, MAX96717_VIDEO_TX0_BPP_MANUAL},
++		{MAX96717_VIDEO_TX1_ADDR, MAX96717_VIDEO_TX1_BPP16},
++		{MAX96717_VIDEO_TX2_ADDR, MAX96717_VIDEO_TX2_DRIFT_DIS},
++		{MAX96717_PIPE_EN_ADDR, MAX96717_PIPE_EN_ALL},
++	};
++	/*
++	 * Release MFP8 (GPIO8) before any other config so the serializer
++	 * stops driving the camera-side M2_I2C bus shared with the BMI088
++	 * IMU. Confirmed on HW: tri-stating GPIO8 restores IMU I2C access.
++	 */
++	struct reg_pair gpio_release[] = {
++		{MAX96717_GPIO8_A_ADDR, MAX96717_GPIO_A_HIGH_Z},
++		{MAX96717_GPIO8_B_ADDR, MAX96717_GPIO_B_NO_PULL},
++	};
++
++	mutex_lock(&priv->lock);
++
++	/*
++	 * After CTRL0 + I2C translation writes in
++	 * setup_control, the MAX96717 needs settling time before
++	 * accepting writes to PIPE_EN (0x02) and FRONTTOP registers.
++	 */
++	usleep_range(5000, 6000);
++
++	/*
++	 * Tri-state MFP8 (GPIO8) first to release the camera-side M2_I2C
++	 * bus shared with the BMI088 IMU before configuring the rest of
++	 * the SER.
++	 */
++	err = max96717_set_registers(dev, gpio_release,
++				    ARRAY_SIZE(gpio_release));
++	if (err)
++		dev_warn(dev, "%s: failed to release MFP8 (IMU M2_I2C bus)\n",
++			 __func__);
++
++	if (priv->pixel_mode) {
++		err = max96717_set_registers(dev, pixel_init,
++					 ARRAY_SIZE(pixel_init));
++		err |= __max96717_set_pipe(dev, 0, GMSL_CSI_DT_YUV422_8,
++				   0, 0);
++	} else {
++		err = max96717_set_registers(dev, map_init, ARRAY_SIZE(map_init));
++
++		for (i = 0; i < MAX96717_MAX_PIPES; i++)
++			err |= __max96717_set_pipe(dev, i, GMSL_CSI_DT_YUV422_8,
++					   GMSL_CSI_DT_EMBED, i);
++	}
++
++	mutex_unlock(&priv->lock);
++
++	return err;
++}
++EXPORT_SYMBOL(max96717_init_settings);
++
++int max96717_set_pipe(struct device *dev, int pipe_id,
++		      u8 data_type1, u8 data_type2, u32 vc_id)
++{
++	struct max96717 *priv = dev_get_drvdata(dev);
++	int err = 0;
++
++	if (pipe_id > (MAX96717_MAX_PIPES - 1)) {
++		dev_info(dev, "%s: input pipe_id: %d exceeds max96717 max pipes\n",
++			 __func__, pipe_id);
++		return -EINVAL;
++	}
++
++	dev_dbg(dev, "%s pipe_id %d, data_type1 %u, data_type2 %u, vc_id %u\n",
++		__func__, pipe_id, data_type1, data_type2, vc_id);
++
++	mutex_lock(&priv->lock);
++
++	err = __max96717_set_pipe(dev, pipe_id, data_type1, data_type2, vc_id);
++
++	mutex_unlock(&priv->lock);
++
++	return err;
++}
++EXPORT_SYMBOL(max96717_set_pipe);
++
++/*
++ * max96717_retrigger_tx - Toggle SER TX to restore tunnel detection after
++ * a DES ONESHOT.  DES ONESHOT resets the data path; the SER must cycle
++ * its TX enable for the DES to re-acquire the tunnel stream.
++ */
++void max96717_retrigger_tx(struct device *dev)
++{
++	max96717_write_reg(dev, MAX96717_PIPE_EN_ADDR, MAX96717_SOFT_RESET);
++	msleep(30);
++	max96717_write_reg(dev, MAX96717_PIPE_EN_ADDR, MAX96717_PIPE_EN_ALL);
++}
++EXPORT_SYMBOL(max96717_retrigger_tx);
++
++/* ===== Probe / Remove ===== */
++
++static struct regmap_config max96717_regmap_config = {
++	.reg_bits = 16,
++	.val_bits = 8,
++	.cache_type = REGCACHE_RBTREE,
++};
++
++static int max96717_probe(struct i2c_client *client,
++			   const struct i2c_device_id *id)
++{
++	struct max96717 *priv;
++	int err = 0;
++	struct device_node *node = client->dev.of_node;
++
++	dev_info(&client->dev, "[MAX96717]: probing GMSL2 Serializer (Tunnel Mode)\n");
++
++	priv = devm_kzalloc(&client->dev, sizeof(*priv), GFP_KERNEL);
++	if (!priv)
++		return -ENOMEM;
++
++	priv->i2c_client = client;
++	priv->regmap = devm_regmap_init_i2c(priv->i2c_client,
++					     &max96717_regmap_config);
++	if (IS_ERR(priv->regmap)) {
++		dev_err(&client->dev,
++			"regmap init failed: %ld\n", PTR_ERR(priv->regmap));
++		return -ENODEV;
++	}
++
++	mutex_init(&priv->lock);
++	priv->pixel_mode = of_property_read_bool(node, "adi,pixel-mode");
++
++	if (of_get_property(node, "is-prim-ser", NULL)) {
++		if (prim_priv__) {
++			dev_err(&client->dev,
++				"prim-ser already exists\n");
++			return -EEXIST;
++		}
++
++		err = of_property_read_u32(node, "reg", &priv->def_addr);
++		if (err < 0) {
++			dev_err(&client->dev, "reg not found\n");
++			return -EINVAL;
++		}
++
++		prim_priv__ = priv;
++	}
++
++	dev_set_drvdata(&client->dev, priv);
++
++	dev_info(&client->dev, "%s: success\n", __func__);
++
++	return err;
++}
++
++static int max96717_remove(struct i2c_client *client)
++{
++	struct max96717 *priv;
++
++	if (client != NULL) {
++		priv = dev_get_drvdata(&client->dev);
++		mutex_destroy(&priv->lock);
++		i2c_unregister_device(client);
++		client = NULL;
++	}
++
++	return 0;
++}
++
++static const struct i2c_device_id max96717_id[] = {
++	{ "max96717", 0 },
++	{ },
++};
++
++static const struct of_device_id max96717_of_match[] = {
++	{ .compatible = "adi,max96717", },
++	{ .compatible = "maxim,max96717", },
++	{ },
++};
++MODULE_DEVICE_TABLE(of, max96717_of_match);
++MODULE_DEVICE_TABLE(i2c, max96717_id);
++
++static struct i2c_driver max96717_i2c_driver = {
++	.driver = {
++		.name = "max96717",
++		.owner = THIS_MODULE,
++		.of_match_table = of_match_ptr(max96717_of_match),
++	},
++	.probe = max96717_probe,
++	.remove = max96717_remove,
++	.id_table = max96717_id,
++};
++
++static int __init max96717_init(void)
++{
++	return i2c_add_driver(&max96717_i2c_driver);
++}
++
++static void __exit max96717_exit(void)
++{
++	i2c_del_driver(&max96717_i2c_driver);
++}
++
++module_init(max96717_init);
++module_exit(max96717_exit);
++
++MODULE_DESCRIPTION("GMSL2 Serializer driver max96717 (Tunnel Mode)");
++MODULE_AUTHOR("RealSense AI");
++MODULE_LICENSE("GPL v2");
+diff --git a/drivers/media/i2c/max96724.c b/drivers/media/i2c/max96724.c
+new file mode 100644
+index 0000000..22bfb47
+--- /dev/null
++++ b/drivers/media/i2c/max96724.c
+@@ -0,0 +1,1916 @@
++/*
++ * max96724.c - MAX96724 GMSL2 Quad Deserializer driver (Tunnel Mode)
++ *
++ * Copyright (c) 2026, RealSense, Inc.  All rights reserved.
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms and conditions of the GNU General Public License,
++ * version 2, as published by the Free Software Foundation.
++ *
++ * This program is distributed in the hope it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
++ * more details.
++ *
++ * You should have received a copy of the GNU General Public License
++ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
++ */
++
++
++#include <linux/gpio.h>
++#include <linux/types.h>
++#include <linux/module.h>
++#include <linux/of.h>
++#include <linux/of_device.h>
++#include <linux/of_gpio.h>
++#include <media/camera_common.h>
++#include <linux/module.h>
++#include <media/max96724.h>
++
++/* ================================================================
++ * Register Addresses
++ * ================================================================ */
++
++/* --- Device ID / Configuration --- */
++
++/* REG0: Device ID (read-only, returns 0xA2) */
++#define MAX96724_DEV_ID_ADDR		0x00
++
++/* ERRB master reset register */
++#define MAX96724_ERRB_MST_RST_ADDR	0x05
++
++/* 
++ *   GMSL Link/PHY Enable and Mode Select
++ *   bits[7:4]: PHY mode (0=GMSL1, 1=GMSL2) per link D/C/B/A
++ *   bits[3:0]: Link Enable per link D/C/B/A
++ */
++#define MAX96724_LINK_EN_ADDR		0x0006
++
++/* 
++ *   GMSL Link/PHY Rate Select (Links A&B)
++ *   bits[7:6]: Tx Rate Link B, bits[5:4]: Rx Rate Link B
++ *   bits[3:2]: Tx Rate Link A, bits[1:0]: Rx Rate Link A
++ *   Tx: 00=187.5Mbps, Rx: 01=3Gbps, 10=6Gbps
++ */
++#define MAX96724_LINK_RATE_AB_ADDR	0x0010
++
++/* GMSL Link/PHY Rate Select (Links C&D) */
++#define MAX96724_LINK_RATE_CD_ADDR	0x0011
++
++/* Link A lock status (bit[3]=LOCK) */
++#define MAX96724_LINK_A_LOCK_ADDR	0x001A
++
++/* 
++ *   GMSL Link Reset
++ *   bits[7:4]: Link reset D/C/B/A, bits[3:0]: One-shot reset D/C/B/A
++ */
++#define MAX96724_ONESHOT_ADDR		0x0018
++
++/* Soft Reset (write 0x40, wait 5ms) */
++#define MAX96724_REG13_ADDR		0x000D
++
++/* 
++ *   Error Channel Power Up registers (required for 6Gbps)
++ *   Write 0x75 immediately after power-up for robust 6Gbps operation
++ */
++#define MAX96724_ERRCH_A_ADDR		0x1449
++#define MAX96724_ERRCH_B_ADDR		0x1549
++#define MAX96724_ERRCH_C_ADDR		0x1649
++#define MAX96724_ERRCH_D_ADDR		0x1749
++#define MAX96724_ERRCH_FORCE_ON		0x75
++
++/* --- I2C Control Channel / Errata --- */
++
++/* 
++ *   Tunnel Mode SRAM LCRC error suppression
++ *   Set 0x458[7:4] = 0x0 to suppress spurious ERRB in tunnel mode
++ */
++#define MAX96724_SRAM_LCRC_ERR_ADDR	0x0458
++
++/* --- Video Pipe Selection --- */
++
++/*
++ *   bits[3:0] = Pipe 0 source (0x0=SIOA)
++ *   bits[7:4] = Pipe 1 source (0x1=SIOB)
++ */
++#define MAX96724_PIPE_SEL0_ADDR		0xF0
++
++/*
++ *   bits[3:0] = Pipe 2 source (0x2=SIOC)
++ *   bits[7:4] = Pipe 3 source (0x3=SIOD)
++ */
++#define MAX96724_PIPE_SEL1_ADDR		0xF1
++
++#define MAX96724_PIPE_EN_ADDR		0xF4
++
++/* --- Pipe Receiver / Tunnel Mode --- */
++
++/*
++ *   bit[5]=1: Tunnel Mode, bits[1:0]=11: 4-lane MIPI out
++ *   Stride: 0x12 per pipe (P0=0x100, P1=0x112, P2=0x124, P3=0x136)
++ */
++#define MAX96724_VID_RX0_P0_ADDR	0x100
++#define MAX96724_VID_RX6_P0_ADDR	0x106
++#define MAX96724_VID_RX_STRIDE		0x12
++
++#define MAX96724_VID_RX1_P0_ADDR	0x101
++
++/* --- CSI-2 Output (BACKTOP) --- */
++
++/* BACKTOP: CSI-2 output port enable
++ *   0x040B bit[1]=CSIB_EN, bit[0]=CSIA_EN
++ */
++#define MAX96724_BACKTOP_EN_ADDR	0x040B
++
++/* --- MIPI DPLL (Data Rate) --- */
++
++/* 
++ *   MIPI PHY DPLL Freq registers
++ *   bits[4:0] = frequency in multiples of 100MHz
++ *   bit[5]    = DPLL enable (must be set for DPLL to lock)
++ *   E.g., 0x27 = 700MHz + enable = 700Mbps/lane D-PHY
++ *   E.g., 0x2F = 1500MHz + enable = 1.5Gbps/lane
++ */
++#define MAX96724_DPLL_FREQ0_ADDR	0x0415
++#define MAX96724_DPLL_FREQ1_ADDR	0x0418
++#define MAX96724_DPLL_FREQ2_ADDR	0x041B
++#define MAX96724_DPLL_FREQ3_ADDR	0x041E
++
++/* 
++ *   DPLL PHY reset control
++ *   0x1D00 = DPLL CSI PHY1 control
++ *   Write 0xF4 to disable/reset, 0xF5 to enable
++ */
++#define MAX96724_DPLL_CSI2_ADDR		0x1D00
++#define MAX96724_DPLL_DISABLE		0xF4
++#define MAX96724_DPLL_ENABLE		0xF5
++
++/* --- CSI-2 Output PHY Configuration --- */
++
++/* 
++ * CSI output mode/config register.
++ * Mode bits (set exactly one of [4:0]):
++ *   bit[0]=0x01: 4x2 mode
++ *   bit[2]=0x04: 2x4 mode        (Ctrl 1 = master for Port A, Ctrl 2 = Port B)
++ *   bit[3]=0x08: 1x4a + 2x2 mode (Ctrl 1 = master for Port A)
++ *   bit[4]=0x10: 1x4b + 2x2 mode (Ctrl 2 = master for Port B)
++ *
++ * Clock-force bits:
++ *   bit[7]=0x80: force ALL MIPI clocks running (continuous HS clock)
++ *   bit[6]=0x40: force PHY 3 MIPI clock running
++ *   bit[5]=0x20: force PHY 0 MIPI clock running
++ */
++#define MAX96724_CSI_OUT_CFG_ADDR	0x08A0
++
++/* 
++ *   MIPI PHY Enable register
++ *   bits[7:4]: Enable PHY 3/2/1/0 (1=enabled, 0=standby)
++ */
++#define MAX96724_CSI_PHY_EN_ADDR	0x08A2
++
++/* MIPI PHY 0 and 1 Lane Mapping */
++#define MAX96724_CSI_LANE_MAP1_ADDR	0x08A3
++
++/* MIPI PHY 2 and 3 Lane Mapping */
++#define MAX96724_CSI_LANE_MAP2_ADDR	0x08A4
++
++/* 
++ *   MIPI output lane polarity (P/N swap) registers.
++ *   0x08A5 = PHY0/PHY1 lane polarity, 0x08A6 = PHY2/PHY3 lane polarity.
++ *   The FangZhu FG24-4CH PCB swaps the differential P/N pairs on the
++ *   MAX96724 CSI output, so the deserializer must invert lane polarity
++ */
++#define MAX96724_CSI_PHY_POL0_ADDR	0x08A5
++#define MAX96724_CSI_PHY_POL1_ADDR	0x08A6
++#define MAX96724_CSI_PHY_POL_SWAP	0x3F
++
++/* Pipe-to-controller mapping */
++#define MAX96724_MIPI_CTRL_SEL_ADDR	0x08CA
++
++/* Method-1 controller mapping */
++#define MAX96724_MIPI_CTRL_SEL_PIXEL	0xE4
++
++/* --- Lane Control per pipe (stride 0x40) --- */
++
++/*
++ *   0xC0 = 4-lane enabled
++ */
++#define MAX96724_LANE_CTRL0_ADDR	0x090A
++#define MAX96724_LANE_CTRL1_ADDR	0x094A
++#define MAX96724_LANE_CTRL2_ADDR	0x098A
++#define MAX96724_LANE_CTRL3_ADDR	0x09CA
++
++/* --- Pipe Mapping Registers (stride 0x40 per pipe) --- */
++
++/*
++ *   Base addresses for Pipe X (Pipe 0)
++ *   Stride: 0x40 per pipe
++ */
++#define MAX96724_TX11_PIPE_X_EN_ADDR		0x090B
++#define MAX96724_TX45_PIPE_X_DST_CTRL_ADDR	0x092D
++#define MAX96724_PIPE_X_SRC_0_MAP_ADDR		0x090D
++#define MAX96724_PIPE_X_DST_0_MAP_ADDR		0x090E
++#define MAX96724_PIPE_X_SRC_1_MAP_ADDR		0x090F
++#define MAX96724_PIPE_X_DST_1_MAP_ADDR		0x0910
++#define MAX96724_PIPE_X_SRC_2_MAP_ADDR		0x0911
++#define MAX96724_PIPE_X_DST_2_MAP_ADDR		0x0912
++#define MAX96724_PIPE_X_SRC_3_MAP_ADDR		0x0913
++#define MAX96724_PIPE_X_DST_3_MAP_ADDR		0x0914
++
++/* --- Stream Select --- */
++
++/*
++ *   Pipe X=0x0933, stride 0x40 per pipe
++ */
++#define MAX96724_PIPE_X_ST_SEL_ADDR	0x0933
++
++/* --- Extended Pipe Mapping (DST_CTRL2-4 / TX49) --- */
++
++/* 
++ *   Extended DST_CTRL for additional mapping pairs
++ *   All to PHY1 (0x55), same as TX45
++ *   Stride: 0x40 per pipe (base = Pipe X)
++ */
++#define MAX96724_TX46_PIPE_X_ADDR	0x092E
++#define MAX96724_TX47_PIPE_X_ADDR	0x092F
++#define MAX96724_TX48_PIPE_X_ADDR	0x0930
++
++/* 
++ *   MIPI_TX49 synchronous concatenation control
++ *   Set to 0x00 (no concat) for single-camera tunnel mode.
++ *   For 4W concat use 0x87.
++ *   Stride: 0x40 per pipe (base = Pipe X)
++ */
++#define MAX96724_TX49_PIPE_X_ADDR	0x0931
++#define MAX96724_TX49_CONCAT_4W		0x87
++
++/* --- Tunnel Mode per-pipe --- */
++
++/*
++ *   bit[0] = TUN_EN, Default=0x08, write 0x01 to enable
++ */
++#define MAX96724_PIPE0_TUN_EN_ADDR	0x0936
++#define MAX96724_PIPE1_TUN_EN_ADDR	0x0976
++#define MAX96724_PIPE2_TUN_EN_ADDR	0x09B6
++#define MAX96724_PIPE3_TUN_EN_ADDR	0x09F6
++
++/*
++ *   bit[6]: disable auto-tunnel-detect
++ *   bits[5:4]: TUN_DEST (00=PHY0, 01=PHY1, 10=PHY2, 11=PHY3)
++ */
++#define MAX96724_PIPE0_TUN_DEST_ADDR	0x0939
++#define MAX96724_PIPE1_TUN_DEST_ADDR	0x0979
++#define MAX96724_PIPE2_TUN_DEST_ADDR	0x09B9
++#define MAX96724_PIPE3_TUN_DEST_ADDR	0x09F9
++
++/* ================================================================
++ * Register Values
++ * ================================================================ */
++
++/* Soft reset value (write to 0x000D) */
++#define MAX96724_SOFT_RESET		0x40
++
++/* 
++ * Link Rate values for 0x0010/0x0011
++ *   Per link pair: bits[1:0]=RxA, [3:2]=TxA, [5:4]=RxB, [7:6]=TxB
++ *   Tx = 00 (187.5Mbps), Rx = 01 (3Gbps) or 10 (6Gbps)
++ *   3Gbps: Tx=00, Rx=01 → per pair 0x01, both pairs = 0x01 in low nibble
++ */
++#define MAX96724_LINK_RATE_3GBPS	0x01  /* Rx=3G, Tx=187.5M for one link pair */
++#define MAX96724_LINK_RATE_6GBPS	0x02  /* Rx=6G, Tx=187.5M for one link pair */
++
++/* 
++ * 0x0006: Link enable / mode values
++ *   bits[7:4] = PHY mode (1=GMSL2 per link)
++ *   bits[3:0] = Link enable per link
++ *   0xF1 = all GMSL2-mode, only Link A enabled
++ *   0xFF = all GMSL2-mode, all 4 links enabled
++ */
++#define MAX96724_LINK_EN_SIOA		0xF1  /* GMSL2 all, enable Link A only */
++#define MAX96724_LINK_EN_ALL		0xFF  /* GMSL2 all, enable all links */
++
++/* BACKTOP_EN (0x040B): CSI output port enable */
++#define MAX96724_BACKTOP_CSIB_EN	0x02
++#define MAX96724_BACKTOP_CSIA_EN	0x01
++
++/* 
++ *   VIDEO_RX0: DIS_PKT_DET=1 (bit0) required for tunnel mode.
++ *   Without it, DES rejects tunnel data as invalid GMSL2 video packets.
++ *   SEQ_MISS_EN=1 (bit4), LINE_CRC_EN=1 (bit1).  XML value: 0x33.
++ */
++#define MAX96724_VID_RX0_CFG_VAL	0x33
++#define MAX96724_VID_RX6_CFG_VAL	0x0A
++
++/* Pixel-mode receiver settings */
++#define MAX96724_VID_RX0_PIXEL_VAL	0x32
++#define MAX96724_VID_RX6_PIXEL_VAL	0x12
++
++/* 
++ *   Tunnel mode enable (MIPI_TX54, 0x0936):
++ *   bit[0] = TUN_EN = 1
++ *   Verified value: 0x01
++ */
++#define MAX96724_TUN_EN			0x01
++
++/* Default/reset state when tunnel is disabled */
++#define MAX96724_TUN_DISABLED		0x08
++
++/* 
++ *   Tunnel controller destination (MIPI_TX57, 0x0939):
++ *   bits[5:4]: TUN_DEST (00=PHY0, 01=PHY1, 10=PHY2, 11=PHY3)
++ *   Verified value: 0x10 = PHY1 destination with auto-detect enabled
++ */
++#define MAX96724_TUN_DEST_CTRL0		0x00  /* Auto-detect + PHY0 */
++#define MAX96724_TUN_DEST_CTRL1		0x10  /* Auto-detect + PHY1 (Port A master) */
++
++#define MAX96724_CSI_MODE_2X4_VAL	0x04  /* bit[2] = clean 2x4: Port A = PHY0+PHY1 */
++
++/* 
++ *   0x84 = 2x4 mode (bit2) + bit[7] "force ALL MIPI clocks running".  The bit[7]
++ *   clock-force is the key part: it keeps the D-PHY clock lane in continuous HS
++ *   mode so the Orin NVCSI/CIL can lock.
++ */
++#define MAX96724_CSI_OUT_EN_VAL		0x84  /* 2x4 + bit[7] force all MIPI clocks running */
++
++#define MAX96724_CSI_PHY_EN_ALL		0xF0
++#define MAX96724_CSI_PHY_EN_01		0x30  /* PHY0+PHY1 only (Port A) */
++#define MAX96724_CSI_PHY_EN_23		0xC0  /* PHY2+PHY3 only (Port B) */
++
++/* Lane mapping default */
++#define MAX96724_CSI_LANE_MAP_DEFAULT	0xE4
++
++/* Lane control: 4-lane enabled */
++#define MAX96724_LANE_CTRL_4LANE	0xC0
++
++/*
++ *   Lane control: 2-lane enabled.
++ *   bits[7:6] = (num_lanes - 1): 01=2-lane(0x40), 11=4-lane(0xC0)
++ *   Ref: gmsl_ser_des_guide §8.2, E2E_enable_guide §5.6.4 
++ */
++#define MAX96724_LANE_CTRL_2LANE	0x40
++
++/* 
++ *   CSI PHY enable: all PHYs powered for DPLL lock.
++ */
++#define MAX96724_CSI_PHY_EN_2LANE	0xF0
++
++/* 
++ *   DPLL for Controller 0 (drives PHY0, 2 lanes).
++ *   bits[4:0] = data-rate / 100 MHz.  700 Mbps / 100 = 7 = 0x07.
++ *   bit[5]    = DPLL enable = 1.
++ *   Result: 0x27 = 700 Mbps/lane D-PHY.
++ */
++#define MAX96724_DPLL_700MBPS_CTRL0	0x27
++
++/* 
++ *   CSI-output DPLL data rate = 1300 Mbps.
++ *   bits[4:0] = data-rate / 100 MHz -> 1300/100 = 13 = 0x0D. bit[5] = DPLL en.
++ */
++#define MAX96724_DPLL_1300MBPS		0x2D
++
++/* One-shot reset: all links */
++#define MAX96724_ONESHOT_ALL		0x0F
++
++/* 
++ *   Pipe source selection values
++ *   Encoding per pipe nibble in tunnel mode:
++ *   0x22 routes all pipes from Link A in tunnel mode.
++ */
++#define MAX96724_PIPE_SEL0_SINGLE	0x22  /* All pipes from Link A */
++#define MAX96724_PIPE_SEL1_SINGLE	0x22  /* All pipes from Link A */
++#define MAX96724_PIPE_SEL0_PIXEL	0x62  /* pixel-mode reference */
++#define MAX96724_PIPE_SEL1_PIXEL	0xEA  /* pixel-mode reference */
++#define MAX96724_PIPE_SEL0_DUAL		0x40  /* Pipe 0 ← A/X, Pipe 1 ← B/X */
++#define MAX96724_PIPE_SEL0_QUAD_LO	0x40  /* Pipe 0 ← A/X, Pipe 1 ← B/X */
++#define MAX96724_PIPE_SEL1_QUAD_HI	0xC8  /* Pipe 2 ← C/X, Pipe 3 ← D/X */
++
++/* Pipe enable values */
++#define MAX96724_PIPE_EN_1		0x01
++#define MAX96724_PIPE_EN_2		0x03
++#define MAX96724_PIPE_EN_4		0x0F
++
++/* Lane control map: bits[7:6] = (num_lanes - 1) */
++#define MAX96724_LANE_CTRL_MAP(num_lanes) \
++	((((num_lanes) - 1) << 6) & 0xC0)
++
++/* Reset all */
++#define MAX96724_RESET_ALL		0x80
++
++/* Stream ID invalid */
++#define MAX96724_INVAL_ST_ID		0xFF
++#define MAX96724_RESET_ST_ID		0x00
++#define MAX96724_ST_ID_SEL_INVALID	0xF
++
++/* Controller mapping: all mappings → Controller 0 */
++#define MAX96724_ALL_MAP_CTRL0		0x00
++/* Controller mapping: all mappings → Controller 1 */
++#define MAX96724_ALL_MAP_CTRL1		0x55
++
++/* Three mappings to controller 1 */
++#define MAX96724_MAP3_CTRL1		0x15
++
++/* ================================================================
++ * Data Structures
++ * ================================================================ */
++
++/* Quad GMSL: up to 4 sources */
++#define MAX96724_MAX_SOURCES		4
++#define MAX96724_MAX_PIPES		4
++
++#define MAX96724_PIPE_X			0
++#define MAX96724_PIPE_Y			1
++#define MAX96724_PIPE_Z			2
++#define MAX96724_PIPE_U			3
++#define MAX96724_PIPE_INVALID		0xF
++
++#define MAX96724_CSI_CTRL_0		0
++#define MAX96724_CSI_CTRL_1		1
++#define MAX96724_CSI_CTRL_2		2
++#define MAX96724_CSI_CTRL_3		3
++
++#define MAX96724_CSI_MODE_2X4		0x08  /* enum tag for the 4-lane Port A (Ctrl1) path */
++
++/* Lane map presets */
++#define MAX96724_LANE_MAP1_2X4		0xE4  /* SC20190112 subset: PHY0 data + PHY1 clock */
++#define MAX96724_LANE_MAP2_2X4		0x44  /* keep unused PHY2/3 straight in 0x08 mode */
++
++struct max96724_source_ctx {
++	struct gmsl_link_ctx *g_ctx;
++	bool st_enabled;
++};
++
++struct pipe_ctx {
++	u32 id;
++	u32 dt_type;
++	u32 dst_csi_ctrl;
++	u32 st_count;
++	u32 st_id_sel;
++};
++
++struct max96724 {
++	struct i2c_client *i2c_client;
++	struct regmap *regmap;
++	u32 num_src;
++	u32 max_src;
++	u32 num_src_found;
++	u32 src_link;
++	bool splitter_enabled;
++	struct max96724_source_ctx sources[MAX96724_MAX_SOURCES];
++	struct mutex lock;
++	u32 sdev_ref;
++	bool lane_setup;
++	bool link_setup;
++	struct pipe_ctx pipe[MAX96724_MAX_PIPES];
++	u8 csi_mode;
++	u8 lane_mp1;
++	u8 lane_mp2;
++	int reset_gpio;
++	int pw_ref;
++	struct regulator *vdd_cam_1v2;
++	u8 link_speed;  /* DT-configurable: 3 or 6 Gbps */
++	bool pixel_mode;
++	bool poc_enabled; /* FG24-4CH board POC/IO enable applied once */
++};
++
++struct reg_pair {
++	u16 addr;
++	u8 val;
++};
++
++/* ================================================================
++ * Low-level I2C
++ * ================================================================ */
++
++static int max96724_write_reg(struct device *dev, u16 addr, u8 val)
++{
++	struct max96724 *priv;
++	int err;
++
++	priv = dev_get_drvdata(dev);
++
++	err = regmap_write(priv->regmap, addr, val);
++	if (err)
++		dev_err(dev, "%s:i2c write failed, 0x%x = %x\n",
++			__func__, addr, val);
++
++	/* delay before next i2c command as required for SERDES link */
++	usleep_range(100, 110);
++
++	return err;
++}
++
++static int max96724_set_registers(struct device *dev, struct reg_pair *map,
++				  u32 count)
++{
++	int err = 0;
++	u32 j;
++
++	for (j = 0; j < count; j++) {
++		err = max96724_write_reg(dev, map[j].addr, map[j].val);
++		if (err)
++			break;
++	}
++
++	return err;
++}
++
++/* ================================================================
++ * Internal Helpers
++ * ================================================================ */
++
++static int max96724_get_sdev_idx(struct device *dev,
++				 struct device *s_dev, unsigned int *idx)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++	unsigned int i;
++	int err = 0;
++
++	mutex_lock(&priv->lock);
++	for (i = 0; i < priv->max_src; i++) {
++		if (priv->sources[i].g_ctx->s_dev == s_dev)
++			break;
++	}
++	if (i == priv->max_src) {
++		dev_err(dev, "no sdev found\n");
++		err = -EINVAL;
++		goto ret;
++	}
++
++	if (idx)
++		*idx = i;
++
++ret:
++	mutex_unlock(&priv->lock);
++	return err;
++}
++
++static void max96724_pipes_reset(struct max96724 *priv)
++{
++	/*
++	 * Default pipe configuration for D5xx/SC1.2:
++	 * In tunnel mode, DT types are not used for filtering
++	 * but we initialize them for d4xx framework compatibility.
++	 */
++	struct pipe_ctx pipe_defaults[] = {
++		{MAX96724_PIPE_X, GMSL_CSI_DT_RAW_12,
++			MAX96724_CSI_CTRL_1, 0, MAX96724_INVAL_ST_ID},
++		{MAX96724_PIPE_Y, GMSL_CSI_DT_RAW_12,
++			MAX96724_CSI_CTRL_1, 0, MAX96724_INVAL_ST_ID},
++		{MAX96724_PIPE_Z, GMSL_CSI_DT_EMBED,
++			MAX96724_CSI_CTRL_1, 0, MAX96724_INVAL_ST_ID},
++		{MAX96724_PIPE_U, GMSL_CSI_DT_EMBED,
++			MAX96724_CSI_CTRL_1, 0, MAX96724_INVAL_ST_ID}
++	};
++
++	memcpy(priv->pipe, pipe_defaults, sizeof(pipe_defaults));
++}
++
++static void max96724_reset_ctx(struct max96724 *priv)
++{
++	unsigned int i;
++
++	priv->link_setup = false;
++	priv->lane_setup = false;
++	priv->num_src_found = 0;
++	priv->src_link = 0;
++	priv->splitter_enabled = false;
++	max96724_pipes_reset(priv);
++	for (i = 0; i < priv->num_src; i++)
++		priv->sources[i].st_enabled = false;
++}
++
++static void max96724_apply_porta_subset(struct device *dev,
++						 struct max96724 *priv)
++{
++	/*
++	 * [XML-verified 4-lane] D-PHY Port A output, 4 data lanes.
++	 * [FG24-4CH working-config verified] 0x04 = 2x4 mode so Port A
++	 * maps to PHY0+PHY1 (the lanes the FG24 PCB wires to Orin).  Output is
++	 * not yet enabled here (bit7 = 0); setup_streaming() asserts 0x84 after
++	 * the full pipeline is configured.
++	 */
++	max96724_write_reg(dev, MAX96724_CSI_OUT_CFG_ADDR,
++			   MAX96724_CSI_MODE_2X4_VAL);
++	/*
++	 * [FG24-4CH working dump] Enable ALL four CSI PHYs (0x08A2=0xF0).
++	 * The working FangZhu config powers every PHY; the MAX96724 DPLL
++	 * needs all PHYs powered to lock reliably (single-PHY enable was
++	 * observed to never lock the output clock). Port A data still
++	 * leaves on PHY0/1 in 2x4 mode; PHY2/3 are just powered.
++	 */
++	max96724_write_reg(dev, MAX96724_CSI_PHY_EN_ADDR,
++			   MAX96724_CSI_PHY_EN_ALL);
++	max96724_write_reg(dev, MAX96724_CSI_LANE_MAP1_ADDR,
++			   priv->lane_mp1);
++	/*
++	 * [FG24-4CH working dump] LANE_MAP2 (PHY2/3) = 0xE4 straight mapping.
++	 * The working config writes 0x08A4=0xE4 (not the chip default 0x44).
++	 */
++	max96724_write_reg(dev, MAX96724_CSI_LANE_MAP2_ADDR,
++			   MAX96724_CSI_LANE_MAP_DEFAULT);
++	/*
++	 * [FG24-4CH board] Switch MIPI output lane polarity (P/N swap).
++	 * The FG24-4CH PCB inverts the differential pairs on the DES->Orin
++	 * output; without this the Orin CIL never locks the HS clock.
++	 * Per FangZhu MAX4CH_FG24_POC_Enable table: 0x08A5/0x08A6 = 0x3F.
++	 */
++	max96724_write_reg(dev, MAX96724_CSI_PHY_POL0_ADDR,
++			   MAX96724_CSI_PHY_POL_SWAP);
++	max96724_write_reg(dev, MAX96724_CSI_PHY_POL1_ADDR,
++			   MAX96724_CSI_PHY_POL_SWAP);
++	max96724_write_reg(dev, MAX96724_LANE_CTRL0_ADDR,
++			   MAX96724_LANE_CTRL_4LANE);
++	max96724_write_reg(dev, MAX96724_LANE_CTRL1_ADDR,
++			   MAX96724_LANE_CTRL_4LANE);
++	max96724_write_reg(dev, MAX96724_LANE_CTRL2_ADDR,
++			   MAX96724_LANE_CTRL_4LANE);
++	max96724_write_reg(dev, MAX96724_LANE_CTRL3_ADDR,
++			   MAX96724_LANE_CTRL_4LANE);
++}
++
++static inline bool max96724_is_pixel_mode(struct max96724 *priv)
++{
++	return priv->pixel_mode;
++}
++
++/* ================================================================
++ * Power Management
++ * ================================================================ */
++
++/* [FG24-4CH board] POC (Power-over-Coax) / IO enable sequence.
++ *   Per FangZhu MAX4CH_FG24_POC_Enable table. On the FG24-4CH board the
++ *   MFP8 line (0x0319 bit4) and the POC IO enable (0x0001 bit5) gate the
++ *   board-level output / POC path. Without these the DES PLL still locks
++ *   and shows internal activity, but no clock reaches the Orin connector.
++ */
++#define MAX96724_POC_IO_EN_ADDR		0x0001
++#define MAX96724_POC_IO_EN_VAL		0xE0  /* Enable POC IO (working dump: 0xE0) */
++#define MAX96724_POC_MFP8_ADDR		0x0319
++#define MAX96724_POC_MFP8_PRE		0x80  /* MFP8 pre-enable */
++#define MAX96724_POC_MFP8_HIGH		0x98  /* Enable POC MFP8 High (working dump: 0x98) */
++
++/*
++ * max96724_board_poc_enable - Apply FG24-4CH POC/IO enable (one-time).
++ * Mirrors the vendor MAX4CH_FG24_POC_Enable table.
++ */
++static void max96724_board_poc_enable(struct device *dev)
++{
++	max96724_write_reg(dev, MAX96724_POC_IO_EN_ADDR,
++			   MAX96724_POC_IO_EN_VAL);
++	max96724_write_reg(dev, MAX96724_POC_MFP8_ADDR,
++			   MAX96724_POC_MFP8_PRE);
++	msleep(100);
++	max96724_write_reg(dev, MAX96724_POC_MFP8_ADDR,
++			   MAX96724_POC_MFP8_HIGH);
++	msleep(500);
++}
++
++/*
++ * max96724_power_on - Power on the MAX96724 deserializer
++ */
++int max96724_power_on(struct device *dev)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++	int err = 0;
++
++	mutex_lock(&priv->lock);
++	if (priv->pw_ref == 0) {
++		usleep_range(1, 2);
++		if (gpio_is_valid(priv->reset_gpio))
++			gpio_set_value(priv->reset_gpio, 0);
++
++		usleep_range(30, 50);
++
++		if (priv->vdd_cam_1v2) {
++			err = regulator_enable(priv->vdd_cam_1v2);
++			if (unlikely(err))
++				goto ret;
++		}
++
++		usleep_range(30, 50);
++
++		/* exit reset mode: XCLR */
++		if (gpio_is_valid(priv->reset_gpio)) {
++			gpio_set_value(priv->reset_gpio, 0);
++			usleep_range(30, 50);
++			gpio_set_value(priv->reset_gpio, 1);
++			usleep_range(30, 50);
++		}
++
++		msleep(20);
++	}
++
++	priv->pw_ref++;
++
++ret:
++	mutex_unlock(&priv->lock);
++	return err;
++}
++EXPORT_SYMBOL(max96724_power_on);
++
++void max96724_power_off(struct device *dev)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++
++	mutex_lock(&priv->lock);
++	priv->pw_ref--;
++
++	if (priv->pw_ref < 0)
++		priv->pw_ref = 0;
++
++	if (priv->pw_ref == 0) {
++		usleep_range(1, 2);
++		if (gpio_is_valid(priv->reset_gpio))
++			gpio_set_value(priv->reset_gpio, 0);
++
++		if (priv->vdd_cam_1v2)
++			regulator_disable(priv->vdd_cam_1v2);
++	}
++
++	mutex_unlock(&priv->lock);
++}
++EXPORT_SYMBOL(max96724_power_off);
++
++/* ================================================================
++ * Link Setup
++ * ================================================================ */
++
++/*
++ * max96724_write_link - Configure a specific GMSL link
++ *
++ * [Users Guide, Link Initialization, p11-12]
++ *   Register 0x0006: Link Enable and Mode Select
++ *   Register 0x0010: Link Rate (Links A/B)
++ *
++ * The link speed is DT-configurable via the "gmsl-link-speed" property.
++ */
++static int max96724_write_link(struct device *dev, u32 link)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++	u8 link_rate_ab, link_rate_cd;
++	u8 link_en_val;
++
++	/*
++	 * [Aardvark-verified] Disable CSI output before link configuration
++	 * This prevents glitches on CSI bus during GMSL link setup.
++	 * Re-enabled in max96724_setup_streaming() after full pipeline config.
++	 */
++	max96724_write_reg(dev, MAX96724_BACKTOP_EN_ADDR, 0x00);
++
++	/* [UG Table 3 + Tech Overview REG26]
++	 * Register 0x0010:
++	 *   bits[7:2] = Link rate configuration
++	 *   bits[1:0] = I2C CC pass-through link select
++	 *     10 = route CC via SIOA (Link A)  [tech overview: 0x02 → SIOA]
++	 *     01 = route CC via SIOB (Link B)
++	 *
++	 * For 6G + Link A: bits[7:2]=001000, bits[1:0]=10 → 0x22
++	 * For 6G + Link B: bits[7:2]=001000, bits[1:0]=01 → 0x21
++	 * For 3G + Link A: bits[7:2]=000100, bits[1:0]=10 → 0x12 (? or 0x11)
++	 * For 3G + Link B: bits[7:2]=000100, bits[1:0]=01 → 0x11 (? or 0x09)
++	 */
++	if (priv->link_speed == 6) {
++		if (link == GMSL_SERDES_CSI_LINK_B) {
++			link_rate_ab = 0x21; /* 6G rate + CC via Link B */
++		} else {
++			link_rate_ab = 0x22; /* 6G rate + CC via Link A */
++		}
++		link_rate_cd = 0x22; /* C/D: 6G rate (CC routing don't care) */
++	} else {
++		if (link == GMSL_SERDES_CSI_LINK_B) {
++			link_rate_ab = 0x09; /* 3G rate + CC via Link B */
++		} else {
++			link_rate_ab = 0x12; /* 3G rate + CC via Link A */
++		}
++		link_rate_cd = 0x11; /* C/D: 3G rate */
++	}
++
++	if (link == GMSL_SERDES_CSI_LINK_A) {
++		link_en_val = MAX96724_LINK_EN_SIOA;
++	} else if (link == GMSL_SERDES_CSI_LINK_B) {
++		link_en_val = 0xF2; /* GMSL2 all, enable Link B only */
++	} else {
++		dev_err(dev, "%s: invalid gmsl link\n", __func__);
++		return -EINVAL;
++	}
++
++	/* [UG Table 3] Set link rates + CC routing */
++	max96724_write_reg(dev, MAX96724_LINK_RATE_AB_ADDR, link_rate_ab);
++	max96724_write_reg(dev, MAX96724_LINK_RATE_CD_ADDR, link_rate_cd);
++
++	/*
++	 * [XML-verified sequence] One-shot reset applies rate configuration
++	 * to the link state machine, then link enable starts training.
++	 * XML order: rate → ONE-SHOT → LINK_EN → wait 1000ms.
++	 * Note: Error channel registers omitted (not in reference XML).
++	 */
++	max96724_write_reg(dev, MAX96724_ONESHOT_ADDR,
++			   MAX96724_ONESHOT_ALL);
++	max96724_write_reg(dev, MAX96724_LINK_EN_ADDR, link_en_val);
++
++	/*
++	 * Wait for link lock.
++	 * [XML] Uses 1000ms regardless of link speed.
++	 * I2C pass-through CC requires fully trained link, not just PHY lock.
++	 */
++	msleep(1000);
++
++	/* Check link lock status on ALL ports for diagnostics */
++	{
++		unsigned int lock_a = 0, lock_b = 0, lock_c = 0, lock_d = 0;
++		unsigned int link_en = 0;
++		unsigned int reg10 = 0, reg11 = 0;
++
++		regmap_read(priv->regmap, 0x001A, &lock_a);
++		regmap_read(priv->regmap, 0x001B, &lock_b);
++		regmap_read(priv->regmap, 0x001C, &lock_c);
++		regmap_read(priv->regmap, 0x001D, &lock_d);
++		regmap_read(priv->regmap, MAX96724_LINK_EN_ADDR, &link_en);
++		regmap_read(priv->regmap, 0x0010, &reg10);
++		regmap_read(priv->regmap, 0x0011, &reg11);
++		dev_info(dev,
++			 "GMSL link status: EN=0x%02x A=0x%02x(%s) B=0x%02x(%s) C=0x%02x(%s) D=0x%02x(%s) REG10=0x%02x REG11=0x%02x\n",
++			 link_en,
++			 lock_a, (lock_a & 0x08) ? "LOCK" : "noLk",
++			 lock_b, (lock_b & 0x08) ? "LOCK" : "noLk",
++			 lock_c, (lock_c & 0x08) ? "LOCK" : "noLk",
++			 lock_d, (lock_d & 0x08) ? "LOCK" : "noLk",
++			 reg10, reg11);
++	}
++
++	return 0;
++}
++
++int max96724_setup_link(struct device *dev, struct device *s_dev)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++	int err = 0;
++	unsigned int i = 0;
++
++	err = max96724_get_sdev_idx(dev, s_dev, &i);
++	if (err)
++		return err;
++
++	/*
++	 * [FG24-4CH] Enable board POC / MFP8 output path BEFORE the GMSL
++	 * link is brought up.  The camera draws power over coax (PoC), so
++	 * without this the remote camera never powers on and the link can
++	 * never lock.  NOTE: this must live here (a path d5xx actually
++	 * invokes via dser_ops->setup_link) and NOT in max96724_power_on(),
++	 * which ds5_gmsl_serdes_setup() deliberately skips.  Run once.
++	 */
++	if (!priv->poc_enabled) {
++		max96724_board_poc_enable(dev);
++		priv->poc_enabled = true;
++	}
++
++	mutex_lock(&priv->lock);
++
++	if (!priv->splitter_enabled) {
++		err = max96724_write_link(dev,
++					  priv->sources[i].g_ctx->serdes_csi_link);
++		if (err)
++			goto ret;
++
++		priv->link_setup = true;
++	}
++
++ret:
++	mutex_unlock(&priv->lock);
++	return err;
++}
++EXPORT_SYMBOL(max96724_setup_link);
++
++/* ================================================================
++ * Control Setup
++ * ================================================================ */
++
++/*
++ * max96724_setup_control - Configure deserializer control pipeline
++ *
++ * Enables splitter mode when multiple sources are present,
++ * configures tunnel mode on all active pipes, and sets up
++ * the MIPI CSI-2 output.
++ */
++int max96724_setup_control(struct device *dev, struct device *s_dev)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++	int err = 0;
++	unsigned int i = 0;
++
++	static const u16 tun_en_addrs[] = {
++		MAX96724_PIPE0_TUN_EN_ADDR,
++		MAX96724_PIPE1_TUN_EN_ADDR,
++		MAX96724_PIPE2_TUN_EN_ADDR,
++		MAX96724_PIPE3_TUN_EN_ADDR,
++	};
++
++	static const u16 tun_dest_addrs[] = {
++		MAX96724_PIPE0_TUN_DEST_ADDR,
++		MAX96724_PIPE1_TUN_DEST_ADDR,
++		MAX96724_PIPE2_TUN_DEST_ADDR,
++		MAX96724_PIPE3_TUN_DEST_ADDR,
++	};
++
++	err = max96724_get_sdev_idx(dev, s_dev, &i);
++	if (err)
++		return err;
++
++	mutex_lock(&priv->lock);
++
++	if (!priv->link_setup) {
++		dev_err(dev, "%s: invalid state\n", __func__);
++		err = -EINVAL;
++		goto error;
++	}
++
++	if (priv->sources[i].g_ctx->serdev_found) {
++		priv->num_src_found++;
++		priv->src_link = priv->sources[i].g_ctx->serdes_csi_link;
++	}
++
++	/* Enable splitter mode for multi-camera configurations */
++	if ((priv->max_src > 1U) &&
++	    (priv->num_src_found > 0U) &&
++	    (priv->splitter_enabled == false)) {
++		/*
++		 * [UG Table 3] Multi-camera: set link rates and enable all links
++		 */
++		u8 link_rate = (priv->link_speed == 6) ? 0x22 : 0x11;
++
++		max96724_write_reg(dev, MAX96724_LINK_RATE_AB_ADDR,
++				   link_rate);
++		max96724_write_reg(dev, MAX96724_LINK_RATE_CD_ADDR,
++				   link_rate);
++		max96724_write_reg(dev, MAX96724_LINK_EN_ADDR,
++				   MAX96724_LINK_EN_ALL);
++
++		/* [Errata #5] For 6Gbps: force Error Channel power-up */
++		if (priv->link_speed == 6) {
++			max96724_write_reg(dev, MAX96724_ERRCH_A_ADDR,
++					   MAX96724_ERRCH_FORCE_ON);
++			max96724_write_reg(dev, MAX96724_ERRCH_B_ADDR,
++					   MAX96724_ERRCH_FORCE_ON);
++			max96724_write_reg(dev, MAX96724_ERRCH_C_ADDR,
++					   MAX96724_ERRCH_FORCE_ON);
++			max96724_write_reg(dev, MAX96724_ERRCH_D_ADDR,
++					   MAX96724_ERRCH_FORCE_ON);
++		}
++
++		priv->splitter_enabled = true;
++
++		msleep(100);
++	}
++
++	if (max96724_is_pixel_mode(priv)) {
++		for (i = 0; i < MAX96724_MAX_PIPES; i++) {
++			max96724_write_reg(dev, tun_en_addrs[i],
++					   MAX96724_TUN_DISABLED);
++		}
++		max96724_write_reg(dev, MAX96724_MIPI_CTRL_SEL_ADDR,
++				   MAX96724_MIPI_CTRL_SEL_PIXEL);
++		max96724_write_reg(dev, MAX96724_ONESHOT_ADDR,
++				   MAX96724_ONESHOT_ALL);
++		priv->sdev_ref++;
++		goto maybe_reset_splitter;
++	}
++
++	/*
++	 * [SC20190112] Enable tunnel mode and route to Controller 1.
++	 *   - TUN_EN   (0x0936): 0x01 (TUN_EN=1)
++	 *   - TUN_DEST (0x0939): 0x10 = Controller 1
++	 *   CSI_OUT_CFG=0x04 (2x4 mode): Controller 1 -> PHY0+1 -> Port A -> Orin
++	 */
++	{
++		for (i = 0; i < MAX96724_MAX_PIPES; i++) {
++			max96724_write_reg(dev, tun_en_addrs[i],
++					   MAX96724_TUN_EN);
++			max96724_write_reg(dev, tun_dest_addrs[i],
++					   MAX96724_TUN_DEST_CTRL1);
++		}
++	}
++
++	/*
++	 * [Errata #2] Tunnel Mode SRAM LCRC: disable ERRB for SRAM LCRC
++	 * errors in tunnel mode when frame/line counters are non-zero.
++	 * This prevents spurious ERRB assertions (no video corruption).
++	 */
++	max96724_write_reg(dev, MAX96724_SRAM_LCRC_ERR_ADDR, 0x00);
++
++	max96724_write_reg(dev, MAX96724_ONESHOT_ADDR,
++			   MAX96724_ONESHOT_ALL);
++
++	priv->sdev_ref++;
++
++maybe_reset_splitter:
++
++	/* Reset splitter mode if not all devices found */
++	if ((priv->sdev_ref == priv->max_src) &&
++	    (priv->splitter_enabled == true) &&
++	    (priv->num_src_found > 0U) &&
++	    (priv->num_src_found < priv->max_src)) {
++		err = max96724_write_link(dev, priv->src_link);
++		if (err)
++			goto error;
++
++		priv->splitter_enabled = false;
++	}
++
++error:
++	mutex_unlock(&priv->lock);
++	return err;
++}
++EXPORT_SYMBOL(max96724_setup_control);
++
++int max96724_reset_control(struct device *dev, struct device *s_dev)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++	int err = 0;
++
++	mutex_lock(&priv->lock);
++	if (!priv->sdev_ref) {
++		dev_info(dev, "%s: dev is already in reset state\n", __func__);
++		goto ret;
++	}
++
++	priv->sdev_ref--;
++	if (priv->sdev_ref == 0) {
++		max96724_reset_ctx(priv);
++		max96724_write_reg(dev, MAX96724_REG13_ADDR,
++				   MAX96724_SOFT_RESET);
++
++		msleep(100);
++	}
++
++ret:
++	mutex_unlock(&priv->lock);
++	return err;
++}
++EXPORT_SYMBOL(max96724_reset_control);
++
++/* ================================================================
++ * Device Registration
++ * ================================================================ */
++
++int max96724_sdev_register(struct device *dev, struct gmsl_link_ctx *g_ctx)
++{
++	struct max96724 *priv = NULL;
++	unsigned int i;
++	int err = 0;
++
++	if (!dev || !g_ctx || !g_ctx->s_dev) {
++		dev_err(dev, "%s: invalid input params\n", __func__);
++		return -EINVAL;
++	}
++
++	priv = dev_get_drvdata(dev);
++
++	mutex_lock(&priv->lock);
++
++	if (priv->num_src > priv->max_src) {
++		dev_err(dev,
++			"%s: MAX96724 inputs size exhausted\n", __func__);
++		err = -ENOMEM;
++		goto error;
++	}
++
++	if (priv->csi_mode == MAX96724_CSI_MODE_2X4) {
++		if (!((g_ctx->csi_mode == GMSL_CSI_1X4_MODE) ||
++		      (g_ctx->csi_mode == GMSL_CSI_2X4_MODE))) {
++			dev_err(dev, "%s: csi mode not supported\n", __func__);
++			err = -EINVAL;
++			goto error;
++		}
++	} else {
++		dev_err(dev, "%s: only csi 2x4 mode is supported\n", __func__);
++		err = -EINVAL;
++		goto error;
++	}
++
++	for (i = 0; i < priv->num_src; i++) {
++		if (g_ctx->serdes_csi_link ==
++		    priv->sources[i].g_ctx->serdes_csi_link) {
++			dev_err(dev,
++				"%s: serdes csi link is in use\n", __func__);
++			err = -EINVAL;
++			goto error;
++		}
++		if (g_ctx->num_csi_lanes !=
++		    priv->sources[i].g_ctx->num_csi_lanes) {
++			dev_err(dev,
++				"%s: csi num lanes mismatch\n", __func__);
++			err = -EINVAL;
++			goto error;
++		}
++	}
++
++	priv->sources[priv->num_src].g_ctx = g_ctx;
++	priv->sources[priv->num_src].st_enabled = false;
++
++	priv->num_src++;
++
++error:
++	mutex_unlock(&priv->lock);
++	return err;
++}
++EXPORT_SYMBOL(max96724_sdev_register);
++
++int max96724_sdev_unregister(struct device *dev, struct device *s_dev)
++{
++	struct max96724 *priv = NULL;
++	int err = 0;
++	unsigned int i = 0;
++
++	if (!dev || !s_dev) {
++		dev_err(dev, "%s: invalid input params\n", __func__);
++		return -EINVAL;
++	}
++
++	priv = dev_get_drvdata(dev);
++	mutex_lock(&priv->lock);
++
++	if (priv->num_src == 0) {
++		dev_err(dev, "%s: no source found\n", __func__);
++		err = -ENODATA;
++		goto error;
++	}
++
++	for (i = 0; i < priv->num_src; i++) {
++		if (s_dev == priv->sources[i].g_ctx->s_dev) {
++			priv->sources[i].g_ctx = NULL;
++			break;
++		}
++	}
++
++	if (i == priv->num_src) {
++		dev_err(dev,
++			"%s: requested device not found\n", __func__);
++		err = -EINVAL;
++		goto error;
++	}
++	priv->num_src--;
++
++error:
++	mutex_unlock(&priv->lock);
++	return err;
++}
++EXPORT_SYMBOL(max96724_sdev_unregister);
++
++/* ================================================================
++ * Streaming Setup
++ * ================================================================ */
++
++/*
++ * max96724_setup_streaming - Configure CSI-2 output pipeline
++ *
++ * In Tunnel Mode, the MAX96724 outputs the reconstructed CSI-2 stream
++ * with all VCs and DTs preserved from the serializer.
++ *
++ * The pipeline configuration:
++ *   1. Configure pipe-to-link routing
++ *   2. Enable tunnel mode on active pipes
++ *   3. Configure MIPI CSI-2 output lanes and PHY
++ *   4. Enable BACKTOP output port
++ *
++ */
++int max96724_setup_streaming(struct device *dev, struct device *s_dev)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++	struct gmsl_link_ctx *g_ctx;
++	int err = 0;
++	unsigned int i = 0;
++	unsigned int src_idx;
++	u8 vid_rx0_cfg;
++	u8 vid_rx6_cfg;
++	u8 st_sel_cfg;
++	u8 pipe_sel0;
++	u8 pipe_sel1;
++	u8 dpll_cfg;
++
++	err = max96724_get_sdev_idx(dev, s_dev, &i);
++	if (err)
++		return err;
++
++	mutex_lock(&priv->lock);
++
++	dev_info(dev, "=== setup_streaming ENTER src=%u st_enabled=%d ===\n",
++		 i, priv->sources[i].st_enabled);
++
++	if (priv->sources[i].st_enabled)
++		goto ret;
++
++	src_idx = i;
++	g_ctx = priv->sources[src_idx].g_ctx;
++	if (max96724_is_pixel_mode(priv)) {
++		pipe_sel0 = MAX96724_PIPE_SEL0_PIXEL;
++		pipe_sel1 = MAX96724_PIPE_SEL1_PIXEL;
++		vid_rx0_cfg = MAX96724_VID_RX0_PIXEL_VAL;
++		vid_rx6_cfg = MAX96724_VID_RX6_PIXEL_VAL;
++		st_sel_cfg = 0x00;
++		dpll_cfg = MAX96724_DPLL_1300MBPS;
++	} else {
++		pipe_sel0 = MAX96724_PIPE_SEL0_PIXEL;
++		pipe_sel1 = MAX96724_PIPE_SEL1_PIXEL;
++		vid_rx0_cfg = MAX96724_VID_RX0_CFG_VAL;
++		vid_rx6_cfg = MAX96724_VID_RX6_CFG_VAL;
++		st_sel_cfg = 0x10;
++		dpll_cfg = MAX96724_DPLL_1300MBPS;
++	}
++
++	/*
++	 * Pipe source routing
++	 * Single cam: all pipes from Link A (0x22/0x22)
++	 * Disable pipes before configuration, enable at the end
++	 */
++	max96724_write_reg(dev, MAX96724_PIPE_SEL0_ADDR, pipe_sel0);
++	max96724_write_reg(dev, MAX96724_PIPE_SEL1_ADDR, pipe_sel1);
++	/* Disable all pipes during configuration */
++	max96724_write_reg(dev, MAX96724_PIPE_EN_ADDR, 0x00);
++
++	/*
++	 * Keep 0x08 mode so PHY1 remains the Port A clock master,
++	 * but restore the live 2-lane subset used by the bridge board.
++	 */
++	max96724_apply_porta_subset(dev, priv);
++
++	/*
++	 * CSI-output DPLL data rate = 1300 Mbps
++	 * on ALL FOUR controller freq registers
++	 */
++	if (!priv->lane_setup) {
++		max96724_write_reg(dev, MAX96724_DPLL_FREQ0_ADDR,
++				   dpll_cfg);
++		max96724_write_reg(dev, MAX96724_DPLL_FREQ1_ADDR,
++				   dpll_cfg);
++		max96724_write_reg(dev, MAX96724_DPLL_FREQ2_ADDR,
++				   dpll_cfg);
++		max96724_write_reg(dev, MAX96724_DPLL_FREQ3_ADDR,
++				   dpll_cfg);
++
++		priv->lane_setup = true;
++	}
++
++	max96724_write_reg(dev, MAX96724_MIPI_CTRL_SEL_ADDR,
++			   MAX96724_MIPI_CTRL_SEL_PIXEL);
++
++	/*
++	 * Stream ID select for all pipes
++	 * 0x0933 + 0x40*pipe = stream select register
++	 * Value 0x10 selects the appropriate stream for tunnel mode
++	 */
++	for (i = 0; i < MAX96724_MAX_PIPES; i++) {
++		max96724_write_reg(dev,
++				   MAX96724_PIPE_X_ST_SEL_ADDR + (0x40 * i),
++				   st_sel_cfg);
++	}
++
++	/* 
++	 * BACKTOP: enable Controller 1 / CSI-B (0x02).
++	 * In 2x4 mode, Controller 1 is master for Port A -> Orin CSI.
++	 */
++	max96724_write_reg(dev, MAX96724_BACKTOP_EN_ADDR,
++			   MAX96724_BACKTOP_CSIB_EN);
++
++	dev_info(dev, "=== setup_streaming: writing 0x84 (force all MIPI clocks) ===\n");
++
++	/*
++	 * Assert 0x08A0=0x84 LAST: 2x4 mode + bit[7] "force all MIPI clocks running".  
++	 * The clock-force keeps the D-PHY clock lane continuous so the Orin CIL can lock;
++	 * written only after the full pipeline is configured.
++	 */
++	max96724_write_reg(dev, MAX96724_CSI_OUT_CFG_ADDR,
++			   MAX96724_CSI_OUT_EN_VAL);
++
++	/* Keep all video receivers aligned with serializer heartbeat mode. */
++	for (i = 0; i < MAX96724_MAX_PIPES; i++) {
++		max96724_write_reg(dev,
++				   MAX96724_VID_RX0_P0_ADDR +
++				   (MAX96724_VID_RX_STRIDE * i),
++				   vid_rx0_cfg);
++		max96724_write_reg(dev,
++				   MAX96724_VID_RX6_P0_ADDR +
++				   (MAX96724_VID_RX_STRIDE * i),
++				   vid_rx6_cfg);
++		if (max96724_is_pixel_mode(priv)) {
++			max96724_write_reg(dev,
++					   MAX96724_PIPE0_TUN_EN_ADDR + (0x40 * i),
++					   MAX96724_TUN_DISABLED);
++		}
++	}
++
++	max96724_write_reg(dev, MAX96724_ONESHOT_ADDR,
++			   MAX96724_ONESHOT_ALL);
++
++	/* Enable all 4 pipes */
++	max96724_write_reg(dev, MAX96724_PIPE_EN_ADDR, MAX96724_PIPE_EN_4);
++
++	priv->sources[src_idx].st_enabled = true;
++
++ret:
++	mutex_unlock(&priv->lock);
++	return err;
++}
++EXPORT_SYMBOL(max96724_setup_streaming);
++
++/* ================================================================
++ * Start / Stop Streaming
++ * ================================================================ */
++
++int max96724_start_streaming(struct device *dev, struct device *s_dev)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++	struct gmsl_link_ctx *g_ctx;
++	struct gmsl_stream *g_stream;
++	int err = 0;
++	unsigned int i = 0;
++
++	err = max96724_get_sdev_idx(dev, s_dev, &i);
++	if (err)
++		return err;
++
++	mutex_lock(&priv->lock);
++	g_ctx = priv->sources[i].g_ctx;
++
++	for (i = 0; i < g_ctx->num_streams; i++) {
++		g_stream = &g_ctx->streams[i];
++
++		if (g_stream->des_pipe != MAX96724_PIPE_INVALID)
++			max96724_write_reg(dev, g_stream->des_pipe,
++					   g_stream->st_id_sel);
++	}
++	mutex_unlock(&priv->lock);
++
++	return 0;
++}
++EXPORT_SYMBOL(max96724_start_streaming);
++
++int max96724_stop_streaming(struct device *dev, struct device *s_dev)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++	struct gmsl_link_ctx *g_ctx;
++	struct gmsl_stream *g_stream;
++	int err = 0;
++	unsigned int i = 0;
++
++	err = max96724_get_sdev_idx(dev, s_dev, &i);
++	if (err)
++		return err;
++
++	mutex_lock(&priv->lock);
++	g_ctx = priv->sources[i].g_ctx;
++
++	for (i = 0; i < g_ctx->num_streams; i++) {
++		g_stream = &g_ctx->streams[i];
++
++		if (g_stream->des_pipe != MAX96724_PIPE_INVALID)
++			max96724_write_reg(dev, g_stream->des_pipe,
++					   MAX96724_RESET_ST_ID);
++	}
++
++	mutex_unlock(&priv->lock);
++
++	return 0;
++}
++EXPORT_SYMBOL(max96724_stop_streaming);
++
++/* ================================================================
++ * Pipe Management
++ * ================================================================ */
++
++int max96724_get_available_pipe_id(struct device *dev, int vc_id)
++{
++	int i;
++	int pipe_id = -ENOMEM;
++	struct max96724 *priv = dev_get_drvdata(dev);
++
++	mutex_lock(&priv->lock);
++	for (i = 0; i < MAX96724_MAX_PIPES; i++) {
++		if (i == vc_id && !priv->pipe[i].st_count) {
++			priv->pipe[i].st_count++;
++			pipe_id = i;
++			break;
++		}
++	}
++	mutex_unlock(&priv->lock);
++
++	return pipe_id;
++}
++EXPORT_SYMBOL(max96724_get_available_pipe_id);
++
++int max96724_release_pipe(struct device *dev, int pipe_id)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++
++	if (pipe_id < 0 || pipe_id >= MAX96724_MAX_PIPES)
++		return -EINVAL;
++
++	mutex_lock(&priv->lock);
++	priv->pipe[pipe_id].st_count = 0;
++	mutex_unlock(&priv->lock);
++
++	return 0;
++}
++EXPORT_SYMBOL(max96724_release_pipe);
++
++int max96724_get_ser_pipe_id(struct device *dev, int dser_pipe_id, int vc_id)
++{
++	/* In Tunnel Mode with MAX96717, all VCs are carried in a single tunnel pipe. */
++	return dser_pipe_id;
++}
++EXPORT_SYMBOL(max96724_get_ser_pipe_id);
++
++void max96724_reset_oneshot(struct device *dev)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++	unsigned int i;
++	u8 pipe_sel0;
++	u8 pipe_sel1;
++	u8 vid_rx0_cfg;
++	u8 vid_rx6_cfg;
++	u8 st_sel_cfg;
++	u8 dpll_cfg;
++
++	mutex_lock(&priv->lock);
++	if (priv->splitter_enabled) {
++		/* Multi-camera: reset all links */
++		u8 link_rate = (priv->link_speed == 6) ? 0x22 : 0x11;
++
++		max96724_write_reg(dev, MAX96724_LINK_RATE_AB_ADDR,
++				   link_rate);
++		max96724_write_reg(dev, MAX96724_LINK_RATE_CD_ADDR,
++				   link_rate);
++		max96724_write_reg(dev, MAX96724_LINK_EN_ADDR,
++				   MAX96724_LINK_EN_ALL);
++	} else {
++		max96724_write_reg(dev, MAX96724_ONESHOT_ADDR,
++				   MAX96724_ONESHOT_ALL);
++	}
++	msleep(100);
++
++	if (max96724_is_pixel_mode(priv)) {
++		pipe_sel0 = MAX96724_PIPE_SEL0_PIXEL;
++		pipe_sel1 = MAX96724_PIPE_SEL1_PIXEL;
++		vid_rx0_cfg = MAX96724_VID_RX0_PIXEL_VAL;
++		vid_rx6_cfg = MAX96724_VID_RX6_PIXEL_VAL;
++		st_sel_cfg = 0x00;
++		dpll_cfg = MAX96724_DPLL_1300MBPS;
++	} else {
++		pipe_sel0 = MAX96724_PIPE_SEL0_PIXEL;
++		pipe_sel1 = MAX96724_PIPE_SEL1_PIXEL;
++		vid_rx0_cfg = MAX96724_VID_RX0_CFG_VAL;
++		vid_rx6_cfg = MAX96724_VID_RX6_CFG_VAL;
++		st_sel_cfg = 0x10;
++		dpll_cfg = MAX96724_DPLL_1300MBPS;
++	}
++
++	/* 
++	 * ONESHOT resets CSI/tunnel state. Restore the full pipeline config.
++	 * Mirror setup_streaming() order: disable pipes -> restore everything ->
++	 * BACKTOP/0x84 -> VID_RX -> final ONESHOT to latch -> enable pipes.
++	 */
++	max96724_write_reg(dev, MAX96724_PIPE_EN_ADDR, 0x00);
++
++	/* Pipe source routing: all pipes from Link A */
++	max96724_write_reg(dev, MAX96724_PIPE_SEL0_ADDR, pipe_sel0);
++	max96724_write_reg(dev, MAX96724_PIPE_SEL1_ADDR, pipe_sel1);
++
++	max96724_apply_porta_subset(dev, priv);
++
++	/*
++	 * CSI-output DPLL data rate = 1300 Mbps on ALL
++	 * FOUR controllers, matching the device-tree serdes_pix_clk_hz (325 MHz).
++	 * reset_oneshot is called by the sensor after setup_streaming, so it must
++	 * mirror the same DPLL values.
++	 */
++	max96724_write_reg(dev, MAX96724_DPLL_FREQ0_ADDR,
++			   dpll_cfg);
++	max96724_write_reg(dev, MAX96724_DPLL_FREQ1_ADDR,
++			   dpll_cfg);
++	max96724_write_reg(dev, MAX96724_DPLL_FREQ2_ADDR,
++			   dpll_cfg);
++	max96724_write_reg(dev, MAX96724_DPLL_FREQ3_ADDR,
++			   dpll_cfg);
++
++	max96724_write_reg(dev, MAX96724_MIPI_CTRL_SEL_ADDR,
++			   MAX96724_MIPI_CTRL_SEL_PIXEL);
++
++	max96724_write_reg(dev, MAX96724_BACKTOP_EN_ADDR,
++			   MAX96724_BACKTOP_CSIB_EN);
++	for (i = 0; i < MAX96724_MAX_PIPES; i++) {
++		max96724_write_reg(dev,
++				   MAX96724_PIPE_X_ST_SEL_ADDR + (0x40 * i),
++				   st_sel_cfg);
++		max96724_write_reg(dev,
++				   MAX96724_VID_RX0_P0_ADDR +
++				   (MAX96724_VID_RX_STRIDE * i),
++				   vid_rx0_cfg);
++		max96724_write_reg(dev,
++				   MAX96724_VID_RX6_P0_ADDR +
++				   (MAX96724_VID_RX_STRIDE * i),
++				   vid_rx6_cfg);
++		max96724_write_reg(dev,
++				   MAX96724_TX49_PIPE_X_ADDR + (0x40 * i),
++				   0x00);
++	}
++	if (max96724_is_pixel_mode(priv)) {
++		max96724_write_reg(dev, MAX96724_PIPE0_TUN_EN_ADDR, MAX96724_TUN_DISABLED);
++		max96724_write_reg(dev, MAX96724_PIPE1_TUN_EN_ADDR, MAX96724_TUN_DISABLED);
++		max96724_write_reg(dev, MAX96724_PIPE2_TUN_EN_ADDR, MAX96724_TUN_DISABLED);
++		max96724_write_reg(dev, MAX96724_PIPE3_TUN_EN_ADDR, MAX96724_TUN_DISABLED);
++	} else {
++		/* Re-enable tunnel on all pipes (ONESHOT resets TUN_EN to 0x08=disabled) */
++		max96724_write_reg(dev, MAX96724_PIPE0_TUN_EN_ADDR, MAX96724_TUN_EN);
++		max96724_write_reg(dev, MAX96724_PIPE1_TUN_EN_ADDR, MAX96724_TUN_EN);
++		max96724_write_reg(dev, MAX96724_PIPE2_TUN_EN_ADDR, MAX96724_TUN_EN);
++		max96724_write_reg(dev, MAX96724_PIPE3_TUN_EN_ADDR, MAX96724_TUN_EN);
++		/* TUN_DEST: set to Controller 1 (0x10) = Port A master in 2x4 mode */
++		max96724_write_reg(dev, MAX96724_PIPE0_TUN_DEST_ADDR,
++				   MAX96724_TUN_DEST_CTRL1);
++		max96724_write_reg(dev, MAX96724_PIPE1_TUN_DEST_ADDR,
++				   MAX96724_TUN_DEST_CTRL1);
++		max96724_write_reg(dev, MAX96724_PIPE2_TUN_DEST_ADDR,
++				   MAX96724_TUN_DEST_CTRL1);
++		max96724_write_reg(dev, MAX96724_PIPE3_TUN_DEST_ADDR,
++				   MAX96724_TUN_DEST_CTRL1);
++	}
++	max96724_write_reg(dev, MAX96724_PIPE_EN_ADDR,
++			   MAX96724_PIPE_EN_4);
++
++	/*
++	 * Assert 0x08A0=0x84 LAST:
++	 * 2x4 mode + bit[7] force all MIPI clocks running.  Must mirror
++	 * setup_streaming because the sensor's oneshot path overwrites it.
++	 */
++	max96724_write_reg(dev, MAX96724_CSI_OUT_CFG_ADDR,
++			   MAX96724_CSI_OUT_EN_VAL);
++
++	msleep(200);
++	mutex_unlock(&priv->lock);
++}
++EXPORT_SYMBOL(max96724_reset_oneshot);
++
++/* ================================================================
++ * Init Settings / Set Pipe
++ * ================================================================ */
++
++/*
++ * __max96724_set_pipe - Configure per-pipe mapping registers
++ */
++static int __max96724_set_pipe(struct device *dev, int pipe_id,
++			       u8 data_type1, u8 data_type2, u32 vc_id)
++{
++	int err = 0;
++	int i;
++	u8 en_mapping_num = 0x0F;
++	u8 all_mapping_phy = MAX96724_ALL_MAP_CTRL1;  /* Controller 1 = Port A master (2x4 mode) */
++	struct max96724 *priv = dev_get_drvdata(dev);
++
++	struct reg_pair map_pipe_control[] = {
++		/* Enable 4 mappings for Pipe X */
++		{MAX96724_TX11_PIPE_X_EN_ADDR, 0x0F},
++		/* Map data_type1 on vc_id */
++		{MAX96724_PIPE_X_SRC_0_MAP_ADDR, 0x1E},
++		{MAX96724_PIPE_X_DST_0_MAP_ADDR, 0x1E},
++		/* Map frame start on vc_id */
++		{MAX96724_PIPE_X_SRC_1_MAP_ADDR, 0x00},
++		{MAX96724_PIPE_X_DST_1_MAP_ADDR, 0x00},
++		/* Map frame end on vc_id */
++		{MAX96724_PIPE_X_SRC_2_MAP_ADDR, 0x01},
++		{MAX96724_PIPE_X_DST_2_MAP_ADDR, 0x01},
++		/* Map data_type2 on vc_id */
++		{MAX96724_PIPE_X_SRC_3_MAP_ADDR, 0x12},
++		{MAX96724_PIPE_X_DST_3_MAP_ADDR, 0x12},
++		/* All mappings to Controller 1 (2x4 mode: Ctrl1 drives Port A) */
++		{MAX96724_TX45_PIPE_X_DST_CTRL_ADDR, MAX96724_ALL_MAP_CTRL1},
++		{MAX96724_TX46_PIPE_X_ADDR, MAX96724_ALL_MAP_CTRL1},
++		{MAX96724_TX47_PIPE_X_ADDR, MAX96724_ALL_MAP_CTRL1},
++		{MAX96724_TX48_PIPE_X_ADDR, MAX96724_ALL_MAP_CTRL1},
++		/* TX49: concat disabled */
++		{MAX96724_TX49_PIPE_X_ADDR, 0x00},
++		/*
++		 * Keep DES heartbeat handling aligned with the serializer's
++		 * LIM_HEART-disabled tunnel mode to avoid persistent VID_SEQ_ERR.
++		 */
++		{0x0100, MAX96724_VID_RX0_CFG_VAL},
++		{0x0106, MAX96724_VID_RX6_CFG_VAL},
++		/*
++		 * Pipe stream control (offset 0x36 per pipe block).
++		 * TUN_EN = 0x01.
++		 */
++		{0x0936, MAX96724_TUN_EN},
++	};
++
++	/* 
++	 * Adjust addresses for pipe offset (stride 0x40 per pipe)
++	 * Entries 0-13: TX11, SRC/DST maps, TX45-TX49 (all stride 0x40)
++	 * Entries 14-15: VID_RX0/6 (stride 0x12)
++	 * Entry 16: Pipe stream control (stride 0x40)
++	 */
++	for (i = 0; i < 14; i++)
++		map_pipe_control[i].addr += 0x40 * pipe_id;
++
++	/* VID_RX offset: 0x12 per pipe */
++	map_pipe_control[14].addr += 0x12 * pipe_id;
++	map_pipe_control[15].addr += 0x12 * pipe_id;
++
++	/* Pipe stream control: stride 0x40 */
++	map_pipe_control[16].addr += 0x40 * pipe_id;
++
++	if (data_type2 == 0x0) {
++		en_mapping_num = 0x07;
++		all_mapping_phy = MAX96724_MAP3_CTRL1;
++	}
++
++	if (max96724_is_pixel_mode(priv)) {
++		map_pipe_control[10].val = 0x00;
++		map_pipe_control[11].val = 0x00;
++		map_pipe_control[12].val = 0x00;
++		map_pipe_control[13].val = 0x00;
++		map_pipe_control[14].val = MAX96724_VID_RX0_PIXEL_VAL;
++		map_pipe_control[15].val = MAX96724_VID_RX6_PIXEL_VAL;
++		map_pipe_control[16].val = MAX96724_TUN_DISABLED;
++	} else {
++		/* no concatenation needed */
++		map_pipe_control[13].val = 0x00;
++	}
++
++	map_pipe_control[0].val = en_mapping_num;
++	/* SRC: match incoming VC from camera (vc_id) */
++	map_pipe_control[1].val = (vc_id << 6) | data_type1;
++	/* DST: preserve VC — NVCSI/VI endpoints expect matching vc-id */
++	map_pipe_control[2].val = (vc_id << 6) | data_type1;
++	map_pipe_control[3].val = (vc_id << 6) | 0x00;
++	map_pipe_control[4].val = (vc_id << 6) | 0x00;
++	map_pipe_control[5].val = (vc_id << 6) | 0x01;
++	map_pipe_control[6].val = (vc_id << 6) | 0x01;
++	map_pipe_control[7].val = (vc_id << 6) | data_type2;
++	map_pipe_control[8].val = (vc_id << 6) | data_type2;
++	map_pipe_control[9].val = all_mapping_phy;
++	/* TX46-TX48 keep 0x55 (Ctrl1) from initializer */
++	/* TX49 set to 0x00 above — overridden per mode in pixel/tunnel branch */
++	/* VID_RX and pipe stream ctrl keep init values */
++
++	err = max96724_set_registers(dev, map_pipe_control,
++				     ARRAY_SIZE(map_pipe_control));
++
++	return err;
++}
++
++/*
++ * max96724_init_settings - Initialize default pipe and tunnel configuration
++ *
++ * Sets up all 4 pipes with default YUV422_8 + EMBED for VC0-3,
++ * matching the d4xx framework expectations.
++ *
++ */
++int max96724_init_settings(struct device *dev)
++{
++	int err = 0;
++	int i;
++	struct max96724 *priv = dev_get_drvdata(dev);
++
++	mutex_lock(&priv->lock);
++
++	for (i = 0; i < MAX96724_MAX_PIPES; i++)
++		err |= __max96724_set_pipe(dev, i, GMSL_CSI_DT_YUV422_8,
++					   GMSL_CSI_DT_EMBED, i);
++
++	mutex_unlock(&priv->lock);
++
++	return err;
++}
++EXPORT_SYMBOL(max96724_init_settings);
++
++int max96724_bind_ser_to_dser_pipe(struct device *dev, int dser_pipe_id,
++				   int ser_pipe_id, u32 vc_id)
++{
++	/* In Tunnel Mode, pipe mapping is 1:1 (each camera → one pipe) */
++	return 0;
++}
++EXPORT_SYMBOL(max96724_bind_ser_to_dser_pipe);
++
++int max96724_set_pipe(struct device *dev, int pipe_id,
++		      u8 data_type1, u8 data_type2, u32 vc_id)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++	int err = 0;
++
++	if (pipe_id > (MAX96724_MAX_PIPES - 1)) {
++		dev_info(dev, "%s: input pipe_id: %d exceeds max96724 max pipes\n",
++			 __func__, pipe_id);
++		return -EINVAL;
++	}
++
++	dev_dbg(dev, "%s pipe_id %d, data_type1 %u, data_type2 %u, vc_id %u\n",
++		__func__, pipe_id, data_type1, data_type2, vc_id);
++
++	mutex_lock(&priv->lock);
++
++	err = __max96724_set_pipe(dev, pipe_id, data_type1, data_type2, vc_id);
++
++	mutex_unlock(&priv->lock);
++
++	return err;
++}
++EXPORT_SYMBOL(max96724_set_pipe);
++
++/* ================================================================
++ * Device Tree Parsing
++ * ================================================================ */
++
++static const struct of_device_id max96724_of_match[] = {
++	{ .compatible = "adi,max96724", },
++	{ },
++};
++MODULE_DEVICE_TABLE(of, max96724_of_match);
++
++static int max96724_parse_dt(struct max96724 *priv,
++			     struct i2c_client *client)
++{
++	struct device_node *node = client->dev.of_node;
++	int err = 0;
++	const char *str_value;
++	int value;
++	const struct of_device_id *match;
++
++	if (!node)
++		return -EINVAL;
++
++	match = of_match_device(max96724_of_match, &client->dev);
++	if (!match) {
++		dev_err(&client->dev, "Failed to find matching dt id\n");
++		return -EFAULT;
++	}
++
++	/* CSI mode: "2x4" or "4x2" */
++	err = of_property_read_string(node, "csi-mode", &str_value);
++	if (err < 0) {
++		dev_err(&client->dev, "csi-mode property not found\n");
++		return err;
++	}
++
++	if (!strcmp(str_value, "2x4")) {
++		priv->csi_mode = MAX96724_CSI_MODE_2X4;
++		priv->lane_mp1 = MAX96724_LANE_MAP1_2X4;
++		priv->lane_mp2 = MAX96724_LANE_MAP2_2X4;
++	} else {
++		dev_err(&client->dev, "invalid csi mode\n");
++		return -EINVAL;
++	}
++
++	/* Max sources */
++	err = of_property_read_u32(node, "max-src", &value);
++	if (err < 0) {
++		dev_err(&client->dev, "No max-src info\n");
++		return err;
++	}
++	priv->max_src = value;
++
++	/* Reset GPIO */
++	priv->reset_gpio = of_get_named_gpio(node, "reset-gpios", 0);
++	if (priv->reset_gpio < 0) {
++		dev_info(&client->dev,
++			 "reset-gpios not found, continuing without external reset\n");
++		priv->reset_gpio = -1;
++	}
++
++	/* GMSL link speed from DT: 3 or 6 (Gbps) */
++	err = of_property_read_u32(node, "gmsl-link-speed", &value);
++	if (err < 0) {
++		/* Default to 3 Gbps if not specified */
++		priv->link_speed = 3;
++		dev_info(&client->dev,
++			 "gmsl-link-speed not specified, defaulting to 3 Gbps\n");
++	} else {
++		if (value != 3 && value != 6) {
++			dev_err(&client->dev,
++				"invalid gmsl-link-speed %d (must be 3 or 6)\n",
++				value);
++			return -EINVAL;
++		}
++		priv->link_speed = value;
++	}
++
++	priv->pixel_mode = of_property_read_bool(node, "adi,pixel-mode");
++
++	/* 1.2V regulator (optional) */
++	if (of_get_property(node, "vdd_cam_1v2-supply", NULL)) {
++		priv->vdd_cam_1v2 = regulator_get(&client->dev, "vdd_cam_1v2");
++		if (IS_ERR(priv->vdd_cam_1v2)) {
++			dev_err(&client->dev,
++				"vdd_cam_1v2 regulator get failed\n");
++			err = PTR_ERR(priv->vdd_cam_1v2);
++			priv->vdd_cam_1v2 = NULL;
++			return err;
++		}
++	} else {
++		priv->vdd_cam_1v2 = NULL;
++	}
++
++	return 0;
++}
++
++/* ================================================================
++ * Probe / Remove
++ * ================================================================ */
++
++static struct regmap_config max96724_regmap_config = {
++	.reg_bits = 16,
++	.val_bits = 8,
++	.cache_type = REGCACHE_NONE,
++};
++
++static int max96724_probe(struct i2c_client *client,
++			   const struct i2c_device_id *id)
++{
++	struct max96724 *priv;
++	int err = 0;
++
++	dev_info(&client->dev,
++		 "[MAX96724]: probing Quad GMSL2 Deserializer (Tunnel Mode)\n");
++
++	priv = devm_kzalloc(&client->dev, sizeof(*priv), GFP_KERNEL);
++	if (!priv)
++		return -ENOMEM;
++
++	priv->i2c_client = client;
++	priv->regmap = devm_regmap_init_i2c(priv->i2c_client,
++					     &max96724_regmap_config);
++	if (IS_ERR(priv->regmap)) {
++		dev_err(&client->dev,
++			"regmap init failed: %ld\n", PTR_ERR(priv->regmap));
++		return -ENODEV;
++	}
++
++	err = max96724_parse_dt(priv, client);
++	if (err) {
++		dev_err(&client->dev, "unable to parse dt\n");
++		return -EFAULT;
++	}
++
++	max96724_pipes_reset(priv);
++
++	if (priv->max_src > MAX96724_MAX_SOURCES) {
++		dev_err(&client->dev,
++			"max sources more than currently supported\n");
++		return -EINVAL;
++	}
++
++	mutex_init(&priv->lock);
++
++	dev_set_drvdata(&client->dev, priv);
++
++	dev_info(&client->dev, "%s: success (link_speed=%d Gbps, max_src=%d)\n",
++		 __func__, priv->link_speed, priv->max_src);
++
++	return err;
++}
++
++static int max96724_remove(struct i2c_client *client)
++{
++	struct max96724 *priv;
++
++	if (client != NULL) {
++		priv = dev_get_drvdata(&client->dev);
++		mutex_destroy(&priv->lock);
++		i2c_unregister_device(client);
++		client = NULL;
++	}
++
++	return 0;
++}
++
++static const struct i2c_device_id max96724_id[] = {
++	{ "max96724", 0 },
++	{ },
++};
++
++MODULE_DEVICE_TABLE(i2c, max96724_id);
++
++static struct i2c_driver max96724_i2c_driver = {
++	.driver = {
++		.name = "max96724",
++		.owner = THIS_MODULE,
++		.of_match_table = of_match_ptr(max96724_of_match),
++	},
++	.probe = max96724_probe,
++	.remove = max96724_remove,
++	.id_table = max96724_id,
++};
++
++static int __init max96724_init(void)
++{
++	return i2c_add_driver(&max96724_i2c_driver);
++}
++
++static void __exit max96724_exit(void)
++{
++	i2c_del_driver(&max96724_i2c_driver);
++}
++
++module_init(max96724_init);
++module_exit(max96724_exit);
++
++MODULE_DESCRIPTION("Quad GMSL2 Deserializer driver max96724 (Tunnel Mode)");
++MODULE_AUTHOR("RealSense AI");
++MODULE_LICENSE("GPL v2");
+diff --git a/include/media/max96717.h b/include/media/max96717.h
+new file mode 100644
+index 0000000..65bf930
+--- /dev/null
++++ b/include/media/max96717.h
+@@ -0,0 +1,151 @@
++/*
++ * max96717.c - MAX96717 GMSL2 Serializer driver (Tunnel Mode)
++ *
++ * Copyright (c) 2026, RealSense, Inc.  All rights reserved.
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms and conditions of the GNU General Public License,
++ * version 2, as published by the Free Software Foundation.
++ *
++ * This program is distributed in the hope it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
++ * more details.
++ *
++ * You should have received a copy of the GNU General Public License
++ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
++ */
++
++/**
++ * @file
++ * <b>MAX96717 API: For Analog Devices MAX96717 GMSL2 serializer</b>
++ *
++ * @b Description: Defines elements used to set up and use an
++ *  Analog Devices MAX96717 GMSL2 serializer in Tunnel Mode.
++ */
++
++#ifndef __MAX96717_H__
++#define __MAX96717_H__
++
++#include <linux/types.h>
++#include <media/gmsl-link.h>
++
++/**
++ * \defgroup max96717 MAX96717 serializer driver
++ *
++ * Controls the MAX96717 GMSL2 serializer module (Tunnel Mode).
++ *
++ * @ingroup serdes_group
++ * @{
++ */
++
++/**
++ * @brief  Configures a single pipe on the serializer.
++ *
++ * In Tunnel Mode, per-pipe DT/VC filtering is not active on the serializer
++ * side (all VCs are tunneled transparently). This function maintains API
++ * compatibility with the d4xx sensor driver framework.
++ *
++ * @param  [in]  dev          The serializer device handle.
++ * @param  [in]  pipe_id      Pipe index (0..3).
++ * @param  [in]  data_type1   Primary CSI-2 data type.
++ * @param  [in]  data_type2   Secondary CSI-2 data type (e.g. embedded).
++ * @param  [in]  vc_id        Virtual channel ID.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96717_set_pipe(struct device *dev, int pipe_id, u8 data_type1,
++		      u8 data_type2, u32 vc_id);
++
++/**
++ * @brief  Toggle SER TX to restore tunnel detection after DES ONESHOT.
++ *
++ * A DES ONESHOT resets the video data path. The serializer must cycle
++ * its TX enable (REG2 0x03→0x43) for the deserializer to re-acquire
++ * the tunnel stream.
++ *
++ * @param  [in]  dev          The serializer device handle.
++ */
++void max96717_retrigger_tx(struct device *dev);
++
++/**
++ * @brief  Powers on the serializer and performs I2C overrides
++ * for sensor and serializer devices.
++ *
++ * Must be called after the deserializer's max96724_setup_link().
++ *
++ * @param  [in]  dev          The serializer device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96717_setup_control(struct device *dev);
++
++/**
++ * @brief  Reverts I2C overrides and resets the serializer.
++ *
++ * @param  [in]  dev          The serializer device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96717_reset_control(struct device *dev);
++
++/**
++ * @brief  Pairs a sensor device with the serializer.
++ *
++ * To be called by the sensor client driver.
++ *
++ * @param  [in]  dev          The serializer device handle.
++ * @param  [in]  g_ctx        The gmsl_link_ctx structure handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96717_sdev_pair(struct device *dev, struct gmsl_link_ctx *g_ctx);
++
++/**
++ * @brief  Unpairs a sensor device from the serializer.
++ *
++ * @param  [in]  dev          The serializer device handle.
++ * @param  [in]  s_dev        The sensor device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96717_sdev_unpair(struct device *dev, struct device *s_dev);
++
++/**
++ * @brief  Sets up the serializer's internal streaming pipeline.
++ *
++ * Configures CSI-2 input mode, lane mapping, and enables Tunnel Mode
++ * (EXT11[7]=1 at register 0x0383).
++ *
++ * @param  [in]  dev          The serializer device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96717_setup_streaming(struct device *dev);
++
++/**
++ * @brief  Applies initial register settings for the serializer.
++ *
++ * Configures default pipe settings and Tunnel Mode registers.
++ *
++ * @param  [in]  dev          The serializer device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96717_init_settings(struct device *dev);
++
++/**
++ * @brief  No-op hook for GPIO-over-GMSL tunneling for FSIN/FOUT signals.
++ *
++ * The signal map is documented, but the concrete MFP_CFG values are
++ * not available yet. This hook currently logs and returns success.
++ *
++ * @param  [in]  dev          The serializer device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96717_setup_gpio_tunneling(struct device *dev);
++
++/** @} */
++
++#endif  /* __MAX96717_H__ */
+diff --git a/include/media/max96724.h b/include/media/max96724.h
+new file mode 100644
+index 0000000..dc5a8ea
+--- /dev/null
++++ b/include/media/max96724.h
+@@ -0,0 +1,183 @@
++/*
++ * max96717.c - MAX96717 GMSL2 Serializer driver (Tunnel Mode)
++ *
++ * Copyright (c) 2026, RealSense, Inc.  All rights reserved.
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms and conditions of the GNU General Public License,
++ * version 2, as published by the Free Software Foundation.
++ *
++ * This program is distributed in the hope it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
++ * more details.
++ *
++ * You should have received a copy of the GNU General Public License
++ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
++ */
++
++/**
++ * @file
++ * <b>MAX96724 API: For Analog Devices MAX96724 GMSL2 quad deserializer</b>
++ *
++ * @b Description: Defines elements used to set up and use an
++ *  Analog Devices MAX96724 quad GMSL2 deserializer in Tunnel Mode.
++ */
++
++#ifndef __MAX96724_H__
++#define __MAX96724_H__
++
++#include <linux/types.h>
++#include <media/gmsl-link.h>
++
++/**
++ * \defgroup max96724 MAX96724 deserializer driver
++ *
++ * Controls the MAX96724 quad GMSL2 deserializer module (Tunnel Mode).
++ *
++ * @ingroup serdes_group
++ * @{
++ */
++
++int max96724_get_available_pipe_id(struct device *dev, int vc_id);
++int max96724_get_ser_pipe_id(struct device *dev, int dser_pipe_id, int vc_id);
++int max96724_set_pipe(struct device *dev, int pipe_id, u8 data_type1,
++		      u8 data_type2, u32 vc_id);
++int max96724_release_pipe(struct device *dev, int pipe_id);
++void max96724_reset_oneshot(struct device *dev);
++
++/**
++ * @brief  Puts the deserializer in single exclusive link mode.
++ *
++ * @param  [in]  dev          The deserializer device handle.
++ * @param  [in]  s_dev        The sensor device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96724_setup_link(struct device *dev, struct device *s_dev);
++
++/**
++ * @brief  Sets up the deserializer link's control pipeline.
++ *
++ * Configures I2C pass-through, splitter mode if needed, and
++ * enables the tunnel mode pipe routing for the source.
++ *
++ * @param  [in]  dev          The deserializer device handle.
++ * @param  [in]  s_dev        The sensor device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96724_setup_control(struct device *dev, struct device *s_dev);
++
++/**
++ * @brief  Resets the deserializer link control pipeline.
++ *
++ * @param  [in]  dev          The deserializer device handle.
++ * @param  [in]  s_dev        The sensor device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96724_reset_control(struct device *dev, struct device *s_dev);
++
++/**
++ * @brief  Registers a source sensor device with the deserializer.
++ *
++ * @param  [in]  dev          The deserializer device handle.
++ * @param  [in]  g_ctx        The gmsl_link_ctx structure handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96724_sdev_register(struct device *dev, struct gmsl_link_ctx *g_ctx);
++
++/**
++ * @brief  Unregisters a source sensor device from the deserializer.
++ *
++ * @param  [in]  dev          The deserializer device handle.
++ * @param  [in]  s_dev        The sensor device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96724_sdev_unregister(struct device *dev, struct device *s_dev);
++
++/**
++ * @brief  Configures the internal streaming pipeline.
++ *
++ * Sets up tunnel mode pipe routing, CSI-2 output lane configuration,
++ * and MIPI PHY settings.
++ *
++ * @param  [in]  dev          The deserializer device handle.
++ * @param  [in]  s_dev        The sensor device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96724_setup_streaming(struct device *dev, struct device *s_dev);
++
++/**
++ * @brief  Enables streaming for a source sensor.
++ *
++ * @param  [in]  dev          The deserializer device handle.
++ * @param  [in]  s_dev        The sensor device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96724_start_streaming(struct device *dev, struct device *s_dev);
++
++/**
++ * @brief  Disables streaming for a source sensor.
++ *
++ * @param  [in]  dev          The deserializer device handle.
++ * @param  [in]  s_dev        The sensor device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96724_stop_streaming(struct device *dev, struct device *s_dev);
++
++/**
++ * @brief  Powers on the MAX96724 deserializer module.
++ *
++ * Asserts shared reset GPIO and powers on the regulator.
++ *
++ * @param  [in]  dev          The deserializer device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96724_power_on(struct device *dev);
++
++/**
++ * @brief  Powers off the MAX96724 deserializer module.
++ *
++ * @param  [in]  dev          The deserializer device handle.
++ */
++void max96724_power_off(struct device *dev);
++
++/**
++ * @brief  Applies initial register settings for the deserializer.
++ *
++ * Configures default pipe mappings, tunnel mode, and CSI output for
++ * the D5xx/SC1.2 use case.
++ *
++ * @param  [in]  dev          The deserializer device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96724_init_settings(struct device *dev);
++
++/**
++ * @brief  Maps deserializer pipe ID to serializer pipe ID.
++ *
++ * In tunnel mode with MAX96717, all data flows through a single pipe
++ * per camera, so the mapping is 1:1.
++ *
++ * @param  [in]  dev             The deserializer device handle.
++ * @param  [in]  dser_pipe_id    Deserializer pipe ID.
++ * @param  [in]  ser_pipe_id     Serializer pipe ID.
++ * @param  [in]  vc_id           VC ID associated with this pipe.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96724_bind_ser_to_dser_pipe(struct device *dev, int dser_pipe_id,
++				   int ser_pipe_id, u32 vc_id);
++
++/** @} */
++
++#endif  /* __MAX96724_H__ */
+-- 
+2.25.1
+

--- a/nvidia-oot/7.0/0001-Porting-nvidia-driver-patches-to-jetpack-6.0.patch
+++ b/nvidia-oot/7.0/0001-Porting-nvidia-driver-patches-to-jetpack-6.0.patch
@@ -25,13 +25,15 @@ diff --git a/drivers/media/i2c/Makefile b/drivers/media/i2c/Makefile
 index 7c5913c6..396b9bc3 100644
 --- a/drivers/media/i2c/Makefile
 +++ b/drivers/media/i2c/Makefile
-@@ -5,6 +5,9 @@ subdir-ccflags-y += -Werror
+@@ -5,6 +5,11 @@ subdir-ccflags-y += -Werror
  ifneq ($(NV_BUILD_SYSTEM_TYPE),embedded-linux)
  obj-m += max9295.o
  obj-m += max9296.o
 +subdir-ccflags-y += -DCONFIG_VIDEO_D4XX_SERDES
 +subdir-ccflags-y += -DCONFIG_TEGRA_CAMERA_PLATFORM
 +obj-m += d4xx.o
++obj-m += max96717.o
++obj-m += max96724.o
  ifndef CONFIG_TEGRA_SYSTEM_TYPE_ACK
  obj-m += max96712.o
  

--- a/nvidia-oot/7.0/0011-Add-MAX96717-serializer-and-MAX96724-deserializer-dr.patch
+++ b/nvidia-oot/7.0/0011-Add-MAX96717-serializer-and-MAX96724-deserializer-dr.patch
@@ -1,0 +1,3147 @@
+From 40fac9b67ddea60055961d32fa89fe8f608396ff Mon Sep 17 00:00:00 2001
+From: RealSense AI <realsense@realsenseai.com>
+Date: Tue, 12 May 2026 17:06:23 +0800
+Subject: [PATCH] Add MAX96717 serializer and MAX96724 deserializer drivers for
+ tunnel mode
+
+Add MAX96717 GMSL2 serializer and MAX96724 GMSL2 quad deserializer
+drivers for Tunnel Mode operation with D5xx cameras.
+
+MAX96717 serializer features:
+- CSI-2 input with 2/4 lane support
+- Tunnel Mode encapsulation of full CSI-2 byte stream
+- I2C address translation for sensor passthrough
+- GPIO-over-GMSL tunneling hook for FSIN/FOUT signals
+
+MAX96724 quad deserializer features:
+- Up to 4 GMSL2 links (quad camera support)
+- Configurable link speed (3 Gbps / 6 Gbps via DT)
+- Tunnel Mode pipe routing and CSI-2 output
+- 2x4 and 4x2 CSI output mode support
+- Power management with GPIO reset and regulator control
+
+Signed-off-by: RealSense AI <realsense@realsenseai.com>
+---
+ drivers/media/i2c/Makefile   |    2 +
+ drivers/media/i2c/max96717.c |  835 ++++++++++++++
+ drivers/media/i2c/max96724.c | 1916 ++++++++++++++++++++++++++++++++++
+ include/media/max96717.h     |  151 ++
+ include/media/max96724.h     |  183 +++
+ 4 files changed, 3085 insertions(+)
+ create mode 100644 drivers/media/i2c/max96717.c
+ create mode 100644 drivers/media/i2c/max96724.c
+ create mode 100644 include/media/max96717.h
+ create mode 100644 include/media/max96724.h
+
+diff --git a/drivers/media/i2c/max96717.c b/drivers/media/i2c/max96717.c
+new file mode 100644
+index 0000000..70d25a3
+--- /dev/null
++++ b/drivers/media/i2c/max96717.c
+@@ -0,0 +1,835 @@
++/*
++ * max96717.c - MAX96717 GMSL2 Serializer driver (Tunnel Mode)
++ *
++ * Copyright (c) 2026, RealSense, Inc.  All rights reserved.
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms and conditions of the GNU General Public License,
++ * version 2, as published by the Free Software Foundation.
++ *
++ * This program is distributed in the hope it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
++ * more details.
++ *
++ * You should have received a copy of the GNU General Public License
++ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
++ */
++
++#include <media/camera_common.h>
++#include <linux/of.h>
++#include <linux/module.h>
++#include <media/max96717.h>
++
++/* ===== Register Addresses ===== */
++
++/* REG0: Device ID (read-only, returns 0x40) */
++#define MAX96717_DEV_ADDR		0x00
++
++/* 
++ *   REG1: Link Speed
++ *   bit[3]=1: 3 Gbps, bit[4]=1: 6 Gbps
++ */
++#define MAX96717_REG1_ADDR		0x01
++
++/* 
++ *   PIPE_EN: Pipe enable / soft reset
++ *   0x03 = soft reset, 0x43 = pipes enabled + video init
++ *   Matches MAX9295 PIPE_EN at 0x02
++ */
++#define MAX96717_PIPE_EN_ADDR		0x02
++
++/* 
++ *   CTRL0: GMSL2 TX Control
++ *   bit[5]=1: GMSL2 mode, bit[0]=1: enable transmitter
++ *   0x21 = GMSL2 mode + TX enable on Link A
++ */
++#define MAX96717_CTRL0_ADDR		0x10
++
++/* 
++ *   CTRL3: Start Video - final enable bit
++ *   bit[0]=1: activate video stream
++ */
++#define MAX96717_CTRL3_ADDR		0x13
++
++/* 
++ *   TX1: FEC Enable
++ *   bit[6]=1: Reed-Solomon FEC enabled
++ */
++#define MAX96717_TX1_ADDR		0x29
++
++/*
++ *   MAX96717 I2C address translation registers (GMSL2 standard):
++ *   SRC_A / DST_A (0x42/0x43): Translation pair A (SER broadcast addr)
++ *   SRC_B / DST_B (0x44/0x45): Translation pair B (sensor passthrough)
++ *
++ *   When host writes to SRC_B address, the MAX96717 translates it to
++ *   DST_B and forwards via GMSL back-channel to the remote sensor.
++ *
++ */
++#define MAX96717_SRC_A_ADDR		0x42
++#define MAX96717_DST_A_ADDR		0x43
++#define MAX96717_I2C4_ADDR		0x44
++#define MAX96717_I2C5_ADDR		0x45
++
++/* 
++ *   TX_STR_SEL: Stream ID select
++ *   bits[1:0]: stream ID for DES pipe routing
++ */
++#define MAX96717_TX_STR_SEL_ADDR	0x5B
++
++/* 
++ *   VIDEO_TX0/TX1: Video TX path config
++ *   0x0110=0xE9, 0x0111=0x10 for tunnel mode data path
++ */
++#define MAX96717_VIDEO_TX0_ADDR		0x110
++#define MAX96717_VIDEO_TX1_ADDR		0x111
++
++/* 
++ *   FRONTTOP_0: Front-end topology
++ *   0x12 = single CSI-2 port A, all VCs pass through
++ */
++#define MAX96717_FRONTTOP0_ADDR		0x308
++
++/* 
++ *   MIPI_RX0-RX3: CSI-2 receiver configuration
++ *   RX0 (0x330): CSI mode (0x00 = D-PHY controller A)
++ *   RX1 (0x331): Lane count - ctrl1_num_lanes bits[5:4]
++ *                0x30 = bits[5:4]=11 (4 lanes)
++ *   RX2 (0x332): Lane mapping - 0xE0 = default 1x4 map
++ *   RX3 (0x333): Lane mapping - 0x04 = default 1x4 map
++ */
++#define MAX96717_MIPI_RX0_ADDR		0x330
++#define MAX96717_MIPI_RX1_ADDR		0x331
++#define MAX96717_MIPI_RX2_ADDR		0x332
++#define MAX96717_MIPI_RX3_ADDR		0x333
++
++/* 
++ *   EXT11: TUNNEL MODE ENABLE
++ *   bit[7]=1: Tun_Mode = ON
++ *   0x383 = 0x80
++ */
++#define MAX96717_EXT11_ADDR		0x383
++
++/* PHY calibration stage-1 value */
++#define MAX96717_PHY_CAL_STAGE1		0x80
++/* PHY calibration stage-2 value */
++#define MAX96717_PHY_CAL_STAGE2		0x90
++/* CSI input timing / frequency config */
++#define MAX96717_CSI_TIMING_3F0		0x59
++#define MAX96717_CSI_TIMING_3F1		0x09
++
++/* ===== Register Values ===== */
++
++/* Soft reset value for PIPE_EN register */
++#define MAX96717_SOFT_RESET		0x03
++
++/* Final enable: pipes enabled + video init */
++#define MAX96717_PIPE_EN_ALL		0x43
++
++/* CTRL0: GMSL2 mode + TX enable (Link A) */
++#define MAX96717_CTRL0_LINK_A		0x21
++/* CTRL0: GMSL2 mode + TX enable (Link B) */
++#define MAX96717_CTRL0_LINK_B		0x22
++
++/* CTRL0 reset all */
++#define MAX96717_RESET_ALL		0x80
++
++/* EXT11 tunnel mode enable value */
++#define MAX96717_TUN_MODE_EN		0x80
++#define MAX96717_TUN_MODE_DIS		0x00
++
++/* VIDEO_TX0 tunnel mode data path enable */
++#define MAX96717_VIDEO_TX0_TUN		0xE9
++/* VIDEO_TX1 tunnel mode config */
++#define MAX96717_VIDEO_TX1_TUN		0x10
++#define MAX96717_VIDEO_TX0_BPP_MANUAL	0x60
++#define MAX96717_VIDEO_TX1_BPP16	0x50
++#define MAX96717_VIDEO_TX2_ADDR		0x112
++#define MAX96717_VIDEO_TX2_DRIFT_DIS	0x08
++
++/* 
++ *   MIPI RX1: 4-lane CSI-2.
++ *   bits[5:4]=11 (4 lanes).  bits[1:0]=11
++ */
++#define MAX96717_CSI_4_LANES		0x33
++/* 2-lane CSI-2, bits[5:4]=01 */
++#define MAX96717_CSI_2_LANES		0x10
++
++/* Lane mapping for 1x4 mode */
++#define MAX96717_CSI_1X4_LANE_MAP1	0xE0
++#define MAX96717_CSI_1X4_LANE_MAP2	0x04
++
++/* FRONTTOP_0: single port A, all VCs */
++#define MAX96717_FRONTTOP0_PORT_A	0x12
++/* Pixel mode from Port B into Pipe Z */
++#define MAX96717_FRONTTOP0_PIXEL_PORT_B	0x64
++#define MAX96717_FRONTTOP5_ADDR		0x30D
++#define MAX96717_FRONTTOP9_ADDR		0x311
++#define MAX96717_FRONTTOP16_ADDR	0x318
++#define MAX96717_FRONTTOP17_ADDR	0x319
++#define MAX96717_FRONTTOP9_START_VIDEO	0x40
++
++/* MIPI_RX0: CSI reset on + non-continuous clock */
++#define MAX96717_MIPI_RX0_RESET		0x08
++/* MIPI_RX0: Normal operation */
++#define MAX96717_MIPI_RX0_NORMAL	0x00
++
++/* REG1: 3 Gbps link speed, bit[3]=1 */
++#define MAX96717_LINK_SPEED_3GBPS	0x08
++/* REG1: 6 Gbps link speed, bit[4]=1 */
++#define MAX96717_LINK_SPEED_6GBPS	0x10
++
++/* EXT11 tunnel mode pre-config (0x0383=0x80) */
++#define MAX96717_EXT11_TUN_PRE		0x80
++
++#define MAX96717_MAX_PIPES		4
++
++/*
++ * MFP8 (GPIO8) high-impedance release.
++ *
++ * At power-up GPIO8 comes up with GPIO_OUT_DIS=0 (output driver enabled,
++ * GPIO8_A=0x9c observed live), so the serializer actively drives the M2_I2C
++ * line and wedges the bus: any IMU I2C access by the camera FW times out
++ * whenever the serializer is powered.  This was confirmed on hardware -
++ * tri-stating GPIO8 alone immediately restored IMU I2C reads.
++ *
++ * GPIO8 is the ONLY serializer pin left driving its net (all other GPIOs,
++ * including MFP3/MFP4 interrupt lines, are already high-Z).  Release GPIO8
++ * (output driver off, no link TX/RX, no pull) so only the M2_I2C bus
++ * masters own the line.
++ *
++ * GPIO_n registers are a 3-byte group (A/B/C) starting at 0x02BE:
++ *   GPIO_n_A = 0x02BE + 3*n
++ */
++#define MAX96717_GPIO8_A_ADDR		0x02D6	/* MFP8 / M2_I2C (pass-through SCL1) */
++#define MAX96717_GPIO8_B_ADDR		0x02D7
++/* GPIO_A: GPIO_OUT_DIS=1 (high-Z), GPIO_TX_EN=0, GPIO_RX_EN=0 */
++#define MAX96717_GPIO_A_HIGH_Z		0x01
++/* GPIO_B: PULL_UPDN_SEL=None, TX_ID=0 */
++#define MAX96717_GPIO_B_NO_PULL		0x00
++
++/* ===== Data Structures ===== */
++
++struct max96717_client_ctx {
++	struct gmsl_link_ctx *g_ctx;
++	bool st_done;
++};
++
++struct max96717 {
++	struct i2c_client *i2c_client;
++	struct regmap *regmap;
++	struct max96717_client_ctx g_client;
++	struct mutex lock;
++	bool pixel_mode;
++	/* primary serializer properties */
++	__u32 def_addr;
++	__u32 pst2_ref;
++};
++
++static struct max96717 *prim_priv__;
++
++struct reg_pair {
++	u16 addr;
++	u8 val;
++};
++
++/* ===== Low-level I2C ===== */
++
++static int max96717_write_reg(struct device *dev, u16 addr, u8 val)
++{
++	struct max96717 *priv = dev_get_drvdata(dev);
++	int err;
++
++	err = regmap_write(priv->regmap, addr, val);
++	if (err)
++		dev_err(dev, "%s:i2c write failed, 0x%x = %x\n",
++			__func__, addr, val);
++
++	/* delay before next i2c command as required for SERDES link */
++	usleep_range(100, 110);
++
++	return err;
++}
++
++static int max96717_set_registers(struct device *dev, struct reg_pair *map,
++				  u32 count)
++{
++	int err = 0;
++	u32 j;
++
++	for (j = 0; j < count; j++) {
++		err = max96717_write_reg(dev, map[j].addr, map[j].val);
++		if (err)
++			break;
++	}
++
++	return err;
++}
++
++/* ===== Streaming Setup ===== */
++
++/*
++ * max96717_setup_streaming - Configure CSI-2 input and enable Tunnel Mode
++ *
++ * In Tunnel Mode (unlike MAX9295 Pixel Mode), the serializer encapsulates
++ * the entire CSI-2 byte stream verbatim into a single GMSL2 tunnel.
++ * All VCs (VC0-VC3) are preserved end-to-end.
++ */
++int max96717_setup_streaming(struct device *dev)
++{
++	struct max96717 *priv = dev_get_drvdata(dev);
++	int err = 0;
++	struct gmsl_link_ctx *g_ctx;
++
++	mutex_lock(&priv->lock);
++
++	if (!priv->g_client.g_ctx) {
++		dev_err(dev, "%s: no sdev client found\n", __func__);
++		err = -EINVAL;
++		goto error;
++	}
++
++	if (priv->g_client.st_done) {
++		dev_dbg(dev, "%s: stream setup is already done\n", __func__);
++		goto error;
++	}
++
++	g_ctx = priv->g_client.g_ctx;
++
++	max96717_write_reg(dev, MAX96717_EXT11_ADDR, MAX96717_TUN_MODE_EN);
++	max96717_write_reg(dev, MAX96717_MIPI_RX1_ADDR, MAX96717_CSI_4_LANES);
++	max96717_write_reg(dev, MAX96717_MIPI_RX2_ADDR, MAX96717_CSI_1X4_LANE_MAP1);
++	max96717_write_reg(dev, MAX96717_MIPI_RX3_ADDR, MAX96717_CSI_1X4_LANE_MAP2);
++	max96717_write_reg(dev, MAX96717_VIDEO_TX0_ADDR, MAX96717_VIDEO_TX0_TUN);
++	max96717_write_reg(dev, MAX96717_VIDEO_TX1_ADDR, MAX96717_VIDEO_TX1_TUN);
++
++	max96717_write_reg(dev, MAX96717_MIPI_RX0_ADDR, MAX96717_MIPI_RX0_RESET);
++	usleep_range(2000, 2100);
++	max96717_write_reg(dev, MAX96717_MIPI_RX0_ADDR, MAX96717_MIPI_RX0_NORMAL);
++
++	/* pipes on + video init */
++	max96717_write_reg(dev, MAX96717_PIPE_EN_ADDR, MAX96717_PIPE_EN_ALL);
++
++	priv->g_client.st_done = true;
++
++error:
++	mutex_unlock(&priv->lock);
++	return err;
++}
++EXPORT_SYMBOL(max96717_setup_streaming);
++
++/* ===== Control Setup ===== */
++
++/*
++ * max96717_setup_control - Set up I2C address translation and link control
++ *
++ * Steps:
++ *   1. Reassign serializer I2C address via DEV_ADDR (reg 0x00)
++ *   2. Configure GMSL2 link mode via CTRL0 (reg 0x10)
++ *   3. Set I2C address translation for sensor passthrough:
++ *      I2C4/SRC_B (0x44) <- (sdev_reg << 1): proxy addr visible to host
++ *      I2C5/DST_B (0x45) <- (sdev_def << 1): real addr on back-channel
++ *
++ */
++int max96717_setup_control(struct device *dev)
++{
++	struct max96717 *priv = dev_get_drvdata(dev);
++	int err = 0;
++	struct gmsl_link_ctx *g_ctx;
++
++	mutex_lock(&priv->lock);
++
++	if (!priv->g_client.g_ctx) {
++		dev_err(dev, "%s: no sensor dev client found\n", __func__);
++		err = -EINVAL;
++		goto error;
++	}
++
++	g_ctx = priv->g_client.g_ctx;
++
++	if (prim_priv__) {
++		unsigned int dev_id;
++		int probe_ret;
++
++		probe_ret = regmap_read(prim_priv__->regmap,
++					MAX96717_DEV_ADDR, &dev_id);
++		if (probe_ret == 0) {
++			/* Primary address (0x40) still responsive — do reassign */
++			max96717_write_reg(&prim_priv__->i2c_client->dev,
++					   MAX96717_DEV_ADDR,
++					   (g_ctx->ser_reg << 1));
++		} else {
++			dev_info(&prim_priv__->i2c_client->dev,
++				 "%s: SER already reassigned (addr 0x40 NACK), skipping DEV_ADDR write\n",
++				 __func__);
++		}
++	}
++
++	/* CTRL0: GMSL2 mode + TX enable */
++	if (g_ctx->serdes_csi_link == GMSL_SERDES_CSI_LINK_A)
++		err = max96717_write_reg(dev, MAX96717_CTRL0_ADDR,
++					 MAX96717_CTRL0_LINK_A);
++	else
++		err = max96717_write_reg(dev, MAX96717_CTRL0_ADDR,
++					 MAX96717_CTRL0_LINK_B);
++
++	if (err) {
++		dev_err(dev, "%s: ERROR: ser device not found\n", __func__);
++		goto error;
++	}
++
++	/* delay to settle link */
++	msleep(100);
++
++	/*
++	 * I2C address translation for sensor passthrough.
++	 *
++	 * I2C4 / SRC_B (0x44): sensor proxy addr visible to Orin host
++	 * I2C5 / DST_B (0x45): sensor real addr on GMSL back-channel
++	 *
++	 * When host sends I2C to sdev_reg (e.g., 0x1a), the MAX96717
++	 * translates it to sdev_def (e.g., 0x42) and forwards via GMSL
++	 * back-channel to the HKR sensor.
++	 */
++	max96717_write_reg(dev, MAX96717_I2C4_ADDR,
++			   (g_ctx->sdev_reg << 1));
++	max96717_write_reg(dev, MAX96717_I2C5_ADDR,
++			   (g_ctx->sdev_def << 1));
++
++	/* dev addr pass-through ref */
++	if (prim_priv__)
++		prim_priv__->pst2_ref++;
++
++	g_ctx->serdev_found = true;
++
++error:
++	mutex_unlock(&priv->lock);
++	return err;
++}
++EXPORT_SYMBOL(max96717_setup_control);
++
++/* ===== GPIO Tunneling ===== */
++
++/*
++ * max96717_setup_gpio_tunneling - GPIO-over-GMSL no-op hook
++ *
++ *   GPIO Signal Mapping:
++ *   MFP0 → GPIO0: FSIN (DES→SER, frame sync in)
++ *   MFP1 → GPIO1: FOUT/STROBE (SER→DES, frame sync out)
++ *   MFP4 → GPIO4: RESET_N (DES→SER, hard reset)
++ *   MFP5 → GPIO5: IRQ (SER→DES, interrupt request)
++ *   MFP6 → GPIO6: ZV_SYNC (DES→SER, IR stereo sync)
++ *
++ */
++int max96717_setup_gpio_tunneling(struct device *dev)
++{
++	struct max96717 *priv = dev_get_drvdata(dev);
++	int err = 0;
++
++	mutex_lock(&priv->lock);
++
++	dev_info(dev, "%s: GPIO tunneling hook is a no-op; MFP_CFG values are not defined yet\n",
++		 __func__);
++
++	mutex_unlock(&priv->lock);
++
++	return err;
++}
++EXPORT_SYMBOL(max96717_setup_gpio_tunneling);
++
++/* ===== Reset Control ===== */
++
++int max96717_reset_control(struct device *dev)
++{
++	struct max96717 *priv = dev_get_drvdata(dev);
++	int err = 0;
++
++	mutex_lock(&priv->lock);
++	if (!priv->g_client.g_ctx) {
++		dev_err(dev, "%s: no sdev client found\n", __func__);
++		err = -EINVAL;
++		goto error;
++	}
++
++	priv->g_client.st_done = false;
++
++	if (prim_priv__) {
++		prim_priv__->pst2_ref--;
++
++		max96717_write_reg(dev, MAX96717_DEV_ADDR,
++				   (prim_priv__->def_addr << 1));
++		if (prim_priv__->pst2_ref == 0)
++			max96717_write_reg(&prim_priv__->i2c_client->dev,
++					   MAX96717_CTRL0_ADDR,
++					   MAX96717_RESET_ALL);
++	}
++
++error:
++	mutex_unlock(&priv->lock);
++	return err;
++}
++EXPORT_SYMBOL(max96717_reset_control);
++
++/* ===== Device Pairing ===== */
++
++int max96717_sdev_pair(struct device *dev, struct gmsl_link_ctx *g_ctx)
++{
++	struct max96717 *priv;
++	int err = 0;
++
++	if (!dev || !g_ctx || !g_ctx->s_dev) {
++		dev_err(dev, "%s: invalid input params\n", __func__);
++		return -EINVAL;
++	}
++
++	priv = dev_get_drvdata(dev);
++	mutex_lock(&priv->lock);
++	if (priv->g_client.g_ctx) {
++		/* 
++		 * Already paired — tolerate if this is a re-probe of
++		 * the same camera after a failed first attempt.
++		 * Simply overwrite with the new g_ctx.
++		 */
++		dev_warn(dev, "%s: re-pairing (previous probe may have failed)\n",
++			 __func__);
++	}
++
++	priv->g_client.st_done = false;
++	priv->g_client.g_ctx = g_ctx;
++
++	/* mutex_unlock in error path, but we have none — inline the unlock */
++	mutex_unlock(&priv->lock);
++	return err;
++}
++EXPORT_SYMBOL(max96717_sdev_pair);
++
++int max96717_sdev_unpair(struct device *dev, struct device *s_dev)
++{
++	struct max96717 *priv = NULL;
++	int err = 0;
++
++	if (!dev || !s_dev) {
++		dev_err(dev, "%s: invalid input params\n", __func__);
++		return -EINVAL;
++	}
++
++	priv = dev_get_drvdata(dev);
++
++	mutex_lock(&priv->lock);
++
++	if (!priv->g_client.g_ctx) {
++		dev_dbg(dev, "%s: device is not paired\n", __func__);
++		err = 0; /* Not an error — already unpaired */
++		goto error;
++	}
++
++	if (priv->g_client.g_ctx->s_dev != s_dev) {
++		dev_warn(dev, "%s: s_dev mismatch, clearing anyway\n", __func__);
++	}
++
++	priv->g_client.g_ctx = NULL;
++	priv->g_client.st_done = false;
++
++error:
++	mutex_unlock(&priv->lock);
++	return err;
++}
++EXPORT_SYMBOL(max96717_sdev_unpair);
++
++/* ===== Pipe Configuration ===== */
++
++/*
++ * __max96717_set_pipe - Configure a single pipe's DT/VC mapping
++ *
++ * In Tunnel Mode, per-pipe DT/VC filtering is bypassed on the serializer。
++ * However, we still write the registers for d4xx framework compatibility.
++ *
++ */
++static int __max96717_set_pipe(struct device *dev, int pipe_id, u8 data_type1,
++			       u8 data_type2, u32 vc_id)
++{
++	int err = 0;
++	u8 bpp = 0x30;
++	struct max96717 *priv = dev_get_drvdata(dev);
++
++	if (priv->pixel_mode) {
++		struct reg_pair pixel_pipe_control[] = {
++			{MAX96717_FRONTTOP16_ADDR, 0x5E},
++			{MAX96717_FRONTTOP17_ADDR, 0x52},
++			{MAX96717_FRONTTOP5_ADDR, 0x01},
++		};
++
++		pixel_pipe_control[0].val = 0x40 | data_type1;
++		pixel_pipe_control[1].val = data_type2 ? (0x40 | data_type2) : 0x00;
++		pixel_pipe_control[2].val = 1 << vc_id;
++
++		return max96717_set_registers(dev, pixel_pipe_control,
++					     ARRAY_SIZE(pixel_pipe_control));
++	} else {
++		struct reg_pair map_pipe_control[] = {
++			/* Pipe X DT addr + 0x2*pipe_id */
++			{0x0314, 0x5E},  /* data_type1 */
++			{0x0315, 0x52},  /* data_type2 */
++			{0x0309, 0x01},  /* VC select */
++			{0x030A, 0x00},
++			{0x031C, 0x30},  /* BPP */
++			{0x0102, 0x0E},  /* LIM_HEART: Disabled */
++		};
++
++		if (data_type1 == GMSL_CSI_DT_RGB_888)
++			bpp = 0x18;
++
++		map_pipe_control[0].addr += 0x2 * pipe_id;
++		map_pipe_control[1].addr += 0x2 * pipe_id;
++		map_pipe_control[2].addr += 0x2 * pipe_id;
++		map_pipe_control[3].addr += 0x2 * pipe_id;
++		map_pipe_control[4].addr += 0x1 * pipe_id;
++		map_pipe_control[5].addr += 0x8 * pipe_id;
++
++		map_pipe_control[0].val = 0x40 | data_type1;
++		map_pipe_control[1].val = 0x40 | data_type2;
++		if (pipe_id == 0)
++			map_pipe_control[1].val |= 0x80;
++		map_pipe_control[2].val = 1 << vc_id;
++		map_pipe_control[3].val = 0x00;
++		map_pipe_control[4].val = bpp;
++		map_pipe_control[5].val = 0x0E;
++
++		err = max96717_set_registers(dev, map_pipe_control,
++					     ARRAY_SIZE(map_pipe_control));
++	}
++
++	return err;
++}
++
++/*
++ * max96717_init_settings - Initialize default pipe/streaming settings
++ *
++ * In Tunnel Mode, per-pipe DT config is not functionally needed
++ * but we configure pipes for d4xx compatibility.
++ * Default: 4 pipes with YUV422_8 + EMBED, VC0-3.
++ */
++int max96717_init_settings(struct device *dev)
++{
++	int err = 0;
++	int i;
++	struct max96717 *priv = dev_get_drvdata(dev);
++
++	struct reg_pair map_init[] = {
++		/* 
++		 * PIPE_EN soft reset first, then enable tunnel mode.
++		 * Note: FRONTTOP0 is bypassed in tunnel mode (per UG) —
++		 * CSI-2 input goes directly into the tunnel, no port config needed.
++		 */
++		{MAX96717_PIPE_EN_ADDR, MAX96717_SOFT_RESET},
++		{MAX96717_EXT11_ADDR, MAX96717_TUN_MODE_EN},
++		{MAX96717_PIPE_EN_ADDR, MAX96717_PIPE_EN_ALL},
++	};
++	struct reg_pair pixel_init[] = {
++		{MAX96717_PIPE_EN_ADDR, MAX96717_SOFT_RESET},
++		{MAX96717_EXT11_ADDR, MAX96717_TUN_MODE_DIS},
++		{MAX96717_FRONTTOP0_ADDR, MAX96717_FRONTTOP0_PIXEL_PORT_B},
++		{MAX96717_FRONTTOP9_ADDR, MAX96717_FRONTTOP9_START_VIDEO},
++		{MAX96717_VIDEO_TX0_ADDR, MAX96717_VIDEO_TX0_BPP_MANUAL},
++		{MAX96717_VIDEO_TX1_ADDR, MAX96717_VIDEO_TX1_BPP16},
++		{MAX96717_VIDEO_TX2_ADDR, MAX96717_VIDEO_TX2_DRIFT_DIS},
++		{MAX96717_PIPE_EN_ADDR, MAX96717_PIPE_EN_ALL},
++	};
++	/*
++	 * Release MFP8 (GPIO8) before any other config so the serializer
++	 * stops driving the camera-side M2_I2C bus shared with the BMI088
++	 * IMU. Confirmed on HW: tri-stating GPIO8 restores IMU I2C access.
++	 */
++	struct reg_pair gpio_release[] = {
++		{MAX96717_GPIO8_A_ADDR, MAX96717_GPIO_A_HIGH_Z},
++		{MAX96717_GPIO8_B_ADDR, MAX96717_GPIO_B_NO_PULL},
++	};
++
++	mutex_lock(&priv->lock);
++
++	/*
++	 * After CTRL0 + I2C translation writes in
++	 * setup_control, the MAX96717 needs settling time before
++	 * accepting writes to PIPE_EN (0x02) and FRONTTOP registers.
++	 */
++	usleep_range(5000, 6000);
++
++	/*
++	 * Tri-state MFP8 (GPIO8) first to release the camera-side M2_I2C
++	 * bus shared with the BMI088 IMU before configuring the rest of
++	 * the SER.
++	 */
++	err = max96717_set_registers(dev, gpio_release,
++				    ARRAY_SIZE(gpio_release));
++	if (err)
++		dev_warn(dev, "%s: failed to release MFP8 (IMU M2_I2C bus)\n",
++			 __func__);
++
++	if (priv->pixel_mode) {
++		err = max96717_set_registers(dev, pixel_init,
++					 ARRAY_SIZE(pixel_init));
++		err |= __max96717_set_pipe(dev, 0, GMSL_CSI_DT_YUV422_8,
++				   0, 0);
++	} else {
++		err = max96717_set_registers(dev, map_init, ARRAY_SIZE(map_init));
++
++		for (i = 0; i < MAX96717_MAX_PIPES; i++)
++			err |= __max96717_set_pipe(dev, i, GMSL_CSI_DT_YUV422_8,
++					   GMSL_CSI_DT_EMBED, i);
++	}
++
++	mutex_unlock(&priv->lock);
++
++	return err;
++}
++EXPORT_SYMBOL(max96717_init_settings);
++
++int max96717_set_pipe(struct device *dev, int pipe_id,
++		      u8 data_type1, u8 data_type2, u32 vc_id)
++{
++	struct max96717 *priv = dev_get_drvdata(dev);
++	int err = 0;
++
++	if (pipe_id > (MAX96717_MAX_PIPES - 1)) {
++		dev_info(dev, "%s: input pipe_id: %d exceeds max96717 max pipes\n",
++			 __func__, pipe_id);
++		return -EINVAL;
++	}
++
++	dev_dbg(dev, "%s pipe_id %d, data_type1 %u, data_type2 %u, vc_id %u\n",
++		__func__, pipe_id, data_type1, data_type2, vc_id);
++
++	mutex_lock(&priv->lock);
++
++	err = __max96717_set_pipe(dev, pipe_id, data_type1, data_type2, vc_id);
++
++	mutex_unlock(&priv->lock);
++
++	return err;
++}
++EXPORT_SYMBOL(max96717_set_pipe);
++
++/*
++ * max96717_retrigger_tx - Toggle SER TX to restore tunnel detection after
++ * a DES ONESHOT.  DES ONESHOT resets the data path; the SER must cycle
++ * its TX enable for the DES to re-acquire the tunnel stream.
++ */
++void max96717_retrigger_tx(struct device *dev)
++{
++	max96717_write_reg(dev, MAX96717_PIPE_EN_ADDR, MAX96717_SOFT_RESET);
++	msleep(30);
++	max96717_write_reg(dev, MAX96717_PIPE_EN_ADDR, MAX96717_PIPE_EN_ALL);
++}
++EXPORT_SYMBOL(max96717_retrigger_tx);
++
++/* ===== Probe / Remove ===== */
++
++static struct regmap_config max96717_regmap_config = {
++	.reg_bits = 16,
++	.val_bits = 8,
++	.cache_type = REGCACHE_RBTREE,
++};
++
++static int max96717_probe(struct i2c_client *client,
++			   const struct i2c_device_id *id)
++{
++	struct max96717 *priv;
++	int err = 0;
++	struct device_node *node = client->dev.of_node;
++
++	dev_info(&client->dev, "[MAX96717]: probing GMSL2 Serializer (Tunnel Mode)\n");
++
++	priv = devm_kzalloc(&client->dev, sizeof(*priv), GFP_KERNEL);
++	if (!priv)
++		return -ENOMEM;
++
++	priv->i2c_client = client;
++	priv->regmap = devm_regmap_init_i2c(priv->i2c_client,
++					     &max96717_regmap_config);
++	if (IS_ERR(priv->regmap)) {
++		dev_err(&client->dev,
++			"regmap init failed: %ld\n", PTR_ERR(priv->regmap));
++		return -ENODEV;
++	}
++
++	mutex_init(&priv->lock);
++	priv->pixel_mode = of_property_read_bool(node, "adi,pixel-mode");
++
++	if (of_get_property(node, "is-prim-ser", NULL)) {
++		if (prim_priv__) {
++			dev_err(&client->dev,
++				"prim-ser already exists\n");
++			return -EEXIST;
++		}
++
++		err = of_property_read_u32(node, "reg", &priv->def_addr);
++		if (err < 0) {
++			dev_err(&client->dev, "reg not found\n");
++			return -EINVAL;
++		}
++
++		prim_priv__ = priv;
++	}
++
++	dev_set_drvdata(&client->dev, priv);
++
++	dev_info(&client->dev, "%s: success\n", __func__);
++
++	return err;
++}
++
++static int max96717_remove(struct i2c_client *client)
++{
++	struct max96717 *priv;
++
++	if (client != NULL) {
++		priv = dev_get_drvdata(&client->dev);
++		mutex_destroy(&priv->lock);
++		i2c_unregister_device(client);
++		client = NULL;
++	}
++
++	return 0;
++}
++
++static const struct i2c_device_id max96717_id[] = {
++	{ "max96717", 0 },
++	{ },
++};
++
++static const struct of_device_id max96717_of_match[] = {
++	{ .compatible = "adi,max96717", },
++	{ .compatible = "maxim,max96717", },
++	{ },
++};
++MODULE_DEVICE_TABLE(of, max96717_of_match);
++MODULE_DEVICE_TABLE(i2c, max96717_id);
++
++static struct i2c_driver max96717_i2c_driver = {
++	.driver = {
++		.name = "max96717",
++		.owner = THIS_MODULE,
++		.of_match_table = of_match_ptr(max96717_of_match),
++	},
++	.probe = max96717_probe,
++	.remove = max96717_remove,
++	.id_table = max96717_id,
++};
++
++static int __init max96717_init(void)
++{
++	return i2c_add_driver(&max96717_i2c_driver);
++}
++
++static void __exit max96717_exit(void)
++{
++	i2c_del_driver(&max96717_i2c_driver);
++}
++
++module_init(max96717_init);
++module_exit(max96717_exit);
++
++MODULE_DESCRIPTION("GMSL2 Serializer driver max96717 (Tunnel Mode)");
++MODULE_AUTHOR("RealSense AI");
++MODULE_LICENSE("GPL v2");
+diff --git a/drivers/media/i2c/max96724.c b/drivers/media/i2c/max96724.c
+new file mode 100644
+index 0000000..22bfb47
+--- /dev/null
++++ b/drivers/media/i2c/max96724.c
+@@ -0,0 +1,1916 @@
++/*
++ * max96724.c - MAX96724 GMSL2 Quad Deserializer driver (Tunnel Mode)
++ *
++ * Copyright (c) 2026, RealSense, Inc.  All rights reserved.
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms and conditions of the GNU General Public License,
++ * version 2, as published by the Free Software Foundation.
++ *
++ * This program is distributed in the hope it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
++ * more details.
++ *
++ * You should have received a copy of the GNU General Public License
++ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
++ */
++
++
++#include <linux/gpio.h>
++#include <linux/types.h>
++#include <linux/module.h>
++#include <linux/of.h>
++#include <linux/of_device.h>
++#include <linux/of_gpio.h>
++#include <media/camera_common.h>
++#include <linux/module.h>
++#include <media/max96724.h>
++
++/* ================================================================
++ * Register Addresses
++ * ================================================================ */
++
++/* --- Device ID / Configuration --- */
++
++/* REG0: Device ID (read-only, returns 0xA2) */
++#define MAX96724_DEV_ID_ADDR		0x00
++
++/* ERRB master reset register */
++#define MAX96724_ERRB_MST_RST_ADDR	0x05
++
++/* 
++ *   GMSL Link/PHY Enable and Mode Select
++ *   bits[7:4]: PHY mode (0=GMSL1, 1=GMSL2) per link D/C/B/A
++ *   bits[3:0]: Link Enable per link D/C/B/A
++ */
++#define MAX96724_LINK_EN_ADDR		0x0006
++
++/* 
++ *   GMSL Link/PHY Rate Select (Links A&B)
++ *   bits[7:6]: Tx Rate Link B, bits[5:4]: Rx Rate Link B
++ *   bits[3:2]: Tx Rate Link A, bits[1:0]: Rx Rate Link A
++ *   Tx: 00=187.5Mbps, Rx: 01=3Gbps, 10=6Gbps
++ */
++#define MAX96724_LINK_RATE_AB_ADDR	0x0010
++
++/* GMSL Link/PHY Rate Select (Links C&D) */
++#define MAX96724_LINK_RATE_CD_ADDR	0x0011
++
++/* Link A lock status (bit[3]=LOCK) */
++#define MAX96724_LINK_A_LOCK_ADDR	0x001A
++
++/* 
++ *   GMSL Link Reset
++ *   bits[7:4]: Link reset D/C/B/A, bits[3:0]: One-shot reset D/C/B/A
++ */
++#define MAX96724_ONESHOT_ADDR		0x0018
++
++/* Soft Reset (write 0x40, wait 5ms) */
++#define MAX96724_REG13_ADDR		0x000D
++
++/* 
++ *   Error Channel Power Up registers (required for 6Gbps)
++ *   Write 0x75 immediately after power-up for robust 6Gbps operation
++ */
++#define MAX96724_ERRCH_A_ADDR		0x1449
++#define MAX96724_ERRCH_B_ADDR		0x1549
++#define MAX96724_ERRCH_C_ADDR		0x1649
++#define MAX96724_ERRCH_D_ADDR		0x1749
++#define MAX96724_ERRCH_FORCE_ON		0x75
++
++/* --- I2C Control Channel / Errata --- */
++
++/* 
++ *   Tunnel Mode SRAM LCRC error suppression
++ *   Set 0x458[7:4] = 0x0 to suppress spurious ERRB in tunnel mode
++ */
++#define MAX96724_SRAM_LCRC_ERR_ADDR	0x0458
++
++/* --- Video Pipe Selection --- */
++
++/*
++ *   bits[3:0] = Pipe 0 source (0x0=SIOA)
++ *   bits[7:4] = Pipe 1 source (0x1=SIOB)
++ */
++#define MAX96724_PIPE_SEL0_ADDR		0xF0
++
++/*
++ *   bits[3:0] = Pipe 2 source (0x2=SIOC)
++ *   bits[7:4] = Pipe 3 source (0x3=SIOD)
++ */
++#define MAX96724_PIPE_SEL1_ADDR		0xF1
++
++#define MAX96724_PIPE_EN_ADDR		0xF4
++
++/* --- Pipe Receiver / Tunnel Mode --- */
++
++/*
++ *   bit[5]=1: Tunnel Mode, bits[1:0]=11: 4-lane MIPI out
++ *   Stride: 0x12 per pipe (P0=0x100, P1=0x112, P2=0x124, P3=0x136)
++ */
++#define MAX96724_VID_RX0_P0_ADDR	0x100
++#define MAX96724_VID_RX6_P0_ADDR	0x106
++#define MAX96724_VID_RX_STRIDE		0x12
++
++#define MAX96724_VID_RX1_P0_ADDR	0x101
++
++/* --- CSI-2 Output (BACKTOP) --- */
++
++/* BACKTOP: CSI-2 output port enable
++ *   0x040B bit[1]=CSIB_EN, bit[0]=CSIA_EN
++ */
++#define MAX96724_BACKTOP_EN_ADDR	0x040B
++
++/* --- MIPI DPLL (Data Rate) --- */
++
++/* 
++ *   MIPI PHY DPLL Freq registers
++ *   bits[4:0] = frequency in multiples of 100MHz
++ *   bit[5]    = DPLL enable (must be set for DPLL to lock)
++ *   E.g., 0x27 = 700MHz + enable = 700Mbps/lane D-PHY
++ *   E.g., 0x2F = 1500MHz + enable = 1.5Gbps/lane
++ */
++#define MAX96724_DPLL_FREQ0_ADDR	0x0415
++#define MAX96724_DPLL_FREQ1_ADDR	0x0418
++#define MAX96724_DPLL_FREQ2_ADDR	0x041B
++#define MAX96724_DPLL_FREQ3_ADDR	0x041E
++
++/* 
++ *   DPLL PHY reset control
++ *   0x1D00 = DPLL CSI PHY1 control
++ *   Write 0xF4 to disable/reset, 0xF5 to enable
++ */
++#define MAX96724_DPLL_CSI2_ADDR		0x1D00
++#define MAX96724_DPLL_DISABLE		0xF4
++#define MAX96724_DPLL_ENABLE		0xF5
++
++/* --- CSI-2 Output PHY Configuration --- */
++
++/* 
++ * CSI output mode/config register.
++ * Mode bits (set exactly one of [4:0]):
++ *   bit[0]=0x01: 4x2 mode
++ *   bit[2]=0x04: 2x4 mode        (Ctrl 1 = master for Port A, Ctrl 2 = Port B)
++ *   bit[3]=0x08: 1x4a + 2x2 mode (Ctrl 1 = master for Port A)
++ *   bit[4]=0x10: 1x4b + 2x2 mode (Ctrl 2 = master for Port B)
++ *
++ * Clock-force bits:
++ *   bit[7]=0x80: force ALL MIPI clocks running (continuous HS clock)
++ *   bit[6]=0x40: force PHY 3 MIPI clock running
++ *   bit[5]=0x20: force PHY 0 MIPI clock running
++ */
++#define MAX96724_CSI_OUT_CFG_ADDR	0x08A0
++
++/* 
++ *   MIPI PHY Enable register
++ *   bits[7:4]: Enable PHY 3/2/1/0 (1=enabled, 0=standby)
++ */
++#define MAX96724_CSI_PHY_EN_ADDR	0x08A2
++
++/* MIPI PHY 0 and 1 Lane Mapping */
++#define MAX96724_CSI_LANE_MAP1_ADDR	0x08A3
++
++/* MIPI PHY 2 and 3 Lane Mapping */
++#define MAX96724_CSI_LANE_MAP2_ADDR	0x08A4
++
++/* 
++ *   MIPI output lane polarity (P/N swap) registers.
++ *   0x08A5 = PHY0/PHY1 lane polarity, 0x08A6 = PHY2/PHY3 lane polarity.
++ *   The FangZhu FG24-4CH PCB swaps the differential P/N pairs on the
++ *   MAX96724 CSI output, so the deserializer must invert lane polarity
++ */
++#define MAX96724_CSI_PHY_POL0_ADDR	0x08A5
++#define MAX96724_CSI_PHY_POL1_ADDR	0x08A6
++#define MAX96724_CSI_PHY_POL_SWAP	0x3F
++
++/* Pipe-to-controller mapping */
++#define MAX96724_MIPI_CTRL_SEL_ADDR	0x08CA
++
++/* Method-1 controller mapping */
++#define MAX96724_MIPI_CTRL_SEL_PIXEL	0xE4
++
++/* --- Lane Control per pipe (stride 0x40) --- */
++
++/*
++ *   0xC0 = 4-lane enabled
++ */
++#define MAX96724_LANE_CTRL0_ADDR	0x090A
++#define MAX96724_LANE_CTRL1_ADDR	0x094A
++#define MAX96724_LANE_CTRL2_ADDR	0x098A
++#define MAX96724_LANE_CTRL3_ADDR	0x09CA
++
++/* --- Pipe Mapping Registers (stride 0x40 per pipe) --- */
++
++/*
++ *   Base addresses for Pipe X (Pipe 0)
++ *   Stride: 0x40 per pipe
++ */
++#define MAX96724_TX11_PIPE_X_EN_ADDR		0x090B
++#define MAX96724_TX45_PIPE_X_DST_CTRL_ADDR	0x092D
++#define MAX96724_PIPE_X_SRC_0_MAP_ADDR		0x090D
++#define MAX96724_PIPE_X_DST_0_MAP_ADDR		0x090E
++#define MAX96724_PIPE_X_SRC_1_MAP_ADDR		0x090F
++#define MAX96724_PIPE_X_DST_1_MAP_ADDR		0x0910
++#define MAX96724_PIPE_X_SRC_2_MAP_ADDR		0x0911
++#define MAX96724_PIPE_X_DST_2_MAP_ADDR		0x0912
++#define MAX96724_PIPE_X_SRC_3_MAP_ADDR		0x0913
++#define MAX96724_PIPE_X_DST_3_MAP_ADDR		0x0914
++
++/* --- Stream Select --- */
++
++/*
++ *   Pipe X=0x0933, stride 0x40 per pipe
++ */
++#define MAX96724_PIPE_X_ST_SEL_ADDR	0x0933
++
++/* --- Extended Pipe Mapping (DST_CTRL2-4 / TX49) --- */
++
++/* 
++ *   Extended DST_CTRL for additional mapping pairs
++ *   All to PHY1 (0x55), same as TX45
++ *   Stride: 0x40 per pipe (base = Pipe X)
++ */
++#define MAX96724_TX46_PIPE_X_ADDR	0x092E
++#define MAX96724_TX47_PIPE_X_ADDR	0x092F
++#define MAX96724_TX48_PIPE_X_ADDR	0x0930
++
++/* 
++ *   MIPI_TX49 synchronous concatenation control
++ *   Set to 0x00 (no concat) for single-camera tunnel mode.
++ *   For 4W concat use 0x87.
++ *   Stride: 0x40 per pipe (base = Pipe X)
++ */
++#define MAX96724_TX49_PIPE_X_ADDR	0x0931
++#define MAX96724_TX49_CONCAT_4W		0x87
++
++/* --- Tunnel Mode per-pipe --- */
++
++/*
++ *   bit[0] = TUN_EN, Default=0x08, write 0x01 to enable
++ */
++#define MAX96724_PIPE0_TUN_EN_ADDR	0x0936
++#define MAX96724_PIPE1_TUN_EN_ADDR	0x0976
++#define MAX96724_PIPE2_TUN_EN_ADDR	0x09B6
++#define MAX96724_PIPE3_TUN_EN_ADDR	0x09F6
++
++/*
++ *   bit[6]: disable auto-tunnel-detect
++ *   bits[5:4]: TUN_DEST (00=PHY0, 01=PHY1, 10=PHY2, 11=PHY3)
++ */
++#define MAX96724_PIPE0_TUN_DEST_ADDR	0x0939
++#define MAX96724_PIPE1_TUN_DEST_ADDR	0x0979
++#define MAX96724_PIPE2_TUN_DEST_ADDR	0x09B9
++#define MAX96724_PIPE3_TUN_DEST_ADDR	0x09F9
++
++/* ================================================================
++ * Register Values
++ * ================================================================ */
++
++/* Soft reset value (write to 0x000D) */
++#define MAX96724_SOFT_RESET		0x40
++
++/* 
++ * Link Rate values for 0x0010/0x0011
++ *   Per link pair: bits[1:0]=RxA, [3:2]=TxA, [5:4]=RxB, [7:6]=TxB
++ *   Tx = 00 (187.5Mbps), Rx = 01 (3Gbps) or 10 (6Gbps)
++ *   3Gbps: Tx=00, Rx=01 → per pair 0x01, both pairs = 0x01 in low nibble
++ */
++#define MAX96724_LINK_RATE_3GBPS	0x01  /* Rx=3G, Tx=187.5M for one link pair */
++#define MAX96724_LINK_RATE_6GBPS	0x02  /* Rx=6G, Tx=187.5M for one link pair */
++
++/* 
++ * 0x0006: Link enable / mode values
++ *   bits[7:4] = PHY mode (1=GMSL2 per link)
++ *   bits[3:0] = Link enable per link
++ *   0xF1 = all GMSL2-mode, only Link A enabled
++ *   0xFF = all GMSL2-mode, all 4 links enabled
++ */
++#define MAX96724_LINK_EN_SIOA		0xF1  /* GMSL2 all, enable Link A only */
++#define MAX96724_LINK_EN_ALL		0xFF  /* GMSL2 all, enable all links */
++
++/* BACKTOP_EN (0x040B): CSI output port enable */
++#define MAX96724_BACKTOP_CSIB_EN	0x02
++#define MAX96724_BACKTOP_CSIA_EN	0x01
++
++/* 
++ *   VIDEO_RX0: DIS_PKT_DET=1 (bit0) required for tunnel mode.
++ *   Without it, DES rejects tunnel data as invalid GMSL2 video packets.
++ *   SEQ_MISS_EN=1 (bit4), LINE_CRC_EN=1 (bit1).  XML value: 0x33.
++ */
++#define MAX96724_VID_RX0_CFG_VAL	0x33
++#define MAX96724_VID_RX6_CFG_VAL	0x0A
++
++/* Pixel-mode receiver settings */
++#define MAX96724_VID_RX0_PIXEL_VAL	0x32
++#define MAX96724_VID_RX6_PIXEL_VAL	0x12
++
++/* 
++ *   Tunnel mode enable (MIPI_TX54, 0x0936):
++ *   bit[0] = TUN_EN = 1
++ *   Verified value: 0x01
++ */
++#define MAX96724_TUN_EN			0x01
++
++/* Default/reset state when tunnel is disabled */
++#define MAX96724_TUN_DISABLED		0x08
++
++/* 
++ *   Tunnel controller destination (MIPI_TX57, 0x0939):
++ *   bits[5:4]: TUN_DEST (00=PHY0, 01=PHY1, 10=PHY2, 11=PHY3)
++ *   Verified value: 0x10 = PHY1 destination with auto-detect enabled
++ */
++#define MAX96724_TUN_DEST_CTRL0		0x00  /* Auto-detect + PHY0 */
++#define MAX96724_TUN_DEST_CTRL1		0x10  /* Auto-detect + PHY1 (Port A master) */
++
++#define MAX96724_CSI_MODE_2X4_VAL	0x04  /* bit[2] = clean 2x4: Port A = PHY0+PHY1 */
++
++/* 
++ *   0x84 = 2x4 mode (bit2) + bit[7] "force ALL MIPI clocks running".  The bit[7]
++ *   clock-force is the key part: it keeps the D-PHY clock lane in continuous HS
++ *   mode so the Orin NVCSI/CIL can lock.
++ */
++#define MAX96724_CSI_OUT_EN_VAL		0x84  /* 2x4 + bit[7] force all MIPI clocks running */
++
++#define MAX96724_CSI_PHY_EN_ALL		0xF0
++#define MAX96724_CSI_PHY_EN_01		0x30  /* PHY0+PHY1 only (Port A) */
++#define MAX96724_CSI_PHY_EN_23		0xC0  /* PHY2+PHY3 only (Port B) */
++
++/* Lane mapping default */
++#define MAX96724_CSI_LANE_MAP_DEFAULT	0xE4
++
++/* Lane control: 4-lane enabled */
++#define MAX96724_LANE_CTRL_4LANE	0xC0
++
++/*
++ *   Lane control: 2-lane enabled.
++ *   bits[7:6] = (num_lanes - 1): 01=2-lane(0x40), 11=4-lane(0xC0)
++ *   Ref: gmsl_ser_des_guide §8.2, E2E_enable_guide §5.6.4 
++ */
++#define MAX96724_LANE_CTRL_2LANE	0x40
++
++/* 
++ *   CSI PHY enable: all PHYs powered for DPLL lock.
++ */
++#define MAX96724_CSI_PHY_EN_2LANE	0xF0
++
++/* 
++ *   DPLL for Controller 0 (drives PHY0, 2 lanes).
++ *   bits[4:0] = data-rate / 100 MHz.  700 Mbps / 100 = 7 = 0x07.
++ *   bit[5]    = DPLL enable = 1.
++ *   Result: 0x27 = 700 Mbps/lane D-PHY.
++ */
++#define MAX96724_DPLL_700MBPS_CTRL0	0x27
++
++/* 
++ *   CSI-output DPLL data rate = 1300 Mbps.
++ *   bits[4:0] = data-rate / 100 MHz -> 1300/100 = 13 = 0x0D. bit[5] = DPLL en.
++ */
++#define MAX96724_DPLL_1300MBPS		0x2D
++
++/* One-shot reset: all links */
++#define MAX96724_ONESHOT_ALL		0x0F
++
++/* 
++ *   Pipe source selection values
++ *   Encoding per pipe nibble in tunnel mode:
++ *   0x22 routes all pipes from Link A in tunnel mode.
++ */
++#define MAX96724_PIPE_SEL0_SINGLE	0x22  /* All pipes from Link A */
++#define MAX96724_PIPE_SEL1_SINGLE	0x22  /* All pipes from Link A */
++#define MAX96724_PIPE_SEL0_PIXEL	0x62  /* pixel-mode reference */
++#define MAX96724_PIPE_SEL1_PIXEL	0xEA  /* pixel-mode reference */
++#define MAX96724_PIPE_SEL0_DUAL		0x40  /* Pipe 0 ← A/X, Pipe 1 ← B/X */
++#define MAX96724_PIPE_SEL0_QUAD_LO	0x40  /* Pipe 0 ← A/X, Pipe 1 ← B/X */
++#define MAX96724_PIPE_SEL1_QUAD_HI	0xC8  /* Pipe 2 ← C/X, Pipe 3 ← D/X */
++
++/* Pipe enable values */
++#define MAX96724_PIPE_EN_1		0x01
++#define MAX96724_PIPE_EN_2		0x03
++#define MAX96724_PIPE_EN_4		0x0F
++
++/* Lane control map: bits[7:6] = (num_lanes - 1) */
++#define MAX96724_LANE_CTRL_MAP(num_lanes) \
++	((((num_lanes) - 1) << 6) & 0xC0)
++
++/* Reset all */
++#define MAX96724_RESET_ALL		0x80
++
++/* Stream ID invalid */
++#define MAX96724_INVAL_ST_ID		0xFF
++#define MAX96724_RESET_ST_ID		0x00
++#define MAX96724_ST_ID_SEL_INVALID	0xF
++
++/* Controller mapping: all mappings → Controller 0 */
++#define MAX96724_ALL_MAP_CTRL0		0x00
++/* Controller mapping: all mappings → Controller 1 */
++#define MAX96724_ALL_MAP_CTRL1		0x55
++
++/* Three mappings to controller 1 */
++#define MAX96724_MAP3_CTRL1		0x15
++
++/* ================================================================
++ * Data Structures
++ * ================================================================ */
++
++/* Quad GMSL: up to 4 sources */
++#define MAX96724_MAX_SOURCES		4
++#define MAX96724_MAX_PIPES		4
++
++#define MAX96724_PIPE_X			0
++#define MAX96724_PIPE_Y			1
++#define MAX96724_PIPE_Z			2
++#define MAX96724_PIPE_U			3
++#define MAX96724_PIPE_INVALID		0xF
++
++#define MAX96724_CSI_CTRL_0		0
++#define MAX96724_CSI_CTRL_1		1
++#define MAX96724_CSI_CTRL_2		2
++#define MAX96724_CSI_CTRL_3		3
++
++#define MAX96724_CSI_MODE_2X4		0x08  /* enum tag for the 4-lane Port A (Ctrl1) path */
++
++/* Lane map presets */
++#define MAX96724_LANE_MAP1_2X4		0xE4  /* SC20190112 subset: PHY0 data + PHY1 clock */
++#define MAX96724_LANE_MAP2_2X4		0x44  /* keep unused PHY2/3 straight in 0x08 mode */
++
++struct max96724_source_ctx {
++	struct gmsl_link_ctx *g_ctx;
++	bool st_enabled;
++};
++
++struct pipe_ctx {
++	u32 id;
++	u32 dt_type;
++	u32 dst_csi_ctrl;
++	u32 st_count;
++	u32 st_id_sel;
++};
++
++struct max96724 {
++	struct i2c_client *i2c_client;
++	struct regmap *regmap;
++	u32 num_src;
++	u32 max_src;
++	u32 num_src_found;
++	u32 src_link;
++	bool splitter_enabled;
++	struct max96724_source_ctx sources[MAX96724_MAX_SOURCES];
++	struct mutex lock;
++	u32 sdev_ref;
++	bool lane_setup;
++	bool link_setup;
++	struct pipe_ctx pipe[MAX96724_MAX_PIPES];
++	u8 csi_mode;
++	u8 lane_mp1;
++	u8 lane_mp2;
++	int reset_gpio;
++	int pw_ref;
++	struct regulator *vdd_cam_1v2;
++	u8 link_speed;  /* DT-configurable: 3 or 6 Gbps */
++	bool pixel_mode;
++	bool poc_enabled; /* FG24-4CH board POC/IO enable applied once */
++};
++
++struct reg_pair {
++	u16 addr;
++	u8 val;
++};
++
++/* ================================================================
++ * Low-level I2C
++ * ================================================================ */
++
++static int max96724_write_reg(struct device *dev, u16 addr, u8 val)
++{
++	struct max96724 *priv;
++	int err;
++
++	priv = dev_get_drvdata(dev);
++
++	err = regmap_write(priv->regmap, addr, val);
++	if (err)
++		dev_err(dev, "%s:i2c write failed, 0x%x = %x\n",
++			__func__, addr, val);
++
++	/* delay before next i2c command as required for SERDES link */
++	usleep_range(100, 110);
++
++	return err;
++}
++
++static int max96724_set_registers(struct device *dev, struct reg_pair *map,
++				  u32 count)
++{
++	int err = 0;
++	u32 j;
++
++	for (j = 0; j < count; j++) {
++		err = max96724_write_reg(dev, map[j].addr, map[j].val);
++		if (err)
++			break;
++	}
++
++	return err;
++}
++
++/* ================================================================
++ * Internal Helpers
++ * ================================================================ */
++
++static int max96724_get_sdev_idx(struct device *dev,
++				 struct device *s_dev, unsigned int *idx)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++	unsigned int i;
++	int err = 0;
++
++	mutex_lock(&priv->lock);
++	for (i = 0; i < priv->max_src; i++) {
++		if (priv->sources[i].g_ctx->s_dev == s_dev)
++			break;
++	}
++	if (i == priv->max_src) {
++		dev_err(dev, "no sdev found\n");
++		err = -EINVAL;
++		goto ret;
++	}
++
++	if (idx)
++		*idx = i;
++
++ret:
++	mutex_unlock(&priv->lock);
++	return err;
++}
++
++static void max96724_pipes_reset(struct max96724 *priv)
++{
++	/*
++	 * Default pipe configuration for D5xx/SC1.2:
++	 * In tunnel mode, DT types are not used for filtering
++	 * but we initialize them for d4xx framework compatibility.
++	 */
++	struct pipe_ctx pipe_defaults[] = {
++		{MAX96724_PIPE_X, GMSL_CSI_DT_RAW_12,
++			MAX96724_CSI_CTRL_1, 0, MAX96724_INVAL_ST_ID},
++		{MAX96724_PIPE_Y, GMSL_CSI_DT_RAW_12,
++			MAX96724_CSI_CTRL_1, 0, MAX96724_INVAL_ST_ID},
++		{MAX96724_PIPE_Z, GMSL_CSI_DT_EMBED,
++			MAX96724_CSI_CTRL_1, 0, MAX96724_INVAL_ST_ID},
++		{MAX96724_PIPE_U, GMSL_CSI_DT_EMBED,
++			MAX96724_CSI_CTRL_1, 0, MAX96724_INVAL_ST_ID}
++	};
++
++	memcpy(priv->pipe, pipe_defaults, sizeof(pipe_defaults));
++}
++
++static void max96724_reset_ctx(struct max96724 *priv)
++{
++	unsigned int i;
++
++	priv->link_setup = false;
++	priv->lane_setup = false;
++	priv->num_src_found = 0;
++	priv->src_link = 0;
++	priv->splitter_enabled = false;
++	max96724_pipes_reset(priv);
++	for (i = 0; i < priv->num_src; i++)
++		priv->sources[i].st_enabled = false;
++}
++
++static void max96724_apply_porta_subset(struct device *dev,
++						 struct max96724 *priv)
++{
++	/*
++	 * [XML-verified 4-lane] D-PHY Port A output, 4 data lanes.
++	 * [FG24-4CH working-config verified] 0x04 = 2x4 mode so Port A
++	 * maps to PHY0+PHY1 (the lanes the FG24 PCB wires to Orin).  Output is
++	 * not yet enabled here (bit7 = 0); setup_streaming() asserts 0x84 after
++	 * the full pipeline is configured.
++	 */
++	max96724_write_reg(dev, MAX96724_CSI_OUT_CFG_ADDR,
++			   MAX96724_CSI_MODE_2X4_VAL);
++	/*
++	 * [FG24-4CH working dump] Enable ALL four CSI PHYs (0x08A2=0xF0).
++	 * The working FangZhu config powers every PHY; the MAX96724 DPLL
++	 * needs all PHYs powered to lock reliably (single-PHY enable was
++	 * observed to never lock the output clock). Port A data still
++	 * leaves on PHY0/1 in 2x4 mode; PHY2/3 are just powered.
++	 */
++	max96724_write_reg(dev, MAX96724_CSI_PHY_EN_ADDR,
++			   MAX96724_CSI_PHY_EN_ALL);
++	max96724_write_reg(dev, MAX96724_CSI_LANE_MAP1_ADDR,
++			   priv->lane_mp1);
++	/*
++	 * [FG24-4CH working dump] LANE_MAP2 (PHY2/3) = 0xE4 straight mapping.
++	 * The working config writes 0x08A4=0xE4 (not the chip default 0x44).
++	 */
++	max96724_write_reg(dev, MAX96724_CSI_LANE_MAP2_ADDR,
++			   MAX96724_CSI_LANE_MAP_DEFAULT);
++	/*
++	 * [FG24-4CH board] Switch MIPI output lane polarity (P/N swap).
++	 * The FG24-4CH PCB inverts the differential pairs on the DES->Orin
++	 * output; without this the Orin CIL never locks the HS clock.
++	 * Per FangZhu MAX4CH_FG24_POC_Enable table: 0x08A5/0x08A6 = 0x3F.
++	 */
++	max96724_write_reg(dev, MAX96724_CSI_PHY_POL0_ADDR,
++			   MAX96724_CSI_PHY_POL_SWAP);
++	max96724_write_reg(dev, MAX96724_CSI_PHY_POL1_ADDR,
++			   MAX96724_CSI_PHY_POL_SWAP);
++	max96724_write_reg(dev, MAX96724_LANE_CTRL0_ADDR,
++			   MAX96724_LANE_CTRL_4LANE);
++	max96724_write_reg(dev, MAX96724_LANE_CTRL1_ADDR,
++			   MAX96724_LANE_CTRL_4LANE);
++	max96724_write_reg(dev, MAX96724_LANE_CTRL2_ADDR,
++			   MAX96724_LANE_CTRL_4LANE);
++	max96724_write_reg(dev, MAX96724_LANE_CTRL3_ADDR,
++			   MAX96724_LANE_CTRL_4LANE);
++}
++
++static inline bool max96724_is_pixel_mode(struct max96724 *priv)
++{
++	return priv->pixel_mode;
++}
++
++/* ================================================================
++ * Power Management
++ * ================================================================ */
++
++/* [FG24-4CH board] POC (Power-over-Coax) / IO enable sequence.
++ *   Per FangZhu MAX4CH_FG24_POC_Enable table. On the FG24-4CH board the
++ *   MFP8 line (0x0319 bit4) and the POC IO enable (0x0001 bit5) gate the
++ *   board-level output / POC path. Without these the DES PLL still locks
++ *   and shows internal activity, but no clock reaches the Orin connector.
++ */
++#define MAX96724_POC_IO_EN_ADDR		0x0001
++#define MAX96724_POC_IO_EN_VAL		0xE0  /* Enable POC IO (working dump: 0xE0) */
++#define MAX96724_POC_MFP8_ADDR		0x0319
++#define MAX96724_POC_MFP8_PRE		0x80  /* MFP8 pre-enable */
++#define MAX96724_POC_MFP8_HIGH		0x98  /* Enable POC MFP8 High (working dump: 0x98) */
++
++/*
++ * max96724_board_poc_enable - Apply FG24-4CH POC/IO enable (one-time).
++ * Mirrors the vendor MAX4CH_FG24_POC_Enable table.
++ */
++static void max96724_board_poc_enable(struct device *dev)
++{
++	max96724_write_reg(dev, MAX96724_POC_IO_EN_ADDR,
++			   MAX96724_POC_IO_EN_VAL);
++	max96724_write_reg(dev, MAX96724_POC_MFP8_ADDR,
++			   MAX96724_POC_MFP8_PRE);
++	msleep(100);
++	max96724_write_reg(dev, MAX96724_POC_MFP8_ADDR,
++			   MAX96724_POC_MFP8_HIGH);
++	msleep(500);
++}
++
++/*
++ * max96724_power_on - Power on the MAX96724 deserializer
++ */
++int max96724_power_on(struct device *dev)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++	int err = 0;
++
++	mutex_lock(&priv->lock);
++	if (priv->pw_ref == 0) {
++		usleep_range(1, 2);
++		if (gpio_is_valid(priv->reset_gpio))
++			gpio_set_value(priv->reset_gpio, 0);
++
++		usleep_range(30, 50);
++
++		if (priv->vdd_cam_1v2) {
++			err = regulator_enable(priv->vdd_cam_1v2);
++			if (unlikely(err))
++				goto ret;
++		}
++
++		usleep_range(30, 50);
++
++		/* exit reset mode: XCLR */
++		if (gpio_is_valid(priv->reset_gpio)) {
++			gpio_set_value(priv->reset_gpio, 0);
++			usleep_range(30, 50);
++			gpio_set_value(priv->reset_gpio, 1);
++			usleep_range(30, 50);
++		}
++
++		msleep(20);
++	}
++
++	priv->pw_ref++;
++
++ret:
++	mutex_unlock(&priv->lock);
++	return err;
++}
++EXPORT_SYMBOL(max96724_power_on);
++
++void max96724_power_off(struct device *dev)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++
++	mutex_lock(&priv->lock);
++	priv->pw_ref--;
++
++	if (priv->pw_ref < 0)
++		priv->pw_ref = 0;
++
++	if (priv->pw_ref == 0) {
++		usleep_range(1, 2);
++		if (gpio_is_valid(priv->reset_gpio))
++			gpio_set_value(priv->reset_gpio, 0);
++
++		if (priv->vdd_cam_1v2)
++			regulator_disable(priv->vdd_cam_1v2);
++	}
++
++	mutex_unlock(&priv->lock);
++}
++EXPORT_SYMBOL(max96724_power_off);
++
++/* ================================================================
++ * Link Setup
++ * ================================================================ */
++
++/*
++ * max96724_write_link - Configure a specific GMSL link
++ *
++ * [Users Guide, Link Initialization, p11-12]
++ *   Register 0x0006: Link Enable and Mode Select
++ *   Register 0x0010: Link Rate (Links A/B)
++ *
++ * The link speed is DT-configurable via the "gmsl-link-speed" property.
++ */
++static int max96724_write_link(struct device *dev, u32 link)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++	u8 link_rate_ab, link_rate_cd;
++	u8 link_en_val;
++
++	/*
++	 * [Aardvark-verified] Disable CSI output before link configuration
++	 * This prevents glitches on CSI bus during GMSL link setup.
++	 * Re-enabled in max96724_setup_streaming() after full pipeline config.
++	 */
++	max96724_write_reg(dev, MAX96724_BACKTOP_EN_ADDR, 0x00);
++
++	/* [UG Table 3 + Tech Overview REG26]
++	 * Register 0x0010:
++	 *   bits[7:2] = Link rate configuration
++	 *   bits[1:0] = I2C CC pass-through link select
++	 *     10 = route CC via SIOA (Link A)  [tech overview: 0x02 → SIOA]
++	 *     01 = route CC via SIOB (Link B)
++	 *
++	 * For 6G + Link A: bits[7:2]=001000, bits[1:0]=10 → 0x22
++	 * For 6G + Link B: bits[7:2]=001000, bits[1:0]=01 → 0x21
++	 * For 3G + Link A: bits[7:2]=000100, bits[1:0]=10 → 0x12 (? or 0x11)
++	 * For 3G + Link B: bits[7:2]=000100, bits[1:0]=01 → 0x11 (? or 0x09)
++	 */
++	if (priv->link_speed == 6) {
++		if (link == GMSL_SERDES_CSI_LINK_B) {
++			link_rate_ab = 0x21; /* 6G rate + CC via Link B */
++		} else {
++			link_rate_ab = 0x22; /* 6G rate + CC via Link A */
++		}
++		link_rate_cd = 0x22; /* C/D: 6G rate (CC routing don't care) */
++	} else {
++		if (link == GMSL_SERDES_CSI_LINK_B) {
++			link_rate_ab = 0x09; /* 3G rate + CC via Link B */
++		} else {
++			link_rate_ab = 0x12; /* 3G rate + CC via Link A */
++		}
++		link_rate_cd = 0x11; /* C/D: 3G rate */
++	}
++
++	if (link == GMSL_SERDES_CSI_LINK_A) {
++		link_en_val = MAX96724_LINK_EN_SIOA;
++	} else if (link == GMSL_SERDES_CSI_LINK_B) {
++		link_en_val = 0xF2; /* GMSL2 all, enable Link B only */
++	} else {
++		dev_err(dev, "%s: invalid gmsl link\n", __func__);
++		return -EINVAL;
++	}
++
++	/* [UG Table 3] Set link rates + CC routing */
++	max96724_write_reg(dev, MAX96724_LINK_RATE_AB_ADDR, link_rate_ab);
++	max96724_write_reg(dev, MAX96724_LINK_RATE_CD_ADDR, link_rate_cd);
++
++	/*
++	 * [XML-verified sequence] One-shot reset applies rate configuration
++	 * to the link state machine, then link enable starts training.
++	 * XML order: rate → ONE-SHOT → LINK_EN → wait 1000ms.
++	 * Note: Error channel registers omitted (not in reference XML).
++	 */
++	max96724_write_reg(dev, MAX96724_ONESHOT_ADDR,
++			   MAX96724_ONESHOT_ALL);
++	max96724_write_reg(dev, MAX96724_LINK_EN_ADDR, link_en_val);
++
++	/*
++	 * Wait for link lock.
++	 * [XML] Uses 1000ms regardless of link speed.
++	 * I2C pass-through CC requires fully trained link, not just PHY lock.
++	 */
++	msleep(1000);
++
++	/* Check link lock status on ALL ports for diagnostics */
++	{
++		unsigned int lock_a = 0, lock_b = 0, lock_c = 0, lock_d = 0;
++		unsigned int link_en = 0;
++		unsigned int reg10 = 0, reg11 = 0;
++
++		regmap_read(priv->regmap, 0x001A, &lock_a);
++		regmap_read(priv->regmap, 0x001B, &lock_b);
++		regmap_read(priv->regmap, 0x001C, &lock_c);
++		regmap_read(priv->regmap, 0x001D, &lock_d);
++		regmap_read(priv->regmap, MAX96724_LINK_EN_ADDR, &link_en);
++		regmap_read(priv->regmap, 0x0010, &reg10);
++		regmap_read(priv->regmap, 0x0011, &reg11);
++		dev_info(dev,
++			 "GMSL link status: EN=0x%02x A=0x%02x(%s) B=0x%02x(%s) C=0x%02x(%s) D=0x%02x(%s) REG10=0x%02x REG11=0x%02x\n",
++			 link_en,
++			 lock_a, (lock_a & 0x08) ? "LOCK" : "noLk",
++			 lock_b, (lock_b & 0x08) ? "LOCK" : "noLk",
++			 lock_c, (lock_c & 0x08) ? "LOCK" : "noLk",
++			 lock_d, (lock_d & 0x08) ? "LOCK" : "noLk",
++			 reg10, reg11);
++	}
++
++	return 0;
++}
++
++int max96724_setup_link(struct device *dev, struct device *s_dev)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++	int err = 0;
++	unsigned int i = 0;
++
++	err = max96724_get_sdev_idx(dev, s_dev, &i);
++	if (err)
++		return err;
++
++	/*
++	 * [FG24-4CH] Enable board POC / MFP8 output path BEFORE the GMSL
++	 * link is brought up.  The camera draws power over coax (PoC), so
++	 * without this the remote camera never powers on and the link can
++	 * never lock.  NOTE: this must live here (a path d5xx actually
++	 * invokes via dser_ops->setup_link) and NOT in max96724_power_on(),
++	 * which ds5_gmsl_serdes_setup() deliberately skips.  Run once.
++	 */
++	if (!priv->poc_enabled) {
++		max96724_board_poc_enable(dev);
++		priv->poc_enabled = true;
++	}
++
++	mutex_lock(&priv->lock);
++
++	if (!priv->splitter_enabled) {
++		err = max96724_write_link(dev,
++					  priv->sources[i].g_ctx->serdes_csi_link);
++		if (err)
++			goto ret;
++
++		priv->link_setup = true;
++	}
++
++ret:
++	mutex_unlock(&priv->lock);
++	return err;
++}
++EXPORT_SYMBOL(max96724_setup_link);
++
++/* ================================================================
++ * Control Setup
++ * ================================================================ */
++
++/*
++ * max96724_setup_control - Configure deserializer control pipeline
++ *
++ * Enables splitter mode when multiple sources are present,
++ * configures tunnel mode on all active pipes, and sets up
++ * the MIPI CSI-2 output.
++ */
++int max96724_setup_control(struct device *dev, struct device *s_dev)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++	int err = 0;
++	unsigned int i = 0;
++
++	static const u16 tun_en_addrs[] = {
++		MAX96724_PIPE0_TUN_EN_ADDR,
++		MAX96724_PIPE1_TUN_EN_ADDR,
++		MAX96724_PIPE2_TUN_EN_ADDR,
++		MAX96724_PIPE3_TUN_EN_ADDR,
++	};
++
++	static const u16 tun_dest_addrs[] = {
++		MAX96724_PIPE0_TUN_DEST_ADDR,
++		MAX96724_PIPE1_TUN_DEST_ADDR,
++		MAX96724_PIPE2_TUN_DEST_ADDR,
++		MAX96724_PIPE3_TUN_DEST_ADDR,
++	};
++
++	err = max96724_get_sdev_idx(dev, s_dev, &i);
++	if (err)
++		return err;
++
++	mutex_lock(&priv->lock);
++
++	if (!priv->link_setup) {
++		dev_err(dev, "%s: invalid state\n", __func__);
++		err = -EINVAL;
++		goto error;
++	}
++
++	if (priv->sources[i].g_ctx->serdev_found) {
++		priv->num_src_found++;
++		priv->src_link = priv->sources[i].g_ctx->serdes_csi_link;
++	}
++
++	/* Enable splitter mode for multi-camera configurations */
++	if ((priv->max_src > 1U) &&
++	    (priv->num_src_found > 0U) &&
++	    (priv->splitter_enabled == false)) {
++		/*
++		 * [UG Table 3] Multi-camera: set link rates and enable all links
++		 */
++		u8 link_rate = (priv->link_speed == 6) ? 0x22 : 0x11;
++
++		max96724_write_reg(dev, MAX96724_LINK_RATE_AB_ADDR,
++				   link_rate);
++		max96724_write_reg(dev, MAX96724_LINK_RATE_CD_ADDR,
++				   link_rate);
++		max96724_write_reg(dev, MAX96724_LINK_EN_ADDR,
++				   MAX96724_LINK_EN_ALL);
++
++		/* [Errata #5] For 6Gbps: force Error Channel power-up */
++		if (priv->link_speed == 6) {
++			max96724_write_reg(dev, MAX96724_ERRCH_A_ADDR,
++					   MAX96724_ERRCH_FORCE_ON);
++			max96724_write_reg(dev, MAX96724_ERRCH_B_ADDR,
++					   MAX96724_ERRCH_FORCE_ON);
++			max96724_write_reg(dev, MAX96724_ERRCH_C_ADDR,
++					   MAX96724_ERRCH_FORCE_ON);
++			max96724_write_reg(dev, MAX96724_ERRCH_D_ADDR,
++					   MAX96724_ERRCH_FORCE_ON);
++		}
++
++		priv->splitter_enabled = true;
++
++		msleep(100);
++	}
++
++	if (max96724_is_pixel_mode(priv)) {
++		for (i = 0; i < MAX96724_MAX_PIPES; i++) {
++			max96724_write_reg(dev, tun_en_addrs[i],
++					   MAX96724_TUN_DISABLED);
++		}
++		max96724_write_reg(dev, MAX96724_MIPI_CTRL_SEL_ADDR,
++				   MAX96724_MIPI_CTRL_SEL_PIXEL);
++		max96724_write_reg(dev, MAX96724_ONESHOT_ADDR,
++				   MAX96724_ONESHOT_ALL);
++		priv->sdev_ref++;
++		goto maybe_reset_splitter;
++	}
++
++	/*
++	 * [SC20190112] Enable tunnel mode and route to Controller 1.
++	 *   - TUN_EN   (0x0936): 0x01 (TUN_EN=1)
++	 *   - TUN_DEST (0x0939): 0x10 = Controller 1
++	 *   CSI_OUT_CFG=0x04 (2x4 mode): Controller 1 -> PHY0+1 -> Port A -> Orin
++	 */
++	{
++		for (i = 0; i < MAX96724_MAX_PIPES; i++) {
++			max96724_write_reg(dev, tun_en_addrs[i],
++					   MAX96724_TUN_EN);
++			max96724_write_reg(dev, tun_dest_addrs[i],
++					   MAX96724_TUN_DEST_CTRL1);
++		}
++	}
++
++	/*
++	 * [Errata #2] Tunnel Mode SRAM LCRC: disable ERRB for SRAM LCRC
++	 * errors in tunnel mode when frame/line counters are non-zero.
++	 * This prevents spurious ERRB assertions (no video corruption).
++	 */
++	max96724_write_reg(dev, MAX96724_SRAM_LCRC_ERR_ADDR, 0x00);
++
++	max96724_write_reg(dev, MAX96724_ONESHOT_ADDR,
++			   MAX96724_ONESHOT_ALL);
++
++	priv->sdev_ref++;
++
++maybe_reset_splitter:
++
++	/* Reset splitter mode if not all devices found */
++	if ((priv->sdev_ref == priv->max_src) &&
++	    (priv->splitter_enabled == true) &&
++	    (priv->num_src_found > 0U) &&
++	    (priv->num_src_found < priv->max_src)) {
++		err = max96724_write_link(dev, priv->src_link);
++		if (err)
++			goto error;
++
++		priv->splitter_enabled = false;
++	}
++
++error:
++	mutex_unlock(&priv->lock);
++	return err;
++}
++EXPORT_SYMBOL(max96724_setup_control);
++
++int max96724_reset_control(struct device *dev, struct device *s_dev)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++	int err = 0;
++
++	mutex_lock(&priv->lock);
++	if (!priv->sdev_ref) {
++		dev_info(dev, "%s: dev is already in reset state\n", __func__);
++		goto ret;
++	}
++
++	priv->sdev_ref--;
++	if (priv->sdev_ref == 0) {
++		max96724_reset_ctx(priv);
++		max96724_write_reg(dev, MAX96724_REG13_ADDR,
++				   MAX96724_SOFT_RESET);
++
++		msleep(100);
++	}
++
++ret:
++	mutex_unlock(&priv->lock);
++	return err;
++}
++EXPORT_SYMBOL(max96724_reset_control);
++
++/* ================================================================
++ * Device Registration
++ * ================================================================ */
++
++int max96724_sdev_register(struct device *dev, struct gmsl_link_ctx *g_ctx)
++{
++	struct max96724 *priv = NULL;
++	unsigned int i;
++	int err = 0;
++
++	if (!dev || !g_ctx || !g_ctx->s_dev) {
++		dev_err(dev, "%s: invalid input params\n", __func__);
++		return -EINVAL;
++	}
++
++	priv = dev_get_drvdata(dev);
++
++	mutex_lock(&priv->lock);
++
++	if (priv->num_src > priv->max_src) {
++		dev_err(dev,
++			"%s: MAX96724 inputs size exhausted\n", __func__);
++		err = -ENOMEM;
++		goto error;
++	}
++
++	if (priv->csi_mode == MAX96724_CSI_MODE_2X4) {
++		if (!((g_ctx->csi_mode == GMSL_CSI_1X4_MODE) ||
++		      (g_ctx->csi_mode == GMSL_CSI_2X4_MODE))) {
++			dev_err(dev, "%s: csi mode not supported\n", __func__);
++			err = -EINVAL;
++			goto error;
++		}
++	} else {
++		dev_err(dev, "%s: only csi 2x4 mode is supported\n", __func__);
++		err = -EINVAL;
++		goto error;
++	}
++
++	for (i = 0; i < priv->num_src; i++) {
++		if (g_ctx->serdes_csi_link ==
++		    priv->sources[i].g_ctx->serdes_csi_link) {
++			dev_err(dev,
++				"%s: serdes csi link is in use\n", __func__);
++			err = -EINVAL;
++			goto error;
++		}
++		if (g_ctx->num_csi_lanes !=
++		    priv->sources[i].g_ctx->num_csi_lanes) {
++			dev_err(dev,
++				"%s: csi num lanes mismatch\n", __func__);
++			err = -EINVAL;
++			goto error;
++		}
++	}
++
++	priv->sources[priv->num_src].g_ctx = g_ctx;
++	priv->sources[priv->num_src].st_enabled = false;
++
++	priv->num_src++;
++
++error:
++	mutex_unlock(&priv->lock);
++	return err;
++}
++EXPORT_SYMBOL(max96724_sdev_register);
++
++int max96724_sdev_unregister(struct device *dev, struct device *s_dev)
++{
++	struct max96724 *priv = NULL;
++	int err = 0;
++	unsigned int i = 0;
++
++	if (!dev || !s_dev) {
++		dev_err(dev, "%s: invalid input params\n", __func__);
++		return -EINVAL;
++	}
++
++	priv = dev_get_drvdata(dev);
++	mutex_lock(&priv->lock);
++
++	if (priv->num_src == 0) {
++		dev_err(dev, "%s: no source found\n", __func__);
++		err = -ENODATA;
++		goto error;
++	}
++
++	for (i = 0; i < priv->num_src; i++) {
++		if (s_dev == priv->sources[i].g_ctx->s_dev) {
++			priv->sources[i].g_ctx = NULL;
++			break;
++		}
++	}
++
++	if (i == priv->num_src) {
++		dev_err(dev,
++			"%s: requested device not found\n", __func__);
++		err = -EINVAL;
++		goto error;
++	}
++	priv->num_src--;
++
++error:
++	mutex_unlock(&priv->lock);
++	return err;
++}
++EXPORT_SYMBOL(max96724_sdev_unregister);
++
++/* ================================================================
++ * Streaming Setup
++ * ================================================================ */
++
++/*
++ * max96724_setup_streaming - Configure CSI-2 output pipeline
++ *
++ * In Tunnel Mode, the MAX96724 outputs the reconstructed CSI-2 stream
++ * with all VCs and DTs preserved from the serializer.
++ *
++ * The pipeline configuration:
++ *   1. Configure pipe-to-link routing
++ *   2. Enable tunnel mode on active pipes
++ *   3. Configure MIPI CSI-2 output lanes and PHY
++ *   4. Enable BACKTOP output port
++ *
++ */
++int max96724_setup_streaming(struct device *dev, struct device *s_dev)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++	struct gmsl_link_ctx *g_ctx;
++	int err = 0;
++	unsigned int i = 0;
++	unsigned int src_idx;
++	u8 vid_rx0_cfg;
++	u8 vid_rx6_cfg;
++	u8 st_sel_cfg;
++	u8 pipe_sel0;
++	u8 pipe_sel1;
++	u8 dpll_cfg;
++
++	err = max96724_get_sdev_idx(dev, s_dev, &i);
++	if (err)
++		return err;
++
++	mutex_lock(&priv->lock);
++
++	dev_info(dev, "=== setup_streaming ENTER src=%u st_enabled=%d ===\n",
++		 i, priv->sources[i].st_enabled);
++
++	if (priv->sources[i].st_enabled)
++		goto ret;
++
++	src_idx = i;
++	g_ctx = priv->sources[src_idx].g_ctx;
++	if (max96724_is_pixel_mode(priv)) {
++		pipe_sel0 = MAX96724_PIPE_SEL0_PIXEL;
++		pipe_sel1 = MAX96724_PIPE_SEL1_PIXEL;
++		vid_rx0_cfg = MAX96724_VID_RX0_PIXEL_VAL;
++		vid_rx6_cfg = MAX96724_VID_RX6_PIXEL_VAL;
++		st_sel_cfg = 0x00;
++		dpll_cfg = MAX96724_DPLL_1300MBPS;
++	} else {
++		pipe_sel0 = MAX96724_PIPE_SEL0_PIXEL;
++		pipe_sel1 = MAX96724_PIPE_SEL1_PIXEL;
++		vid_rx0_cfg = MAX96724_VID_RX0_CFG_VAL;
++		vid_rx6_cfg = MAX96724_VID_RX6_CFG_VAL;
++		st_sel_cfg = 0x10;
++		dpll_cfg = MAX96724_DPLL_1300MBPS;
++	}
++
++	/*
++	 * Pipe source routing
++	 * Single cam: all pipes from Link A (0x22/0x22)
++	 * Disable pipes before configuration, enable at the end
++	 */
++	max96724_write_reg(dev, MAX96724_PIPE_SEL0_ADDR, pipe_sel0);
++	max96724_write_reg(dev, MAX96724_PIPE_SEL1_ADDR, pipe_sel1);
++	/* Disable all pipes during configuration */
++	max96724_write_reg(dev, MAX96724_PIPE_EN_ADDR, 0x00);
++
++	/*
++	 * Keep 0x08 mode so PHY1 remains the Port A clock master,
++	 * but restore the live 2-lane subset used by the bridge board.
++	 */
++	max96724_apply_porta_subset(dev, priv);
++
++	/*
++	 * CSI-output DPLL data rate = 1300 Mbps
++	 * on ALL FOUR controller freq registers
++	 */
++	if (!priv->lane_setup) {
++		max96724_write_reg(dev, MAX96724_DPLL_FREQ0_ADDR,
++				   dpll_cfg);
++		max96724_write_reg(dev, MAX96724_DPLL_FREQ1_ADDR,
++				   dpll_cfg);
++		max96724_write_reg(dev, MAX96724_DPLL_FREQ2_ADDR,
++				   dpll_cfg);
++		max96724_write_reg(dev, MAX96724_DPLL_FREQ3_ADDR,
++				   dpll_cfg);
++
++		priv->lane_setup = true;
++	}
++
++	max96724_write_reg(dev, MAX96724_MIPI_CTRL_SEL_ADDR,
++			   MAX96724_MIPI_CTRL_SEL_PIXEL);
++
++	/*
++	 * Stream ID select for all pipes
++	 * 0x0933 + 0x40*pipe = stream select register
++	 * Value 0x10 selects the appropriate stream for tunnel mode
++	 */
++	for (i = 0; i < MAX96724_MAX_PIPES; i++) {
++		max96724_write_reg(dev,
++				   MAX96724_PIPE_X_ST_SEL_ADDR + (0x40 * i),
++				   st_sel_cfg);
++	}
++
++	/* 
++	 * BACKTOP: enable Controller 1 / CSI-B (0x02).
++	 * In 2x4 mode, Controller 1 is master for Port A -> Orin CSI.
++	 */
++	max96724_write_reg(dev, MAX96724_BACKTOP_EN_ADDR,
++			   MAX96724_BACKTOP_CSIB_EN);
++
++	dev_info(dev, "=== setup_streaming: writing 0x84 (force all MIPI clocks) ===\n");
++
++	/*
++	 * Assert 0x08A0=0x84 LAST: 2x4 mode + bit[7] "force all MIPI clocks running".  
++	 * The clock-force keeps the D-PHY clock lane continuous so the Orin CIL can lock;
++	 * written only after the full pipeline is configured.
++	 */
++	max96724_write_reg(dev, MAX96724_CSI_OUT_CFG_ADDR,
++			   MAX96724_CSI_OUT_EN_VAL);
++
++	/* Keep all video receivers aligned with serializer heartbeat mode. */
++	for (i = 0; i < MAX96724_MAX_PIPES; i++) {
++		max96724_write_reg(dev,
++				   MAX96724_VID_RX0_P0_ADDR +
++				   (MAX96724_VID_RX_STRIDE * i),
++				   vid_rx0_cfg);
++		max96724_write_reg(dev,
++				   MAX96724_VID_RX6_P0_ADDR +
++				   (MAX96724_VID_RX_STRIDE * i),
++				   vid_rx6_cfg);
++		if (max96724_is_pixel_mode(priv)) {
++			max96724_write_reg(dev,
++					   MAX96724_PIPE0_TUN_EN_ADDR + (0x40 * i),
++					   MAX96724_TUN_DISABLED);
++		}
++	}
++
++	max96724_write_reg(dev, MAX96724_ONESHOT_ADDR,
++			   MAX96724_ONESHOT_ALL);
++
++	/* Enable all 4 pipes */
++	max96724_write_reg(dev, MAX96724_PIPE_EN_ADDR, MAX96724_PIPE_EN_4);
++
++	priv->sources[src_idx].st_enabled = true;
++
++ret:
++	mutex_unlock(&priv->lock);
++	return err;
++}
++EXPORT_SYMBOL(max96724_setup_streaming);
++
++/* ================================================================
++ * Start / Stop Streaming
++ * ================================================================ */
++
++int max96724_start_streaming(struct device *dev, struct device *s_dev)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++	struct gmsl_link_ctx *g_ctx;
++	struct gmsl_stream *g_stream;
++	int err = 0;
++	unsigned int i = 0;
++
++	err = max96724_get_sdev_idx(dev, s_dev, &i);
++	if (err)
++		return err;
++
++	mutex_lock(&priv->lock);
++	g_ctx = priv->sources[i].g_ctx;
++
++	for (i = 0; i < g_ctx->num_streams; i++) {
++		g_stream = &g_ctx->streams[i];
++
++		if (g_stream->des_pipe != MAX96724_PIPE_INVALID)
++			max96724_write_reg(dev, g_stream->des_pipe,
++					   g_stream->st_id_sel);
++	}
++	mutex_unlock(&priv->lock);
++
++	return 0;
++}
++EXPORT_SYMBOL(max96724_start_streaming);
++
++int max96724_stop_streaming(struct device *dev, struct device *s_dev)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++	struct gmsl_link_ctx *g_ctx;
++	struct gmsl_stream *g_stream;
++	int err = 0;
++	unsigned int i = 0;
++
++	err = max96724_get_sdev_idx(dev, s_dev, &i);
++	if (err)
++		return err;
++
++	mutex_lock(&priv->lock);
++	g_ctx = priv->sources[i].g_ctx;
++
++	for (i = 0; i < g_ctx->num_streams; i++) {
++		g_stream = &g_ctx->streams[i];
++
++		if (g_stream->des_pipe != MAX96724_PIPE_INVALID)
++			max96724_write_reg(dev, g_stream->des_pipe,
++					   MAX96724_RESET_ST_ID);
++	}
++
++	mutex_unlock(&priv->lock);
++
++	return 0;
++}
++EXPORT_SYMBOL(max96724_stop_streaming);
++
++/* ================================================================
++ * Pipe Management
++ * ================================================================ */
++
++int max96724_get_available_pipe_id(struct device *dev, int vc_id)
++{
++	int i;
++	int pipe_id = -ENOMEM;
++	struct max96724 *priv = dev_get_drvdata(dev);
++
++	mutex_lock(&priv->lock);
++	for (i = 0; i < MAX96724_MAX_PIPES; i++) {
++		if (i == vc_id && !priv->pipe[i].st_count) {
++			priv->pipe[i].st_count++;
++			pipe_id = i;
++			break;
++		}
++	}
++	mutex_unlock(&priv->lock);
++
++	return pipe_id;
++}
++EXPORT_SYMBOL(max96724_get_available_pipe_id);
++
++int max96724_release_pipe(struct device *dev, int pipe_id)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++
++	if (pipe_id < 0 || pipe_id >= MAX96724_MAX_PIPES)
++		return -EINVAL;
++
++	mutex_lock(&priv->lock);
++	priv->pipe[pipe_id].st_count = 0;
++	mutex_unlock(&priv->lock);
++
++	return 0;
++}
++EXPORT_SYMBOL(max96724_release_pipe);
++
++int max96724_get_ser_pipe_id(struct device *dev, int dser_pipe_id, int vc_id)
++{
++	/* In Tunnel Mode with MAX96717, all VCs are carried in a single tunnel pipe. */
++	return dser_pipe_id;
++}
++EXPORT_SYMBOL(max96724_get_ser_pipe_id);
++
++void max96724_reset_oneshot(struct device *dev)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++	unsigned int i;
++	u8 pipe_sel0;
++	u8 pipe_sel1;
++	u8 vid_rx0_cfg;
++	u8 vid_rx6_cfg;
++	u8 st_sel_cfg;
++	u8 dpll_cfg;
++
++	mutex_lock(&priv->lock);
++	if (priv->splitter_enabled) {
++		/* Multi-camera: reset all links */
++		u8 link_rate = (priv->link_speed == 6) ? 0x22 : 0x11;
++
++		max96724_write_reg(dev, MAX96724_LINK_RATE_AB_ADDR,
++				   link_rate);
++		max96724_write_reg(dev, MAX96724_LINK_RATE_CD_ADDR,
++				   link_rate);
++		max96724_write_reg(dev, MAX96724_LINK_EN_ADDR,
++				   MAX96724_LINK_EN_ALL);
++	} else {
++		max96724_write_reg(dev, MAX96724_ONESHOT_ADDR,
++				   MAX96724_ONESHOT_ALL);
++	}
++	msleep(100);
++
++	if (max96724_is_pixel_mode(priv)) {
++		pipe_sel0 = MAX96724_PIPE_SEL0_PIXEL;
++		pipe_sel1 = MAX96724_PIPE_SEL1_PIXEL;
++		vid_rx0_cfg = MAX96724_VID_RX0_PIXEL_VAL;
++		vid_rx6_cfg = MAX96724_VID_RX6_PIXEL_VAL;
++		st_sel_cfg = 0x00;
++		dpll_cfg = MAX96724_DPLL_1300MBPS;
++	} else {
++		pipe_sel0 = MAX96724_PIPE_SEL0_PIXEL;
++		pipe_sel1 = MAX96724_PIPE_SEL1_PIXEL;
++		vid_rx0_cfg = MAX96724_VID_RX0_CFG_VAL;
++		vid_rx6_cfg = MAX96724_VID_RX6_CFG_VAL;
++		st_sel_cfg = 0x10;
++		dpll_cfg = MAX96724_DPLL_1300MBPS;
++	}
++
++	/* 
++	 * ONESHOT resets CSI/tunnel state. Restore the full pipeline config.
++	 * Mirror setup_streaming() order: disable pipes -> restore everything ->
++	 * BACKTOP/0x84 -> VID_RX -> final ONESHOT to latch -> enable pipes.
++	 */
++	max96724_write_reg(dev, MAX96724_PIPE_EN_ADDR, 0x00);
++
++	/* Pipe source routing: all pipes from Link A */
++	max96724_write_reg(dev, MAX96724_PIPE_SEL0_ADDR, pipe_sel0);
++	max96724_write_reg(dev, MAX96724_PIPE_SEL1_ADDR, pipe_sel1);
++
++	max96724_apply_porta_subset(dev, priv);
++
++	/*
++	 * CSI-output DPLL data rate = 1300 Mbps on ALL
++	 * FOUR controllers, matching the device-tree serdes_pix_clk_hz (325 MHz).
++	 * reset_oneshot is called by the sensor after setup_streaming, so it must
++	 * mirror the same DPLL values.
++	 */
++	max96724_write_reg(dev, MAX96724_DPLL_FREQ0_ADDR,
++			   dpll_cfg);
++	max96724_write_reg(dev, MAX96724_DPLL_FREQ1_ADDR,
++			   dpll_cfg);
++	max96724_write_reg(dev, MAX96724_DPLL_FREQ2_ADDR,
++			   dpll_cfg);
++	max96724_write_reg(dev, MAX96724_DPLL_FREQ3_ADDR,
++			   dpll_cfg);
++
++	max96724_write_reg(dev, MAX96724_MIPI_CTRL_SEL_ADDR,
++			   MAX96724_MIPI_CTRL_SEL_PIXEL);
++
++	max96724_write_reg(dev, MAX96724_BACKTOP_EN_ADDR,
++			   MAX96724_BACKTOP_CSIB_EN);
++	for (i = 0; i < MAX96724_MAX_PIPES; i++) {
++		max96724_write_reg(dev,
++				   MAX96724_PIPE_X_ST_SEL_ADDR + (0x40 * i),
++				   st_sel_cfg);
++		max96724_write_reg(dev,
++				   MAX96724_VID_RX0_P0_ADDR +
++				   (MAX96724_VID_RX_STRIDE * i),
++				   vid_rx0_cfg);
++		max96724_write_reg(dev,
++				   MAX96724_VID_RX6_P0_ADDR +
++				   (MAX96724_VID_RX_STRIDE * i),
++				   vid_rx6_cfg);
++		max96724_write_reg(dev,
++				   MAX96724_TX49_PIPE_X_ADDR + (0x40 * i),
++				   0x00);
++	}
++	if (max96724_is_pixel_mode(priv)) {
++		max96724_write_reg(dev, MAX96724_PIPE0_TUN_EN_ADDR, MAX96724_TUN_DISABLED);
++		max96724_write_reg(dev, MAX96724_PIPE1_TUN_EN_ADDR, MAX96724_TUN_DISABLED);
++		max96724_write_reg(dev, MAX96724_PIPE2_TUN_EN_ADDR, MAX96724_TUN_DISABLED);
++		max96724_write_reg(dev, MAX96724_PIPE3_TUN_EN_ADDR, MAX96724_TUN_DISABLED);
++	} else {
++		/* Re-enable tunnel on all pipes (ONESHOT resets TUN_EN to 0x08=disabled) */
++		max96724_write_reg(dev, MAX96724_PIPE0_TUN_EN_ADDR, MAX96724_TUN_EN);
++		max96724_write_reg(dev, MAX96724_PIPE1_TUN_EN_ADDR, MAX96724_TUN_EN);
++		max96724_write_reg(dev, MAX96724_PIPE2_TUN_EN_ADDR, MAX96724_TUN_EN);
++		max96724_write_reg(dev, MAX96724_PIPE3_TUN_EN_ADDR, MAX96724_TUN_EN);
++		/* TUN_DEST: set to Controller 1 (0x10) = Port A master in 2x4 mode */
++		max96724_write_reg(dev, MAX96724_PIPE0_TUN_DEST_ADDR,
++				   MAX96724_TUN_DEST_CTRL1);
++		max96724_write_reg(dev, MAX96724_PIPE1_TUN_DEST_ADDR,
++				   MAX96724_TUN_DEST_CTRL1);
++		max96724_write_reg(dev, MAX96724_PIPE2_TUN_DEST_ADDR,
++				   MAX96724_TUN_DEST_CTRL1);
++		max96724_write_reg(dev, MAX96724_PIPE3_TUN_DEST_ADDR,
++				   MAX96724_TUN_DEST_CTRL1);
++	}
++	max96724_write_reg(dev, MAX96724_PIPE_EN_ADDR,
++			   MAX96724_PIPE_EN_4);
++
++	/*
++	 * Assert 0x08A0=0x84 LAST:
++	 * 2x4 mode + bit[7] force all MIPI clocks running.  Must mirror
++	 * setup_streaming because the sensor's oneshot path overwrites it.
++	 */
++	max96724_write_reg(dev, MAX96724_CSI_OUT_CFG_ADDR,
++			   MAX96724_CSI_OUT_EN_VAL);
++
++	msleep(200);
++	mutex_unlock(&priv->lock);
++}
++EXPORT_SYMBOL(max96724_reset_oneshot);
++
++/* ================================================================
++ * Init Settings / Set Pipe
++ * ================================================================ */
++
++/*
++ * __max96724_set_pipe - Configure per-pipe mapping registers
++ */
++static int __max96724_set_pipe(struct device *dev, int pipe_id,
++			       u8 data_type1, u8 data_type2, u32 vc_id)
++{
++	int err = 0;
++	int i;
++	u8 en_mapping_num = 0x0F;
++	u8 all_mapping_phy = MAX96724_ALL_MAP_CTRL1;  /* Controller 1 = Port A master (2x4 mode) */
++	struct max96724 *priv = dev_get_drvdata(dev);
++
++	struct reg_pair map_pipe_control[] = {
++		/* Enable 4 mappings for Pipe X */
++		{MAX96724_TX11_PIPE_X_EN_ADDR, 0x0F},
++		/* Map data_type1 on vc_id */
++		{MAX96724_PIPE_X_SRC_0_MAP_ADDR, 0x1E},
++		{MAX96724_PIPE_X_DST_0_MAP_ADDR, 0x1E},
++		/* Map frame start on vc_id */
++		{MAX96724_PIPE_X_SRC_1_MAP_ADDR, 0x00},
++		{MAX96724_PIPE_X_DST_1_MAP_ADDR, 0x00},
++		/* Map frame end on vc_id */
++		{MAX96724_PIPE_X_SRC_2_MAP_ADDR, 0x01},
++		{MAX96724_PIPE_X_DST_2_MAP_ADDR, 0x01},
++		/* Map data_type2 on vc_id */
++		{MAX96724_PIPE_X_SRC_3_MAP_ADDR, 0x12},
++		{MAX96724_PIPE_X_DST_3_MAP_ADDR, 0x12},
++		/* All mappings to Controller 1 (2x4 mode: Ctrl1 drives Port A) */
++		{MAX96724_TX45_PIPE_X_DST_CTRL_ADDR, MAX96724_ALL_MAP_CTRL1},
++		{MAX96724_TX46_PIPE_X_ADDR, MAX96724_ALL_MAP_CTRL1},
++		{MAX96724_TX47_PIPE_X_ADDR, MAX96724_ALL_MAP_CTRL1},
++		{MAX96724_TX48_PIPE_X_ADDR, MAX96724_ALL_MAP_CTRL1},
++		/* TX49: concat disabled */
++		{MAX96724_TX49_PIPE_X_ADDR, 0x00},
++		/*
++		 * Keep DES heartbeat handling aligned with the serializer's
++		 * LIM_HEART-disabled tunnel mode to avoid persistent VID_SEQ_ERR.
++		 */
++		{0x0100, MAX96724_VID_RX0_CFG_VAL},
++		{0x0106, MAX96724_VID_RX6_CFG_VAL},
++		/*
++		 * Pipe stream control (offset 0x36 per pipe block).
++		 * TUN_EN = 0x01.
++		 */
++		{0x0936, MAX96724_TUN_EN},
++	};
++
++	/* 
++	 * Adjust addresses for pipe offset (stride 0x40 per pipe)
++	 * Entries 0-13: TX11, SRC/DST maps, TX45-TX49 (all stride 0x40)
++	 * Entries 14-15: VID_RX0/6 (stride 0x12)
++	 * Entry 16: Pipe stream control (stride 0x40)
++	 */
++	for (i = 0; i < 14; i++)
++		map_pipe_control[i].addr += 0x40 * pipe_id;
++
++	/* VID_RX offset: 0x12 per pipe */
++	map_pipe_control[14].addr += 0x12 * pipe_id;
++	map_pipe_control[15].addr += 0x12 * pipe_id;
++
++	/* Pipe stream control: stride 0x40 */
++	map_pipe_control[16].addr += 0x40 * pipe_id;
++
++	if (data_type2 == 0x0) {
++		en_mapping_num = 0x07;
++		all_mapping_phy = MAX96724_MAP3_CTRL1;
++	}
++
++	if (max96724_is_pixel_mode(priv)) {
++		map_pipe_control[10].val = 0x00;
++		map_pipe_control[11].val = 0x00;
++		map_pipe_control[12].val = 0x00;
++		map_pipe_control[13].val = 0x00;
++		map_pipe_control[14].val = MAX96724_VID_RX0_PIXEL_VAL;
++		map_pipe_control[15].val = MAX96724_VID_RX6_PIXEL_VAL;
++		map_pipe_control[16].val = MAX96724_TUN_DISABLED;
++	} else {
++		/* no concatenation needed */
++		map_pipe_control[13].val = 0x00;
++	}
++
++	map_pipe_control[0].val = en_mapping_num;
++	/* SRC: match incoming VC from camera (vc_id) */
++	map_pipe_control[1].val = (vc_id << 6) | data_type1;
++	/* DST: preserve VC — NVCSI/VI endpoints expect matching vc-id */
++	map_pipe_control[2].val = (vc_id << 6) | data_type1;
++	map_pipe_control[3].val = (vc_id << 6) | 0x00;
++	map_pipe_control[4].val = (vc_id << 6) | 0x00;
++	map_pipe_control[5].val = (vc_id << 6) | 0x01;
++	map_pipe_control[6].val = (vc_id << 6) | 0x01;
++	map_pipe_control[7].val = (vc_id << 6) | data_type2;
++	map_pipe_control[8].val = (vc_id << 6) | data_type2;
++	map_pipe_control[9].val = all_mapping_phy;
++	/* TX46-TX48 keep 0x55 (Ctrl1) from initializer */
++	/* TX49 set to 0x00 above — overridden per mode in pixel/tunnel branch */
++	/* VID_RX and pipe stream ctrl keep init values */
++
++	err = max96724_set_registers(dev, map_pipe_control,
++				     ARRAY_SIZE(map_pipe_control));
++
++	return err;
++}
++
++/*
++ * max96724_init_settings - Initialize default pipe and tunnel configuration
++ *
++ * Sets up all 4 pipes with default YUV422_8 + EMBED for VC0-3,
++ * matching the d4xx framework expectations.
++ *
++ */
++int max96724_init_settings(struct device *dev)
++{
++	int err = 0;
++	int i;
++	struct max96724 *priv = dev_get_drvdata(dev);
++
++	mutex_lock(&priv->lock);
++
++	for (i = 0; i < MAX96724_MAX_PIPES; i++)
++		err |= __max96724_set_pipe(dev, i, GMSL_CSI_DT_YUV422_8,
++					   GMSL_CSI_DT_EMBED, i);
++
++	mutex_unlock(&priv->lock);
++
++	return err;
++}
++EXPORT_SYMBOL(max96724_init_settings);
++
++int max96724_bind_ser_to_dser_pipe(struct device *dev, int dser_pipe_id,
++				   int ser_pipe_id, u32 vc_id)
++{
++	/* In Tunnel Mode, pipe mapping is 1:1 (each camera → one pipe) */
++	return 0;
++}
++EXPORT_SYMBOL(max96724_bind_ser_to_dser_pipe);
++
++int max96724_set_pipe(struct device *dev, int pipe_id,
++		      u8 data_type1, u8 data_type2, u32 vc_id)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++	int err = 0;
++
++	if (pipe_id > (MAX96724_MAX_PIPES - 1)) {
++		dev_info(dev, "%s: input pipe_id: %d exceeds max96724 max pipes\n",
++			 __func__, pipe_id);
++		return -EINVAL;
++	}
++
++	dev_dbg(dev, "%s pipe_id %d, data_type1 %u, data_type2 %u, vc_id %u\n",
++		__func__, pipe_id, data_type1, data_type2, vc_id);
++
++	mutex_lock(&priv->lock);
++
++	err = __max96724_set_pipe(dev, pipe_id, data_type1, data_type2, vc_id);
++
++	mutex_unlock(&priv->lock);
++
++	return err;
++}
++EXPORT_SYMBOL(max96724_set_pipe);
++
++/* ================================================================
++ * Device Tree Parsing
++ * ================================================================ */
++
++static const struct of_device_id max96724_of_match[] = {
++	{ .compatible = "adi,max96724", },
++	{ },
++};
++MODULE_DEVICE_TABLE(of, max96724_of_match);
++
++static int max96724_parse_dt(struct max96724 *priv,
++			     struct i2c_client *client)
++{
++	struct device_node *node = client->dev.of_node;
++	int err = 0;
++	const char *str_value;
++	int value;
++	const struct of_device_id *match;
++
++	if (!node)
++		return -EINVAL;
++
++	match = of_match_device(max96724_of_match, &client->dev);
++	if (!match) {
++		dev_err(&client->dev, "Failed to find matching dt id\n");
++		return -EFAULT;
++	}
++
++	/* CSI mode: "2x4" or "4x2" */
++	err = of_property_read_string(node, "csi-mode", &str_value);
++	if (err < 0) {
++		dev_err(&client->dev, "csi-mode property not found\n");
++		return err;
++	}
++
++	if (!strcmp(str_value, "2x4")) {
++		priv->csi_mode = MAX96724_CSI_MODE_2X4;
++		priv->lane_mp1 = MAX96724_LANE_MAP1_2X4;
++		priv->lane_mp2 = MAX96724_LANE_MAP2_2X4;
++	} else {
++		dev_err(&client->dev, "invalid csi mode\n");
++		return -EINVAL;
++	}
++
++	/* Max sources */
++	err = of_property_read_u32(node, "max-src", &value);
++	if (err < 0) {
++		dev_err(&client->dev, "No max-src info\n");
++		return err;
++	}
++	priv->max_src = value;
++
++	/* Reset GPIO */
++	priv->reset_gpio = of_get_named_gpio(node, "reset-gpios", 0);
++	if (priv->reset_gpio < 0) {
++		dev_info(&client->dev,
++			 "reset-gpios not found, continuing without external reset\n");
++		priv->reset_gpio = -1;
++	}
++
++	/* GMSL link speed from DT: 3 or 6 (Gbps) */
++	err = of_property_read_u32(node, "gmsl-link-speed", &value);
++	if (err < 0) {
++		/* Default to 3 Gbps if not specified */
++		priv->link_speed = 3;
++		dev_info(&client->dev,
++			 "gmsl-link-speed not specified, defaulting to 3 Gbps\n");
++	} else {
++		if (value != 3 && value != 6) {
++			dev_err(&client->dev,
++				"invalid gmsl-link-speed %d (must be 3 or 6)\n",
++				value);
++			return -EINVAL;
++		}
++		priv->link_speed = value;
++	}
++
++	priv->pixel_mode = of_property_read_bool(node, "adi,pixel-mode");
++
++	/* 1.2V regulator (optional) */
++	if (of_get_property(node, "vdd_cam_1v2-supply", NULL)) {
++		priv->vdd_cam_1v2 = regulator_get(&client->dev, "vdd_cam_1v2");
++		if (IS_ERR(priv->vdd_cam_1v2)) {
++			dev_err(&client->dev,
++				"vdd_cam_1v2 regulator get failed\n");
++			err = PTR_ERR(priv->vdd_cam_1v2);
++			priv->vdd_cam_1v2 = NULL;
++			return err;
++		}
++	} else {
++		priv->vdd_cam_1v2 = NULL;
++	}
++
++	return 0;
++}
++
++/* ================================================================
++ * Probe / Remove
++ * ================================================================ */
++
++static struct regmap_config max96724_regmap_config = {
++	.reg_bits = 16,
++	.val_bits = 8,
++	.cache_type = REGCACHE_NONE,
++};
++
++static int max96724_probe(struct i2c_client *client,
++			   const struct i2c_device_id *id)
++{
++	struct max96724 *priv;
++	int err = 0;
++
++	dev_info(&client->dev,
++		 "[MAX96724]: probing Quad GMSL2 Deserializer (Tunnel Mode)\n");
++
++	priv = devm_kzalloc(&client->dev, sizeof(*priv), GFP_KERNEL);
++	if (!priv)
++		return -ENOMEM;
++
++	priv->i2c_client = client;
++	priv->regmap = devm_regmap_init_i2c(priv->i2c_client,
++					     &max96724_regmap_config);
++	if (IS_ERR(priv->regmap)) {
++		dev_err(&client->dev,
++			"regmap init failed: %ld\n", PTR_ERR(priv->regmap));
++		return -ENODEV;
++	}
++
++	err = max96724_parse_dt(priv, client);
++	if (err) {
++		dev_err(&client->dev, "unable to parse dt\n");
++		return -EFAULT;
++	}
++
++	max96724_pipes_reset(priv);
++
++	if (priv->max_src > MAX96724_MAX_SOURCES) {
++		dev_err(&client->dev,
++			"max sources more than currently supported\n");
++		return -EINVAL;
++	}
++
++	mutex_init(&priv->lock);
++
++	dev_set_drvdata(&client->dev, priv);
++
++	dev_info(&client->dev, "%s: success (link_speed=%d Gbps, max_src=%d)\n",
++		 __func__, priv->link_speed, priv->max_src);
++
++	return err;
++}
++
++static int max96724_remove(struct i2c_client *client)
++{
++	struct max96724 *priv;
++
++	if (client != NULL) {
++		priv = dev_get_drvdata(&client->dev);
++		mutex_destroy(&priv->lock);
++		i2c_unregister_device(client);
++		client = NULL;
++	}
++
++	return 0;
++}
++
++static const struct i2c_device_id max96724_id[] = {
++	{ "max96724", 0 },
++	{ },
++};
++
++MODULE_DEVICE_TABLE(i2c, max96724_id);
++
++static struct i2c_driver max96724_i2c_driver = {
++	.driver = {
++		.name = "max96724",
++		.owner = THIS_MODULE,
++		.of_match_table = of_match_ptr(max96724_of_match),
++	},
++	.probe = max96724_probe,
++	.remove = max96724_remove,
++	.id_table = max96724_id,
++};
++
++static int __init max96724_init(void)
++{
++	return i2c_add_driver(&max96724_i2c_driver);
++}
++
++static void __exit max96724_exit(void)
++{
++	i2c_del_driver(&max96724_i2c_driver);
++}
++
++module_init(max96724_init);
++module_exit(max96724_exit);
++
++MODULE_DESCRIPTION("Quad GMSL2 Deserializer driver max96724 (Tunnel Mode)");
++MODULE_AUTHOR("RealSense AI");
++MODULE_LICENSE("GPL v2");
+diff --git a/include/media/max96717.h b/include/media/max96717.h
+new file mode 100644
+index 0000000..65bf930
+--- /dev/null
++++ b/include/media/max96717.h
+@@ -0,0 +1,151 @@
++/*
++ * max96717.c - MAX96717 GMSL2 Serializer driver (Tunnel Mode)
++ *
++ * Copyright (c) 2026, RealSense, Inc.  All rights reserved.
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms and conditions of the GNU General Public License,
++ * version 2, as published by the Free Software Foundation.
++ *
++ * This program is distributed in the hope it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
++ * more details.
++ *
++ * You should have received a copy of the GNU General Public License
++ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
++ */
++
++/**
++ * @file
++ * <b>MAX96717 API: For Analog Devices MAX96717 GMSL2 serializer</b>
++ *
++ * @b Description: Defines elements used to set up and use an
++ *  Analog Devices MAX96717 GMSL2 serializer in Tunnel Mode.
++ */
++
++#ifndef __MAX96717_H__
++#define __MAX96717_H__
++
++#include <linux/types.h>
++#include <media/gmsl-link.h>
++
++/**
++ * \defgroup max96717 MAX96717 serializer driver
++ *
++ * Controls the MAX96717 GMSL2 serializer module (Tunnel Mode).
++ *
++ * @ingroup serdes_group
++ * @{
++ */
++
++/**
++ * @brief  Configures a single pipe on the serializer.
++ *
++ * In Tunnel Mode, per-pipe DT/VC filtering is not active on the serializer
++ * side (all VCs are tunneled transparently). This function maintains API
++ * compatibility with the d4xx sensor driver framework.
++ *
++ * @param  [in]  dev          The serializer device handle.
++ * @param  [in]  pipe_id      Pipe index (0..3).
++ * @param  [in]  data_type1   Primary CSI-2 data type.
++ * @param  [in]  data_type2   Secondary CSI-2 data type (e.g. embedded).
++ * @param  [in]  vc_id        Virtual channel ID.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96717_set_pipe(struct device *dev, int pipe_id, u8 data_type1,
++		      u8 data_type2, u32 vc_id);
++
++/**
++ * @brief  Toggle SER TX to restore tunnel detection after DES ONESHOT.
++ *
++ * A DES ONESHOT resets the video data path. The serializer must cycle
++ * its TX enable (REG2 0x03→0x43) for the deserializer to re-acquire
++ * the tunnel stream.
++ *
++ * @param  [in]  dev          The serializer device handle.
++ */
++void max96717_retrigger_tx(struct device *dev);
++
++/**
++ * @brief  Powers on the serializer and performs I2C overrides
++ * for sensor and serializer devices.
++ *
++ * Must be called after the deserializer's max96724_setup_link().
++ *
++ * @param  [in]  dev          The serializer device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96717_setup_control(struct device *dev);
++
++/**
++ * @brief  Reverts I2C overrides and resets the serializer.
++ *
++ * @param  [in]  dev          The serializer device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96717_reset_control(struct device *dev);
++
++/**
++ * @brief  Pairs a sensor device with the serializer.
++ *
++ * To be called by the sensor client driver.
++ *
++ * @param  [in]  dev          The serializer device handle.
++ * @param  [in]  g_ctx        The gmsl_link_ctx structure handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96717_sdev_pair(struct device *dev, struct gmsl_link_ctx *g_ctx);
++
++/**
++ * @brief  Unpairs a sensor device from the serializer.
++ *
++ * @param  [in]  dev          The serializer device handle.
++ * @param  [in]  s_dev        The sensor device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96717_sdev_unpair(struct device *dev, struct device *s_dev);
++
++/**
++ * @brief  Sets up the serializer's internal streaming pipeline.
++ *
++ * Configures CSI-2 input mode, lane mapping, and enables Tunnel Mode
++ * (EXT11[7]=1 at register 0x0383).
++ *
++ * @param  [in]  dev          The serializer device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96717_setup_streaming(struct device *dev);
++
++/**
++ * @brief  Applies initial register settings for the serializer.
++ *
++ * Configures default pipe settings and Tunnel Mode registers.
++ *
++ * @param  [in]  dev          The serializer device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96717_init_settings(struct device *dev);
++
++/**
++ * @brief  No-op hook for GPIO-over-GMSL tunneling for FSIN/FOUT signals.
++ *
++ * The signal map is documented, but the concrete MFP_CFG values are
++ * not available yet. This hook currently logs and returns success.
++ *
++ * @param  [in]  dev          The serializer device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96717_setup_gpio_tunneling(struct device *dev);
++
++/** @} */
++
++#endif  /* __MAX96717_H__ */
+diff --git a/include/media/max96724.h b/include/media/max96724.h
+new file mode 100644
+index 0000000..dc5a8ea
+--- /dev/null
++++ b/include/media/max96724.h
+@@ -0,0 +1,183 @@
++/*
++ * max96717.c - MAX96717 GMSL2 Serializer driver (Tunnel Mode)
++ *
++ * Copyright (c) 2026, RealSense, Inc.  All rights reserved.
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms and conditions of the GNU General Public License,
++ * version 2, as published by the Free Software Foundation.
++ *
++ * This program is distributed in the hope it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
++ * more details.
++ *
++ * You should have received a copy of the GNU General Public License
++ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
++ */
++
++/**
++ * @file
++ * <b>MAX96724 API: For Analog Devices MAX96724 GMSL2 quad deserializer</b>
++ *
++ * @b Description: Defines elements used to set up and use an
++ *  Analog Devices MAX96724 quad GMSL2 deserializer in Tunnel Mode.
++ */
++
++#ifndef __MAX96724_H__
++#define __MAX96724_H__
++
++#include <linux/types.h>
++#include <media/gmsl-link.h>
++
++/**
++ * \defgroup max96724 MAX96724 deserializer driver
++ *
++ * Controls the MAX96724 quad GMSL2 deserializer module (Tunnel Mode).
++ *
++ * @ingroup serdes_group
++ * @{
++ */
++
++int max96724_get_available_pipe_id(struct device *dev, int vc_id);
++int max96724_get_ser_pipe_id(struct device *dev, int dser_pipe_id, int vc_id);
++int max96724_set_pipe(struct device *dev, int pipe_id, u8 data_type1,
++		      u8 data_type2, u32 vc_id);
++int max96724_release_pipe(struct device *dev, int pipe_id);
++void max96724_reset_oneshot(struct device *dev);
++
++/**
++ * @brief  Puts the deserializer in single exclusive link mode.
++ *
++ * @param  [in]  dev          The deserializer device handle.
++ * @param  [in]  s_dev        The sensor device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96724_setup_link(struct device *dev, struct device *s_dev);
++
++/**
++ * @brief  Sets up the deserializer link's control pipeline.
++ *
++ * Configures I2C pass-through, splitter mode if needed, and
++ * enables the tunnel mode pipe routing for the source.
++ *
++ * @param  [in]  dev          The deserializer device handle.
++ * @param  [in]  s_dev        The sensor device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96724_setup_control(struct device *dev, struct device *s_dev);
++
++/**
++ * @brief  Resets the deserializer link control pipeline.
++ *
++ * @param  [in]  dev          The deserializer device handle.
++ * @param  [in]  s_dev        The sensor device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96724_reset_control(struct device *dev, struct device *s_dev);
++
++/**
++ * @brief  Registers a source sensor device with the deserializer.
++ *
++ * @param  [in]  dev          The deserializer device handle.
++ * @param  [in]  g_ctx        The gmsl_link_ctx structure handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96724_sdev_register(struct device *dev, struct gmsl_link_ctx *g_ctx);
++
++/**
++ * @brief  Unregisters a source sensor device from the deserializer.
++ *
++ * @param  [in]  dev          The deserializer device handle.
++ * @param  [in]  s_dev        The sensor device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96724_sdev_unregister(struct device *dev, struct device *s_dev);
++
++/**
++ * @brief  Configures the internal streaming pipeline.
++ *
++ * Sets up tunnel mode pipe routing, CSI-2 output lane configuration,
++ * and MIPI PHY settings.
++ *
++ * @param  [in]  dev          The deserializer device handle.
++ * @param  [in]  s_dev        The sensor device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96724_setup_streaming(struct device *dev, struct device *s_dev);
++
++/**
++ * @brief  Enables streaming for a source sensor.
++ *
++ * @param  [in]  dev          The deserializer device handle.
++ * @param  [in]  s_dev        The sensor device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96724_start_streaming(struct device *dev, struct device *s_dev);
++
++/**
++ * @brief  Disables streaming for a source sensor.
++ *
++ * @param  [in]  dev          The deserializer device handle.
++ * @param  [in]  s_dev        The sensor device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96724_stop_streaming(struct device *dev, struct device *s_dev);
++
++/**
++ * @brief  Powers on the MAX96724 deserializer module.
++ *
++ * Asserts shared reset GPIO and powers on the regulator.
++ *
++ * @param  [in]  dev          The deserializer device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96724_power_on(struct device *dev);
++
++/**
++ * @brief  Powers off the MAX96724 deserializer module.
++ *
++ * @param  [in]  dev          The deserializer device handle.
++ */
++void max96724_power_off(struct device *dev);
++
++/**
++ * @brief  Applies initial register settings for the deserializer.
++ *
++ * Configures default pipe mappings, tunnel mode, and CSI output for
++ * the D5xx/SC1.2 use case.
++ *
++ * @param  [in]  dev          The deserializer device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96724_init_settings(struct device *dev);
++
++/**
++ * @brief  Maps deserializer pipe ID to serializer pipe ID.
++ *
++ * In tunnel mode with MAX96717, all data flows through a single pipe
++ * per camera, so the mapping is 1:1.
++ *
++ * @param  [in]  dev             The deserializer device handle.
++ * @param  [in]  dser_pipe_id    Deserializer pipe ID.
++ * @param  [in]  ser_pipe_id     Serializer pipe ID.
++ * @param  [in]  vc_id           VC ID associated with this pipe.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96724_bind_ser_to_dser_pipe(struct device *dev, int dser_pipe_id,
++				   int ser_pipe_id, u32 vc_id);
++
++/** @} */
++
++#endif  /* __MAX96724_H__ */
+-- 
+2.25.1
+

--- a/nvidia-oot/7.1/0001-Porting-nvidia-driver-patches-to-jetpack-6.0.patch
+++ b/nvidia-oot/7.1/0001-Porting-nvidia-driver-patches-to-jetpack-6.0.patch
@@ -25,13 +25,15 @@ diff --git a/drivers/media/i2c/Makefile b/drivers/media/i2c/Makefile
 index 7c5913c6..396b9bc3 100644
 --- a/drivers/media/i2c/Makefile
 +++ b/drivers/media/i2c/Makefile
-@@ -5,6 +5,9 @@ subdir-ccflags-y += -Werror
+@@ -5,6 +5,11 @@ subdir-ccflags-y += -Werror
  ifneq ($(NV_BUILD_SYSTEM_TYPE),embedded-linux)
  obj-m += max9295.o
  obj-m += max9296.o
 +subdir-ccflags-y += -DCONFIG_VIDEO_D4XX_SERDES
 +subdir-ccflags-y += -DCONFIG_TEGRA_CAMERA_PLATFORM
 +obj-m += d4xx.o
++obj-m += max96717.o
++obj-m += max96724.o
  ifndef CONFIG_TEGRA_SYSTEM_TYPE_ACK
  obj-m += max96712.o
  

--- a/nvidia-oot/7.1/0011-Add-MAX96717-serializer-and-MAX96724-deserializer-dr.patch
+++ b/nvidia-oot/7.1/0011-Add-MAX96717-serializer-and-MAX96724-deserializer-dr.patch
@@ -1,0 +1,3147 @@
+From 40fac9b67ddea60055961d32fa89fe8f608396ff Mon Sep 17 00:00:00 2001
+From: RealSense AI <realsense@realsenseai.com>
+Date: Tue, 12 May 2026 17:06:23 +0800
+Subject: [PATCH] Add MAX96717 serializer and MAX96724 deserializer drivers for
+ tunnel mode
+
+Add MAX96717 GMSL2 serializer and MAX96724 GMSL2 quad deserializer
+drivers for Tunnel Mode operation with D5xx cameras.
+
+MAX96717 serializer features:
+- CSI-2 input with 2/4 lane support
+- Tunnel Mode encapsulation of full CSI-2 byte stream
+- I2C address translation for sensor passthrough
+- GPIO-over-GMSL tunneling hook for FSIN/FOUT signals
+
+MAX96724 quad deserializer features:
+- Up to 4 GMSL2 links (quad camera support)
+- Configurable link speed (3 Gbps / 6 Gbps via DT)
+- Tunnel Mode pipe routing and CSI-2 output
+- 2x4 and 4x2 CSI output mode support
+- Power management with GPIO reset and regulator control
+
+Signed-off-by: RealSense AI <realsense@realsenseai.com>
+---
+ drivers/media/i2c/Makefile   |    2 +
+ drivers/media/i2c/max96717.c |  835 ++++++++++++++
+ drivers/media/i2c/max96724.c | 1916 ++++++++++++++++++++++++++++++++++
+ include/media/max96717.h     |  151 ++
+ include/media/max96724.h     |  183 +++
+ 4 files changed, 3085 insertions(+)
+ create mode 100644 drivers/media/i2c/max96717.c
+ create mode 100644 drivers/media/i2c/max96724.c
+ create mode 100644 include/media/max96717.h
+ create mode 100644 include/media/max96724.h
+
+diff --git a/drivers/media/i2c/max96717.c b/drivers/media/i2c/max96717.c
+new file mode 100644
+index 0000000..70d25a3
+--- /dev/null
++++ b/drivers/media/i2c/max96717.c
+@@ -0,0 +1,835 @@
++/*
++ * max96717.c - MAX96717 GMSL2 Serializer driver (Tunnel Mode)
++ *
++ * Copyright (c) 2026, RealSense, Inc.  All rights reserved.
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms and conditions of the GNU General Public License,
++ * version 2, as published by the Free Software Foundation.
++ *
++ * This program is distributed in the hope it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
++ * more details.
++ *
++ * You should have received a copy of the GNU General Public License
++ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
++ */
++
++#include <media/camera_common.h>
++#include <linux/of.h>
++#include <linux/module.h>
++#include <media/max96717.h>
++
++/* ===== Register Addresses ===== */
++
++/* REG0: Device ID (read-only, returns 0x40) */
++#define MAX96717_DEV_ADDR		0x00
++
++/* 
++ *   REG1: Link Speed
++ *   bit[3]=1: 3 Gbps, bit[4]=1: 6 Gbps
++ */
++#define MAX96717_REG1_ADDR		0x01
++
++/* 
++ *   PIPE_EN: Pipe enable / soft reset
++ *   0x03 = soft reset, 0x43 = pipes enabled + video init
++ *   Matches MAX9295 PIPE_EN at 0x02
++ */
++#define MAX96717_PIPE_EN_ADDR		0x02
++
++/* 
++ *   CTRL0: GMSL2 TX Control
++ *   bit[5]=1: GMSL2 mode, bit[0]=1: enable transmitter
++ *   0x21 = GMSL2 mode + TX enable on Link A
++ */
++#define MAX96717_CTRL0_ADDR		0x10
++
++/* 
++ *   CTRL3: Start Video - final enable bit
++ *   bit[0]=1: activate video stream
++ */
++#define MAX96717_CTRL3_ADDR		0x13
++
++/* 
++ *   TX1: FEC Enable
++ *   bit[6]=1: Reed-Solomon FEC enabled
++ */
++#define MAX96717_TX1_ADDR		0x29
++
++/*
++ *   MAX96717 I2C address translation registers (GMSL2 standard):
++ *   SRC_A / DST_A (0x42/0x43): Translation pair A (SER broadcast addr)
++ *   SRC_B / DST_B (0x44/0x45): Translation pair B (sensor passthrough)
++ *
++ *   When host writes to SRC_B address, the MAX96717 translates it to
++ *   DST_B and forwards via GMSL back-channel to the remote sensor.
++ *
++ */
++#define MAX96717_SRC_A_ADDR		0x42
++#define MAX96717_DST_A_ADDR		0x43
++#define MAX96717_I2C4_ADDR		0x44
++#define MAX96717_I2C5_ADDR		0x45
++
++/* 
++ *   TX_STR_SEL: Stream ID select
++ *   bits[1:0]: stream ID for DES pipe routing
++ */
++#define MAX96717_TX_STR_SEL_ADDR	0x5B
++
++/* 
++ *   VIDEO_TX0/TX1: Video TX path config
++ *   0x0110=0xE9, 0x0111=0x10 for tunnel mode data path
++ */
++#define MAX96717_VIDEO_TX0_ADDR		0x110
++#define MAX96717_VIDEO_TX1_ADDR		0x111
++
++/* 
++ *   FRONTTOP_0: Front-end topology
++ *   0x12 = single CSI-2 port A, all VCs pass through
++ */
++#define MAX96717_FRONTTOP0_ADDR		0x308
++
++/* 
++ *   MIPI_RX0-RX3: CSI-2 receiver configuration
++ *   RX0 (0x330): CSI mode (0x00 = D-PHY controller A)
++ *   RX1 (0x331): Lane count - ctrl1_num_lanes bits[5:4]
++ *                0x30 = bits[5:4]=11 (4 lanes)
++ *   RX2 (0x332): Lane mapping - 0xE0 = default 1x4 map
++ *   RX3 (0x333): Lane mapping - 0x04 = default 1x4 map
++ */
++#define MAX96717_MIPI_RX0_ADDR		0x330
++#define MAX96717_MIPI_RX1_ADDR		0x331
++#define MAX96717_MIPI_RX2_ADDR		0x332
++#define MAX96717_MIPI_RX3_ADDR		0x333
++
++/* 
++ *   EXT11: TUNNEL MODE ENABLE
++ *   bit[7]=1: Tun_Mode = ON
++ *   0x383 = 0x80
++ */
++#define MAX96717_EXT11_ADDR		0x383
++
++/* PHY calibration stage-1 value */
++#define MAX96717_PHY_CAL_STAGE1		0x80
++/* PHY calibration stage-2 value */
++#define MAX96717_PHY_CAL_STAGE2		0x90
++/* CSI input timing / frequency config */
++#define MAX96717_CSI_TIMING_3F0		0x59
++#define MAX96717_CSI_TIMING_3F1		0x09
++
++/* ===== Register Values ===== */
++
++/* Soft reset value for PIPE_EN register */
++#define MAX96717_SOFT_RESET		0x03
++
++/* Final enable: pipes enabled + video init */
++#define MAX96717_PIPE_EN_ALL		0x43
++
++/* CTRL0: GMSL2 mode + TX enable (Link A) */
++#define MAX96717_CTRL0_LINK_A		0x21
++/* CTRL0: GMSL2 mode + TX enable (Link B) */
++#define MAX96717_CTRL0_LINK_B		0x22
++
++/* CTRL0 reset all */
++#define MAX96717_RESET_ALL		0x80
++
++/* EXT11 tunnel mode enable value */
++#define MAX96717_TUN_MODE_EN		0x80
++#define MAX96717_TUN_MODE_DIS		0x00
++
++/* VIDEO_TX0 tunnel mode data path enable */
++#define MAX96717_VIDEO_TX0_TUN		0xE9
++/* VIDEO_TX1 tunnel mode config */
++#define MAX96717_VIDEO_TX1_TUN		0x10
++#define MAX96717_VIDEO_TX0_BPP_MANUAL	0x60
++#define MAX96717_VIDEO_TX1_BPP16	0x50
++#define MAX96717_VIDEO_TX2_ADDR		0x112
++#define MAX96717_VIDEO_TX2_DRIFT_DIS	0x08
++
++/* 
++ *   MIPI RX1: 4-lane CSI-2.
++ *   bits[5:4]=11 (4 lanes).  bits[1:0]=11
++ */
++#define MAX96717_CSI_4_LANES		0x33
++/* 2-lane CSI-2, bits[5:4]=01 */
++#define MAX96717_CSI_2_LANES		0x10
++
++/* Lane mapping for 1x4 mode */
++#define MAX96717_CSI_1X4_LANE_MAP1	0xE0
++#define MAX96717_CSI_1X4_LANE_MAP2	0x04
++
++/* FRONTTOP_0: single port A, all VCs */
++#define MAX96717_FRONTTOP0_PORT_A	0x12
++/* Pixel mode from Port B into Pipe Z */
++#define MAX96717_FRONTTOP0_PIXEL_PORT_B	0x64
++#define MAX96717_FRONTTOP5_ADDR		0x30D
++#define MAX96717_FRONTTOP9_ADDR		0x311
++#define MAX96717_FRONTTOP16_ADDR	0x318
++#define MAX96717_FRONTTOP17_ADDR	0x319
++#define MAX96717_FRONTTOP9_START_VIDEO	0x40
++
++/* MIPI_RX0: CSI reset on + non-continuous clock */
++#define MAX96717_MIPI_RX0_RESET		0x08
++/* MIPI_RX0: Normal operation */
++#define MAX96717_MIPI_RX0_NORMAL	0x00
++
++/* REG1: 3 Gbps link speed, bit[3]=1 */
++#define MAX96717_LINK_SPEED_3GBPS	0x08
++/* REG1: 6 Gbps link speed, bit[4]=1 */
++#define MAX96717_LINK_SPEED_6GBPS	0x10
++
++/* EXT11 tunnel mode pre-config (0x0383=0x80) */
++#define MAX96717_EXT11_TUN_PRE		0x80
++
++#define MAX96717_MAX_PIPES		4
++
++/*
++ * MFP8 (GPIO8) high-impedance release.
++ *
++ * At power-up GPIO8 comes up with GPIO_OUT_DIS=0 (output driver enabled,
++ * GPIO8_A=0x9c observed live), so the serializer actively drives the M2_I2C
++ * line and wedges the bus: any IMU I2C access by the camera FW times out
++ * whenever the serializer is powered.  This was confirmed on hardware -
++ * tri-stating GPIO8 alone immediately restored IMU I2C reads.
++ *
++ * GPIO8 is the ONLY serializer pin left driving its net (all other GPIOs,
++ * including MFP3/MFP4 interrupt lines, are already high-Z).  Release GPIO8
++ * (output driver off, no link TX/RX, no pull) so only the M2_I2C bus
++ * masters own the line.
++ *
++ * GPIO_n registers are a 3-byte group (A/B/C) starting at 0x02BE:
++ *   GPIO_n_A = 0x02BE + 3*n
++ */
++#define MAX96717_GPIO8_A_ADDR		0x02D6	/* MFP8 / M2_I2C (pass-through SCL1) */
++#define MAX96717_GPIO8_B_ADDR		0x02D7
++/* GPIO_A: GPIO_OUT_DIS=1 (high-Z), GPIO_TX_EN=0, GPIO_RX_EN=0 */
++#define MAX96717_GPIO_A_HIGH_Z		0x01
++/* GPIO_B: PULL_UPDN_SEL=None, TX_ID=0 */
++#define MAX96717_GPIO_B_NO_PULL		0x00
++
++/* ===== Data Structures ===== */
++
++struct max96717_client_ctx {
++	struct gmsl_link_ctx *g_ctx;
++	bool st_done;
++};
++
++struct max96717 {
++	struct i2c_client *i2c_client;
++	struct regmap *regmap;
++	struct max96717_client_ctx g_client;
++	struct mutex lock;
++	bool pixel_mode;
++	/* primary serializer properties */
++	__u32 def_addr;
++	__u32 pst2_ref;
++};
++
++static struct max96717 *prim_priv__;
++
++struct reg_pair {
++	u16 addr;
++	u8 val;
++};
++
++/* ===== Low-level I2C ===== */
++
++static int max96717_write_reg(struct device *dev, u16 addr, u8 val)
++{
++	struct max96717 *priv = dev_get_drvdata(dev);
++	int err;
++
++	err = regmap_write(priv->regmap, addr, val);
++	if (err)
++		dev_err(dev, "%s:i2c write failed, 0x%x = %x\n",
++			__func__, addr, val);
++
++	/* delay before next i2c command as required for SERDES link */
++	usleep_range(100, 110);
++
++	return err;
++}
++
++static int max96717_set_registers(struct device *dev, struct reg_pair *map,
++				  u32 count)
++{
++	int err = 0;
++	u32 j;
++
++	for (j = 0; j < count; j++) {
++		err = max96717_write_reg(dev, map[j].addr, map[j].val);
++		if (err)
++			break;
++	}
++
++	return err;
++}
++
++/* ===== Streaming Setup ===== */
++
++/*
++ * max96717_setup_streaming - Configure CSI-2 input and enable Tunnel Mode
++ *
++ * In Tunnel Mode (unlike MAX9295 Pixel Mode), the serializer encapsulates
++ * the entire CSI-2 byte stream verbatim into a single GMSL2 tunnel.
++ * All VCs (VC0-VC3) are preserved end-to-end.
++ */
++int max96717_setup_streaming(struct device *dev)
++{
++	struct max96717 *priv = dev_get_drvdata(dev);
++	int err = 0;
++	struct gmsl_link_ctx *g_ctx;
++
++	mutex_lock(&priv->lock);
++
++	if (!priv->g_client.g_ctx) {
++		dev_err(dev, "%s: no sdev client found\n", __func__);
++		err = -EINVAL;
++		goto error;
++	}
++
++	if (priv->g_client.st_done) {
++		dev_dbg(dev, "%s: stream setup is already done\n", __func__);
++		goto error;
++	}
++
++	g_ctx = priv->g_client.g_ctx;
++
++	max96717_write_reg(dev, MAX96717_EXT11_ADDR, MAX96717_TUN_MODE_EN);
++	max96717_write_reg(dev, MAX96717_MIPI_RX1_ADDR, MAX96717_CSI_4_LANES);
++	max96717_write_reg(dev, MAX96717_MIPI_RX2_ADDR, MAX96717_CSI_1X4_LANE_MAP1);
++	max96717_write_reg(dev, MAX96717_MIPI_RX3_ADDR, MAX96717_CSI_1X4_LANE_MAP2);
++	max96717_write_reg(dev, MAX96717_VIDEO_TX0_ADDR, MAX96717_VIDEO_TX0_TUN);
++	max96717_write_reg(dev, MAX96717_VIDEO_TX1_ADDR, MAX96717_VIDEO_TX1_TUN);
++
++	max96717_write_reg(dev, MAX96717_MIPI_RX0_ADDR, MAX96717_MIPI_RX0_RESET);
++	usleep_range(2000, 2100);
++	max96717_write_reg(dev, MAX96717_MIPI_RX0_ADDR, MAX96717_MIPI_RX0_NORMAL);
++
++	/* pipes on + video init */
++	max96717_write_reg(dev, MAX96717_PIPE_EN_ADDR, MAX96717_PIPE_EN_ALL);
++
++	priv->g_client.st_done = true;
++
++error:
++	mutex_unlock(&priv->lock);
++	return err;
++}
++EXPORT_SYMBOL(max96717_setup_streaming);
++
++/* ===== Control Setup ===== */
++
++/*
++ * max96717_setup_control - Set up I2C address translation and link control
++ *
++ * Steps:
++ *   1. Reassign serializer I2C address via DEV_ADDR (reg 0x00)
++ *   2. Configure GMSL2 link mode via CTRL0 (reg 0x10)
++ *   3. Set I2C address translation for sensor passthrough:
++ *      I2C4/SRC_B (0x44) <- (sdev_reg << 1): proxy addr visible to host
++ *      I2C5/DST_B (0x45) <- (sdev_def << 1): real addr on back-channel
++ *
++ */
++int max96717_setup_control(struct device *dev)
++{
++	struct max96717 *priv = dev_get_drvdata(dev);
++	int err = 0;
++	struct gmsl_link_ctx *g_ctx;
++
++	mutex_lock(&priv->lock);
++
++	if (!priv->g_client.g_ctx) {
++		dev_err(dev, "%s: no sensor dev client found\n", __func__);
++		err = -EINVAL;
++		goto error;
++	}
++
++	g_ctx = priv->g_client.g_ctx;
++
++	if (prim_priv__) {
++		unsigned int dev_id;
++		int probe_ret;
++
++		probe_ret = regmap_read(prim_priv__->regmap,
++					MAX96717_DEV_ADDR, &dev_id);
++		if (probe_ret == 0) {
++			/* Primary address (0x40) still responsive — do reassign */
++			max96717_write_reg(&prim_priv__->i2c_client->dev,
++					   MAX96717_DEV_ADDR,
++					   (g_ctx->ser_reg << 1));
++		} else {
++			dev_info(&prim_priv__->i2c_client->dev,
++				 "%s: SER already reassigned (addr 0x40 NACK), skipping DEV_ADDR write\n",
++				 __func__);
++		}
++	}
++
++	/* CTRL0: GMSL2 mode + TX enable */
++	if (g_ctx->serdes_csi_link == GMSL_SERDES_CSI_LINK_A)
++		err = max96717_write_reg(dev, MAX96717_CTRL0_ADDR,
++					 MAX96717_CTRL0_LINK_A);
++	else
++		err = max96717_write_reg(dev, MAX96717_CTRL0_ADDR,
++					 MAX96717_CTRL0_LINK_B);
++
++	if (err) {
++		dev_err(dev, "%s: ERROR: ser device not found\n", __func__);
++		goto error;
++	}
++
++	/* delay to settle link */
++	msleep(100);
++
++	/*
++	 * I2C address translation for sensor passthrough.
++	 *
++	 * I2C4 / SRC_B (0x44): sensor proxy addr visible to Orin host
++	 * I2C5 / DST_B (0x45): sensor real addr on GMSL back-channel
++	 *
++	 * When host sends I2C to sdev_reg (e.g., 0x1a), the MAX96717
++	 * translates it to sdev_def (e.g., 0x42) and forwards via GMSL
++	 * back-channel to the HKR sensor.
++	 */
++	max96717_write_reg(dev, MAX96717_I2C4_ADDR,
++			   (g_ctx->sdev_reg << 1));
++	max96717_write_reg(dev, MAX96717_I2C5_ADDR,
++			   (g_ctx->sdev_def << 1));
++
++	/* dev addr pass-through ref */
++	if (prim_priv__)
++		prim_priv__->pst2_ref++;
++
++	g_ctx->serdev_found = true;
++
++error:
++	mutex_unlock(&priv->lock);
++	return err;
++}
++EXPORT_SYMBOL(max96717_setup_control);
++
++/* ===== GPIO Tunneling ===== */
++
++/*
++ * max96717_setup_gpio_tunneling - GPIO-over-GMSL no-op hook
++ *
++ *   GPIO Signal Mapping:
++ *   MFP0 → GPIO0: FSIN (DES→SER, frame sync in)
++ *   MFP1 → GPIO1: FOUT/STROBE (SER→DES, frame sync out)
++ *   MFP4 → GPIO4: RESET_N (DES→SER, hard reset)
++ *   MFP5 → GPIO5: IRQ (SER→DES, interrupt request)
++ *   MFP6 → GPIO6: ZV_SYNC (DES→SER, IR stereo sync)
++ *
++ */
++int max96717_setup_gpio_tunneling(struct device *dev)
++{
++	struct max96717 *priv = dev_get_drvdata(dev);
++	int err = 0;
++
++	mutex_lock(&priv->lock);
++
++	dev_info(dev, "%s: GPIO tunneling hook is a no-op; MFP_CFG values are not defined yet\n",
++		 __func__);
++
++	mutex_unlock(&priv->lock);
++
++	return err;
++}
++EXPORT_SYMBOL(max96717_setup_gpio_tunneling);
++
++/* ===== Reset Control ===== */
++
++int max96717_reset_control(struct device *dev)
++{
++	struct max96717 *priv = dev_get_drvdata(dev);
++	int err = 0;
++
++	mutex_lock(&priv->lock);
++	if (!priv->g_client.g_ctx) {
++		dev_err(dev, "%s: no sdev client found\n", __func__);
++		err = -EINVAL;
++		goto error;
++	}
++
++	priv->g_client.st_done = false;
++
++	if (prim_priv__) {
++		prim_priv__->pst2_ref--;
++
++		max96717_write_reg(dev, MAX96717_DEV_ADDR,
++				   (prim_priv__->def_addr << 1));
++		if (prim_priv__->pst2_ref == 0)
++			max96717_write_reg(&prim_priv__->i2c_client->dev,
++					   MAX96717_CTRL0_ADDR,
++					   MAX96717_RESET_ALL);
++	}
++
++error:
++	mutex_unlock(&priv->lock);
++	return err;
++}
++EXPORT_SYMBOL(max96717_reset_control);
++
++/* ===== Device Pairing ===== */
++
++int max96717_sdev_pair(struct device *dev, struct gmsl_link_ctx *g_ctx)
++{
++	struct max96717 *priv;
++	int err = 0;
++
++	if (!dev || !g_ctx || !g_ctx->s_dev) {
++		dev_err(dev, "%s: invalid input params\n", __func__);
++		return -EINVAL;
++	}
++
++	priv = dev_get_drvdata(dev);
++	mutex_lock(&priv->lock);
++	if (priv->g_client.g_ctx) {
++		/* 
++		 * Already paired — tolerate if this is a re-probe of
++		 * the same camera after a failed first attempt.
++		 * Simply overwrite with the new g_ctx.
++		 */
++		dev_warn(dev, "%s: re-pairing (previous probe may have failed)\n",
++			 __func__);
++	}
++
++	priv->g_client.st_done = false;
++	priv->g_client.g_ctx = g_ctx;
++
++	/* mutex_unlock in error path, but we have none — inline the unlock */
++	mutex_unlock(&priv->lock);
++	return err;
++}
++EXPORT_SYMBOL(max96717_sdev_pair);
++
++int max96717_sdev_unpair(struct device *dev, struct device *s_dev)
++{
++	struct max96717 *priv = NULL;
++	int err = 0;
++
++	if (!dev || !s_dev) {
++		dev_err(dev, "%s: invalid input params\n", __func__);
++		return -EINVAL;
++	}
++
++	priv = dev_get_drvdata(dev);
++
++	mutex_lock(&priv->lock);
++
++	if (!priv->g_client.g_ctx) {
++		dev_dbg(dev, "%s: device is not paired\n", __func__);
++		err = 0; /* Not an error — already unpaired */
++		goto error;
++	}
++
++	if (priv->g_client.g_ctx->s_dev != s_dev) {
++		dev_warn(dev, "%s: s_dev mismatch, clearing anyway\n", __func__);
++	}
++
++	priv->g_client.g_ctx = NULL;
++	priv->g_client.st_done = false;
++
++error:
++	mutex_unlock(&priv->lock);
++	return err;
++}
++EXPORT_SYMBOL(max96717_sdev_unpair);
++
++/* ===== Pipe Configuration ===== */
++
++/*
++ * __max96717_set_pipe - Configure a single pipe's DT/VC mapping
++ *
++ * In Tunnel Mode, per-pipe DT/VC filtering is bypassed on the serializer。
++ * However, we still write the registers for d4xx framework compatibility.
++ *
++ */
++static int __max96717_set_pipe(struct device *dev, int pipe_id, u8 data_type1,
++			       u8 data_type2, u32 vc_id)
++{
++	int err = 0;
++	u8 bpp = 0x30;
++	struct max96717 *priv = dev_get_drvdata(dev);
++
++	if (priv->pixel_mode) {
++		struct reg_pair pixel_pipe_control[] = {
++			{MAX96717_FRONTTOP16_ADDR, 0x5E},
++			{MAX96717_FRONTTOP17_ADDR, 0x52},
++			{MAX96717_FRONTTOP5_ADDR, 0x01},
++		};
++
++		pixel_pipe_control[0].val = 0x40 | data_type1;
++		pixel_pipe_control[1].val = data_type2 ? (0x40 | data_type2) : 0x00;
++		pixel_pipe_control[2].val = 1 << vc_id;
++
++		return max96717_set_registers(dev, pixel_pipe_control,
++					     ARRAY_SIZE(pixel_pipe_control));
++	} else {
++		struct reg_pair map_pipe_control[] = {
++			/* Pipe X DT addr + 0x2*pipe_id */
++			{0x0314, 0x5E},  /* data_type1 */
++			{0x0315, 0x52},  /* data_type2 */
++			{0x0309, 0x01},  /* VC select */
++			{0x030A, 0x00},
++			{0x031C, 0x30},  /* BPP */
++			{0x0102, 0x0E},  /* LIM_HEART: Disabled */
++		};
++
++		if (data_type1 == GMSL_CSI_DT_RGB_888)
++			bpp = 0x18;
++
++		map_pipe_control[0].addr += 0x2 * pipe_id;
++		map_pipe_control[1].addr += 0x2 * pipe_id;
++		map_pipe_control[2].addr += 0x2 * pipe_id;
++		map_pipe_control[3].addr += 0x2 * pipe_id;
++		map_pipe_control[4].addr += 0x1 * pipe_id;
++		map_pipe_control[5].addr += 0x8 * pipe_id;
++
++		map_pipe_control[0].val = 0x40 | data_type1;
++		map_pipe_control[1].val = 0x40 | data_type2;
++		if (pipe_id == 0)
++			map_pipe_control[1].val |= 0x80;
++		map_pipe_control[2].val = 1 << vc_id;
++		map_pipe_control[3].val = 0x00;
++		map_pipe_control[4].val = bpp;
++		map_pipe_control[5].val = 0x0E;
++
++		err = max96717_set_registers(dev, map_pipe_control,
++					     ARRAY_SIZE(map_pipe_control));
++	}
++
++	return err;
++}
++
++/*
++ * max96717_init_settings - Initialize default pipe/streaming settings
++ *
++ * In Tunnel Mode, per-pipe DT config is not functionally needed
++ * but we configure pipes for d4xx compatibility.
++ * Default: 4 pipes with YUV422_8 + EMBED, VC0-3.
++ */
++int max96717_init_settings(struct device *dev)
++{
++	int err = 0;
++	int i;
++	struct max96717 *priv = dev_get_drvdata(dev);
++
++	struct reg_pair map_init[] = {
++		/* 
++		 * PIPE_EN soft reset first, then enable tunnel mode.
++		 * Note: FRONTTOP0 is bypassed in tunnel mode (per UG) —
++		 * CSI-2 input goes directly into the tunnel, no port config needed.
++		 */
++		{MAX96717_PIPE_EN_ADDR, MAX96717_SOFT_RESET},
++		{MAX96717_EXT11_ADDR, MAX96717_TUN_MODE_EN},
++		{MAX96717_PIPE_EN_ADDR, MAX96717_PIPE_EN_ALL},
++	};
++	struct reg_pair pixel_init[] = {
++		{MAX96717_PIPE_EN_ADDR, MAX96717_SOFT_RESET},
++		{MAX96717_EXT11_ADDR, MAX96717_TUN_MODE_DIS},
++		{MAX96717_FRONTTOP0_ADDR, MAX96717_FRONTTOP0_PIXEL_PORT_B},
++		{MAX96717_FRONTTOP9_ADDR, MAX96717_FRONTTOP9_START_VIDEO},
++		{MAX96717_VIDEO_TX0_ADDR, MAX96717_VIDEO_TX0_BPP_MANUAL},
++		{MAX96717_VIDEO_TX1_ADDR, MAX96717_VIDEO_TX1_BPP16},
++		{MAX96717_VIDEO_TX2_ADDR, MAX96717_VIDEO_TX2_DRIFT_DIS},
++		{MAX96717_PIPE_EN_ADDR, MAX96717_PIPE_EN_ALL},
++	};
++	/*
++	 * Release MFP8 (GPIO8) before any other config so the serializer
++	 * stops driving the camera-side M2_I2C bus shared with the BMI088
++	 * IMU. Confirmed on HW: tri-stating GPIO8 restores IMU I2C access.
++	 */
++	struct reg_pair gpio_release[] = {
++		{MAX96717_GPIO8_A_ADDR, MAX96717_GPIO_A_HIGH_Z},
++		{MAX96717_GPIO8_B_ADDR, MAX96717_GPIO_B_NO_PULL},
++	};
++
++	mutex_lock(&priv->lock);
++
++	/*
++	 * After CTRL0 + I2C translation writes in
++	 * setup_control, the MAX96717 needs settling time before
++	 * accepting writes to PIPE_EN (0x02) and FRONTTOP registers.
++	 */
++	usleep_range(5000, 6000);
++
++	/*
++	 * Tri-state MFP8 (GPIO8) first to release the camera-side M2_I2C
++	 * bus shared with the BMI088 IMU before configuring the rest of
++	 * the SER.
++	 */
++	err = max96717_set_registers(dev, gpio_release,
++				    ARRAY_SIZE(gpio_release));
++	if (err)
++		dev_warn(dev, "%s: failed to release MFP8 (IMU M2_I2C bus)\n",
++			 __func__);
++
++	if (priv->pixel_mode) {
++		err = max96717_set_registers(dev, pixel_init,
++					 ARRAY_SIZE(pixel_init));
++		err |= __max96717_set_pipe(dev, 0, GMSL_CSI_DT_YUV422_8,
++				   0, 0);
++	} else {
++		err = max96717_set_registers(dev, map_init, ARRAY_SIZE(map_init));
++
++		for (i = 0; i < MAX96717_MAX_PIPES; i++)
++			err |= __max96717_set_pipe(dev, i, GMSL_CSI_DT_YUV422_8,
++					   GMSL_CSI_DT_EMBED, i);
++	}
++
++	mutex_unlock(&priv->lock);
++
++	return err;
++}
++EXPORT_SYMBOL(max96717_init_settings);
++
++int max96717_set_pipe(struct device *dev, int pipe_id,
++		      u8 data_type1, u8 data_type2, u32 vc_id)
++{
++	struct max96717 *priv = dev_get_drvdata(dev);
++	int err = 0;
++
++	if (pipe_id > (MAX96717_MAX_PIPES - 1)) {
++		dev_info(dev, "%s: input pipe_id: %d exceeds max96717 max pipes\n",
++			 __func__, pipe_id);
++		return -EINVAL;
++	}
++
++	dev_dbg(dev, "%s pipe_id %d, data_type1 %u, data_type2 %u, vc_id %u\n",
++		__func__, pipe_id, data_type1, data_type2, vc_id);
++
++	mutex_lock(&priv->lock);
++
++	err = __max96717_set_pipe(dev, pipe_id, data_type1, data_type2, vc_id);
++
++	mutex_unlock(&priv->lock);
++
++	return err;
++}
++EXPORT_SYMBOL(max96717_set_pipe);
++
++/*
++ * max96717_retrigger_tx - Toggle SER TX to restore tunnel detection after
++ * a DES ONESHOT.  DES ONESHOT resets the data path; the SER must cycle
++ * its TX enable for the DES to re-acquire the tunnel stream.
++ */
++void max96717_retrigger_tx(struct device *dev)
++{
++	max96717_write_reg(dev, MAX96717_PIPE_EN_ADDR, MAX96717_SOFT_RESET);
++	msleep(30);
++	max96717_write_reg(dev, MAX96717_PIPE_EN_ADDR, MAX96717_PIPE_EN_ALL);
++}
++EXPORT_SYMBOL(max96717_retrigger_tx);
++
++/* ===== Probe / Remove ===== */
++
++static struct regmap_config max96717_regmap_config = {
++	.reg_bits = 16,
++	.val_bits = 8,
++	.cache_type = REGCACHE_RBTREE,
++};
++
++static int max96717_probe(struct i2c_client *client,
++			   const struct i2c_device_id *id)
++{
++	struct max96717 *priv;
++	int err = 0;
++	struct device_node *node = client->dev.of_node;
++
++	dev_info(&client->dev, "[MAX96717]: probing GMSL2 Serializer (Tunnel Mode)\n");
++
++	priv = devm_kzalloc(&client->dev, sizeof(*priv), GFP_KERNEL);
++	if (!priv)
++		return -ENOMEM;
++
++	priv->i2c_client = client;
++	priv->regmap = devm_regmap_init_i2c(priv->i2c_client,
++					     &max96717_regmap_config);
++	if (IS_ERR(priv->regmap)) {
++		dev_err(&client->dev,
++			"regmap init failed: %ld\n", PTR_ERR(priv->regmap));
++		return -ENODEV;
++	}
++
++	mutex_init(&priv->lock);
++	priv->pixel_mode = of_property_read_bool(node, "adi,pixel-mode");
++
++	if (of_get_property(node, "is-prim-ser", NULL)) {
++		if (prim_priv__) {
++			dev_err(&client->dev,
++				"prim-ser already exists\n");
++			return -EEXIST;
++		}
++
++		err = of_property_read_u32(node, "reg", &priv->def_addr);
++		if (err < 0) {
++			dev_err(&client->dev, "reg not found\n");
++			return -EINVAL;
++		}
++
++		prim_priv__ = priv;
++	}
++
++	dev_set_drvdata(&client->dev, priv);
++
++	dev_info(&client->dev, "%s: success\n", __func__);
++
++	return err;
++}
++
++static int max96717_remove(struct i2c_client *client)
++{
++	struct max96717 *priv;
++
++	if (client != NULL) {
++		priv = dev_get_drvdata(&client->dev);
++		mutex_destroy(&priv->lock);
++		i2c_unregister_device(client);
++		client = NULL;
++	}
++
++	return 0;
++}
++
++static const struct i2c_device_id max96717_id[] = {
++	{ "max96717", 0 },
++	{ },
++};
++
++static const struct of_device_id max96717_of_match[] = {
++	{ .compatible = "adi,max96717", },
++	{ .compatible = "maxim,max96717", },
++	{ },
++};
++MODULE_DEVICE_TABLE(of, max96717_of_match);
++MODULE_DEVICE_TABLE(i2c, max96717_id);
++
++static struct i2c_driver max96717_i2c_driver = {
++	.driver = {
++		.name = "max96717",
++		.owner = THIS_MODULE,
++		.of_match_table = of_match_ptr(max96717_of_match),
++	},
++	.probe = max96717_probe,
++	.remove = max96717_remove,
++	.id_table = max96717_id,
++};
++
++static int __init max96717_init(void)
++{
++	return i2c_add_driver(&max96717_i2c_driver);
++}
++
++static void __exit max96717_exit(void)
++{
++	i2c_del_driver(&max96717_i2c_driver);
++}
++
++module_init(max96717_init);
++module_exit(max96717_exit);
++
++MODULE_DESCRIPTION("GMSL2 Serializer driver max96717 (Tunnel Mode)");
++MODULE_AUTHOR("RealSense AI");
++MODULE_LICENSE("GPL v2");
+diff --git a/drivers/media/i2c/max96724.c b/drivers/media/i2c/max96724.c
+new file mode 100644
+index 0000000..22bfb47
+--- /dev/null
++++ b/drivers/media/i2c/max96724.c
+@@ -0,0 +1,1916 @@
++/*
++ * max96724.c - MAX96724 GMSL2 Quad Deserializer driver (Tunnel Mode)
++ *
++ * Copyright (c) 2026, RealSense, Inc.  All rights reserved.
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms and conditions of the GNU General Public License,
++ * version 2, as published by the Free Software Foundation.
++ *
++ * This program is distributed in the hope it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
++ * more details.
++ *
++ * You should have received a copy of the GNU General Public License
++ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
++ */
++
++
++#include <linux/gpio.h>
++#include <linux/types.h>
++#include <linux/module.h>
++#include <linux/of.h>
++#include <linux/of_device.h>
++#include <linux/of_gpio.h>
++#include <media/camera_common.h>
++#include <linux/module.h>
++#include <media/max96724.h>
++
++/* ================================================================
++ * Register Addresses
++ * ================================================================ */
++
++/* --- Device ID / Configuration --- */
++
++/* REG0: Device ID (read-only, returns 0xA2) */
++#define MAX96724_DEV_ID_ADDR		0x00
++
++/* ERRB master reset register */
++#define MAX96724_ERRB_MST_RST_ADDR	0x05
++
++/* 
++ *   GMSL Link/PHY Enable and Mode Select
++ *   bits[7:4]: PHY mode (0=GMSL1, 1=GMSL2) per link D/C/B/A
++ *   bits[3:0]: Link Enable per link D/C/B/A
++ */
++#define MAX96724_LINK_EN_ADDR		0x0006
++
++/* 
++ *   GMSL Link/PHY Rate Select (Links A&B)
++ *   bits[7:6]: Tx Rate Link B, bits[5:4]: Rx Rate Link B
++ *   bits[3:2]: Tx Rate Link A, bits[1:0]: Rx Rate Link A
++ *   Tx: 00=187.5Mbps, Rx: 01=3Gbps, 10=6Gbps
++ */
++#define MAX96724_LINK_RATE_AB_ADDR	0x0010
++
++/* GMSL Link/PHY Rate Select (Links C&D) */
++#define MAX96724_LINK_RATE_CD_ADDR	0x0011
++
++/* Link A lock status (bit[3]=LOCK) */
++#define MAX96724_LINK_A_LOCK_ADDR	0x001A
++
++/* 
++ *   GMSL Link Reset
++ *   bits[7:4]: Link reset D/C/B/A, bits[3:0]: One-shot reset D/C/B/A
++ */
++#define MAX96724_ONESHOT_ADDR		0x0018
++
++/* Soft Reset (write 0x40, wait 5ms) */
++#define MAX96724_REG13_ADDR		0x000D
++
++/* 
++ *   Error Channel Power Up registers (required for 6Gbps)
++ *   Write 0x75 immediately after power-up for robust 6Gbps operation
++ */
++#define MAX96724_ERRCH_A_ADDR		0x1449
++#define MAX96724_ERRCH_B_ADDR		0x1549
++#define MAX96724_ERRCH_C_ADDR		0x1649
++#define MAX96724_ERRCH_D_ADDR		0x1749
++#define MAX96724_ERRCH_FORCE_ON		0x75
++
++/* --- I2C Control Channel / Errata --- */
++
++/* 
++ *   Tunnel Mode SRAM LCRC error suppression
++ *   Set 0x458[7:4] = 0x0 to suppress spurious ERRB in tunnel mode
++ */
++#define MAX96724_SRAM_LCRC_ERR_ADDR	0x0458
++
++/* --- Video Pipe Selection --- */
++
++/*
++ *   bits[3:0] = Pipe 0 source (0x0=SIOA)
++ *   bits[7:4] = Pipe 1 source (0x1=SIOB)
++ */
++#define MAX96724_PIPE_SEL0_ADDR		0xF0
++
++/*
++ *   bits[3:0] = Pipe 2 source (0x2=SIOC)
++ *   bits[7:4] = Pipe 3 source (0x3=SIOD)
++ */
++#define MAX96724_PIPE_SEL1_ADDR		0xF1
++
++#define MAX96724_PIPE_EN_ADDR		0xF4
++
++/* --- Pipe Receiver / Tunnel Mode --- */
++
++/*
++ *   bit[5]=1: Tunnel Mode, bits[1:0]=11: 4-lane MIPI out
++ *   Stride: 0x12 per pipe (P0=0x100, P1=0x112, P2=0x124, P3=0x136)
++ */
++#define MAX96724_VID_RX0_P0_ADDR	0x100
++#define MAX96724_VID_RX6_P0_ADDR	0x106
++#define MAX96724_VID_RX_STRIDE		0x12
++
++#define MAX96724_VID_RX1_P0_ADDR	0x101
++
++/* --- CSI-2 Output (BACKTOP) --- */
++
++/* BACKTOP: CSI-2 output port enable
++ *   0x040B bit[1]=CSIB_EN, bit[0]=CSIA_EN
++ */
++#define MAX96724_BACKTOP_EN_ADDR	0x040B
++
++/* --- MIPI DPLL (Data Rate) --- */
++
++/* 
++ *   MIPI PHY DPLL Freq registers
++ *   bits[4:0] = frequency in multiples of 100MHz
++ *   bit[5]    = DPLL enable (must be set for DPLL to lock)
++ *   E.g., 0x27 = 700MHz + enable = 700Mbps/lane D-PHY
++ *   E.g., 0x2F = 1500MHz + enable = 1.5Gbps/lane
++ */
++#define MAX96724_DPLL_FREQ0_ADDR	0x0415
++#define MAX96724_DPLL_FREQ1_ADDR	0x0418
++#define MAX96724_DPLL_FREQ2_ADDR	0x041B
++#define MAX96724_DPLL_FREQ3_ADDR	0x041E
++
++/* 
++ *   DPLL PHY reset control
++ *   0x1D00 = DPLL CSI PHY1 control
++ *   Write 0xF4 to disable/reset, 0xF5 to enable
++ */
++#define MAX96724_DPLL_CSI2_ADDR		0x1D00
++#define MAX96724_DPLL_DISABLE		0xF4
++#define MAX96724_DPLL_ENABLE		0xF5
++
++/* --- CSI-2 Output PHY Configuration --- */
++
++/* 
++ * CSI output mode/config register.
++ * Mode bits (set exactly one of [4:0]):
++ *   bit[0]=0x01: 4x2 mode
++ *   bit[2]=0x04: 2x4 mode        (Ctrl 1 = master for Port A, Ctrl 2 = Port B)
++ *   bit[3]=0x08: 1x4a + 2x2 mode (Ctrl 1 = master for Port A)
++ *   bit[4]=0x10: 1x4b + 2x2 mode (Ctrl 2 = master for Port B)
++ *
++ * Clock-force bits:
++ *   bit[7]=0x80: force ALL MIPI clocks running (continuous HS clock)
++ *   bit[6]=0x40: force PHY 3 MIPI clock running
++ *   bit[5]=0x20: force PHY 0 MIPI clock running
++ */
++#define MAX96724_CSI_OUT_CFG_ADDR	0x08A0
++
++/* 
++ *   MIPI PHY Enable register
++ *   bits[7:4]: Enable PHY 3/2/1/0 (1=enabled, 0=standby)
++ */
++#define MAX96724_CSI_PHY_EN_ADDR	0x08A2
++
++/* MIPI PHY 0 and 1 Lane Mapping */
++#define MAX96724_CSI_LANE_MAP1_ADDR	0x08A3
++
++/* MIPI PHY 2 and 3 Lane Mapping */
++#define MAX96724_CSI_LANE_MAP2_ADDR	0x08A4
++
++/* 
++ *   MIPI output lane polarity (P/N swap) registers.
++ *   0x08A5 = PHY0/PHY1 lane polarity, 0x08A6 = PHY2/PHY3 lane polarity.
++ *   The FangZhu FG24-4CH PCB swaps the differential P/N pairs on the
++ *   MAX96724 CSI output, so the deserializer must invert lane polarity
++ */
++#define MAX96724_CSI_PHY_POL0_ADDR	0x08A5
++#define MAX96724_CSI_PHY_POL1_ADDR	0x08A6
++#define MAX96724_CSI_PHY_POL_SWAP	0x3F
++
++/* Pipe-to-controller mapping */
++#define MAX96724_MIPI_CTRL_SEL_ADDR	0x08CA
++
++/* Method-1 controller mapping */
++#define MAX96724_MIPI_CTRL_SEL_PIXEL	0xE4
++
++/* --- Lane Control per pipe (stride 0x40) --- */
++
++/*
++ *   0xC0 = 4-lane enabled
++ */
++#define MAX96724_LANE_CTRL0_ADDR	0x090A
++#define MAX96724_LANE_CTRL1_ADDR	0x094A
++#define MAX96724_LANE_CTRL2_ADDR	0x098A
++#define MAX96724_LANE_CTRL3_ADDR	0x09CA
++
++/* --- Pipe Mapping Registers (stride 0x40 per pipe) --- */
++
++/*
++ *   Base addresses for Pipe X (Pipe 0)
++ *   Stride: 0x40 per pipe
++ */
++#define MAX96724_TX11_PIPE_X_EN_ADDR		0x090B
++#define MAX96724_TX45_PIPE_X_DST_CTRL_ADDR	0x092D
++#define MAX96724_PIPE_X_SRC_0_MAP_ADDR		0x090D
++#define MAX96724_PIPE_X_DST_0_MAP_ADDR		0x090E
++#define MAX96724_PIPE_X_SRC_1_MAP_ADDR		0x090F
++#define MAX96724_PIPE_X_DST_1_MAP_ADDR		0x0910
++#define MAX96724_PIPE_X_SRC_2_MAP_ADDR		0x0911
++#define MAX96724_PIPE_X_DST_2_MAP_ADDR		0x0912
++#define MAX96724_PIPE_X_SRC_3_MAP_ADDR		0x0913
++#define MAX96724_PIPE_X_DST_3_MAP_ADDR		0x0914
++
++/* --- Stream Select --- */
++
++/*
++ *   Pipe X=0x0933, stride 0x40 per pipe
++ */
++#define MAX96724_PIPE_X_ST_SEL_ADDR	0x0933
++
++/* --- Extended Pipe Mapping (DST_CTRL2-4 / TX49) --- */
++
++/* 
++ *   Extended DST_CTRL for additional mapping pairs
++ *   All to PHY1 (0x55), same as TX45
++ *   Stride: 0x40 per pipe (base = Pipe X)
++ */
++#define MAX96724_TX46_PIPE_X_ADDR	0x092E
++#define MAX96724_TX47_PIPE_X_ADDR	0x092F
++#define MAX96724_TX48_PIPE_X_ADDR	0x0930
++
++/* 
++ *   MIPI_TX49 synchronous concatenation control
++ *   Set to 0x00 (no concat) for single-camera tunnel mode.
++ *   For 4W concat use 0x87.
++ *   Stride: 0x40 per pipe (base = Pipe X)
++ */
++#define MAX96724_TX49_PIPE_X_ADDR	0x0931
++#define MAX96724_TX49_CONCAT_4W		0x87
++
++/* --- Tunnel Mode per-pipe --- */
++
++/*
++ *   bit[0] = TUN_EN, Default=0x08, write 0x01 to enable
++ */
++#define MAX96724_PIPE0_TUN_EN_ADDR	0x0936
++#define MAX96724_PIPE1_TUN_EN_ADDR	0x0976
++#define MAX96724_PIPE2_TUN_EN_ADDR	0x09B6
++#define MAX96724_PIPE3_TUN_EN_ADDR	0x09F6
++
++/*
++ *   bit[6]: disable auto-tunnel-detect
++ *   bits[5:4]: TUN_DEST (00=PHY0, 01=PHY1, 10=PHY2, 11=PHY3)
++ */
++#define MAX96724_PIPE0_TUN_DEST_ADDR	0x0939
++#define MAX96724_PIPE1_TUN_DEST_ADDR	0x0979
++#define MAX96724_PIPE2_TUN_DEST_ADDR	0x09B9
++#define MAX96724_PIPE3_TUN_DEST_ADDR	0x09F9
++
++/* ================================================================
++ * Register Values
++ * ================================================================ */
++
++/* Soft reset value (write to 0x000D) */
++#define MAX96724_SOFT_RESET		0x40
++
++/* 
++ * Link Rate values for 0x0010/0x0011
++ *   Per link pair: bits[1:0]=RxA, [3:2]=TxA, [5:4]=RxB, [7:6]=TxB
++ *   Tx = 00 (187.5Mbps), Rx = 01 (3Gbps) or 10 (6Gbps)
++ *   3Gbps: Tx=00, Rx=01 → per pair 0x01, both pairs = 0x01 in low nibble
++ */
++#define MAX96724_LINK_RATE_3GBPS	0x01  /* Rx=3G, Tx=187.5M for one link pair */
++#define MAX96724_LINK_RATE_6GBPS	0x02  /* Rx=6G, Tx=187.5M for one link pair */
++
++/* 
++ * 0x0006: Link enable / mode values
++ *   bits[7:4] = PHY mode (1=GMSL2 per link)
++ *   bits[3:0] = Link enable per link
++ *   0xF1 = all GMSL2-mode, only Link A enabled
++ *   0xFF = all GMSL2-mode, all 4 links enabled
++ */
++#define MAX96724_LINK_EN_SIOA		0xF1  /* GMSL2 all, enable Link A only */
++#define MAX96724_LINK_EN_ALL		0xFF  /* GMSL2 all, enable all links */
++
++/* BACKTOP_EN (0x040B): CSI output port enable */
++#define MAX96724_BACKTOP_CSIB_EN	0x02
++#define MAX96724_BACKTOP_CSIA_EN	0x01
++
++/* 
++ *   VIDEO_RX0: DIS_PKT_DET=1 (bit0) required for tunnel mode.
++ *   Without it, DES rejects tunnel data as invalid GMSL2 video packets.
++ *   SEQ_MISS_EN=1 (bit4), LINE_CRC_EN=1 (bit1).  XML value: 0x33.
++ */
++#define MAX96724_VID_RX0_CFG_VAL	0x33
++#define MAX96724_VID_RX6_CFG_VAL	0x0A
++
++/* Pixel-mode receiver settings */
++#define MAX96724_VID_RX0_PIXEL_VAL	0x32
++#define MAX96724_VID_RX6_PIXEL_VAL	0x12
++
++/* 
++ *   Tunnel mode enable (MIPI_TX54, 0x0936):
++ *   bit[0] = TUN_EN = 1
++ *   Verified value: 0x01
++ */
++#define MAX96724_TUN_EN			0x01
++
++/* Default/reset state when tunnel is disabled */
++#define MAX96724_TUN_DISABLED		0x08
++
++/* 
++ *   Tunnel controller destination (MIPI_TX57, 0x0939):
++ *   bits[5:4]: TUN_DEST (00=PHY0, 01=PHY1, 10=PHY2, 11=PHY3)
++ *   Verified value: 0x10 = PHY1 destination with auto-detect enabled
++ */
++#define MAX96724_TUN_DEST_CTRL0		0x00  /* Auto-detect + PHY0 */
++#define MAX96724_TUN_DEST_CTRL1		0x10  /* Auto-detect + PHY1 (Port A master) */
++
++#define MAX96724_CSI_MODE_2X4_VAL	0x04  /* bit[2] = clean 2x4: Port A = PHY0+PHY1 */
++
++/* 
++ *   0x84 = 2x4 mode (bit2) + bit[7] "force ALL MIPI clocks running".  The bit[7]
++ *   clock-force is the key part: it keeps the D-PHY clock lane in continuous HS
++ *   mode so the Orin NVCSI/CIL can lock.
++ */
++#define MAX96724_CSI_OUT_EN_VAL		0x84  /* 2x4 + bit[7] force all MIPI clocks running */
++
++#define MAX96724_CSI_PHY_EN_ALL		0xF0
++#define MAX96724_CSI_PHY_EN_01		0x30  /* PHY0+PHY1 only (Port A) */
++#define MAX96724_CSI_PHY_EN_23		0xC0  /* PHY2+PHY3 only (Port B) */
++
++/* Lane mapping default */
++#define MAX96724_CSI_LANE_MAP_DEFAULT	0xE4
++
++/* Lane control: 4-lane enabled */
++#define MAX96724_LANE_CTRL_4LANE	0xC0
++
++/*
++ *   Lane control: 2-lane enabled.
++ *   bits[7:6] = (num_lanes - 1): 01=2-lane(0x40), 11=4-lane(0xC0)
++ *   Ref: gmsl_ser_des_guide §8.2, E2E_enable_guide §5.6.4 
++ */
++#define MAX96724_LANE_CTRL_2LANE	0x40
++
++/* 
++ *   CSI PHY enable: all PHYs powered for DPLL lock.
++ */
++#define MAX96724_CSI_PHY_EN_2LANE	0xF0
++
++/* 
++ *   DPLL for Controller 0 (drives PHY0, 2 lanes).
++ *   bits[4:0] = data-rate / 100 MHz.  700 Mbps / 100 = 7 = 0x07.
++ *   bit[5]    = DPLL enable = 1.
++ *   Result: 0x27 = 700 Mbps/lane D-PHY.
++ */
++#define MAX96724_DPLL_700MBPS_CTRL0	0x27
++
++/* 
++ *   CSI-output DPLL data rate = 1300 Mbps.
++ *   bits[4:0] = data-rate / 100 MHz -> 1300/100 = 13 = 0x0D. bit[5] = DPLL en.
++ */
++#define MAX96724_DPLL_1300MBPS		0x2D
++
++/* One-shot reset: all links */
++#define MAX96724_ONESHOT_ALL		0x0F
++
++/* 
++ *   Pipe source selection values
++ *   Encoding per pipe nibble in tunnel mode:
++ *   0x22 routes all pipes from Link A in tunnel mode.
++ */
++#define MAX96724_PIPE_SEL0_SINGLE	0x22  /* All pipes from Link A */
++#define MAX96724_PIPE_SEL1_SINGLE	0x22  /* All pipes from Link A */
++#define MAX96724_PIPE_SEL0_PIXEL	0x62  /* pixel-mode reference */
++#define MAX96724_PIPE_SEL1_PIXEL	0xEA  /* pixel-mode reference */
++#define MAX96724_PIPE_SEL0_DUAL		0x40  /* Pipe 0 ← A/X, Pipe 1 ← B/X */
++#define MAX96724_PIPE_SEL0_QUAD_LO	0x40  /* Pipe 0 ← A/X, Pipe 1 ← B/X */
++#define MAX96724_PIPE_SEL1_QUAD_HI	0xC8  /* Pipe 2 ← C/X, Pipe 3 ← D/X */
++
++/* Pipe enable values */
++#define MAX96724_PIPE_EN_1		0x01
++#define MAX96724_PIPE_EN_2		0x03
++#define MAX96724_PIPE_EN_4		0x0F
++
++/* Lane control map: bits[7:6] = (num_lanes - 1) */
++#define MAX96724_LANE_CTRL_MAP(num_lanes) \
++	((((num_lanes) - 1) << 6) & 0xC0)
++
++/* Reset all */
++#define MAX96724_RESET_ALL		0x80
++
++/* Stream ID invalid */
++#define MAX96724_INVAL_ST_ID		0xFF
++#define MAX96724_RESET_ST_ID		0x00
++#define MAX96724_ST_ID_SEL_INVALID	0xF
++
++/* Controller mapping: all mappings → Controller 0 */
++#define MAX96724_ALL_MAP_CTRL0		0x00
++/* Controller mapping: all mappings → Controller 1 */
++#define MAX96724_ALL_MAP_CTRL1		0x55
++
++/* Three mappings to controller 1 */
++#define MAX96724_MAP3_CTRL1		0x15
++
++/* ================================================================
++ * Data Structures
++ * ================================================================ */
++
++/* Quad GMSL: up to 4 sources */
++#define MAX96724_MAX_SOURCES		4
++#define MAX96724_MAX_PIPES		4
++
++#define MAX96724_PIPE_X			0
++#define MAX96724_PIPE_Y			1
++#define MAX96724_PIPE_Z			2
++#define MAX96724_PIPE_U			3
++#define MAX96724_PIPE_INVALID		0xF
++
++#define MAX96724_CSI_CTRL_0		0
++#define MAX96724_CSI_CTRL_1		1
++#define MAX96724_CSI_CTRL_2		2
++#define MAX96724_CSI_CTRL_3		3
++
++#define MAX96724_CSI_MODE_2X4		0x08  /* enum tag for the 4-lane Port A (Ctrl1) path */
++
++/* Lane map presets */
++#define MAX96724_LANE_MAP1_2X4		0xE4  /* SC20190112 subset: PHY0 data + PHY1 clock */
++#define MAX96724_LANE_MAP2_2X4		0x44  /* keep unused PHY2/3 straight in 0x08 mode */
++
++struct max96724_source_ctx {
++	struct gmsl_link_ctx *g_ctx;
++	bool st_enabled;
++};
++
++struct pipe_ctx {
++	u32 id;
++	u32 dt_type;
++	u32 dst_csi_ctrl;
++	u32 st_count;
++	u32 st_id_sel;
++};
++
++struct max96724 {
++	struct i2c_client *i2c_client;
++	struct regmap *regmap;
++	u32 num_src;
++	u32 max_src;
++	u32 num_src_found;
++	u32 src_link;
++	bool splitter_enabled;
++	struct max96724_source_ctx sources[MAX96724_MAX_SOURCES];
++	struct mutex lock;
++	u32 sdev_ref;
++	bool lane_setup;
++	bool link_setup;
++	struct pipe_ctx pipe[MAX96724_MAX_PIPES];
++	u8 csi_mode;
++	u8 lane_mp1;
++	u8 lane_mp2;
++	int reset_gpio;
++	int pw_ref;
++	struct regulator *vdd_cam_1v2;
++	u8 link_speed;  /* DT-configurable: 3 or 6 Gbps */
++	bool pixel_mode;
++	bool poc_enabled; /* FG24-4CH board POC/IO enable applied once */
++};
++
++struct reg_pair {
++	u16 addr;
++	u8 val;
++};
++
++/* ================================================================
++ * Low-level I2C
++ * ================================================================ */
++
++static int max96724_write_reg(struct device *dev, u16 addr, u8 val)
++{
++	struct max96724 *priv;
++	int err;
++
++	priv = dev_get_drvdata(dev);
++
++	err = regmap_write(priv->regmap, addr, val);
++	if (err)
++		dev_err(dev, "%s:i2c write failed, 0x%x = %x\n",
++			__func__, addr, val);
++
++	/* delay before next i2c command as required for SERDES link */
++	usleep_range(100, 110);
++
++	return err;
++}
++
++static int max96724_set_registers(struct device *dev, struct reg_pair *map,
++				  u32 count)
++{
++	int err = 0;
++	u32 j;
++
++	for (j = 0; j < count; j++) {
++		err = max96724_write_reg(dev, map[j].addr, map[j].val);
++		if (err)
++			break;
++	}
++
++	return err;
++}
++
++/* ================================================================
++ * Internal Helpers
++ * ================================================================ */
++
++static int max96724_get_sdev_idx(struct device *dev,
++				 struct device *s_dev, unsigned int *idx)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++	unsigned int i;
++	int err = 0;
++
++	mutex_lock(&priv->lock);
++	for (i = 0; i < priv->max_src; i++) {
++		if (priv->sources[i].g_ctx->s_dev == s_dev)
++			break;
++	}
++	if (i == priv->max_src) {
++		dev_err(dev, "no sdev found\n");
++		err = -EINVAL;
++		goto ret;
++	}
++
++	if (idx)
++		*idx = i;
++
++ret:
++	mutex_unlock(&priv->lock);
++	return err;
++}
++
++static void max96724_pipes_reset(struct max96724 *priv)
++{
++	/*
++	 * Default pipe configuration for D5xx/SC1.2:
++	 * In tunnel mode, DT types are not used for filtering
++	 * but we initialize them for d4xx framework compatibility.
++	 */
++	struct pipe_ctx pipe_defaults[] = {
++		{MAX96724_PIPE_X, GMSL_CSI_DT_RAW_12,
++			MAX96724_CSI_CTRL_1, 0, MAX96724_INVAL_ST_ID},
++		{MAX96724_PIPE_Y, GMSL_CSI_DT_RAW_12,
++			MAX96724_CSI_CTRL_1, 0, MAX96724_INVAL_ST_ID},
++		{MAX96724_PIPE_Z, GMSL_CSI_DT_EMBED,
++			MAX96724_CSI_CTRL_1, 0, MAX96724_INVAL_ST_ID},
++		{MAX96724_PIPE_U, GMSL_CSI_DT_EMBED,
++			MAX96724_CSI_CTRL_1, 0, MAX96724_INVAL_ST_ID}
++	};
++
++	memcpy(priv->pipe, pipe_defaults, sizeof(pipe_defaults));
++}
++
++static void max96724_reset_ctx(struct max96724 *priv)
++{
++	unsigned int i;
++
++	priv->link_setup = false;
++	priv->lane_setup = false;
++	priv->num_src_found = 0;
++	priv->src_link = 0;
++	priv->splitter_enabled = false;
++	max96724_pipes_reset(priv);
++	for (i = 0; i < priv->num_src; i++)
++		priv->sources[i].st_enabled = false;
++}
++
++static void max96724_apply_porta_subset(struct device *dev,
++						 struct max96724 *priv)
++{
++	/*
++	 * [XML-verified 4-lane] D-PHY Port A output, 4 data lanes.
++	 * [FG24-4CH working-config verified] 0x04 = 2x4 mode so Port A
++	 * maps to PHY0+PHY1 (the lanes the FG24 PCB wires to Orin).  Output is
++	 * not yet enabled here (bit7 = 0); setup_streaming() asserts 0x84 after
++	 * the full pipeline is configured.
++	 */
++	max96724_write_reg(dev, MAX96724_CSI_OUT_CFG_ADDR,
++			   MAX96724_CSI_MODE_2X4_VAL);
++	/*
++	 * [FG24-4CH working dump] Enable ALL four CSI PHYs (0x08A2=0xF0).
++	 * The working FangZhu config powers every PHY; the MAX96724 DPLL
++	 * needs all PHYs powered to lock reliably (single-PHY enable was
++	 * observed to never lock the output clock). Port A data still
++	 * leaves on PHY0/1 in 2x4 mode; PHY2/3 are just powered.
++	 */
++	max96724_write_reg(dev, MAX96724_CSI_PHY_EN_ADDR,
++			   MAX96724_CSI_PHY_EN_ALL);
++	max96724_write_reg(dev, MAX96724_CSI_LANE_MAP1_ADDR,
++			   priv->lane_mp1);
++	/*
++	 * [FG24-4CH working dump] LANE_MAP2 (PHY2/3) = 0xE4 straight mapping.
++	 * The working config writes 0x08A4=0xE4 (not the chip default 0x44).
++	 */
++	max96724_write_reg(dev, MAX96724_CSI_LANE_MAP2_ADDR,
++			   MAX96724_CSI_LANE_MAP_DEFAULT);
++	/*
++	 * [FG24-4CH board] Switch MIPI output lane polarity (P/N swap).
++	 * The FG24-4CH PCB inverts the differential pairs on the DES->Orin
++	 * output; without this the Orin CIL never locks the HS clock.
++	 * Per FangZhu MAX4CH_FG24_POC_Enable table: 0x08A5/0x08A6 = 0x3F.
++	 */
++	max96724_write_reg(dev, MAX96724_CSI_PHY_POL0_ADDR,
++			   MAX96724_CSI_PHY_POL_SWAP);
++	max96724_write_reg(dev, MAX96724_CSI_PHY_POL1_ADDR,
++			   MAX96724_CSI_PHY_POL_SWAP);
++	max96724_write_reg(dev, MAX96724_LANE_CTRL0_ADDR,
++			   MAX96724_LANE_CTRL_4LANE);
++	max96724_write_reg(dev, MAX96724_LANE_CTRL1_ADDR,
++			   MAX96724_LANE_CTRL_4LANE);
++	max96724_write_reg(dev, MAX96724_LANE_CTRL2_ADDR,
++			   MAX96724_LANE_CTRL_4LANE);
++	max96724_write_reg(dev, MAX96724_LANE_CTRL3_ADDR,
++			   MAX96724_LANE_CTRL_4LANE);
++}
++
++static inline bool max96724_is_pixel_mode(struct max96724 *priv)
++{
++	return priv->pixel_mode;
++}
++
++/* ================================================================
++ * Power Management
++ * ================================================================ */
++
++/* [FG24-4CH board] POC (Power-over-Coax) / IO enable sequence.
++ *   Per FangZhu MAX4CH_FG24_POC_Enable table. On the FG24-4CH board the
++ *   MFP8 line (0x0319 bit4) and the POC IO enable (0x0001 bit5) gate the
++ *   board-level output / POC path. Without these the DES PLL still locks
++ *   and shows internal activity, but no clock reaches the Orin connector.
++ */
++#define MAX96724_POC_IO_EN_ADDR		0x0001
++#define MAX96724_POC_IO_EN_VAL		0xE0  /* Enable POC IO (working dump: 0xE0) */
++#define MAX96724_POC_MFP8_ADDR		0x0319
++#define MAX96724_POC_MFP8_PRE		0x80  /* MFP8 pre-enable */
++#define MAX96724_POC_MFP8_HIGH		0x98  /* Enable POC MFP8 High (working dump: 0x98) */
++
++/*
++ * max96724_board_poc_enable - Apply FG24-4CH POC/IO enable (one-time).
++ * Mirrors the vendor MAX4CH_FG24_POC_Enable table.
++ */
++static void max96724_board_poc_enable(struct device *dev)
++{
++	max96724_write_reg(dev, MAX96724_POC_IO_EN_ADDR,
++			   MAX96724_POC_IO_EN_VAL);
++	max96724_write_reg(dev, MAX96724_POC_MFP8_ADDR,
++			   MAX96724_POC_MFP8_PRE);
++	msleep(100);
++	max96724_write_reg(dev, MAX96724_POC_MFP8_ADDR,
++			   MAX96724_POC_MFP8_HIGH);
++	msleep(500);
++}
++
++/*
++ * max96724_power_on - Power on the MAX96724 deserializer
++ */
++int max96724_power_on(struct device *dev)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++	int err = 0;
++
++	mutex_lock(&priv->lock);
++	if (priv->pw_ref == 0) {
++		usleep_range(1, 2);
++		if (gpio_is_valid(priv->reset_gpio))
++			gpio_set_value(priv->reset_gpio, 0);
++
++		usleep_range(30, 50);
++
++		if (priv->vdd_cam_1v2) {
++			err = regulator_enable(priv->vdd_cam_1v2);
++			if (unlikely(err))
++				goto ret;
++		}
++
++		usleep_range(30, 50);
++
++		/* exit reset mode: XCLR */
++		if (gpio_is_valid(priv->reset_gpio)) {
++			gpio_set_value(priv->reset_gpio, 0);
++			usleep_range(30, 50);
++			gpio_set_value(priv->reset_gpio, 1);
++			usleep_range(30, 50);
++		}
++
++		msleep(20);
++	}
++
++	priv->pw_ref++;
++
++ret:
++	mutex_unlock(&priv->lock);
++	return err;
++}
++EXPORT_SYMBOL(max96724_power_on);
++
++void max96724_power_off(struct device *dev)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++
++	mutex_lock(&priv->lock);
++	priv->pw_ref--;
++
++	if (priv->pw_ref < 0)
++		priv->pw_ref = 0;
++
++	if (priv->pw_ref == 0) {
++		usleep_range(1, 2);
++		if (gpio_is_valid(priv->reset_gpio))
++			gpio_set_value(priv->reset_gpio, 0);
++
++		if (priv->vdd_cam_1v2)
++			regulator_disable(priv->vdd_cam_1v2);
++	}
++
++	mutex_unlock(&priv->lock);
++}
++EXPORT_SYMBOL(max96724_power_off);
++
++/* ================================================================
++ * Link Setup
++ * ================================================================ */
++
++/*
++ * max96724_write_link - Configure a specific GMSL link
++ *
++ * [Users Guide, Link Initialization, p11-12]
++ *   Register 0x0006: Link Enable and Mode Select
++ *   Register 0x0010: Link Rate (Links A/B)
++ *
++ * The link speed is DT-configurable via the "gmsl-link-speed" property.
++ */
++static int max96724_write_link(struct device *dev, u32 link)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++	u8 link_rate_ab, link_rate_cd;
++	u8 link_en_val;
++
++	/*
++	 * [Aardvark-verified] Disable CSI output before link configuration
++	 * This prevents glitches on CSI bus during GMSL link setup.
++	 * Re-enabled in max96724_setup_streaming() after full pipeline config.
++	 */
++	max96724_write_reg(dev, MAX96724_BACKTOP_EN_ADDR, 0x00);
++
++	/* [UG Table 3 + Tech Overview REG26]
++	 * Register 0x0010:
++	 *   bits[7:2] = Link rate configuration
++	 *   bits[1:0] = I2C CC pass-through link select
++	 *     10 = route CC via SIOA (Link A)  [tech overview: 0x02 → SIOA]
++	 *     01 = route CC via SIOB (Link B)
++	 *
++	 * For 6G + Link A: bits[7:2]=001000, bits[1:0]=10 → 0x22
++	 * For 6G + Link B: bits[7:2]=001000, bits[1:0]=01 → 0x21
++	 * For 3G + Link A: bits[7:2]=000100, bits[1:0]=10 → 0x12 (? or 0x11)
++	 * For 3G + Link B: bits[7:2]=000100, bits[1:0]=01 → 0x11 (? or 0x09)
++	 */
++	if (priv->link_speed == 6) {
++		if (link == GMSL_SERDES_CSI_LINK_B) {
++			link_rate_ab = 0x21; /* 6G rate + CC via Link B */
++		} else {
++			link_rate_ab = 0x22; /* 6G rate + CC via Link A */
++		}
++		link_rate_cd = 0x22; /* C/D: 6G rate (CC routing don't care) */
++	} else {
++		if (link == GMSL_SERDES_CSI_LINK_B) {
++			link_rate_ab = 0x09; /* 3G rate + CC via Link B */
++		} else {
++			link_rate_ab = 0x12; /* 3G rate + CC via Link A */
++		}
++		link_rate_cd = 0x11; /* C/D: 3G rate */
++	}
++
++	if (link == GMSL_SERDES_CSI_LINK_A) {
++		link_en_val = MAX96724_LINK_EN_SIOA;
++	} else if (link == GMSL_SERDES_CSI_LINK_B) {
++		link_en_val = 0xF2; /* GMSL2 all, enable Link B only */
++	} else {
++		dev_err(dev, "%s: invalid gmsl link\n", __func__);
++		return -EINVAL;
++	}
++
++	/* [UG Table 3] Set link rates + CC routing */
++	max96724_write_reg(dev, MAX96724_LINK_RATE_AB_ADDR, link_rate_ab);
++	max96724_write_reg(dev, MAX96724_LINK_RATE_CD_ADDR, link_rate_cd);
++
++	/*
++	 * [XML-verified sequence] One-shot reset applies rate configuration
++	 * to the link state machine, then link enable starts training.
++	 * XML order: rate → ONE-SHOT → LINK_EN → wait 1000ms.
++	 * Note: Error channel registers omitted (not in reference XML).
++	 */
++	max96724_write_reg(dev, MAX96724_ONESHOT_ADDR,
++			   MAX96724_ONESHOT_ALL);
++	max96724_write_reg(dev, MAX96724_LINK_EN_ADDR, link_en_val);
++
++	/*
++	 * Wait for link lock.
++	 * [XML] Uses 1000ms regardless of link speed.
++	 * I2C pass-through CC requires fully trained link, not just PHY lock.
++	 */
++	msleep(1000);
++
++	/* Check link lock status on ALL ports for diagnostics */
++	{
++		unsigned int lock_a = 0, lock_b = 0, lock_c = 0, lock_d = 0;
++		unsigned int link_en = 0;
++		unsigned int reg10 = 0, reg11 = 0;
++
++		regmap_read(priv->regmap, 0x001A, &lock_a);
++		regmap_read(priv->regmap, 0x001B, &lock_b);
++		regmap_read(priv->regmap, 0x001C, &lock_c);
++		regmap_read(priv->regmap, 0x001D, &lock_d);
++		regmap_read(priv->regmap, MAX96724_LINK_EN_ADDR, &link_en);
++		regmap_read(priv->regmap, 0x0010, &reg10);
++		regmap_read(priv->regmap, 0x0011, &reg11);
++		dev_info(dev,
++			 "GMSL link status: EN=0x%02x A=0x%02x(%s) B=0x%02x(%s) C=0x%02x(%s) D=0x%02x(%s) REG10=0x%02x REG11=0x%02x\n",
++			 link_en,
++			 lock_a, (lock_a & 0x08) ? "LOCK" : "noLk",
++			 lock_b, (lock_b & 0x08) ? "LOCK" : "noLk",
++			 lock_c, (lock_c & 0x08) ? "LOCK" : "noLk",
++			 lock_d, (lock_d & 0x08) ? "LOCK" : "noLk",
++			 reg10, reg11);
++	}
++
++	return 0;
++}
++
++int max96724_setup_link(struct device *dev, struct device *s_dev)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++	int err = 0;
++	unsigned int i = 0;
++
++	err = max96724_get_sdev_idx(dev, s_dev, &i);
++	if (err)
++		return err;
++
++	/*
++	 * [FG24-4CH] Enable board POC / MFP8 output path BEFORE the GMSL
++	 * link is brought up.  The camera draws power over coax (PoC), so
++	 * without this the remote camera never powers on and the link can
++	 * never lock.  NOTE: this must live here (a path d5xx actually
++	 * invokes via dser_ops->setup_link) and NOT in max96724_power_on(),
++	 * which ds5_gmsl_serdes_setup() deliberately skips.  Run once.
++	 */
++	if (!priv->poc_enabled) {
++		max96724_board_poc_enable(dev);
++		priv->poc_enabled = true;
++	}
++
++	mutex_lock(&priv->lock);
++
++	if (!priv->splitter_enabled) {
++		err = max96724_write_link(dev,
++					  priv->sources[i].g_ctx->serdes_csi_link);
++		if (err)
++			goto ret;
++
++		priv->link_setup = true;
++	}
++
++ret:
++	mutex_unlock(&priv->lock);
++	return err;
++}
++EXPORT_SYMBOL(max96724_setup_link);
++
++/* ================================================================
++ * Control Setup
++ * ================================================================ */
++
++/*
++ * max96724_setup_control - Configure deserializer control pipeline
++ *
++ * Enables splitter mode when multiple sources are present,
++ * configures tunnel mode on all active pipes, and sets up
++ * the MIPI CSI-2 output.
++ */
++int max96724_setup_control(struct device *dev, struct device *s_dev)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++	int err = 0;
++	unsigned int i = 0;
++
++	static const u16 tun_en_addrs[] = {
++		MAX96724_PIPE0_TUN_EN_ADDR,
++		MAX96724_PIPE1_TUN_EN_ADDR,
++		MAX96724_PIPE2_TUN_EN_ADDR,
++		MAX96724_PIPE3_TUN_EN_ADDR,
++	};
++
++	static const u16 tun_dest_addrs[] = {
++		MAX96724_PIPE0_TUN_DEST_ADDR,
++		MAX96724_PIPE1_TUN_DEST_ADDR,
++		MAX96724_PIPE2_TUN_DEST_ADDR,
++		MAX96724_PIPE3_TUN_DEST_ADDR,
++	};
++
++	err = max96724_get_sdev_idx(dev, s_dev, &i);
++	if (err)
++		return err;
++
++	mutex_lock(&priv->lock);
++
++	if (!priv->link_setup) {
++		dev_err(dev, "%s: invalid state\n", __func__);
++		err = -EINVAL;
++		goto error;
++	}
++
++	if (priv->sources[i].g_ctx->serdev_found) {
++		priv->num_src_found++;
++		priv->src_link = priv->sources[i].g_ctx->serdes_csi_link;
++	}
++
++	/* Enable splitter mode for multi-camera configurations */
++	if ((priv->max_src > 1U) &&
++	    (priv->num_src_found > 0U) &&
++	    (priv->splitter_enabled == false)) {
++		/*
++		 * [UG Table 3] Multi-camera: set link rates and enable all links
++		 */
++		u8 link_rate = (priv->link_speed == 6) ? 0x22 : 0x11;
++
++		max96724_write_reg(dev, MAX96724_LINK_RATE_AB_ADDR,
++				   link_rate);
++		max96724_write_reg(dev, MAX96724_LINK_RATE_CD_ADDR,
++				   link_rate);
++		max96724_write_reg(dev, MAX96724_LINK_EN_ADDR,
++				   MAX96724_LINK_EN_ALL);
++
++		/* [Errata #5] For 6Gbps: force Error Channel power-up */
++		if (priv->link_speed == 6) {
++			max96724_write_reg(dev, MAX96724_ERRCH_A_ADDR,
++					   MAX96724_ERRCH_FORCE_ON);
++			max96724_write_reg(dev, MAX96724_ERRCH_B_ADDR,
++					   MAX96724_ERRCH_FORCE_ON);
++			max96724_write_reg(dev, MAX96724_ERRCH_C_ADDR,
++					   MAX96724_ERRCH_FORCE_ON);
++			max96724_write_reg(dev, MAX96724_ERRCH_D_ADDR,
++					   MAX96724_ERRCH_FORCE_ON);
++		}
++
++		priv->splitter_enabled = true;
++
++		msleep(100);
++	}
++
++	if (max96724_is_pixel_mode(priv)) {
++		for (i = 0; i < MAX96724_MAX_PIPES; i++) {
++			max96724_write_reg(dev, tun_en_addrs[i],
++					   MAX96724_TUN_DISABLED);
++		}
++		max96724_write_reg(dev, MAX96724_MIPI_CTRL_SEL_ADDR,
++				   MAX96724_MIPI_CTRL_SEL_PIXEL);
++		max96724_write_reg(dev, MAX96724_ONESHOT_ADDR,
++				   MAX96724_ONESHOT_ALL);
++		priv->sdev_ref++;
++		goto maybe_reset_splitter;
++	}
++
++	/*
++	 * [SC20190112] Enable tunnel mode and route to Controller 1.
++	 *   - TUN_EN   (0x0936): 0x01 (TUN_EN=1)
++	 *   - TUN_DEST (0x0939): 0x10 = Controller 1
++	 *   CSI_OUT_CFG=0x04 (2x4 mode): Controller 1 -> PHY0+1 -> Port A -> Orin
++	 */
++	{
++		for (i = 0; i < MAX96724_MAX_PIPES; i++) {
++			max96724_write_reg(dev, tun_en_addrs[i],
++					   MAX96724_TUN_EN);
++			max96724_write_reg(dev, tun_dest_addrs[i],
++					   MAX96724_TUN_DEST_CTRL1);
++		}
++	}
++
++	/*
++	 * [Errata #2] Tunnel Mode SRAM LCRC: disable ERRB for SRAM LCRC
++	 * errors in tunnel mode when frame/line counters are non-zero.
++	 * This prevents spurious ERRB assertions (no video corruption).
++	 */
++	max96724_write_reg(dev, MAX96724_SRAM_LCRC_ERR_ADDR, 0x00);
++
++	max96724_write_reg(dev, MAX96724_ONESHOT_ADDR,
++			   MAX96724_ONESHOT_ALL);
++
++	priv->sdev_ref++;
++
++maybe_reset_splitter:
++
++	/* Reset splitter mode if not all devices found */
++	if ((priv->sdev_ref == priv->max_src) &&
++	    (priv->splitter_enabled == true) &&
++	    (priv->num_src_found > 0U) &&
++	    (priv->num_src_found < priv->max_src)) {
++		err = max96724_write_link(dev, priv->src_link);
++		if (err)
++			goto error;
++
++		priv->splitter_enabled = false;
++	}
++
++error:
++	mutex_unlock(&priv->lock);
++	return err;
++}
++EXPORT_SYMBOL(max96724_setup_control);
++
++int max96724_reset_control(struct device *dev, struct device *s_dev)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++	int err = 0;
++
++	mutex_lock(&priv->lock);
++	if (!priv->sdev_ref) {
++		dev_info(dev, "%s: dev is already in reset state\n", __func__);
++		goto ret;
++	}
++
++	priv->sdev_ref--;
++	if (priv->sdev_ref == 0) {
++		max96724_reset_ctx(priv);
++		max96724_write_reg(dev, MAX96724_REG13_ADDR,
++				   MAX96724_SOFT_RESET);
++
++		msleep(100);
++	}
++
++ret:
++	mutex_unlock(&priv->lock);
++	return err;
++}
++EXPORT_SYMBOL(max96724_reset_control);
++
++/* ================================================================
++ * Device Registration
++ * ================================================================ */
++
++int max96724_sdev_register(struct device *dev, struct gmsl_link_ctx *g_ctx)
++{
++	struct max96724 *priv = NULL;
++	unsigned int i;
++	int err = 0;
++
++	if (!dev || !g_ctx || !g_ctx->s_dev) {
++		dev_err(dev, "%s: invalid input params\n", __func__);
++		return -EINVAL;
++	}
++
++	priv = dev_get_drvdata(dev);
++
++	mutex_lock(&priv->lock);
++
++	if (priv->num_src > priv->max_src) {
++		dev_err(dev,
++			"%s: MAX96724 inputs size exhausted\n", __func__);
++		err = -ENOMEM;
++		goto error;
++	}
++
++	if (priv->csi_mode == MAX96724_CSI_MODE_2X4) {
++		if (!((g_ctx->csi_mode == GMSL_CSI_1X4_MODE) ||
++		      (g_ctx->csi_mode == GMSL_CSI_2X4_MODE))) {
++			dev_err(dev, "%s: csi mode not supported\n", __func__);
++			err = -EINVAL;
++			goto error;
++		}
++	} else {
++		dev_err(dev, "%s: only csi 2x4 mode is supported\n", __func__);
++		err = -EINVAL;
++		goto error;
++	}
++
++	for (i = 0; i < priv->num_src; i++) {
++		if (g_ctx->serdes_csi_link ==
++		    priv->sources[i].g_ctx->serdes_csi_link) {
++			dev_err(dev,
++				"%s: serdes csi link is in use\n", __func__);
++			err = -EINVAL;
++			goto error;
++		}
++		if (g_ctx->num_csi_lanes !=
++		    priv->sources[i].g_ctx->num_csi_lanes) {
++			dev_err(dev,
++				"%s: csi num lanes mismatch\n", __func__);
++			err = -EINVAL;
++			goto error;
++		}
++	}
++
++	priv->sources[priv->num_src].g_ctx = g_ctx;
++	priv->sources[priv->num_src].st_enabled = false;
++
++	priv->num_src++;
++
++error:
++	mutex_unlock(&priv->lock);
++	return err;
++}
++EXPORT_SYMBOL(max96724_sdev_register);
++
++int max96724_sdev_unregister(struct device *dev, struct device *s_dev)
++{
++	struct max96724 *priv = NULL;
++	int err = 0;
++	unsigned int i = 0;
++
++	if (!dev || !s_dev) {
++		dev_err(dev, "%s: invalid input params\n", __func__);
++		return -EINVAL;
++	}
++
++	priv = dev_get_drvdata(dev);
++	mutex_lock(&priv->lock);
++
++	if (priv->num_src == 0) {
++		dev_err(dev, "%s: no source found\n", __func__);
++		err = -ENODATA;
++		goto error;
++	}
++
++	for (i = 0; i < priv->num_src; i++) {
++		if (s_dev == priv->sources[i].g_ctx->s_dev) {
++			priv->sources[i].g_ctx = NULL;
++			break;
++		}
++	}
++
++	if (i == priv->num_src) {
++		dev_err(dev,
++			"%s: requested device not found\n", __func__);
++		err = -EINVAL;
++		goto error;
++	}
++	priv->num_src--;
++
++error:
++	mutex_unlock(&priv->lock);
++	return err;
++}
++EXPORT_SYMBOL(max96724_sdev_unregister);
++
++/* ================================================================
++ * Streaming Setup
++ * ================================================================ */
++
++/*
++ * max96724_setup_streaming - Configure CSI-2 output pipeline
++ *
++ * In Tunnel Mode, the MAX96724 outputs the reconstructed CSI-2 stream
++ * with all VCs and DTs preserved from the serializer.
++ *
++ * The pipeline configuration:
++ *   1. Configure pipe-to-link routing
++ *   2. Enable tunnel mode on active pipes
++ *   3. Configure MIPI CSI-2 output lanes and PHY
++ *   4. Enable BACKTOP output port
++ *
++ */
++int max96724_setup_streaming(struct device *dev, struct device *s_dev)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++	struct gmsl_link_ctx *g_ctx;
++	int err = 0;
++	unsigned int i = 0;
++	unsigned int src_idx;
++	u8 vid_rx0_cfg;
++	u8 vid_rx6_cfg;
++	u8 st_sel_cfg;
++	u8 pipe_sel0;
++	u8 pipe_sel1;
++	u8 dpll_cfg;
++
++	err = max96724_get_sdev_idx(dev, s_dev, &i);
++	if (err)
++		return err;
++
++	mutex_lock(&priv->lock);
++
++	dev_info(dev, "=== setup_streaming ENTER src=%u st_enabled=%d ===\n",
++		 i, priv->sources[i].st_enabled);
++
++	if (priv->sources[i].st_enabled)
++		goto ret;
++
++	src_idx = i;
++	g_ctx = priv->sources[src_idx].g_ctx;
++	if (max96724_is_pixel_mode(priv)) {
++		pipe_sel0 = MAX96724_PIPE_SEL0_PIXEL;
++		pipe_sel1 = MAX96724_PIPE_SEL1_PIXEL;
++		vid_rx0_cfg = MAX96724_VID_RX0_PIXEL_VAL;
++		vid_rx6_cfg = MAX96724_VID_RX6_PIXEL_VAL;
++		st_sel_cfg = 0x00;
++		dpll_cfg = MAX96724_DPLL_1300MBPS;
++	} else {
++		pipe_sel0 = MAX96724_PIPE_SEL0_PIXEL;
++		pipe_sel1 = MAX96724_PIPE_SEL1_PIXEL;
++		vid_rx0_cfg = MAX96724_VID_RX0_CFG_VAL;
++		vid_rx6_cfg = MAX96724_VID_RX6_CFG_VAL;
++		st_sel_cfg = 0x10;
++		dpll_cfg = MAX96724_DPLL_1300MBPS;
++	}
++
++	/*
++	 * Pipe source routing
++	 * Single cam: all pipes from Link A (0x22/0x22)
++	 * Disable pipes before configuration, enable at the end
++	 */
++	max96724_write_reg(dev, MAX96724_PIPE_SEL0_ADDR, pipe_sel0);
++	max96724_write_reg(dev, MAX96724_PIPE_SEL1_ADDR, pipe_sel1);
++	/* Disable all pipes during configuration */
++	max96724_write_reg(dev, MAX96724_PIPE_EN_ADDR, 0x00);
++
++	/*
++	 * Keep 0x08 mode so PHY1 remains the Port A clock master,
++	 * but restore the live 2-lane subset used by the bridge board.
++	 */
++	max96724_apply_porta_subset(dev, priv);
++
++	/*
++	 * CSI-output DPLL data rate = 1300 Mbps
++	 * on ALL FOUR controller freq registers
++	 */
++	if (!priv->lane_setup) {
++		max96724_write_reg(dev, MAX96724_DPLL_FREQ0_ADDR,
++				   dpll_cfg);
++		max96724_write_reg(dev, MAX96724_DPLL_FREQ1_ADDR,
++				   dpll_cfg);
++		max96724_write_reg(dev, MAX96724_DPLL_FREQ2_ADDR,
++				   dpll_cfg);
++		max96724_write_reg(dev, MAX96724_DPLL_FREQ3_ADDR,
++				   dpll_cfg);
++
++		priv->lane_setup = true;
++	}
++
++	max96724_write_reg(dev, MAX96724_MIPI_CTRL_SEL_ADDR,
++			   MAX96724_MIPI_CTRL_SEL_PIXEL);
++
++	/*
++	 * Stream ID select for all pipes
++	 * 0x0933 + 0x40*pipe = stream select register
++	 * Value 0x10 selects the appropriate stream for tunnel mode
++	 */
++	for (i = 0; i < MAX96724_MAX_PIPES; i++) {
++		max96724_write_reg(dev,
++				   MAX96724_PIPE_X_ST_SEL_ADDR + (0x40 * i),
++				   st_sel_cfg);
++	}
++
++	/* 
++	 * BACKTOP: enable Controller 1 / CSI-B (0x02).
++	 * In 2x4 mode, Controller 1 is master for Port A -> Orin CSI.
++	 */
++	max96724_write_reg(dev, MAX96724_BACKTOP_EN_ADDR,
++			   MAX96724_BACKTOP_CSIB_EN);
++
++	dev_info(dev, "=== setup_streaming: writing 0x84 (force all MIPI clocks) ===\n");
++
++	/*
++	 * Assert 0x08A0=0x84 LAST: 2x4 mode + bit[7] "force all MIPI clocks running".  
++	 * The clock-force keeps the D-PHY clock lane continuous so the Orin CIL can lock;
++	 * written only after the full pipeline is configured.
++	 */
++	max96724_write_reg(dev, MAX96724_CSI_OUT_CFG_ADDR,
++			   MAX96724_CSI_OUT_EN_VAL);
++
++	/* Keep all video receivers aligned with serializer heartbeat mode. */
++	for (i = 0; i < MAX96724_MAX_PIPES; i++) {
++		max96724_write_reg(dev,
++				   MAX96724_VID_RX0_P0_ADDR +
++				   (MAX96724_VID_RX_STRIDE * i),
++				   vid_rx0_cfg);
++		max96724_write_reg(dev,
++				   MAX96724_VID_RX6_P0_ADDR +
++				   (MAX96724_VID_RX_STRIDE * i),
++				   vid_rx6_cfg);
++		if (max96724_is_pixel_mode(priv)) {
++			max96724_write_reg(dev,
++					   MAX96724_PIPE0_TUN_EN_ADDR + (0x40 * i),
++					   MAX96724_TUN_DISABLED);
++		}
++	}
++
++	max96724_write_reg(dev, MAX96724_ONESHOT_ADDR,
++			   MAX96724_ONESHOT_ALL);
++
++	/* Enable all 4 pipes */
++	max96724_write_reg(dev, MAX96724_PIPE_EN_ADDR, MAX96724_PIPE_EN_4);
++
++	priv->sources[src_idx].st_enabled = true;
++
++ret:
++	mutex_unlock(&priv->lock);
++	return err;
++}
++EXPORT_SYMBOL(max96724_setup_streaming);
++
++/* ================================================================
++ * Start / Stop Streaming
++ * ================================================================ */
++
++int max96724_start_streaming(struct device *dev, struct device *s_dev)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++	struct gmsl_link_ctx *g_ctx;
++	struct gmsl_stream *g_stream;
++	int err = 0;
++	unsigned int i = 0;
++
++	err = max96724_get_sdev_idx(dev, s_dev, &i);
++	if (err)
++		return err;
++
++	mutex_lock(&priv->lock);
++	g_ctx = priv->sources[i].g_ctx;
++
++	for (i = 0; i < g_ctx->num_streams; i++) {
++		g_stream = &g_ctx->streams[i];
++
++		if (g_stream->des_pipe != MAX96724_PIPE_INVALID)
++			max96724_write_reg(dev, g_stream->des_pipe,
++					   g_stream->st_id_sel);
++	}
++	mutex_unlock(&priv->lock);
++
++	return 0;
++}
++EXPORT_SYMBOL(max96724_start_streaming);
++
++int max96724_stop_streaming(struct device *dev, struct device *s_dev)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++	struct gmsl_link_ctx *g_ctx;
++	struct gmsl_stream *g_stream;
++	int err = 0;
++	unsigned int i = 0;
++
++	err = max96724_get_sdev_idx(dev, s_dev, &i);
++	if (err)
++		return err;
++
++	mutex_lock(&priv->lock);
++	g_ctx = priv->sources[i].g_ctx;
++
++	for (i = 0; i < g_ctx->num_streams; i++) {
++		g_stream = &g_ctx->streams[i];
++
++		if (g_stream->des_pipe != MAX96724_PIPE_INVALID)
++			max96724_write_reg(dev, g_stream->des_pipe,
++					   MAX96724_RESET_ST_ID);
++	}
++
++	mutex_unlock(&priv->lock);
++
++	return 0;
++}
++EXPORT_SYMBOL(max96724_stop_streaming);
++
++/* ================================================================
++ * Pipe Management
++ * ================================================================ */
++
++int max96724_get_available_pipe_id(struct device *dev, int vc_id)
++{
++	int i;
++	int pipe_id = -ENOMEM;
++	struct max96724 *priv = dev_get_drvdata(dev);
++
++	mutex_lock(&priv->lock);
++	for (i = 0; i < MAX96724_MAX_PIPES; i++) {
++		if (i == vc_id && !priv->pipe[i].st_count) {
++			priv->pipe[i].st_count++;
++			pipe_id = i;
++			break;
++		}
++	}
++	mutex_unlock(&priv->lock);
++
++	return pipe_id;
++}
++EXPORT_SYMBOL(max96724_get_available_pipe_id);
++
++int max96724_release_pipe(struct device *dev, int pipe_id)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++
++	if (pipe_id < 0 || pipe_id >= MAX96724_MAX_PIPES)
++		return -EINVAL;
++
++	mutex_lock(&priv->lock);
++	priv->pipe[pipe_id].st_count = 0;
++	mutex_unlock(&priv->lock);
++
++	return 0;
++}
++EXPORT_SYMBOL(max96724_release_pipe);
++
++int max96724_get_ser_pipe_id(struct device *dev, int dser_pipe_id, int vc_id)
++{
++	/* In Tunnel Mode with MAX96717, all VCs are carried in a single tunnel pipe. */
++	return dser_pipe_id;
++}
++EXPORT_SYMBOL(max96724_get_ser_pipe_id);
++
++void max96724_reset_oneshot(struct device *dev)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++	unsigned int i;
++	u8 pipe_sel0;
++	u8 pipe_sel1;
++	u8 vid_rx0_cfg;
++	u8 vid_rx6_cfg;
++	u8 st_sel_cfg;
++	u8 dpll_cfg;
++
++	mutex_lock(&priv->lock);
++	if (priv->splitter_enabled) {
++		/* Multi-camera: reset all links */
++		u8 link_rate = (priv->link_speed == 6) ? 0x22 : 0x11;
++
++		max96724_write_reg(dev, MAX96724_LINK_RATE_AB_ADDR,
++				   link_rate);
++		max96724_write_reg(dev, MAX96724_LINK_RATE_CD_ADDR,
++				   link_rate);
++		max96724_write_reg(dev, MAX96724_LINK_EN_ADDR,
++				   MAX96724_LINK_EN_ALL);
++	} else {
++		max96724_write_reg(dev, MAX96724_ONESHOT_ADDR,
++				   MAX96724_ONESHOT_ALL);
++	}
++	msleep(100);
++
++	if (max96724_is_pixel_mode(priv)) {
++		pipe_sel0 = MAX96724_PIPE_SEL0_PIXEL;
++		pipe_sel1 = MAX96724_PIPE_SEL1_PIXEL;
++		vid_rx0_cfg = MAX96724_VID_RX0_PIXEL_VAL;
++		vid_rx6_cfg = MAX96724_VID_RX6_PIXEL_VAL;
++		st_sel_cfg = 0x00;
++		dpll_cfg = MAX96724_DPLL_1300MBPS;
++	} else {
++		pipe_sel0 = MAX96724_PIPE_SEL0_PIXEL;
++		pipe_sel1 = MAX96724_PIPE_SEL1_PIXEL;
++		vid_rx0_cfg = MAX96724_VID_RX0_CFG_VAL;
++		vid_rx6_cfg = MAX96724_VID_RX6_CFG_VAL;
++		st_sel_cfg = 0x10;
++		dpll_cfg = MAX96724_DPLL_1300MBPS;
++	}
++
++	/* 
++	 * ONESHOT resets CSI/tunnel state. Restore the full pipeline config.
++	 * Mirror setup_streaming() order: disable pipes -> restore everything ->
++	 * BACKTOP/0x84 -> VID_RX -> final ONESHOT to latch -> enable pipes.
++	 */
++	max96724_write_reg(dev, MAX96724_PIPE_EN_ADDR, 0x00);
++
++	/* Pipe source routing: all pipes from Link A */
++	max96724_write_reg(dev, MAX96724_PIPE_SEL0_ADDR, pipe_sel0);
++	max96724_write_reg(dev, MAX96724_PIPE_SEL1_ADDR, pipe_sel1);
++
++	max96724_apply_porta_subset(dev, priv);
++
++	/*
++	 * CSI-output DPLL data rate = 1300 Mbps on ALL
++	 * FOUR controllers, matching the device-tree serdes_pix_clk_hz (325 MHz).
++	 * reset_oneshot is called by the sensor after setup_streaming, so it must
++	 * mirror the same DPLL values.
++	 */
++	max96724_write_reg(dev, MAX96724_DPLL_FREQ0_ADDR,
++			   dpll_cfg);
++	max96724_write_reg(dev, MAX96724_DPLL_FREQ1_ADDR,
++			   dpll_cfg);
++	max96724_write_reg(dev, MAX96724_DPLL_FREQ2_ADDR,
++			   dpll_cfg);
++	max96724_write_reg(dev, MAX96724_DPLL_FREQ3_ADDR,
++			   dpll_cfg);
++
++	max96724_write_reg(dev, MAX96724_MIPI_CTRL_SEL_ADDR,
++			   MAX96724_MIPI_CTRL_SEL_PIXEL);
++
++	max96724_write_reg(dev, MAX96724_BACKTOP_EN_ADDR,
++			   MAX96724_BACKTOP_CSIB_EN);
++	for (i = 0; i < MAX96724_MAX_PIPES; i++) {
++		max96724_write_reg(dev,
++				   MAX96724_PIPE_X_ST_SEL_ADDR + (0x40 * i),
++				   st_sel_cfg);
++		max96724_write_reg(dev,
++				   MAX96724_VID_RX0_P0_ADDR +
++				   (MAX96724_VID_RX_STRIDE * i),
++				   vid_rx0_cfg);
++		max96724_write_reg(dev,
++				   MAX96724_VID_RX6_P0_ADDR +
++				   (MAX96724_VID_RX_STRIDE * i),
++				   vid_rx6_cfg);
++		max96724_write_reg(dev,
++				   MAX96724_TX49_PIPE_X_ADDR + (0x40 * i),
++				   0x00);
++	}
++	if (max96724_is_pixel_mode(priv)) {
++		max96724_write_reg(dev, MAX96724_PIPE0_TUN_EN_ADDR, MAX96724_TUN_DISABLED);
++		max96724_write_reg(dev, MAX96724_PIPE1_TUN_EN_ADDR, MAX96724_TUN_DISABLED);
++		max96724_write_reg(dev, MAX96724_PIPE2_TUN_EN_ADDR, MAX96724_TUN_DISABLED);
++		max96724_write_reg(dev, MAX96724_PIPE3_TUN_EN_ADDR, MAX96724_TUN_DISABLED);
++	} else {
++		/* Re-enable tunnel on all pipes (ONESHOT resets TUN_EN to 0x08=disabled) */
++		max96724_write_reg(dev, MAX96724_PIPE0_TUN_EN_ADDR, MAX96724_TUN_EN);
++		max96724_write_reg(dev, MAX96724_PIPE1_TUN_EN_ADDR, MAX96724_TUN_EN);
++		max96724_write_reg(dev, MAX96724_PIPE2_TUN_EN_ADDR, MAX96724_TUN_EN);
++		max96724_write_reg(dev, MAX96724_PIPE3_TUN_EN_ADDR, MAX96724_TUN_EN);
++		/* TUN_DEST: set to Controller 1 (0x10) = Port A master in 2x4 mode */
++		max96724_write_reg(dev, MAX96724_PIPE0_TUN_DEST_ADDR,
++				   MAX96724_TUN_DEST_CTRL1);
++		max96724_write_reg(dev, MAX96724_PIPE1_TUN_DEST_ADDR,
++				   MAX96724_TUN_DEST_CTRL1);
++		max96724_write_reg(dev, MAX96724_PIPE2_TUN_DEST_ADDR,
++				   MAX96724_TUN_DEST_CTRL1);
++		max96724_write_reg(dev, MAX96724_PIPE3_TUN_DEST_ADDR,
++				   MAX96724_TUN_DEST_CTRL1);
++	}
++	max96724_write_reg(dev, MAX96724_PIPE_EN_ADDR,
++			   MAX96724_PIPE_EN_4);
++
++	/*
++	 * Assert 0x08A0=0x84 LAST:
++	 * 2x4 mode + bit[7] force all MIPI clocks running.  Must mirror
++	 * setup_streaming because the sensor's oneshot path overwrites it.
++	 */
++	max96724_write_reg(dev, MAX96724_CSI_OUT_CFG_ADDR,
++			   MAX96724_CSI_OUT_EN_VAL);
++
++	msleep(200);
++	mutex_unlock(&priv->lock);
++}
++EXPORT_SYMBOL(max96724_reset_oneshot);
++
++/* ================================================================
++ * Init Settings / Set Pipe
++ * ================================================================ */
++
++/*
++ * __max96724_set_pipe - Configure per-pipe mapping registers
++ */
++static int __max96724_set_pipe(struct device *dev, int pipe_id,
++			       u8 data_type1, u8 data_type2, u32 vc_id)
++{
++	int err = 0;
++	int i;
++	u8 en_mapping_num = 0x0F;
++	u8 all_mapping_phy = MAX96724_ALL_MAP_CTRL1;  /* Controller 1 = Port A master (2x4 mode) */
++	struct max96724 *priv = dev_get_drvdata(dev);
++
++	struct reg_pair map_pipe_control[] = {
++		/* Enable 4 mappings for Pipe X */
++		{MAX96724_TX11_PIPE_X_EN_ADDR, 0x0F},
++		/* Map data_type1 on vc_id */
++		{MAX96724_PIPE_X_SRC_0_MAP_ADDR, 0x1E},
++		{MAX96724_PIPE_X_DST_0_MAP_ADDR, 0x1E},
++		/* Map frame start on vc_id */
++		{MAX96724_PIPE_X_SRC_1_MAP_ADDR, 0x00},
++		{MAX96724_PIPE_X_DST_1_MAP_ADDR, 0x00},
++		/* Map frame end on vc_id */
++		{MAX96724_PIPE_X_SRC_2_MAP_ADDR, 0x01},
++		{MAX96724_PIPE_X_DST_2_MAP_ADDR, 0x01},
++		/* Map data_type2 on vc_id */
++		{MAX96724_PIPE_X_SRC_3_MAP_ADDR, 0x12},
++		{MAX96724_PIPE_X_DST_3_MAP_ADDR, 0x12},
++		/* All mappings to Controller 1 (2x4 mode: Ctrl1 drives Port A) */
++		{MAX96724_TX45_PIPE_X_DST_CTRL_ADDR, MAX96724_ALL_MAP_CTRL1},
++		{MAX96724_TX46_PIPE_X_ADDR, MAX96724_ALL_MAP_CTRL1},
++		{MAX96724_TX47_PIPE_X_ADDR, MAX96724_ALL_MAP_CTRL1},
++		{MAX96724_TX48_PIPE_X_ADDR, MAX96724_ALL_MAP_CTRL1},
++		/* TX49: concat disabled */
++		{MAX96724_TX49_PIPE_X_ADDR, 0x00},
++		/*
++		 * Keep DES heartbeat handling aligned with the serializer's
++		 * LIM_HEART-disabled tunnel mode to avoid persistent VID_SEQ_ERR.
++		 */
++		{0x0100, MAX96724_VID_RX0_CFG_VAL},
++		{0x0106, MAX96724_VID_RX6_CFG_VAL},
++		/*
++		 * Pipe stream control (offset 0x36 per pipe block).
++		 * TUN_EN = 0x01.
++		 */
++		{0x0936, MAX96724_TUN_EN},
++	};
++
++	/* 
++	 * Adjust addresses for pipe offset (stride 0x40 per pipe)
++	 * Entries 0-13: TX11, SRC/DST maps, TX45-TX49 (all stride 0x40)
++	 * Entries 14-15: VID_RX0/6 (stride 0x12)
++	 * Entry 16: Pipe stream control (stride 0x40)
++	 */
++	for (i = 0; i < 14; i++)
++		map_pipe_control[i].addr += 0x40 * pipe_id;
++
++	/* VID_RX offset: 0x12 per pipe */
++	map_pipe_control[14].addr += 0x12 * pipe_id;
++	map_pipe_control[15].addr += 0x12 * pipe_id;
++
++	/* Pipe stream control: stride 0x40 */
++	map_pipe_control[16].addr += 0x40 * pipe_id;
++
++	if (data_type2 == 0x0) {
++		en_mapping_num = 0x07;
++		all_mapping_phy = MAX96724_MAP3_CTRL1;
++	}
++
++	if (max96724_is_pixel_mode(priv)) {
++		map_pipe_control[10].val = 0x00;
++		map_pipe_control[11].val = 0x00;
++		map_pipe_control[12].val = 0x00;
++		map_pipe_control[13].val = 0x00;
++		map_pipe_control[14].val = MAX96724_VID_RX0_PIXEL_VAL;
++		map_pipe_control[15].val = MAX96724_VID_RX6_PIXEL_VAL;
++		map_pipe_control[16].val = MAX96724_TUN_DISABLED;
++	} else {
++		/* no concatenation needed */
++		map_pipe_control[13].val = 0x00;
++	}
++
++	map_pipe_control[0].val = en_mapping_num;
++	/* SRC: match incoming VC from camera (vc_id) */
++	map_pipe_control[1].val = (vc_id << 6) | data_type1;
++	/* DST: preserve VC — NVCSI/VI endpoints expect matching vc-id */
++	map_pipe_control[2].val = (vc_id << 6) | data_type1;
++	map_pipe_control[3].val = (vc_id << 6) | 0x00;
++	map_pipe_control[4].val = (vc_id << 6) | 0x00;
++	map_pipe_control[5].val = (vc_id << 6) | 0x01;
++	map_pipe_control[6].val = (vc_id << 6) | 0x01;
++	map_pipe_control[7].val = (vc_id << 6) | data_type2;
++	map_pipe_control[8].val = (vc_id << 6) | data_type2;
++	map_pipe_control[9].val = all_mapping_phy;
++	/* TX46-TX48 keep 0x55 (Ctrl1) from initializer */
++	/* TX49 set to 0x00 above — overridden per mode in pixel/tunnel branch */
++	/* VID_RX and pipe stream ctrl keep init values */
++
++	err = max96724_set_registers(dev, map_pipe_control,
++				     ARRAY_SIZE(map_pipe_control));
++
++	return err;
++}
++
++/*
++ * max96724_init_settings - Initialize default pipe and tunnel configuration
++ *
++ * Sets up all 4 pipes with default YUV422_8 + EMBED for VC0-3,
++ * matching the d4xx framework expectations.
++ *
++ */
++int max96724_init_settings(struct device *dev)
++{
++	int err = 0;
++	int i;
++	struct max96724 *priv = dev_get_drvdata(dev);
++
++	mutex_lock(&priv->lock);
++
++	for (i = 0; i < MAX96724_MAX_PIPES; i++)
++		err |= __max96724_set_pipe(dev, i, GMSL_CSI_DT_YUV422_8,
++					   GMSL_CSI_DT_EMBED, i);
++
++	mutex_unlock(&priv->lock);
++
++	return err;
++}
++EXPORT_SYMBOL(max96724_init_settings);
++
++int max96724_bind_ser_to_dser_pipe(struct device *dev, int dser_pipe_id,
++				   int ser_pipe_id, u32 vc_id)
++{
++	/* In Tunnel Mode, pipe mapping is 1:1 (each camera → one pipe) */
++	return 0;
++}
++EXPORT_SYMBOL(max96724_bind_ser_to_dser_pipe);
++
++int max96724_set_pipe(struct device *dev, int pipe_id,
++		      u8 data_type1, u8 data_type2, u32 vc_id)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++	int err = 0;
++
++	if (pipe_id > (MAX96724_MAX_PIPES - 1)) {
++		dev_info(dev, "%s: input pipe_id: %d exceeds max96724 max pipes\n",
++			 __func__, pipe_id);
++		return -EINVAL;
++	}
++
++	dev_dbg(dev, "%s pipe_id %d, data_type1 %u, data_type2 %u, vc_id %u\n",
++		__func__, pipe_id, data_type1, data_type2, vc_id);
++
++	mutex_lock(&priv->lock);
++
++	err = __max96724_set_pipe(dev, pipe_id, data_type1, data_type2, vc_id);
++
++	mutex_unlock(&priv->lock);
++
++	return err;
++}
++EXPORT_SYMBOL(max96724_set_pipe);
++
++/* ================================================================
++ * Device Tree Parsing
++ * ================================================================ */
++
++static const struct of_device_id max96724_of_match[] = {
++	{ .compatible = "adi,max96724", },
++	{ },
++};
++MODULE_DEVICE_TABLE(of, max96724_of_match);
++
++static int max96724_parse_dt(struct max96724 *priv,
++			     struct i2c_client *client)
++{
++	struct device_node *node = client->dev.of_node;
++	int err = 0;
++	const char *str_value;
++	int value;
++	const struct of_device_id *match;
++
++	if (!node)
++		return -EINVAL;
++
++	match = of_match_device(max96724_of_match, &client->dev);
++	if (!match) {
++		dev_err(&client->dev, "Failed to find matching dt id\n");
++		return -EFAULT;
++	}
++
++	/* CSI mode: "2x4" or "4x2" */
++	err = of_property_read_string(node, "csi-mode", &str_value);
++	if (err < 0) {
++		dev_err(&client->dev, "csi-mode property not found\n");
++		return err;
++	}
++
++	if (!strcmp(str_value, "2x4")) {
++		priv->csi_mode = MAX96724_CSI_MODE_2X4;
++		priv->lane_mp1 = MAX96724_LANE_MAP1_2X4;
++		priv->lane_mp2 = MAX96724_LANE_MAP2_2X4;
++	} else {
++		dev_err(&client->dev, "invalid csi mode\n");
++		return -EINVAL;
++	}
++
++	/* Max sources */
++	err = of_property_read_u32(node, "max-src", &value);
++	if (err < 0) {
++		dev_err(&client->dev, "No max-src info\n");
++		return err;
++	}
++	priv->max_src = value;
++
++	/* Reset GPIO */
++	priv->reset_gpio = of_get_named_gpio(node, "reset-gpios", 0);
++	if (priv->reset_gpio < 0) {
++		dev_info(&client->dev,
++			 "reset-gpios not found, continuing without external reset\n");
++		priv->reset_gpio = -1;
++	}
++
++	/* GMSL link speed from DT: 3 or 6 (Gbps) */
++	err = of_property_read_u32(node, "gmsl-link-speed", &value);
++	if (err < 0) {
++		/* Default to 3 Gbps if not specified */
++		priv->link_speed = 3;
++		dev_info(&client->dev,
++			 "gmsl-link-speed not specified, defaulting to 3 Gbps\n");
++	} else {
++		if (value != 3 && value != 6) {
++			dev_err(&client->dev,
++				"invalid gmsl-link-speed %d (must be 3 or 6)\n",
++				value);
++			return -EINVAL;
++		}
++		priv->link_speed = value;
++	}
++
++	priv->pixel_mode = of_property_read_bool(node, "adi,pixel-mode");
++
++	/* 1.2V regulator (optional) */
++	if (of_get_property(node, "vdd_cam_1v2-supply", NULL)) {
++		priv->vdd_cam_1v2 = regulator_get(&client->dev, "vdd_cam_1v2");
++		if (IS_ERR(priv->vdd_cam_1v2)) {
++			dev_err(&client->dev,
++				"vdd_cam_1v2 regulator get failed\n");
++			err = PTR_ERR(priv->vdd_cam_1v2);
++			priv->vdd_cam_1v2 = NULL;
++			return err;
++		}
++	} else {
++		priv->vdd_cam_1v2 = NULL;
++	}
++
++	return 0;
++}
++
++/* ================================================================
++ * Probe / Remove
++ * ================================================================ */
++
++static struct regmap_config max96724_regmap_config = {
++	.reg_bits = 16,
++	.val_bits = 8,
++	.cache_type = REGCACHE_NONE,
++};
++
++static int max96724_probe(struct i2c_client *client,
++			   const struct i2c_device_id *id)
++{
++	struct max96724 *priv;
++	int err = 0;
++
++	dev_info(&client->dev,
++		 "[MAX96724]: probing Quad GMSL2 Deserializer (Tunnel Mode)\n");
++
++	priv = devm_kzalloc(&client->dev, sizeof(*priv), GFP_KERNEL);
++	if (!priv)
++		return -ENOMEM;
++
++	priv->i2c_client = client;
++	priv->regmap = devm_regmap_init_i2c(priv->i2c_client,
++					     &max96724_regmap_config);
++	if (IS_ERR(priv->regmap)) {
++		dev_err(&client->dev,
++			"regmap init failed: %ld\n", PTR_ERR(priv->regmap));
++		return -ENODEV;
++	}
++
++	err = max96724_parse_dt(priv, client);
++	if (err) {
++		dev_err(&client->dev, "unable to parse dt\n");
++		return -EFAULT;
++	}
++
++	max96724_pipes_reset(priv);
++
++	if (priv->max_src > MAX96724_MAX_SOURCES) {
++		dev_err(&client->dev,
++			"max sources more than currently supported\n");
++		return -EINVAL;
++	}
++
++	mutex_init(&priv->lock);
++
++	dev_set_drvdata(&client->dev, priv);
++
++	dev_info(&client->dev, "%s: success (link_speed=%d Gbps, max_src=%d)\n",
++		 __func__, priv->link_speed, priv->max_src);
++
++	return err;
++}
++
++static int max96724_remove(struct i2c_client *client)
++{
++	struct max96724 *priv;
++
++	if (client != NULL) {
++		priv = dev_get_drvdata(&client->dev);
++		mutex_destroy(&priv->lock);
++		i2c_unregister_device(client);
++		client = NULL;
++	}
++
++	return 0;
++}
++
++static const struct i2c_device_id max96724_id[] = {
++	{ "max96724", 0 },
++	{ },
++};
++
++MODULE_DEVICE_TABLE(i2c, max96724_id);
++
++static struct i2c_driver max96724_i2c_driver = {
++	.driver = {
++		.name = "max96724",
++		.owner = THIS_MODULE,
++		.of_match_table = of_match_ptr(max96724_of_match),
++	},
++	.probe = max96724_probe,
++	.remove = max96724_remove,
++	.id_table = max96724_id,
++};
++
++static int __init max96724_init(void)
++{
++	return i2c_add_driver(&max96724_i2c_driver);
++}
++
++static void __exit max96724_exit(void)
++{
++	i2c_del_driver(&max96724_i2c_driver);
++}
++
++module_init(max96724_init);
++module_exit(max96724_exit);
++
++MODULE_DESCRIPTION("Quad GMSL2 Deserializer driver max96724 (Tunnel Mode)");
++MODULE_AUTHOR("RealSense AI");
++MODULE_LICENSE("GPL v2");
+diff --git a/include/media/max96717.h b/include/media/max96717.h
+new file mode 100644
+index 0000000..65bf930
+--- /dev/null
++++ b/include/media/max96717.h
+@@ -0,0 +1,151 @@
++/*
++ * max96717.c - MAX96717 GMSL2 Serializer driver (Tunnel Mode)
++ *
++ * Copyright (c) 2026, RealSense, Inc.  All rights reserved.
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms and conditions of the GNU General Public License,
++ * version 2, as published by the Free Software Foundation.
++ *
++ * This program is distributed in the hope it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
++ * more details.
++ *
++ * You should have received a copy of the GNU General Public License
++ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
++ */
++
++/**
++ * @file
++ * <b>MAX96717 API: For Analog Devices MAX96717 GMSL2 serializer</b>
++ *
++ * @b Description: Defines elements used to set up and use an
++ *  Analog Devices MAX96717 GMSL2 serializer in Tunnel Mode.
++ */
++
++#ifndef __MAX96717_H__
++#define __MAX96717_H__
++
++#include <linux/types.h>
++#include <media/gmsl-link.h>
++
++/**
++ * \defgroup max96717 MAX96717 serializer driver
++ *
++ * Controls the MAX96717 GMSL2 serializer module (Tunnel Mode).
++ *
++ * @ingroup serdes_group
++ * @{
++ */
++
++/**
++ * @brief  Configures a single pipe on the serializer.
++ *
++ * In Tunnel Mode, per-pipe DT/VC filtering is not active on the serializer
++ * side (all VCs are tunneled transparently). This function maintains API
++ * compatibility with the d4xx sensor driver framework.
++ *
++ * @param  [in]  dev          The serializer device handle.
++ * @param  [in]  pipe_id      Pipe index (0..3).
++ * @param  [in]  data_type1   Primary CSI-2 data type.
++ * @param  [in]  data_type2   Secondary CSI-2 data type (e.g. embedded).
++ * @param  [in]  vc_id        Virtual channel ID.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96717_set_pipe(struct device *dev, int pipe_id, u8 data_type1,
++		      u8 data_type2, u32 vc_id);
++
++/**
++ * @brief  Toggle SER TX to restore tunnel detection after DES ONESHOT.
++ *
++ * A DES ONESHOT resets the video data path. The serializer must cycle
++ * its TX enable (REG2 0x03→0x43) for the deserializer to re-acquire
++ * the tunnel stream.
++ *
++ * @param  [in]  dev          The serializer device handle.
++ */
++void max96717_retrigger_tx(struct device *dev);
++
++/**
++ * @brief  Powers on the serializer and performs I2C overrides
++ * for sensor and serializer devices.
++ *
++ * Must be called after the deserializer's max96724_setup_link().
++ *
++ * @param  [in]  dev          The serializer device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96717_setup_control(struct device *dev);
++
++/**
++ * @brief  Reverts I2C overrides and resets the serializer.
++ *
++ * @param  [in]  dev          The serializer device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96717_reset_control(struct device *dev);
++
++/**
++ * @brief  Pairs a sensor device with the serializer.
++ *
++ * To be called by the sensor client driver.
++ *
++ * @param  [in]  dev          The serializer device handle.
++ * @param  [in]  g_ctx        The gmsl_link_ctx structure handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96717_sdev_pair(struct device *dev, struct gmsl_link_ctx *g_ctx);
++
++/**
++ * @brief  Unpairs a sensor device from the serializer.
++ *
++ * @param  [in]  dev          The serializer device handle.
++ * @param  [in]  s_dev        The sensor device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96717_sdev_unpair(struct device *dev, struct device *s_dev);
++
++/**
++ * @brief  Sets up the serializer's internal streaming pipeline.
++ *
++ * Configures CSI-2 input mode, lane mapping, and enables Tunnel Mode
++ * (EXT11[7]=1 at register 0x0383).
++ *
++ * @param  [in]  dev          The serializer device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96717_setup_streaming(struct device *dev);
++
++/**
++ * @brief  Applies initial register settings for the serializer.
++ *
++ * Configures default pipe settings and Tunnel Mode registers.
++ *
++ * @param  [in]  dev          The serializer device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96717_init_settings(struct device *dev);
++
++/**
++ * @brief  No-op hook for GPIO-over-GMSL tunneling for FSIN/FOUT signals.
++ *
++ * The signal map is documented, but the concrete MFP_CFG values are
++ * not available yet. This hook currently logs and returns success.
++ *
++ * @param  [in]  dev          The serializer device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96717_setup_gpio_tunneling(struct device *dev);
++
++/** @} */
++
++#endif  /* __MAX96717_H__ */
+diff --git a/include/media/max96724.h b/include/media/max96724.h
+new file mode 100644
+index 0000000..dc5a8ea
+--- /dev/null
++++ b/include/media/max96724.h
+@@ -0,0 +1,183 @@
++/*
++ * max96717.c - MAX96717 GMSL2 Serializer driver (Tunnel Mode)
++ *
++ * Copyright (c) 2026, RealSense, Inc.  All rights reserved.
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms and conditions of the GNU General Public License,
++ * version 2, as published by the Free Software Foundation.
++ *
++ * This program is distributed in the hope it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
++ * more details.
++ *
++ * You should have received a copy of the GNU General Public License
++ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
++ */
++
++/**
++ * @file
++ * <b>MAX96724 API: For Analog Devices MAX96724 GMSL2 quad deserializer</b>
++ *
++ * @b Description: Defines elements used to set up and use an
++ *  Analog Devices MAX96724 quad GMSL2 deserializer in Tunnel Mode.
++ */
++
++#ifndef __MAX96724_H__
++#define __MAX96724_H__
++
++#include <linux/types.h>
++#include <media/gmsl-link.h>
++
++/**
++ * \defgroup max96724 MAX96724 deserializer driver
++ *
++ * Controls the MAX96724 quad GMSL2 deserializer module (Tunnel Mode).
++ *
++ * @ingroup serdes_group
++ * @{
++ */
++
++int max96724_get_available_pipe_id(struct device *dev, int vc_id);
++int max96724_get_ser_pipe_id(struct device *dev, int dser_pipe_id, int vc_id);
++int max96724_set_pipe(struct device *dev, int pipe_id, u8 data_type1,
++		      u8 data_type2, u32 vc_id);
++int max96724_release_pipe(struct device *dev, int pipe_id);
++void max96724_reset_oneshot(struct device *dev);
++
++/**
++ * @brief  Puts the deserializer in single exclusive link mode.
++ *
++ * @param  [in]  dev          The deserializer device handle.
++ * @param  [in]  s_dev        The sensor device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96724_setup_link(struct device *dev, struct device *s_dev);
++
++/**
++ * @brief  Sets up the deserializer link's control pipeline.
++ *
++ * Configures I2C pass-through, splitter mode if needed, and
++ * enables the tunnel mode pipe routing for the source.
++ *
++ * @param  [in]  dev          The deserializer device handle.
++ * @param  [in]  s_dev        The sensor device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96724_setup_control(struct device *dev, struct device *s_dev);
++
++/**
++ * @brief  Resets the deserializer link control pipeline.
++ *
++ * @param  [in]  dev          The deserializer device handle.
++ * @param  [in]  s_dev        The sensor device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96724_reset_control(struct device *dev, struct device *s_dev);
++
++/**
++ * @brief  Registers a source sensor device with the deserializer.
++ *
++ * @param  [in]  dev          The deserializer device handle.
++ * @param  [in]  g_ctx        The gmsl_link_ctx structure handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96724_sdev_register(struct device *dev, struct gmsl_link_ctx *g_ctx);
++
++/**
++ * @brief  Unregisters a source sensor device from the deserializer.
++ *
++ * @param  [in]  dev          The deserializer device handle.
++ * @param  [in]  s_dev        The sensor device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96724_sdev_unregister(struct device *dev, struct device *s_dev);
++
++/**
++ * @brief  Configures the internal streaming pipeline.
++ *
++ * Sets up tunnel mode pipe routing, CSI-2 output lane configuration,
++ * and MIPI PHY settings.
++ *
++ * @param  [in]  dev          The deserializer device handle.
++ * @param  [in]  s_dev        The sensor device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96724_setup_streaming(struct device *dev, struct device *s_dev);
++
++/**
++ * @brief  Enables streaming for a source sensor.
++ *
++ * @param  [in]  dev          The deserializer device handle.
++ * @param  [in]  s_dev        The sensor device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96724_start_streaming(struct device *dev, struct device *s_dev);
++
++/**
++ * @brief  Disables streaming for a source sensor.
++ *
++ * @param  [in]  dev          The deserializer device handle.
++ * @param  [in]  s_dev        The sensor device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96724_stop_streaming(struct device *dev, struct device *s_dev);
++
++/**
++ * @brief  Powers on the MAX96724 deserializer module.
++ *
++ * Asserts shared reset GPIO and powers on the regulator.
++ *
++ * @param  [in]  dev          The deserializer device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96724_power_on(struct device *dev);
++
++/**
++ * @brief  Powers off the MAX96724 deserializer module.
++ *
++ * @param  [in]  dev          The deserializer device handle.
++ */
++void max96724_power_off(struct device *dev);
++
++/**
++ * @brief  Applies initial register settings for the deserializer.
++ *
++ * Configures default pipe mappings, tunnel mode, and CSI output for
++ * the D5xx/SC1.2 use case.
++ *
++ * @param  [in]  dev          The deserializer device handle.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96724_init_settings(struct device *dev);
++
++/**
++ * @brief  Maps deserializer pipe ID to serializer pipe ID.
++ *
++ * In tunnel mode with MAX96717, all data flows through a single pipe
++ * per camera, so the mapping is 1:1.
++ *
++ * @param  [in]  dev             The deserializer device handle.
++ * @param  [in]  dser_pipe_id    Deserializer pipe ID.
++ * @param  [in]  ser_pipe_id     Serializer pipe ID.
++ * @param  [in]  vc_id           VC ID associated with this pipe.
++ *
++ * @return  0 for success, or negative error code.
++ */
++int max96724_bind_ser_to_dser_pipe(struct device *dev, int dser_pipe_id,
++				   int ser_pipe_id, u32 vc_id);
++
++/** @} */
++
++#endif  /* __MAX96724_H__ */
+-- 
+2.25.1
+


### PR DESCRIPTION
## What & why

The D5xx (D58x / HKR) camera support added on `d500_gmsl_dev` was a **parallel 6256-line fork** of `d4xx.c` (`d5xx.c`). This folds it back into a **single driver / module (`d4xx.ko`)** that serves both the D4xx (D40x–D46x) and D5xx (D58x) families, so there is one driver to maintain. Net change to the driver is **+334 additive lines** (vs. a 6256-line second file).

## How it's abstracted

- **Serializer** — new `struct ser_interface` (`ser_ops`) mirroring the existing `dser_interface`, with `max9295_interface` + `max96717_interface`. All direct `max9295_*` calls now route through `ser_ops`. Tunnel-mode-only hooks (`retrigger_tx`, `setup_streaming`) are `NULL` for max9295, so the D4xx flow is unchanged.
- **Deserializer** — add `max96724_interface` (with an optional `setup_streaming` op) next to max9296/max96712; add the tunnel-mode pipeline (one-shot reset → serializer retrigger → streaming setup), gated on op presence.
- **D58X family** — `DS5_DEVICE_TYPE_D58X` + `d58x_*` resolution/format tables wired into the device-type switches (depth/IR/RGB/sync-mode/validity); new `device_type` RO V4L2 control.
- **Binding** — probes both `intel,d4xx` and `realsense,d5xx` (one `i2c_driver`). Serializer DT node matched by `strncmp` **prefix** (node names carry a `_a`/`_prim` link suffix).
- **Build/patch** — new `0011` MAX96717/MAX96724 nvidia-oot patch; `0001` Makefile builds one `d4xx.o` + all five SerDes modules (`max9295/96/96712` + `max96717/96724`), **no `d5xx.o`**. `build_all.sh`/`apply_patches.sh` keep `--fg`/`--lane`, drop the d5xx-object switch, and wire the d5xx DT overlay.

## Build verification

Built clean on **JP6.2**, both setups (reset → reapply → build):
- `./build_all.sh 6.2` and `./build_all.sh --fg --lane 2 6.2`
- `modinfo d4xx.ko` → `depends: max9296,max96717,max9295,max96724,max96712`
- `tegra234-camera-d5xx-overlay.dtbo` + all D4xx overlays build; **no `d5xx.ko`** produced.

## ⚠️ Draft — needs rebase + remaining work

- **Based on `c51c0ea`** (origin/dev at fork time). `dev` has since advanced with overlapping changes — `RSDSO-20950 clean unused D46x`, `RSDEV-6449 Simplify sync mode to 3-value API` (both touch the d4xx.c regions edited here), and removal of `.github/copilot-instructions.md`. **Rebase onto current `dev` and reconcile the sync-mode + D46x deltas before marking ready.**
- **Hardware validation pending** on fw-orin-nano-1 (D401+D457): deploy + `v4l2-test`/`streaming-test`.
- **Deferred follow-ups** (not needed for build/streaming): hwmc_rw/UAMG "UVC-compat" enhancement (dev already has its own hwmc_rw), `DS5_BYPASS_CAMERA_I2C` (opt-in HKR mode), `reset_ref_dser` per-deserializer reset refinement, and the FG24-4CH d5xx overlay `.dts` (not committed upstream — intentionally not wired into the overlay Makefile to keep `make dtbs` green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)