### PR TITLE
gmsl: enable SER deskew for FG24 tunnel mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@
 /.vscode/*.db*
 /.vscode/compile_commands.json
 jetpack_version
+*.code-workspace
+*.tar.gz
+logs

--- a/hardware/realsense/tegra234-camera-d5xx-overlay-fg24-4ch.dts
+++ b/hardware/realsense/tegra234-camera-d5xx-overlay-fg24-4ch.dts
@@ -420,6 +420,8 @@
 								phy_mode = "DPHY";
 								discontinuous_clk = "no";
 								cil_settletime = "0";
+								deskew_initial_enable = "true";
+								deskew_periodic_enable = "true";
 								mclk_khz = "24000";
 								pix_clk_hz = "500000000";
 								serdes_pix_clk_hz = "500000000";
@@ -478,6 +480,8 @@
 								phy_mode = "DPHY";
 								discontinuous_clk = "no";
 								cil_settletime = "0";
+								deskew_initial_enable = "true";
+								deskew_periodic_enable = "true";
 								mclk_khz = "24000";
 								pix_clk_hz = "500000000";
 								serdes_pix_clk_hz = "500000000";
@@ -537,6 +541,8 @@
 								phy_mode = "DPHY";
 								discontinuous_clk = "no";
 								cil_settletime = "0";
+								deskew_initial_enable = "true";
+								deskew_periodic_enable = "true";
 								mclk_khz = "24000";
 								pix_clk_hz = "1000000000";
 								serdes_pix_clk_hz = "1000000000";
@@ -555,6 +561,8 @@
 								phy_mode = "DPHY";
 								discontinuous_clk = "no";
 								cil_settletime = "0";
+								deskew_initial_enable = "true";
+								deskew_periodic_enable = "true";
 								mclk_khz = "24000";
 								pix_clk_hz = "500000000";
 								serdes_pix_clk_hz = "500000000";
@@ -613,6 +621,8 @@
 								phy_mode = "DPHY";
 								discontinuous_clk = "no";
 								cil_settletime = "0";
+								deskew_initial_enable = "true";
+								deskew_periodic_enable = "true";
 								mclk_khz = "24000";
 								pix_clk_hz = "1000000000";
 								serdes_pix_clk_hz = "1000000000";

--- a/hardware/realsense/tegra234-camera-d5xx-overlay-fg24-4ch.dts
+++ b/hardware/realsense/tegra234-camera-d5xx-overlay-fg24-4ch.dts
@@ -18,14 +18,16 @@
  * GMSL link:
  *   GMSL2 Tunnel Mode, 6 Gbps
  *   HKR MIPI Tx → MAX96717: 4-lane CSI-2
- *   MAX96724 → Orin NVCSI:  4-lane CSI-2 (FG24-4CH → Orin CAM1 / CSI-C / serial_c)
+ *   MAX96724 Port A → Orin NVCSI: 4-lane CSI-2 over the Orin Nano CAM1
+ *   22-pin connector.
  *
  * CSI port / control I2C:
- *   Orin CAM1 connector control I2C = board "IIC-10" = GPIO mux channel 1 = mux node i2c@1
- *   (mux-gpio AON_GPIO(CC,3) driven HIGH). NOTE: Linux runtime i2c-10 is HDMI DDC,
- *   unrelated; the camera control bus is cam_i2c (i2c@3180000) + GPIO mux.
- *   Orin CAM1 connector = CSI-C brick = port-index 2 = serial_c (per fzcam ref: i2c mux
- *   channel 1 pairs with serial_c). I2C control on GPIO mux channel 1 (i2c@1).
+ *   The physical CAM1 connector is not auto-bound to I2C by Linux. This
+ *   overlay explicitly binds the video path to Orin NVCSI CSI-C via
+ *   port-index 2 / tegra_sinterface "serial_c", and binds control I2C to
+ *   cam_i2c (i2c@3180000) through the GPIO mux channel 1 node i2c@1
+ *   (mux-gpio AON_GPIO(CC,3) driven HIGH). Linux runtime i2c-10 is HDMI DDC
+ *   on this platform and is not the camera control bus.
  *
  * I2C address map (7-bit):
  *   GPIO mux:     AON_GPIO(CC, 3)
@@ -125,7 +127,7 @@
 				status = "okay";
 				compatible = "nvidia, tegra-camera-platform";
 				num_csi_lanes = <4>;
-				max_lane_speed = <1300000>;
+				max_lane_speed = <2000000>;
 				min_bits_per_pixel = <10>;
 				vi_peak_byte_per_pixel = <2>;
 				vi_bw_margin_pct = <25>;
@@ -310,8 +312,10 @@
 					mux-gpios = <&gpio_aon CAM_I2C_MUX GPIO_ACTIVE_HIGH>;
 
 					/*
-					 * Orin CAM1 control path = board "IIC-10" = GPIO mux channel 1
-					 * (mux-gpio driven HIGH). DES/SER/D585 live here.
+					 * Camera control path for this CAM1-wired design:
+					 * cam_i2c -> GPIO mux channel 1 (i2c@1, mux-gpio HIGH).
+					 * The video path is selected separately by serial_c /
+					 * port-index 2 on all NVCSI and sensor endpoints.
 					 */
 					i2c@1 {
 						reg = <1>;
@@ -331,7 +335,7 @@
 							compatible = "adi,max96724";
 							csi-mode = "2x4";
 							max-src = <1>;
-							gmsl-link-speed = <3>;
+							gmsl-link-speed = <6>;
 						};
 
 						/*
@@ -386,6 +390,26 @@
 								};
 							};
 
+							/*
+							 * Pixel clock reference for mixed-VC tunnel mode:
+							 *   pix_clk_hz = lane_rate_bps * lane_count / bits_per_pixel
+							 *
+							 * The MAX96724->Orin D-PHY output is configured to
+							 * 2.0Gbps/lane over 4 lanes, so the payload budget is
+							 * 2,000,000,000 * 4 = 8,000,000,000 bits/s.
+							 *
+							 * Tunnel mode carries each source packet as-is. There is
+							 * no single rewritten DES-side BPP when VC0-3 run
+							 * concurrently, so each Orin mode uses its own
+							 * csi_pixel_bit_depth:
+							 *   16-bit modes: 8,000,000,000 / 16 = 500,000,000 Hz
+							 *   8-bit modes:  8,000,000,000 /  8 = 1,000,000,000 Hz
+							 *
+							 * Aggregate bandwidth closure is still checked against
+							 * the shared 4-lane physical link and the 6Gbps GMSL2
+							 * forward link; pix_clk_hz here is the per-mode parser
+							 * clock NVIDIA uses for VI/NVCSI bandwidth setup.
+							 */
 							mode0 {
 								pixel_t = "yuv_uyvy16";
 								num_lanes = "4";
@@ -397,8 +421,8 @@
 								discontinuous_clk = "no";
 								cil_settletime = "0";
 								mclk_khz = "24000";
-								pix_clk_hz = "325000000";
-							serdes_pix_clk_hz = "325000000";
+								pix_clk_hz = "500000000";
+								serdes_pix_clk_hz = "500000000";
 								line_length = "1280";
 								embedded_metadata_height = "1";
 							};
@@ -455,8 +479,8 @@
 								discontinuous_clk = "no";
 								cil_settletime = "0";
 								mclk_khz = "24000";
-								pix_clk_hz = "325000000";
-							serdes_pix_clk_hz = "325000000";
+								pix_clk_hz = "500000000";
+								serdes_pix_clk_hz = "500000000";
 								line_length = "1920";
 								embedded_metadata_height = "1";
 							};
@@ -514,8 +538,8 @@
 								discontinuous_clk = "no";
 								cil_settletime = "0";
 								mclk_khz = "24000";
-								pix_clk_hz = "325000000";
-								serdes_pix_clk_hz = "325000000";
+								pix_clk_hz = "1000000000";
+								serdes_pix_clk_hz = "1000000000";
 								line_length = "1280";
 								embedded_metadata_height = "1";
 							};
@@ -532,8 +556,8 @@
 								discontinuous_clk = "no";
 								cil_settletime = "0";
 								mclk_khz = "24000";
-								pix_clk_hz = "325000000";
-								serdes_pix_clk_hz = "325000000";
+								pix_clk_hz = "500000000";
+								serdes_pix_clk_hz = "500000000";
 								line_length = "1280";
 								embedded_metadata_height = "1";
 							};
@@ -590,8 +614,8 @@
 								discontinuous_clk = "no";
 								cil_settletime = "0";
 								mclk_khz = "24000";
-								pix_clk_hz = "325000000";
-							serdes_pix_clk_hz = "325000000";
+								pix_clk_hz = "1000000000";
+								serdes_pix_clk_hz = "1000000000";
 								line_length = "1280";
 								embedded_metadata_height = "0";
 							};

--- a/nvidia-oot/6.0/0011-Add-MAX96717-serializer-and-MAX96724-deserializer-dr.patch
+++ b/nvidia-oot/6.0/0011-Add-MAX96717-serializer-and-MAX96724-deserializer-dr.patch
@@ -1245,10 +1245,10 @@ index 0000000..22bfb47
 +#define MAX96724_DPLL_700MBPS_CTRL0	0x27
 +
 +/* 
-+ *   CSI-output DPLL data rate = 1300 Mbps.
-+ *   bits[4:0] = data-rate / 100 MHz -> 1300/100 = 13 = 0x0D. bit[5] = DPLL en.
++ *   CSI-output DPLL data rate = 2000 Mbps.
++ *   bits[4:0] = data-rate / 100 MHz -> 2000/100 = 20 = 0x14. bit[5] = DPLL en.
 + */
-+#define MAX96724_DPLL_1300MBPS		0x2D
++#define MAX96724_DPLL_2000MBPS		0x34
 +
 +/* One-shot reset: all links */
 +#define MAX96724_ONESHOT_ALL		0x0F
@@ -2089,14 +2089,14 @@ index 0000000..22bfb47
 +		vid_rx0_cfg = MAX96724_VID_RX0_PIXEL_VAL;
 +		vid_rx6_cfg = MAX96724_VID_RX6_PIXEL_VAL;
 +		st_sel_cfg = 0x00;
