### PR TITLE
install_to_kernel.sh: accept any rootfs.tar.* compression for JP6/7

### DIFF
--- a/scripts/install_to_kernel.sh
+++ b/scripts/install_to_kernel.sh
@@ -57,9 +57,12 @@ if [ "${JETPACK_VERSION}" = "5.0.2" ]; then
           sudo cp videobuf-vmalloc.ko /lib/modules/$(uname -r)/updates/
 elif [ "${JETPACK_VERSION}" = "6.0" ] || [ "${JETPACK_VERSION}" = "6.1" ] || [ "${JETPACK_VERSION}" = "6.2" ] || [ "${JETPACK_VERSION}" = "6.2.1" ] || [ "${JETPACK_VERSION}" = "7.0" ] || [ "${JETPACK_VERSION}" = "7.1" ] || [ "${JETPACK_VERSION}" = "7.2" ]; then
     MODULES_DIR="lib/modules/$(uname -r)"
-    echo "Extracting rootfs.tar.gz..."
-    if ! tar xf rootfs.tar.gz; then
-        echo "Error: Failed to extract rootfs.tar.gz; not modifying kernel modules."
+    # Accept any compression (rootfs.tar.gz, rootfs.tar.bz2, rootfs.tar.xz, ...);
+    # tar autodetects the format from the file contents.
+    ROOTFS_TARBALL=$(ls rootfs.tar.* 2>/dev/null | head -n1)
+    echo "Extracting ${ROOTFS_TARBALL:-rootfs.tar.*}..."
+    if [ -z "${ROOTFS_TARBALL}" ] || ! tar xf "${ROOTFS_TARBALL}"; then
+        echo "Error: Failed to extract rootfs tarball (rootfs.tar.*); not modifying kernel modules."
         exit 1
     fi
     if [ ! -d "${MODULES_DIR}" ] || [ -z "$(ls -A "${MODULES_DIR}" 2>/dev/null)" ]; then


### PR DESCRIPTION
**Overview:** `install_to_kernel.sh` hardcodes `rootfs.tar.gz` in the JP6/7 install branch, so a release packaged as `rootfs.tar.bz2` (or `.xz`) fails to extract and the script aborts without updating the kernel modules.

### Problem
On a Jetson Orin running JetPack 6.2, with the rootfs packaged as `rootfs.tar.bz2`:

```
Extracting rootfs.tar.gz...
tar: rootfs.tar.gz: Cannot open: No such file or directory
tar: Error is not recoverable: exiting now
Error: Failed to extract rootfs.tar.gz; not modifying kernel modules.
```

The JP6/7 branch only ever tries `tar xf rootfs.tar.gz`, ignoring any other compression.

### Fix
Resolve the actual `rootfs.tar.*` file and let `tar` autodetect the compression (gz/bz2/xz/...):

```bash
ROOTFS_TARBALL=$(ls rootfs.tar.* 2>/dev/null | head -n1)
echo "Extracting ${ROOTFS_TARBALL:-rootfs.tar.*}..."
if [ -z "${ROOTFS_TARBALL}" ] || ! tar xf "${ROOTFS_TARBALL}"; then
    echo "Error: Failed to extract rootfs tarball (rootfs.tar.*); not modifying kernel modules."
    exit 1
fi
```

This resolves the single matching tarball first (so a stray second match isn't misread as a tar member) and still errors clearly when none exists. Scope is limited to the JP6/7 branch where the hard failure occurs.

🤖 Generated by AI