-+		dpll_cfg = MAX96724_DPLL_1300MBPS;
++		dpll_cfg = MAX96724_DPLL_2000MBPS;
 +	} else {
 +		pipe_sel0 = MAX96724_PIPE_SEL0_PIXEL;
 +		pipe_sel1 = MAX96724_PIPE_SEL1_PIXEL;
 +		vid_rx0_cfg = MAX96724_VID_RX0_CFG_VAL;
 +		vid_rx6_cfg = MAX96724_VID_RX6_CFG_VAL;
 +		st_sel_cfg = 0x10;
-+		dpll_cfg = MAX96724_DPLL_1300MBPS;
++		dpll_cfg = MAX96724_DPLL_2000MBPS;
 +	}
 +
 +	/*
@@ -2116,7 +2116,7 @@ index 0000000..22bfb47
 +	max96724_apply_porta_subset(dev, priv);
 +
 +	/*
-+	 * CSI-output DPLL data rate = 1300 Mbps
++	 * CSI-output DPLL data rate = 2000 Mbps
 +	 * on ALL FOUR controller freq registers
 +	 */
 +	if (!priv->lane_setup) {
@@ -2335,14 +2335,14 @@ index 0000000..22bfb47
 +		vid_rx0_cfg = MAX96724_VID_RX0_PIXEL_VAL;
 +		vid_rx6_cfg = MAX96724_VID_RX6_PIXEL_VAL;
 +		st_sel_cfg = 0x00;
-+		dpll_cfg = MAX96724_DPLL_1300MBPS;
++		dpll_cfg = MAX96724_DPLL_2000MBPS;
 +	} else {
 +		pipe_sel0 = MAX96724_PIPE_SEL0_PIXEL;
 +		pipe_sel1 = MAX96724_PIPE_SEL1_PIXEL;
 +		vid_rx0_cfg = MAX96724_VID_RX0_CFG_VAL;
 +		vid_rx6_cfg = MAX96724_VID_RX6_CFG_VAL;
 +		st_sel_cfg = 0x10;
-+		dpll_cfg = MAX96724_DPLL_1300MBPS;
++		dpll_cfg = MAX96724_DPLL_2000MBPS;
 +	}
 +
 +	/* 
@@ -2359,8 +2359,9 @@ index 0000000..22bfb47
 +	max96724_apply_porta_subset(dev, priv);
 +
 +	/*
-+	 * CSI-output DPLL data rate = 1300 Mbps on ALL
-+	 * FOUR controllers, matching the device-tree serdes_pix_clk_hz (325 MHz).
++	 * CSI-output DPLL data rate = 2000 Mbps on ALL controllers.
++	 * This matches the device-tree serdes_pix_clk_hz values:
++	 * 500 MHz for 16-bit modes and 1000 MHz for 8-bit modes.
 +	 * reset_oneshot is called by the sensor after setup_streaming, so it must
 +	 * mirror the same DPLL values.
 +	 */
@@ -3144,4 +3145,3 @@ index 0000000..dc5a8ea
 +#endif  /* __MAX96724_H__ */
 -- 
 2.25.1
-

--- a/nvidia-oot/6.0/0011-Add-MAX96717-serializer-and-MAX96724-deserializer-dr.patch
+++ b/nvidia-oot/6.0/0011-Add-MAX96717-serializer-and-MAX96724-deserializer-dr.patch
@@ -23,11 +23,11 @@ MAX96724 quad deserializer features:
 Signed-off-by: RealSense AI <realsense@realsenseai.com>
 ---
  drivers/media/i2c/Makefile   |    2 +
- drivers/media/i2c/max96717.c |  835 ++++++++++++++
+ drivers/media/i2c/max96717.c |  836 ++++++++++++++
  drivers/media/i2c/max96724.c | 1916 ++++++++++++++++++++++++++++++++++
  include/media/max96717.h     |  151 ++
  include/media/max96724.h     |  183 +++
- 4 files changed, 3085 insertions(+)
+ 4 files changed, 3086 insertions(+)
  create mode 100644 drivers/media/i2c/max96717.c
  create mode 100644 drivers/media/i2c/max96724.c
  create mode 100644 include/media/max96717.h
@@ -38,7 +38,7 @@ new file mode 100644
 index 0000000..70d25a3
 --- /dev/null
 +++ b/drivers/media/i2c/max96717.c
-@@ -0,0 +1,835 @@
+@@ -0,0 +1,836 @@
 +/*
 + * max96717.c - MAX96717 GMSL2 Serializer driver (Tunnel Mode)
 + *
@@ -68,8 +68,9 @@ index 0000000..70d25a3
 +#define MAX96717_DEV_ADDR		0x00
 +
 +/* 
-+ *   REG1: Link Speed
-+ *   bit[3]=1: 3 Gbps, bit[4]=1: 6 Gbps
++ *   REG1: GMSL2 link rate
++ *   TX_RATE[3:2]: 01=3Gbps, 10=6Gbps
++ *   RX_RATE[1:0]: 00=187.5Mbps reverse
 + */
 +#define MAX96717_REG1_ADDR		0x01
 +
@@ -216,10 +217,10 @@ index 0000000..70d25a3
 +/* MIPI_RX0: Normal operation */
 +#define MAX96717_MIPI_RX0_NORMAL	0x00
 +
-+/* REG1: 3 Gbps link speed, bit[3]=1 */
-+#define MAX96717_LINK_SPEED_3GBPS	0x08
-+/* REG1: 6 Gbps link speed, bit[4]=1 */
-+#define MAX96717_LINK_SPEED_6GBPS	0x10
++/* REG1: TX_RATE[3:2]=01, RX_RATE[1:0]=00 */
++#define MAX96717_LINK_SPEED_3GBPS	0x04
++/* REG1: TX_RATE[3:2]=10, RX_RATE[1:0]=00 */
++#define MAX96717_LINK_SPEED_6GBPS	0x08
 +
 +/* EXT11 tunnel mode pre-config (0x0383=0x80) */
 +#define MAX96717_EXT11_TUN_PRE		0x80

--- a/nvidia-oot/6.1/0011-Add-MAX96717-serializer-and-MAX96724-deserializer-dr.patch
+++ b/nvidia-oot/6.1/0011-Add-MAX96717-serializer-and-MAX96724-deserializer-dr.patch
@@ -1245,10 +1245,10 @@ index 0000000..22bfb47
 +#define MAX96724_DPLL_700MBPS_CTRL0	0x27
 +
 +/* 
-+ *   CSI-output DPLL data rate = 1300 Mbps.
-+ *   bits[4:0] = data-rate / 100 MHz -> 1300/100 = 13 = 0x0D. bit[5] = DPLL en.
++ *   CSI-output DPLL data rate = 2000 Mbps.
++ *   bits[4:0] = data-rate / 100 MHz -> 2000/100 = 20 = 0x14. bit[5] = DPLL en.
 + */
-+#define MAX96724_DPLL_1300MBPS		0x2D
++#define MAX96724_DPLL_2000MBPS		0x34
 +
 +/* One-shot reset: all links */
 +#define MAX96724_ONESHOT_ALL		0x0F
@@ -2089,14 +2089,14 @@ index 0000000..22bfb47
 +		vid_rx0_cfg = MAX96724_VID_RX0_PIXEL_VAL;
 +		vid_rx6_cfg = MAX96724_VID_RX6_PIXEL_VAL;
 +		st_sel_cfg = 0x00;
-+		dpll_cfg = MAX96724_DPLL_1300MBPS;
++		dpll_cfg = MAX96724_DPLL_2000MBPS;
 +	} else {
 +		pipe_sel0 = MAX96724_PIPE_SEL0_PIXEL;
 +		pipe_sel1 = MAX96724_PIPE_SEL1_PIXEL;
 +		vid_rx0_cfg = MAX96724_VID_RX0_CFG_VAL;
 +		vid_rx6_cfg = MAX96724_VID_RX6_CFG_VAL;
 +		st_sel_cfg = 0x10;
-+		dpll_cfg = MAX96724_DPLL_1300MBPS;
++		dpll_cfg = MAX96724_DPLL_2000MBPS;
 +	}
 +
 +	/*
@@ -2116,7 +2116,7 @@ index 0000000..22bfb47
 +	max96724_apply_porta_subset(dev, priv);
 +
 +	/*
-+	 * CSI-output DPLL data rate = 1300 Mbps
++	 * CSI-output DPLL data rate = 2000 Mbps
 +	 * on ALL FOUR controller freq registers
 +	 */
 +	if (!priv->lane_setup) {
@@ -2335,14 +2335,14 @@ index 0000000..22bfb47
 +		vid_rx0_cfg = MAX96724_VID_RX0_PIXEL_VAL;
 +		vid_rx6_cfg = MAX96724_VID_RX6_PIXEL_VAL;
 +		st_sel_cfg = 0x00;
-+		dpll_cfg = MAX96724_DPLL_1300MBPS;
++		dpll_cfg = MAX96724_DPLL_2000MBPS;
 +	} else {
 +		pipe_sel0 = MAX96724_PIPE_SEL0_PIXEL;
 +		pipe_sel1 = MAX96724_PIPE_SEL1_PIXEL;
 +		vid_rx0_cfg = MAX96724_VID_RX0_CFG_VAL;
 +		vid_rx6_cfg = MAX96724_VID_RX6_CFG_VAL;
 +		st_sel_cfg = 0x10;
-+		dpll_cfg = MAX96724_DPLL_1300MBPS;
++		dpll_cfg = MAX96724_DPLL_2000MBPS;
 +	}
 +
 +	/* 
@@ -2359,8 +2359,9 @@ index 0000000..22bfb47
 +	max96724_apply_porta_subset(dev, priv);
 +
 +	/*
-+	 * CSI-output DPLL data rate = 1300 Mbps on ALL
-+	 * FOUR controllers, matching the device-tree serdes_pix_clk_hz (325 MHz).
++	 * CSI-output DPLL data rate = 2000 Mbps on ALL controllers.
++	 * This matches the device-tree serdes_pix_clk_hz values:
++	 * 500 MHz for 16-bit modes and 1000 MHz for 8-bit modes.
 +	 * reset_oneshot is called by the sensor after setup_streaming, so it must
 +	 * mirror the same DPLL values.
 +	 */
@@ -3144,4 +3145,3 @@ index 0000000..dc5a8ea
 +#endif  /* __MAX96724_H__ */
 -- 
 2.25.1
-

--- a/nvidia-oot/6.1/0011-Add-MAX96717-serializer-and-MAX96724-deserializer-dr.patch
+++ b/nvidia-oot/6.1/0011-Add-MAX96717-serializer-and-MAX96724-deserializer-dr.patch
@@ -23,11 +23,11 @@ MAX96724 quad deserializer features:
 Signed-off-by: RealSense AI <realsense@realsenseai.com>
 ---
  drivers/media/i2c/Makefile   |    2 +
- drivers/media/i2c/max96717.c |  835 ++++++++++++++
+ drivers/media/i2c/max96717.c |  836 ++++++++++++++
  drivers/media/i2c/max96724.c | 1916 ++++++++++++++++++++++++++++++++++
  include/media/max96717.h     |  151 ++
  include/media/max96724.h     |  183 +++
- 4 files changed, 3085 insertions(+)
+ 4 files changed, 3086 insertions(+)
  create mode 100644 drivers/media/i2c/max96717.c
  create mode 100644 drivers/media/i2c/max96724.c
  create mode 100644 include/media/max96717.h
@@ -38,7 +38,7 @@ new file mode 100644
 index 0000000..70d25a3
 --- /dev/null
 +++ b/drivers/media/i2c/max96717.c
-@@ -0,0 +1,835 @@
+@@ -0,0 +1,836 @@
 +/*
 + * max96717.c - MAX96717 GMSL2 Serializer driver (Tunnel Mode)
 + *
@@ -68,8 +68,9 @@ index 0000000..70d25a3
 +#define MAX96717_DEV_ADDR		0x00
 +
 +/* 
-+ *   REG1: Link Speed
-+ *   bit[3]=1: 3 Gbps, bit[4]=1: 6 Gbps
++ *   REG1: GMSL2 link rate
++ *   TX_RATE[3:2]: 01=3Gbps, 10=6Gbps
++ *   RX_RATE[1:0]: 00=187.5Mbps reverse
 + */
 +#define MAX96717_REG1_ADDR		0x01
 +
@@ -216,10 +217,10 @@ index 0000000..70d25a3
 +/* MIPI_RX0: Normal operation */
 +#define MAX96717_MIPI_RX0_NORMAL	0x00
 +
-+/* REG1: 3 Gbps link speed, bit[3]=1 */
-+#define MAX96717_LINK_SPEED_3GBPS	0x08
-+/* REG1: 6 Gbps link speed, bit[4]=1 */
-+#define MAX96717_LINK_SPEED_6GBPS	0x10
++/* REG1: TX_RATE[3:2]=01, RX_RATE[1:0]=00 */
++#define MAX96717_LINK_SPEED_3GBPS	0x04
++/* REG1: TX_RATE[3:2]=10, RX_RATE[1:0]=00 */
++#define MAX96717_LINK_SPEED_6GBPS	0x08
 +
 +/* EXT11 tunnel mode pre-config (0x0383=0x80) */
 +#define MAX96717_EXT11_TUN_PRE		0x80

--- a/nvidia-oot/6.2/0011-Add-MAX96717-serializer-and-MAX96724-deserializer-dr.patch
+++ b/nvidia-oot/6.2/0011-Add-MAX96717-serializer-and-MAX96724-deserializer-dr.patch
@@ -22,12 +22,11 @@ MAX96724 quad deserializer features:
 
 Signed-off-by: RealSense AI <realsense@realsenseai.com>
 ---
- drivers/media/i2c/Makefile   |    2 +
- drivers/media/i2c/max96717.c |  835 ++++++++++++++
- drivers/media/i2c/max96724.c | 1916 ++++++++++++++++++++++++++++++++++
+ drivers/media/i2c/max96717.c |  853 ++++++++++++++
+ drivers/media/i2c/max96724.c | 1992 ++++++++++++++++++++++++++++++++++
  include/media/max96717.h     |  151 ++
  include/media/max96724.h     |  183 +++
- 4 files changed, 3085 insertions(+)
+ 4 files changed, 3179 insertions(+)
  create mode 100644 drivers/media/i2c/max96717.c
  create mode 100644 drivers/media/i2c/max96724.c
  create mode 100644 include/media/max96717.h
@@ -38,7 +37,7 @@ new file mode 100644
 index 0000000..70d25a3
 --- /dev/null
 +++ b/drivers/media/i2c/max96717.c
-@@ -0,0 +1,835 @@
+@@ -0,0 +1,853 @@
 +/*
 + * max96717.c - MAX96717 GMSL2 Serializer driver (Tunnel Mode)
 + *
@@ -67,9 +66,9 @@ index 0000000..70d25a3
 +/* REG0: Device ID (read-only, returns 0x40) */
 +#define MAX96717_DEV_ADDR		0x00
 +
-+/* 
-+ *   REG1: Link Speed
-+ *   bit[3]=1: 3 Gbps, bit[4]=1: 6 Gbps
++/*
++ *   REG1: GMSL2 link rate
++ *   0x48: 6Gbps forward / 187.5Mbps reverse
 + */
 +#define MAX96717_REG1_ADDR		0x01
 +
@@ -216,10 +215,10 @@ index 0000000..70d25a3
 +/* MIPI_RX0: Normal operation */
 +#define MAX96717_MIPI_RX0_NORMAL	0x00
 +
-+/* REG1: 3 Gbps link speed, bit[3]=1 */
++/* REG1: 3Gbps forward / 187.5Mbps reverse */
 +#define MAX96717_LINK_SPEED_3GBPS	0x08
-+/* REG1: 6 Gbps link speed, bit[4]=1 */
-+#define MAX96717_LINK_SPEED_6GBPS	0x10
++/* REG1: 6Gbps forward / 187.5Mbps reverse */
++#define MAX96717_LINK_SPEED_6GBPS	0x48
 +
 +/* EXT11 tunnel mode pre-config (0x0383=0x80) */
 +#define MAX96717_EXT11_TUN_PRE		0x80
@@ -378,6 +377,7 @@ index 0000000..70d25a3
 +	struct max96717 *priv = dev_get_drvdata(dev);
 +	int err = 0;
 +	struct gmsl_link_ctx *g_ctx;
++	u8 ctrl0_val;
 +
 +	mutex_lock(&priv->lock);
 +
@@ -397,9 +397,12 @@ index 0000000..70d25a3
 +					MAX96717_DEV_ADDR, &dev_id);
 +		if (probe_ret == 0) {
 +			/* Primary address (0x40) still responsive — do reassign */
-+			max96717_write_reg(&prim_priv__->i2c_client->dev,
-+					   MAX96717_DEV_ADDR,
-+					   (g_ctx->ser_reg << 1));
++			err = max96717_write_reg(&prim_priv__->i2c_client->dev,
++						 MAX96717_DEV_ADDR,
++						 (g_ctx->ser_reg << 1));
++			if (err)
++				goto error;
++			msleep(20);
 +		} else {
 +			dev_info(&prim_priv__->i2c_client->dev,
 +				 "%s: SER already reassigned (addr 0x40 NACK), skipping DEV_ADDR write\n",
@@ -407,13 +410,27 @@ index 0000000..70d25a3
 +		}
 +	}
 +
-+	/* CTRL0: GMSL2 mode + TX enable */
++	/* Match MAX96724 6Gbps forward / 187.5Mbps reverse link setup. */
++	err = max96717_write_reg(dev, MAX96717_REG1_ADDR,
++				 MAX96717_LINK_SPEED_6GBPS);
++	if (err) {
++		dev_err(dev, "%s: failed to configure serializer link rate\n",
++			__func__);
++		goto error;
++	}
++
 +	if (g_ctx->serdes_csi_link == GMSL_SERDES_CSI_LINK_A)
-+		err = max96717_write_reg(dev, MAX96717_CTRL0_ADDR,
-+					 MAX96717_CTRL0_LINK_A);
++		ctrl0_val = MAX96717_CTRL0_LINK_A;
 +	else
-+		err = max96717_write_reg(dev, MAX96717_CTRL0_ADDR,
-+					 MAX96717_CTRL0_LINK_B);
++		ctrl0_val = MAX96717_CTRL0_LINK_B;
++
++	dev_info(dev, "%s: SER rate=6Gbps/187.5Mbps link=%c CTRL0=0x%02x\n",
++		 __func__,
++		 (g_ctx->serdes_csi_link == GMSL_SERDES_CSI_LINK_A) ? 'A' : 'B',
++		 ctrl0_val);
++
++	/* CTRL0: manual single-link mode + one-shot reset on selected PHY. */
++	err = max96717_write_reg(dev, MAX96717_CTRL0_ADDR, ctrl0_val);
 +
 +	if (err) {
 +		dev_err(dev, "%s: ERROR: ser device not found\n", __func__);
@@ -879,7 +896,7 @@ new file mode 100644
 index 0000000..22bfb47
 --- /dev/null
 +++ b/drivers/media/i2c/max96724.c
-@@ -0,0 +1,1916 @@
+@@ -0,0 +1,1992 @@
 +/*
 + * max96724.c - MAX96724 GMSL2 Quad Deserializer driver (Tunnel Mode)
 + *
@@ -939,8 +956,11 @@ index 0000000..22bfb47
 +/* GMSL Link/PHY Rate Select (Links C&D) */
 +#define MAX96724_LINK_RATE_CD_ADDR	0x0011
 +
-+/* Link A lock status (bit[3]=LOCK) */
++/* Link lock status (bit[3]=LOCK). */
 +#define MAX96724_LINK_A_LOCK_ADDR	0x001A
++#define MAX96724_LINK_B_LOCK_ADDR	0x001B
++#define MAX96724_LINK_C_LOCK_ADDR	0x001C
++#define MAX96724_LINK_D_LOCK_ADDR	0x001D
 +
 +/* 
 + *   GMSL Link Reset
@@ -1171,6 +1191,10 @@ index 0000000..22bfb47
 +#define MAX96724_LINK_EN_SIOA		0xF1  /* GMSL2 all, enable Link A only */
 +#define MAX96724_LINK_EN_ALL		0xFF  /* GMSL2 all, enable all links */
 +
++#define MAX96724_LINK_LOCKED		0x08
++#define MAX96724_LINK_LOCK_POLL_MS	100
++#define MAX96724_LINK_LOCK_TIMEOUT_MS	5000
++
 +/* BACKTOP_EN (0x040B): CSI output port enable */
 +#define MAX96724_BACKTOP_CSIB_EN	0x02
 +#define MAX96724_BACKTOP_CSIA_EN	0x01
@@ -1245,10 +1269,10 @@ index 0000000..22bfb47
 +#define MAX96724_DPLL_700MBPS_CTRL0	0x27
 +
 +/* 
-+ *   CSI-output DPLL data rate = 1300 Mbps.
-+ *   bits[4:0] = data-rate / 100 MHz -> 1300/100 = 13 = 0x0D. bit[5] = DPLL en.
++ *   CSI-output DPLL data rate = 2000 Mbps.
++ *   bits[4:0] = data-rate / 100 MHz -> 2000/100 = 20 = 0x14. bit[5] = DPLL en.
 + */
-+#define MAX96724_DPLL_1300MBPS		0x2D
++#define MAX96724_DPLL_2000MBPS		0x34
 +
 +/* One-shot reset: all links */
 +#define MAX96724_ONESHOT_ALL		0x0F
@@ -1394,6 +1418,94 @@ index 0000000..22bfb47
 +	}
 +
 +	return err;
++}
++
++static const char *max96724_link_name(u32 link)
++{
++	switch (link) {
++	case GMSL_SERDES_CSI_LINK_A:
++		return "A";
++	case GMSL_SERDES_CSI_LINK_B:
++		return "B";
++	default:
++		return "?";
++	}
++}
++
++static u16 max96724_link_lock_addr(u32 link)
++{
++	switch (link) {
++	case GMSL_SERDES_CSI_LINK_A:
++		return MAX96724_LINK_A_LOCK_ADDR;
++	case GMSL_SERDES_CSI_LINK_B:
++		return MAX96724_LINK_B_LOCK_ADDR;
++	default:
++		return 0;
++	}
++}
++
++static void max96724_log_link_status(struct device *dev, const char *tag)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++	unsigned int lock_a = 0, lock_b = 0, lock_c = 0, lock_d = 0;
++	unsigned int link_en = 0, reg10 = 0, reg11 = 0;
++
++	regmap_read(priv->regmap, MAX96724_LINK_A_LOCK_ADDR, &lock_a);
++	regmap_read(priv->regmap, MAX96724_LINK_B_LOCK_ADDR, &lock_b);
++	regmap_read(priv->regmap, MAX96724_LINK_C_LOCK_ADDR, &lock_c);
++	regmap_read(priv->regmap, MAX96724_LINK_D_LOCK_ADDR, &lock_d);
++	regmap_read(priv->regmap, MAX96724_LINK_EN_ADDR, &link_en);
++	regmap_read(priv->regmap, MAX96724_LINK_RATE_AB_ADDR, &reg10);
++	regmap_read(priv->regmap, MAX96724_LINK_RATE_CD_ADDR, &reg11);
++
++	dev_info(dev,
++		 "GMSL link status[%s]: EN=0x%02x A@0x%04x=0x%02x(%s) B@0x%04x=0x%02x(%s) C@0x%04x=0x%02x(%s) D@0x%04x=0x%02x(%s) REG10=0x%02x REG11=0x%02x\n",
++		 tag, link_en,
++		 MAX96724_LINK_A_LOCK_ADDR,
++		 lock_a, (lock_a & MAX96724_LINK_LOCKED) ? "LOCK" : "noLk",
++		 MAX96724_LINK_B_LOCK_ADDR,
++		 lock_b, (lock_b & MAX96724_LINK_LOCKED) ? "LOCK" : "noLk",
++		 MAX96724_LINK_C_LOCK_ADDR,
++		 lock_c, (lock_c & MAX96724_LINK_LOCKED) ? "LOCK" : "noLk",
++		 MAX96724_LINK_D_LOCK_ADDR,
++		 lock_d, (lock_d & MAX96724_LINK_LOCKED) ? "LOCK" : "noLk",
++		 reg10, reg11);
++}
++
++static int max96724_wait_link_lock(struct device *dev, u32 link)
++{
++	struct max96724 *priv = dev_get_drvdata(dev);
++	u16 lock_addr = max96724_link_lock_addr(link);
++	unsigned int lock = 0;
++	int elapsed;
++	int err;
++
++	if (!lock_addr)
++		return -EINVAL;
++
++	for (elapsed = 0;
++	     elapsed <= MAX96724_LINK_LOCK_TIMEOUT_MS;
++	     elapsed += MAX96724_LINK_LOCK_POLL_MS) {
++		err = regmap_read(priv->regmap, lock_addr, &lock);
++		if (err)
++			return err;
++
++		if (lock & MAX96724_LINK_LOCKED) {
++			dev_info(dev, "GMSL Link %s locked after %d ms (reg 0x%04x=0x%02x)\n",
++				 max96724_link_name(link), elapsed, lock_addr, lock);
++			return 0;
++		}
++
++		if (elapsed < MAX96724_LINK_LOCK_TIMEOUT_MS)
++			msleep(MAX96724_LINK_LOCK_POLL_MS);
++	}
++
++	dev_err(dev, "GMSL Link %s lock timeout after %d ms (reg 0x%04x=0x%02x)\n",
++		max96724_link_name(link), MAX96724_LINK_LOCK_TIMEOUT_MS,
++		lock_addr, lock);
++	max96724_log_link_status(dev, "timeout");
++
++	return -ETIMEDOUT;
 +}
 +
 +/* ================================================================
@@ -1631,6 +1743,7 @@ index 0000000..22bfb47
 +	struct max96724 *priv = dev_get_drvdata(dev);
 +	u8 link_rate_ab, link_rate_cd;
 +	u8 link_en_val;
++	int err;
 +
 +	/*
 +	 * [Aardvark-verified] Disable CSI output before link configuration
@@ -1691,34 +1804,13 @@ index 0000000..22bfb47
 +	max96724_write_reg(dev, MAX96724_LINK_EN_ADDR, link_en_val);
 +
 +	/*
-+	 * Wait for link lock.
-+	 * [XML] Uses 1000ms regardless of link speed.
-+	 * I2C pass-through CC requires fully trained link, not just PHY lock.
++	 * Poll the selected physical GMSL input until link lock before
++	 * accessing the remote serializer over the control channel.
 +	 */
-+	msleep(1000);
-+
-+	/* Check link lock status on ALL ports for diagnostics */
-+	{
-+		unsigned int lock_a = 0, lock_b = 0, lock_c = 0, lock_d = 0;
-+		unsigned int link_en = 0;
-+		unsigned int reg10 = 0, reg11 = 0;
-+
-+		regmap_read(priv->regmap, 0x001A, &lock_a);
-+		regmap_read(priv->regmap, 0x001B, &lock_b);
-+		regmap_read(priv->regmap, 0x001C, &lock_c);
-+		regmap_read(priv->regmap, 0x001D, &lock_d);
-+		regmap_read(priv->regmap, MAX96724_LINK_EN_ADDR, &link_en);
-+		regmap_read(priv->regmap, 0x0010, &reg10);
-+		regmap_read(priv->regmap, 0x0011, &reg11);
-+		dev_info(dev,
-+			 "GMSL link status: EN=0x%02x A=0x%02x(%s) B=0x%02x(%s) C=0x%02x(%s) D=0x%02x(%s) REG10=0x%02x REG11=0x%02x\n",
-+			 link_en,
-+			 lock_a, (lock_a & 0x08) ? "LOCK" : "noLk",
-+			 lock_b, (lock_b & 0x08) ? "LOCK" : "noLk",
-+			 lock_c, (lock_c & 0x08) ? "LOCK" : "noLk",
-+			 lock_d, (lock_d & 0x08) ? "LOCK" : "noLk",
-+			 reg10, reg11);
-+	}
++	err = max96724_wait_link_lock(dev, link);
++	max96724_log_link_status(dev, err ? "after-timeout" : "after-lock");
++	if (err)
++		return err;
 +
 +	return 0;
 +}
@@ -2089,14 +2181,14 @@ index 0000000..22bfb47
 +		vid_rx0_cfg = MAX96724_VID_RX0_PIXEL_VAL;
 +		vid_rx6_cfg = MAX96724_VID_RX6_PIXEL_VAL;
 +		st_sel_cfg = 0x00;
-+		dpll_cfg = MAX96724_DPLL_1300MBPS;
++		dpll_cfg = MAX96724_DPLL_2000MBPS;
 +	} else {
 +		pipe_sel0 = MAX96724_PIPE_SEL0_PIXEL;
 +		pipe_sel1 = MAX96724_PIPE_SEL1_PIXEL;
 +		vid_rx0_cfg = MAX96724_VID_RX0_CFG_VAL;
 +		vid_rx6_cfg = MAX96724_VID_RX6_CFG_VAL;
 +		st_sel_cfg = 0x10;
-+		dpll_cfg = MAX96724_DPLL_1300MBPS;
++		dpll_cfg = MAX96724_DPLL_2000MBPS;
 +	}
 +
 +	/*
@@ -2116,7 +2208,7 @@ index 0000000..22bfb47
 +	max96724_apply_porta_subset(dev, priv);
 +
 +	/*
-+	 * CSI-output DPLL data rate = 1300 Mbps
++	 * CSI-output DPLL data rate = 2000 Mbps
 +	 * on ALL FOUR controller freq registers
 +	 */
 +	if (!priv->lane_setup) {
@@ -2335,14 +2427,14 @@ index 0000000..22bfb47
 +		vid_rx0_cfg = MAX96724_VID_RX0_PIXEL_VAL;
 +		vid_rx6_cfg = MAX96724_VID_RX6_PIXEL_VAL;
 +		st_sel_cfg = 0x00;
-+		dpll_cfg = MAX96724_DPLL_1300MBPS;
++		dpll_cfg = MAX96724_DPLL_2000MBPS;
 +	} else {
 +		pipe_sel0 = MAX96724_PIPE_SEL0_PIXEL;
 +		pipe_sel1 = MAX96724_PIPE_SEL1_PIXEL;
 +		vid_rx0_cfg = MAX96724_VID_RX0_CFG_VAL;
 +		vid_rx6_cfg = MAX96724_VID_RX6_CFG_VAL;
 +		st_sel_cfg = 0x10;
-+		dpll_cfg = MAX96724_DPLL_1300MBPS;
++		dpll_cfg = MAX96724_DPLL_2000MBPS;
 +	}
 +
 +	/* 
@@ -2359,8 +2451,9 @@ index 0000000..22bfb47
 +	max96724_apply_porta_subset(dev, priv);
 +
 +	/*
-+	 * CSI-output DPLL data rate = 1300 Mbps on ALL
-+	 * FOUR controllers, matching the device-tree serdes_pix_clk_hz (325 MHz).
++	 * CSI-output DPLL data rate = 2000 Mbps on ALL controllers.
++	 * This matches the device-tree serdes_pix_clk_hz values:
++	 * 500 MHz for 16-bit modes and 1000 MHz for 8-bit modes.
 +	 * reset_oneshot is called by the sensor after setup_streaming, so it must
 +	 * mirror the same DPLL values.
 +	 */
@@ -3144,4 +3237,3 @@ index 0000000..dc5a8ea
 +#endif  /* __MAX96724_H__ */
 -- 
 2.25.1
-

--- a/nvidia-oot/6.2/0011-Add-MAX96717-serializer-and-MAX96724-deserializer-dr.patch
+++ b/nvidia-oot/6.2/0011-Add-MAX96717-serializer-and-MAX96724-deserializer-dr.patch
@@ -22,11 +22,11 @@ MAX96724 quad deserializer features:
 
 Signed-off-by: RealSense AI <realsense@realsenseai.com>
 ---
- drivers/media/i2c/max96717.c |  853 ++++++++++++++
+ drivers/media/i2c/max96717.c |  854 ++++++++++++++
  drivers/media/i2c/max96724.c | 1992 ++++++++++++++++++++++++++++++++++
  include/media/max96717.h     |  151 ++
  include/media/max96724.h     |  183 +++
- 4 files changed, 3179 insertions(+)
+ 4 files changed, 3180 insertions(+)
  create mode 100644 drivers/media/i2c/max96717.c
  create mode 100644 drivers/media/i2c/max96724.c
  create mode 100644 include/media/max96717.h
@@ -37,7 +37,7 @@ new file mode 100644
 index 0000000..70d25a3
 --- /dev/null
 +++ b/drivers/media/i2c/max96717.c
-@@ -0,0 +1,853 @@
+@@ -0,0 +1,854 @@
 +/*
 + * max96717.c - MAX96717 GMSL2 Serializer driver (Tunnel Mode)
 + *
@@ -68,7 +68,8 @@ index 0000000..70d25a3
 +
 +/*
 + *   REG1: GMSL2 link rate
-+ *   0x48: 6Gbps forward / 187.5Mbps reverse
++ *   TX_RATE[3:2]: 01=3Gbps, 10=6Gbps
++ *   RX_RATE[1:0]: 00=187.5Mbps reverse
 + */
 +#define MAX96717_REG1_ADDR		0x01
 +
@@ -215,10 +216,10 @@ index 0000000..70d25a3
 +/* MIPI_RX0: Normal operation */
 +#define MAX96717_MIPI_RX0_NORMAL	0x00
 +
-+/* REG1: 3Gbps forward / 187.5Mbps reverse */
-+#define MAX96717_LINK_SPEED_3GBPS	0x08
-+/* REG1: 6Gbps forward / 187.5Mbps reverse */
-+#define MAX96717_LINK_SPEED_6GBPS	0x48
++/* REG1: TX_RATE[3:2]=01, RX_RATE[1:0]=00 */
++#define MAX96717_LINK_SPEED_3GBPS	0x04
++/* REG1: TX_RATE[3:2]=10, RX_RATE[1:0]=00 */
++#define MAX96717_LINK_SPEED_6GBPS	0x08
 +
 +/* EXT11 tunnel mode pre-config (0x0383=0x80) */
 +#define MAX96717_EXT11_TUN_PRE		0x80

--- a/nvidia-oot/6.2/0011-Add-MAX96717-serializer-and-MAX96724-deserializer-dr.patch
+++ b/nvidia-oot/6.2/0011-Add-MAX96717-serializer-and-MAX96724-deserializer-dr.patch
@@ -22,11 +22,11 @@ MAX96724 quad deserializer features:
 
 Signed-off-by: RealSense AI <realsense@realsenseai.com>
 ---
- drivers/media/i2c/max96717.c |  854 ++++++++++++++
- drivers/media/i2c/max96724.c | 1992 ++++++++++++++++++++++++++++++++++
+ drivers/media/i2c/max96717.c |  857 ++++++++++++++
+ drivers/media/i2c/max96724.c | 1994 ++++++++++++++++++++++++++++++++++
  include/media/max96717.h     |  151 ++
  include/media/max96724.h     |  183 +++
- 4 files changed, 3180 insertions(+)
+ 4 files changed, 3185 insertions(+)
  create mode 100644 drivers/media/i2c/max96717.c
  create mode 100644 drivers/media/i2c/max96724.c
  create mode 100644 include/media/max96717.h
@@ -37,7 +37,7 @@ new file mode 100644
 index 0000000..70d25a3
 --- /dev/null
 +++ b/drivers/media/i2c/max96717.c
-@@ -0,0 +1,854 @@
+@@ -0,0 +1,857 @@
 +/*
 + * max96717.c - MAX96717 GMSL2 Serializer driver (Tunnel Mode)
 + *
@@ -67,7 +67,7 @@ index 0000000..70d25a3
 +#define MAX96717_DEV_ADDR		0x00
 +
 +/*
-+ *   REG1: GMSL2 link rate
++ *   REG1: GMSL2 link rate, CC pin routing, pass-through I2C enables
 + *   TX_RATE[3:2]: 01=3Gbps, 10=6Gbps
 + *   RX_RATE[1:0]: 00=187.5Mbps reverse
 + */
@@ -135,8 +135,8 @@ index 0000000..70d25a3
 +/* 
 + *   MIPI_RX0-RX3: CSI-2 receiver configuration
 + *   RX0 (0x330): CSI mode (0x00 = D-PHY controller A)
-+ *   RX1 (0x331): Lane count - ctrl1_num_lanes bits[5:4]
-+ *                0x30 = bits[5:4]=11 (4 lanes)
++ *   RX1 (0x331): bit[6] deskew + ctrl1_num_lanes bits[5:4]
++ *                0x70 = deskew enabled + bits[5:4]=11 (4 lanes)
 + *   RX2 (0x332): Lane mapping - 0xE0 = default 1x4 map
 + *   RX3 (0x333): Lane mapping - 0x04 = default 1x4 map
 + */
@@ -190,10 +190,10 @@ index 0000000..70d25a3
 +#define MAX96717_VIDEO_TX2_DRIFT_DIS	0x08
 +
 +/* 
-+ *   MIPI RX1: 4-lane CSI-2.
-+ *   bits[5:4]=11 (4 lanes).  bits[1:0]=11
++ *   MIPI RX1: 4-lane CSI-2 with input deskew enabled.
++ *   bit[6]=1 (deskew), bits[5:4]=11 (4 lanes).
 + */
-+#define MAX96717_CSI_4_LANES		0x33
++#define MAX96717_CSI_4_LANES		0x70
 +/* 2-lane CSI-2, bits[5:4]=01 */
 +#define MAX96717_CSI_2_LANES		0x10
 +
@@ -218,8 +218,8 @@ index 0000000..70d25a3
 +
 +/* REG1: TX_RATE[3:2]=01, RX_RATE[1:0]=00 */
 +#define MAX96717_LINK_SPEED_3GBPS	0x04
-+/* REG1: TX_RATE[3:2]=10, RX_RATE[1:0]=00 */
-+#define MAX96717_LINK_SPEED_6GBPS	0x08
++/* REG1: IIC_2_EN=1, DIS_LOCAL_CC=0, TX_RATE[3:2]=10, RX_RATE[1:0]=00 */
++#define MAX96717_LINK_SPEED_6GBPS	0x88
 +
 +/* EXT11 tunnel mode pre-config (0x0383=0x80) */
 +#define MAX96717_EXT11_TUN_PRE		0x80
@@ -227,7 +227,7 @@ index 0000000..70d25a3
 +#define MAX96717_MAX_PIPES		4
 +
 +/*
-+ * MFP8 (GPIO8) high-impedance release.
++ * MFP7/MFP8 high-impedance release.
 + *
 + * At power-up GPIO8 comes up with GPIO_OUT_DIS=0 (output driver enabled,
 + * GPIO8_A=0x9c observed live), so the serializer actively drives the M2_I2C
@@ -235,15 +235,16 @@ index 0000000..70d25a3
 + * whenever the serializer is powered.  This was confirmed on hardware -
 + * tri-stating GPIO8 alone immediately restored IMU I2C reads.
 + *
-+ * GPIO8 is the ONLY serializer pin left driving its net (all other GPIOs,
-+ * including MFP3/MFP4 interrupt lines, are already high-Z).  Release GPIO8
-+ * (output driver off, no link TX/RX, no pull) so only the M2_I2C bus
++ * Release MFP7/MFP8 (output driver off, no link TX/RX, no pull) so only
++ * the M2_I2C bus
 + * masters own the line.
 + *
 + * GPIO_n registers are a 3-byte group (A/B/C) starting at 0x02BE:
 + *   GPIO_n_A = 0x02BE + 3*n
 + */
-+#define MAX96717_GPIO8_A_ADDR		0x02D6	/* MFP8 / M2_I2C (pass-through SCL1) */
++#define MAX96717_GPIO7_A_ADDR		0x02D3	/* MFP7 / pass-through SDA1 */
++#define MAX96717_GPIO7_B_ADDR		0x02D4
++#define MAX96717_GPIO8_A_ADDR		0x02D6	/* MFP8 / pass-through SCL1 */
 +#define MAX96717_GPIO8_B_ADDR		0x02D7
 +/* GPIO_A: GPIO_OUT_DIS=1 (high-Z), GPIO_TX_EN=0, GPIO_RX_EN=0 */
 +#define MAX96717_GPIO_A_HIGH_Z		0x01
@@ -411,7 +412,7 @@ index 0000000..70d25a3
 +		}
 +	}
 +
-+	/* Match MAX96724 6Gbps forward / 187.5Mbps reverse link setup. */
++	/* Enable 6Gbps GMSL and keep local CC on MFP9/MFP10 for HKR I2C. */
 +	err = max96717_write_reg(dev, MAX96717_REG1_ADDR,
 +				 MAX96717_LINK_SPEED_6GBPS);
 +	if (err) {
@@ -425,7 +426,7 @@ index 0000000..70d25a3
 +	else
 +		ctrl0_val = MAX96717_CTRL0_LINK_B;
 +
-+	dev_info(dev, "%s: SER rate=6Gbps/187.5Mbps link=%c CTRL0=0x%02x\n",
++	dev_info(dev, "%s: SER rate=6Gbps/187.5Mbps local_CC(MFP9/10)=on PT2_I2C=on link=%c CTRL0=0x%02x\n",
 +		 __func__,
 +		 (g_ctx->serdes_csi_link == GMSL_SERDES_CSI_LINK_A) ? 'A' : 'B',
 +		 ctrl0_val);
@@ -696,11 +697,13 @@ index 0000000..70d25a3
 +		{MAX96717_PIPE_EN_ADDR, MAX96717_PIPE_EN_ALL},
 +	};
 +	/*
-+	 * Release MFP8 (GPIO8) before any other config so the serializer
++	 * Release MFP7/MFP8 before any other config so the serializer
 +	 * stops driving the camera-side M2_I2C bus shared with the BMI088
 +	 * IMU. Confirmed on HW: tri-stating GPIO8 restores IMU I2C access.
 +	 */
 +	struct reg_pair gpio_release[] = {
++		{MAX96717_GPIO7_A_ADDR, MAX96717_GPIO_A_HIGH_Z},
++		{MAX96717_GPIO7_B_ADDR, MAX96717_GPIO_B_NO_PULL},
 +		{MAX96717_GPIO8_A_ADDR, MAX96717_GPIO_A_HIGH_Z},
 +		{MAX96717_GPIO8_B_ADDR, MAX96717_GPIO_B_NO_PULL},
 +	};
@@ -715,14 +718,14 @@ index 0000000..70d25a3
 +	usleep_range(5000, 6000);
 +
 +	/*
-+	 * Tri-state MFP8 (GPIO8) first to release the camera-side M2_I2C
++	 * Tri-state MFP7/MFP8 first to release the camera-side M2_I2C
 +	 * bus shared with the BMI088 IMU before configuring the rest of
 +	 * the SER.
 +	 */
 +	err = max96717_set_registers(dev, gpio_release,
 +				    ARRAY_SIZE(gpio_release));
 +	if (err)
-+		dev_warn(dev, "%s: failed to release MFP8 (IMU M2_I2C bus)\n",
++		dev_warn(dev, "%s: failed to release MFP7/MFP8 (M2_I2C bus)\n",
 +			 __func__);
 +
 +	if (priv->pixel_mode) {
@@ -897,7 +900,7 @@ new file mode 100644
 index 0000000..22bfb47
 --- /dev/null
 +++ b/drivers/media/i2c/max96724.c
-@@ -0,0 +1,1992 @@
+@@ -0,0 +1,1994 @@
 +/*
 + * max96724.c - MAX96724 GMSL2 Quad Deserializer driver (Tunnel Mode)
 + *
@@ -1215,9 +1218,11 @@ index 0000000..22bfb47
 +/* 
 + *   Tunnel mode enable (MIPI_TX54, 0x0936):
 + *   bit[0] = TUN_EN = 1
-+ *   Verified value: 0x01
++ *   bits[6:5] = DESKEW_TUN = 1, periodic deskew follows SER.
++ *   This keeps the MAX96724 D-PHY output deskew cadence aligned with
++ *   the tunneled CSI-2 source when HKR->SER runs at >= 1.5Gbps/lane.
 + */
-+#define MAX96724_TUN_EN			0x01
++#define MAX96724_TUN_EN			0x21
 +
 +/* Default/reset state when tunnel is disabled */
 +#define MAX96724_TUN_DISABLED		0x08

--- a/nvidia-oot/6.2/0012-Enable-Tegra-CSI-debugfs.patch
+++ b/nvidia-oot/6.2/0012-Enable-Tegra-CSI-debugfs.patch
@@ -1,0 +1,192 @@
+diff --git a/drivers/media/platform/tegra/camera/csi/csi.c b/drivers/media/platform/tegra/camera/csi/csi.c
+index 7e3dfb3a..3d221ac6 100644
+--- a/drivers/media/platform/tegra/camera/csi/csi.c
++++ b/drivers/media/platform/tegra/camera/csi/csi.c
+@@ -7,7 +7,9 @@
+ #include <nvidia/conftest.h>
+ 
+ #include <linux/clk.h>
++#include <linux/debugfs.h>
+ #include <linux/device.h>
++#include <linux/err.h>
+ #include <linux/gpio/consumer.h>
+ #include <linux/of.h>
+ #include <linux/of_graph.h>
+@@ -15,6 +17,7 @@
+ #include <linux/of_platform.h>
+ #include <linux/property.h>
+ #include <linux/nospec.h>
++#include <linux/seq_file.h>
+ 
+ #include <media/media-entity.h>
+ #include <media/v4l2-async.h>
+@@ -155,6 +158,151 @@ u64 read_mipi_clk_from_dt(struct tegra_csi_channel *chan)
+ 	return mipi_clk;
+ }
+ 
++#ifdef CONFIG_DEBUG_FS
++static const char *tegra_csi_debugfs_port_name(u32 port)
++{
++	switch (port) {
++	case NVCSI_PORT_A:
++		return "serial_a";
++	case NVCSI_PORT_B:
++		return "serial_b";
++	case NVCSI_PORT_C:
++		return "serial_c";
++	case NVCSI_PORT_D:
++		return "serial_d";
++	case NVCSI_PORT_E:
++		return "serial_e";
++	case NVCSI_PORT_F:
++		return "serial_f";
++	case NVCSI_PORT_G:
++		return "serial_g";
++	case NVCSI_PORT_H:
++		return "serial_h";
++	default:
++		return "unspecified";
++	}
++}
++
++static void tegra_csi_debugfs_mode_show(struct seq_file *s,
++					struct camera_common_data *s_data)
++{
++	struct sensor_mode_properties *mode;
++	struct sensor_signal_properties *sig;
++	struct sensor_image_properties *img;
++	int idx;
++	u32 num_modes;
++
++	if (!s_data) {
++		seq_puts(s, "  sensor: unavailable\n");
++		return;
++	}
++
++	idx = s_data->mode_prop_idx;
++	num_modes = s_data->sensor_props.num_modes;
++	seq_printf(s,
++		   "  sensor: csi_port=%d (%s) numlanes=%d mode_prop_idx=%d num_modes=%u\n",
++		   s_data->csi_port,
++		   tegra_csi_debugfs_port_name(s_data->csi_port),
++		   s_data->numlanes, idx, num_modes);
++
++	if (idx < 0 || idx >= (int)num_modes) {
++		seq_puts(s, "  mode: unavailable\n");
++		return;
++	}
++
++	mode = &s_data->sensor_props.sensor_modes[idx];
++	sig = &mode->signal_properties;
++	img = &mode->image_properties;
++
++	seq_printf(s,
++		   "  mode: width=%u height=%u line_length=%u embedded_metadata_height=%u pixel_format=0x%x\n",
++		   img->width, img->height, img->line_length,
++		   img->embedded_metadata_height, img->pixel_format);
++	seq_printf(s,
++		   "  clocks: pixel_clock=%llu serdes_pixel_clock=%llu mipi_clock=%llu lane_rate_dphy=%llu\n",
++		   (unsigned long long)sig->pixel_clock.val,
++		   (unsigned long long)sig->serdes_pixel_clock.val,
++		   (unsigned long long)sig->mipi_clock.val,
++		   (unsigned long long)(sig->mipi_clock.val * 2));
++	seq_printf(s,
++		   "  signal: num_lanes=%u tegra_sinterface=%u phy_mode=%u cil_settletime=%u deskew_initial=%u deskew_periodic=%u\n",
++		   sig->num_lanes, sig->tegra_sinterface, sig->phy_mode,
++		   sig->cil_settletime, sig->deskew_initial_enable,
++		   sig->deskew_periodic_enable);
++}
++
++static int tegra_csi_debugfs_summary_show(struct seq_file *s, void *unused)
++{
++	struct tegra_csi_device *csi = s->private;
++	struct tegra_csi_channel *chan;
++	int i;
++
++	if (!csi)
++		return 0;
++
++	seq_printf(s, "device: %s\n", dev_name(csi->dev));
++	seq_printf(s, "channels: %d\n", csi->num_channels);
++	seq_printf(s, "power_ref: %d\n", atomic_read(&csi->power_ref));
++	seq_printf(s, "tpg_active: %d\n", csi->tpg_active);
++	seq_printf(s, "sensor_active: %d\n", csi->sensor_active);
++
++	list_for_each_entry(chan, &csi->csi_chans, list) {
++		seq_printf(s,
++			   "\nchannel%u: streaming=%d pg_mode=%u numports=%u numlanes=%u of_node=%pOF\n",
++			   chan->id, atomic_read(&chan->is_streaming),
++			   chan->pg_mode, chan->numports, chan->numlanes,
++			   chan->of_node);
++
++		for (i = 0; i < chan->numports; i++) {
++			struct tegra_csi_port *port = &chan->ports[i];
++
++			seq_printf(s,
++				   "  port%d: csi_port=%u (%s) stream_id=%u vc=%u lanes=%u format=%ux%u code=0x%x\n",
++				   i, port->csi_port,
++				   tegra_csi_debugfs_port_name(port->csi_port),
++				   port->stream_id, port->virtual_channel_id,
++				   port->lanes, port->format.width,
++				   port->format.height, port->format.code);
++		}
++
++		tegra_csi_debugfs_mode_show(s, chan->s_data);
++	}
++
++	return 0;
++}
++
++DEFINE_SHOW_ATTRIBUTE(tegra_csi_debugfs_summary);
++
++static void tegra_csi_debugfs_init(struct tegra_csi_device *csi)
++{
++	if (!debugfs_initialized())
++		return;
++
++	csi->debugdir = debugfs_create_dir("csi", NULL);
++	if (IS_ERR_OR_NULL(csi->debugdir)) {
++		csi->debugdir = NULL;
++		return;
++	}
++
++	debugfs_create_file("summary", 0444, csi->debugdir, csi,
++			    &tegra_csi_debugfs_summary_fops);
++}
++
++static void tegra_csi_debugfs_remove(struct tegra_csi_device *csi)
++{
++	debugfs_remove_recursive(csi->debugdir);
++	csi->debugdir = NULL;
++}
++#else
++static inline void tegra_csi_debugfs_init(struct tegra_csi_device *csi)
++{
++}
++
++static inline void tegra_csi_debugfs_remove(struct tegra_csi_device *csi)
++{
++}
++#endif
++
+ void set_csi_portinfo(struct tegra_csi_device *csi,
+ 	unsigned int port, unsigned int numlanes)
+ {
+@@ -1154,6 +1302,8 @@ int tegra_csi_media_controller_init(struct tegra_csi_device *csi,
+ 	if (ret < 0)
+ 		dev_err(&pdev->dev, "Failed to init csi property,clks\n");
+ 
++	tegra_csi_debugfs_init(csi);
++
+ 	return 0;
+ }
+ EXPORT_SYMBOL(tegra_csi_media_controller_init);
+@@ -1163,6 +1313,8 @@ int tegra_csi_media_controller_remove(struct tegra_csi_device *csi)
+ 	struct tegra_csi_channel *chan;
+ 	struct v4l2_subdev *sd;
+ 
++	tegra_csi_debugfs_remove(csi);
++
+ 	list_for_each_entry(chan, &csi->csi_chans, list) {
+ 		sd = &chan->subdev;
+ #if defined(CONFIG_V4L2_ASYNC)

--- a/nvidia-oot/7.0/0011-Add-MAX96717-serializer-and-MAX96724-deserializer-dr.patch
+++ b/nvidia-oot/7.0/0011-Add-MAX96717-serializer-and-MAX96724-deserializer-dr.patch
@@ -1245,10 +1245,10 @@ index 0000000..22bfb47
 +#define MAX96724_DPLL_700MBPS_CTRL0	0x27
 +
 +/* 
-+ *   CSI-output DPLL data rate = 1300 Mbps.
-+ *   bits[4:0] = data-rate / 100 MHz -> 1300/100 = 13 = 0x0D. bit[5] = DPLL en.
++ *   CSI-output DPLL data rate = 2000 Mbps.
++ *   bits[4:0] = data-rate / 100 MHz -> 2000/100 = 20 = 0x14. bit[5] = DPLL en.
 + */
-+#define MAX96724_DPLL_1300MBPS		0x2D
++#define MAX96724_DPLL_2000MBPS		0x34
 +
 +/* One-shot reset: all links */
 +#define MAX96724_ONESHOT_ALL		0x0F
@@ -2089,14 +2089,14 @@ index 0000000..22bfb47
 +		vid_rx0_cfg = MAX96724_VID_RX0_PIXEL_VAL;
 +		vid_rx6_cfg = MAX96724_VID_RX6_PIXEL_VAL;
 +		st_sel_cfg = 0x00;
-+		dpll_cfg = MAX96724_DPLL_1300MBPS;
++		dpll_cfg = MAX96724_DPLL_2000MBPS;
 +	} else {
 +		pipe_sel0 = MAX96724_PIPE_SEL0_PIXEL;
 +		pipe_sel1 = MAX96724_PIPE_SEL1_PIXEL;
 +		vid_rx0_cfg = MAX96724_VID_RX0_CFG_VAL;
 +		vid_rx6_cfg = MAX96724_VID_RX6_CFG_VAL;
 +		st_sel_cfg = 0x10;
-+		dpll_cfg = MAX96724_DPLL_1300MBPS;
++		dpll_cfg = MAX96724_DPLL_2000MBPS;
 +	}
 +
 +	/*
@@ -2116,7 +2116,7 @@ index 0000000..22bfb47
 +	max96724_apply_porta_subset(dev, priv);
 +
 +	/*
-+	 * CSI-output DPLL data rate = 1300 Mbps
++	 * CSI-output DPLL data rate = 2000 Mbps
 +	 * on ALL FOUR controller freq registers
 +	 */
 +	if (!priv->lane_setup) {
@@ -2335,14 +2335,14 @@ index 0000000..22bfb47
 +		vid_rx0_cfg = MAX96724_VID_RX0_PIXEL_VAL;
 +		vid_rx6_cfg = MAX96724_VID_RX6_PIXEL_VAL;
 +		st_sel_cfg = 0x00;
-+		dpll_cfg = MAX96724_DPLL_1300MBPS;
++		dpll_cfg = MAX96724_DPLL_2000MBPS;
 +	} else {
 +		pipe_sel0 = MAX96724_PIPE_SEL0_PIXEL;
 +		pipe_sel1 = MAX96724_PIPE_SEL1_PIXEL;
 +		vid_rx0_cfg = MAX96724_VID_RX0_CFG_VAL;
 +		vid_rx6_cfg = MAX96724_VID_RX6_CFG_VAL;
 +		st_sel_cfg = 0x10;
-+		dpll_cfg = MAX96724_DPLL_1300MBPS;
++		dpll_cfg = MAX96724_DPLL_2000MBPS;
 +	}
 +
 +	/* 
@@ -2359,8 +2359,9 @@ index 0000000..22bfb47
 +	max96724_apply_porta_subset(dev, priv);
 +
 +	/*
-+	 * CSI-output DPLL data rate = 1300 Mbps on ALL
-+	 * FOUR controllers, matching the device-tree serdes_pix_clk_hz (325 MHz).
++	 * CSI-output DPLL data rate = 2000 Mbps on ALL controllers.
++	 * This matches the device-tree serdes_pix_clk_hz values:
++	 * 500 MHz for 16-bit modes and 1000 MHz for 8-bit modes.
 +	 * reset_oneshot is called by the sensor after setup_streaming, so it must
 +	 * mirror the same DPLL values.
 +	 */
@@ -3144,4 +3145,3 @@ index 0000000..dc5a8ea
 +#endif  /* __MAX96724_H__ */
 -- 
 2.25.1
-

--- a/nvidia-oot/7.0/0011-Add-MAX96717-serializer-and-MAX96724-deserializer-dr.patch
+++ b/nvidia-oot/7.0/0011-Add-MAX96717-serializer-and-MAX96724-deserializer-dr.patch
@@ -23,11 +23,11 @@ MAX96724 quad deserializer features:
 Signed-off-by: RealSense AI <realsense@realsenseai.com>
 ---
  drivers/media/i2c/Makefile   |    2 +
- drivers/media/i2c/max96717.c |  835 ++++++++++++++
+ drivers/media/i2c/max96717.c |  836 ++++++++++++++
  drivers/media/i2c/max96724.c | 1916 ++++++++++++++++++++++++++++++++++
  include/media/max96717.h     |  151 ++
  include/media/max96724.h     |  183 +++
- 4 files changed, 3085 insertions(+)
+ 4 files changed, 3086 insertions(+)
  create mode 100644 drivers/media/i2c/max96717.c
  create mode 100644 drivers/media/i2c/max96724.c
  create mode 100644 include/media/max96717.h
@@ -38,7 +38,7 @@ new file mode 100644
 index 0000000..70d25a3
 --- /dev/null
 +++ b/drivers/media/i2c/max96717.c
-@@ -0,0 +1,835 @@
+@@ -0,0 +1,836 @@
 +/*
 + * max96717.c - MAX96717 GMSL2 Serializer driver (Tunnel Mode)
 + *
@@ -68,8 +68,9 @@ index 0000000..70d25a3
 +#define MAX96717_DEV_ADDR		0x00
 +
 +/* 
-+ *   REG1: Link Speed
-+ *   bit[3]=1: 3 Gbps, bit[4]=1: 6 Gbps
++ *   REG1: GMSL2 link rate
++ *   TX_RATE[3:2]: 01=3Gbps, 10=6Gbps
++ *   RX_RATE[1:0]: 00=187.5Mbps reverse
 + */
 +#define MAX96717_REG1_ADDR		0x01
 +
@@ -216,10 +217,10 @@ index 0000000..70d25a3
 +/* MIPI_RX0: Normal operation */
 +#define MAX96717_MIPI_RX0_NORMAL	0x00
 +
-+/* REG1: 3 Gbps link speed, bit[3]=1 */
-+#define MAX96717_LINK_SPEED_3GBPS	0x08
-+/* REG1: 6 Gbps link speed, bit[4]=1 */
-+#define MAX96717_LINK_SPEED_6GBPS	0x10
++/* REG1: TX_RATE[3:2]=01, RX_RATE[1:0]=00 */
++#define MAX96717_LINK_SPEED_3GBPS	0x04
++/* REG1: TX_RATE[3:2]=10, RX_RATE[1:0]=00 */
++#define MAX96717_LINK_SPEED_6GBPS	0x08
 +
 +/* EXT11 tunnel mode pre-config (0x0383=0x80) */
 +#define MAX96717_EXT11_TUN_PRE		0x80

--- a/nvidia-oot/7.1/0011-Add-MAX96717-serializer-and-MAX96724-deserializer-dr.patch
+++ b/nvidia-oot/7.1/0011-Add-MAX96717-serializer-and-MAX96724-deserializer-dr.patch
@@ -1245,10 +1245,10 @@ index 0000000..22bfb47
 +#define MAX96724_DPLL_700MBPS_CTRL0	0x27
 +
 +/* 
-+ *   CSI-output DPLL data rate = 1300 Mbps.
-+ *   bits[4:0] = data-rate / 100 MHz -> 1300/100 = 13 = 0x0D. bit[5] = DPLL en.
++ *   CSI-output DPLL data rate = 2000 Mbps.
++ *   bits[4:0] = data-rate / 100 MHz -> 2000/100 = 20 = 0x14. bit[5] = DPLL en.
 + */
-+#define MAX96724_DPLL_1300MBPS		0x2D
++#define MAX96724_DPLL_2000MBPS		0x34
 +
 +/* One-shot reset: all links */
 +#define MAX96724_ONESHOT_ALL		0x0F
@@ -2089,14 +2089,14 @@ index 0000000..22bfb47
 +		vid_rx0_cfg = MAX96724_VID_RX0_PIXEL_VAL;
 +		vid_rx6_cfg = MAX96724_VID_RX6_PIXEL_VAL;
 +		st_sel_cfg = 0x00;
-+		dpll_cfg = MAX96724_DPLL_1300MBPS;
++		dpll_cfg = MAX96724_DPLL_2000MBPS;
 +	} else {
 +		pipe_sel0 = MAX96724_PIPE_SEL0_PIXEL;
 +		pipe_sel1 = MAX96724_PIPE_SEL1_PIXEL;
 +		vid_rx0_cfg = MAX96724_VID_RX0_CFG_VAL;
 +		vid_rx6_cfg = MAX96724_VID_RX6_CFG_VAL;
 +		st_sel_cfg = 0x10;
-+		dpll_cfg = MAX96724_DPLL_1300MBPS;
++		dpll_cfg = MAX96724_DPLL_2000MBPS;
 +	}
 +
 +	/*
@@ -2116,7 +2116,7 @@ index 0000000..22bfb47
 +	max96724_apply_porta_subset(dev, priv);
 +
 +	/*
-+	 * CSI-output DPLL data rate = 1300 Mbps
++	 * CSI-output DPLL data rate = 2000 Mbps
 +	 * on ALL FOUR controller freq registers
 +	 */
 +	if (!priv->lane_setup) {
@@ -2335,14 +2335,14 @@ index 0000000..22bfb47
 +		vid_rx0_cfg = MAX96724_VID_RX0_PIXEL_VAL;
 +		vid_rx6_cfg = MAX96724_VID_RX6_PIXEL_VAL;
 +		st_sel_cfg = 0x00;
-+		dpll_cfg = MAX96724_DPLL_1300MBPS;
++		dpll_cfg = MAX96724_DPLL_2000MBPS;
 +	} else {
 +		pipe_sel0 = MAX96724_PIPE_SEL0_PIXEL;
 +		pipe_sel1 = MAX96724_PIPE_SEL1_PIXEL;
 +		vid_rx0_cfg = MAX96724_VID_RX0_CFG_VAL;
 +		vid_rx6_cfg = MAX96724_VID_RX6_CFG_VAL;
 +		st_sel_cfg = 0x10;
-+		dpll_cfg = MAX96724_DPLL_1300MBPS;
++		dpll_cfg = MAX96724_DPLL_2000MBPS;
 +	}
 +
 +	/* 
@@ -2359,8 +2359,9 @@ index 0000000..22bfb47
 +	max96724_apply_porta_subset(dev, priv);
 +
 +	/*
-+	 * CSI-output DPLL data rate = 1300 Mbps on ALL
-+	 * FOUR controllers, matching the device-tree serdes_pix_clk_hz (325 MHz).
++	 * CSI-output DPLL data rate = 2000 Mbps on ALL controllers.
++	 * This matches the device-tree serdes_pix_clk_hz values:
++	 * 500 MHz for 16-bit modes and 1000 MHz for 8-bit modes.
 +	 * reset_oneshot is called by the sensor after setup_streaming, so it must
 +	 * mirror the same DPLL values.
 +	 */
@@ -3144,4 +3145,3 @@ index 0000000..dc5a8ea
 +#endif  /* __MAX96724_H__ */
 -- 
 2.25.1
-

--- a/nvidia-oot/7.1/0011-Add-MAX96717-serializer-and-MAX96724-deserializer-dr.patch
+++ b/nvidia-oot/7.1/0011-Add-MAX96717-serializer-and-MAX96724-deserializer-dr.patch
@@ -23,11 +23,11 @@ MAX96724 quad deserializer features:
 Signed-off-by: RealSense AI <realsense@realsenseai.com>
 ---
  drivers/media/i2c/Makefile   |    2 +
- drivers/media/i2c/max96717.c |  835 ++++++++++++++
+ drivers/media/i2c/max96717.c |  836 ++++++++++++++
  drivers/media/i2c/max96724.c | 1916 ++++++++++++++++++++++++++++++++++
  include/media/max96717.h     |  151 ++
  include/media/max96724.h     |  183 +++
- 4 files changed, 3085 insertions(+)
+ 4 files changed, 3086 insertions(+)
  create mode 100644 drivers/media/i2c/max96717.c
  create mode 100644 drivers/media/i2c/max96724.c
  create mode 100644 include/media/max96717.h
@@ -38,7 +38,7 @@ new file mode 100644
 index 0000000..70d25a3
 --- /dev/null
 +++ b/drivers/media/i2c/max96717.c
-@@ -0,0 +1,835 @@
+@@ -0,0 +1,836 @@
 +/*
 + * max96717.c - MAX96717 GMSL2 Serializer driver (Tunnel Mode)
 + *
@@ -68,8 +68,9 @@ index 0000000..70d25a3
 +#define MAX96717_DEV_ADDR		0x00
 +
 +/* 
-+ *   REG1: Link Speed
-+ *   bit[3]=1: 3 Gbps, bit[4]=1: 6 Gbps
++ *   REG1: GMSL2 link rate
++ *   TX_RATE[3:2]: 01=3Gbps, 10=6Gbps
++ *   RX_RATE[1:0]: 00=187.5Mbps reverse
 + */
 +#define MAX96717_REG1_ADDR		0x01
 +
@@ -216,10 +217,10 @@ index 0000000..70d25a3
 +/* MIPI_RX0: Normal operation */
 +#define MAX96717_MIPI_RX0_NORMAL	0x00
 +
-+/* REG1: 3 Gbps link speed, bit[3]=1 */
-+#define MAX96717_LINK_SPEED_3GBPS	0x08
-+/* REG1: 6 Gbps link speed, bit[4]=1 */
-+#define MAX96717_LINK_SPEED_6GBPS	0x10
++/* REG1: TX_RATE[3:2]=01, RX_RATE[1:0]=00 */
++#define MAX96717_LINK_SPEED_3GBPS	0x04
++/* REG1: TX_RATE[3:2]=10, RX_RATE[1:0]=00 */
++#define MAX96717_LINK_SPEED_6GBPS	0x08
 +
 +/* EXT11 tunnel mode pre-config (0x0383=0x80) */
 +#define MAX96717_EXT11_TUN_PRE		0x80


### PR DESCRIPTION
## Summary
- Enable MAX96717 CSI input deskew for the 4-lane HKR source path by programming `MIPI_RX1=0x70`.
- Keep the HKR camera I2C path on MAX96717 MFP9/MFP10 by using `REG1=0x88` for 6Gbps GMSL plus pass-through I2C channel 2, while leaving MFP7/MFP8 high-Z.
- Configure MAX96724 tunnel pipes with `TUN_EN=0x21` so periodic tunnel deskew follows the serializer for tunneled CSI-2.
- Enable Orin NVCSI initial and periodic deskew in the FG24 4-channel overlay modes.
- Refresh the 6.2 SerDes patch metadata after the serializer/deserializer source changes so the 6.2.2 symlinked patch flow applies the same code.

## Validation
- Built, deployed, and reboot-verified on `jetson@192.168.112.67` / JetPack 6.2.2 / R36.5.0 with `orin-gmsl --target 6.2.2 all --reboot`.
- Deploy version check passed with `d5xx`, `max96717`, and `max96724` loaded and deployed artifacts matching the installed package.
- Orin CSI summary reports `lane_rate_dphy=2000000000` and `deskew_initial=1`, `deskew_periodic=1` for the active FG24 channels.
- Latest no-regression diagnostic on Jetson 67:
  `./gmsl_link_diagnostic.sh --target-rate 2000 --no-dmesg`
  Result: `PASS=60 WARN=15 CRITICAL=0`.
- HKR I2C pass-through validation passed: logical `0x0300` version block matched the expected prefix, and logical `0x4000` depth CSI-DT read back `0x31`, a valid CSI-2 user-defined byte-based data type.
- SER validation passed: `MIPI_RX1=0x70`, `MIPI_RX19=0x00`, `MIPI_RX20=0x00`, MFP9/MFP10 I2C path enabled, and MFP7/MFP8 high-Z.
- DES validation passed: SIOA locked, DPLL output lane rate is 2000 Mbps/lane, Pipe0-3 `TUN_EN=0x21`, and Pipe0 `VID_SEQ_ERR=no` in the no-regression run.

## Known Follow-Up
- The 1500 Mbps/lane HKR-to-SER streaming frame-corruption issue is not claimed fixed by this change. The separate streaming after-run still points to SER `CSI_FRAME_COUNT_ERROR` and DES Pipe0 video sequence error, so HKR CSI TX timing/packet sequencing remains the next root-cause focus.