### PR TITLE
gmsl: keep D5x SER changes scoped to JP6.2

### DIFF
--- a/nvidia-oot/6.0/0011-Add-MAX96717-serializer-and-MAX96724-deserializer-dr.patch
+++ b/nvidia-oot/6.0/0011-Add-MAX96717-serializer-and-MAX96724-deserializer-dr.patch
@@ -23,11 +23,11 @@ MAX96724 quad deserializer features:
 Signed-off-by: RealSense AI <realsense@realsenseai.com>
 ---
  drivers/media/i2c/Makefile   |    2 +
- drivers/media/i2c/max96717.c |  836 ++++++++++++++
+ drivers/media/i2c/max96717.c |  835 ++++++++++++++
  drivers/media/i2c/max96724.c | 1916 ++++++++++++++++++++++++++++++++++
  include/media/max96717.h     |  151 ++
  include/media/max96724.h     |  183 +++
- 4 files changed, 3086 insertions(+)
+ 4 files changed, 3085 insertions(+)
  create mode 100644 drivers/media/i2c/max96717.c
  create mode 100644 drivers/media/i2c/max96724.c
  create mode 100644 include/media/max96717.h
@@ -38,7 +38,7 @@ new file mode 100644
 index 0000000..70d25a3
 --- /dev/null
 +++ b/drivers/media/i2c/max96717.c
-@@ -0,0 +1,836 @@
+@@ -0,0 +1,835 @@
 +/*
 + * max96717.c - MAX96717 GMSL2 Serializer driver (Tunnel Mode)
 + *
@@ -68,9 +68,8 @@ index 0000000..70d25a3
 +#define MAX96717_DEV_ADDR		0x00
 +
 +/* 
-+ *   REG1: GMSL2 link rate
-+ *   TX_RATE[3:2]: 01=3Gbps, 10=6Gbps
-+ *   RX_RATE[1:0]: 00=187.5Mbps reverse
++ *   REG1: Link Speed
++ *   bit[3]=1: 3 Gbps, bit[4]=1: 6 Gbps
 + */
 +#define MAX96717_REG1_ADDR		0x01
 +
@@ -217,10 +216,10 @@ index 0000000..70d25a3
 +/* MIPI_RX0: Normal operation */
 +#define MAX96717_MIPI_RX0_NORMAL	0x00
 +
-+/* REG1: TX_RATE[3:2]=01, RX_RATE[1:0]=00 */
-+#define MAX96717_LINK_SPEED_3GBPS	0x04
-+/* REG1: TX_RATE[3:2]=10, RX_RATE[1:0]=00 */
-+#define MAX96717_LINK_SPEED_6GBPS	0x08
++/* REG1: 3 Gbps link speed, bit[3]=1 */
++#define MAX96717_LINK_SPEED_3GBPS	0x08
++/* REG1: 6 Gbps link speed, bit[4]=1 */
++#define MAX96717_LINK_SPEED_6GBPS	0x10
 +
 +/* EXT11 tunnel mode pre-config (0x0383=0x80) */
 +#define MAX96717_EXT11_TUN_PRE		0x80
@@ -1246,10 +1245,10 @@ index 0000000..22bfb47
 +#define MAX96724_DPLL_700MBPS_CTRL0	0x27
 +
 +/* 
-+ *   CSI-output DPLL data rate = 2000 Mbps.
-+ *   bits[4:0] = data-rate / 100 MHz -> 2000/100 = 20 = 0x14. bit[5] = DPLL en.
++ *   CSI-output DPLL data rate = 1300 Mbps.
++ *   bits[4:0] = data-rate / 100 MHz -> 1300/100 = 13 = 0x0D. bit[5] = DPLL en.
 + */
-+#define MAX96724_DPLL_2000MBPS		0x34
++#define MAX96724_DPLL_1300MBPS		0x2D
 +
 +/* One-shot reset: all links */
 +#define MAX96724_ONESHOT_ALL		0x0F
@@ -2090,14 +2089,14 @@ index 0000000..22bfb47
 +		vid_rx0_cfg = MAX96724_VID_RX0_PIXEL_VAL;
 +		vid_rx6_cfg = MAX96724_VID_RX6_PIXEL_VAL;
 +		st_sel_cfg = 0x00;
-+		dpll_cfg = MAX96724_DPLL_2000MBPS;
++		dpll_cfg = MAX96724_DPLL_1300MBPS;
 +	} else {
 +		pipe_sel0 = MAX96724_PIPE_SEL0_PIXEL;
 +		pipe_sel1 = MAX96724_PIPE_SEL1_PIXEL;
 +		vid_rx0_cfg = MAX96724_VID_RX0_CFG_VAL;
 +		vid_rx6_cfg = MAX96724_VID_RX6_CFG_VAL;
 +		st_sel_cfg = 0x10;
-+		dpll_cfg = MAX96724_DPLL_2000MBPS;
++		dpll_cfg = MAX96724_DPLL_1300MBPS;
 +	}
 +
 +	/*
@@ -2117,7 +2116,7 @@ index 0000000..22bfb47
 +	max96724_apply_porta_subset(dev, priv);
 +
 +	/*
-+	 * CSI-output DPLL data rate = 2000 Mbps
++	 * CSI-output DPLL data rate = 1300 Mbps
 +	 * on ALL FOUR controller freq registers
 +	 */
 +	if (!priv->lane_setup) {
@@ -2336,14 +2335,14 @@ index 0000000..22bfb47
 +		vid_rx0_cfg = MAX96724_VID_RX0_PIXEL_VAL;
 +		vid_rx6_cfg = MAX96724_VID_RX6_PIXEL_VAL;
 +		st_sel_cfg = 0x00;
-+		dpll_cfg = MAX96724_DPLL_2000MBPS;
++		dpll_cfg = MAX96724_DPLL_1300MBPS;
 +	} else {
 +		pipe_sel0 = MAX96724_PIPE_SEL0_PIXEL;
 +		pipe_sel1 = MAX96724_PIPE_SEL1_PIXEL;
 +		vid_rx0_cfg = MAX96724_VID_RX0_CFG_VAL;
 +		vid_rx6_cfg = MAX96724_VID_RX6_CFG_VAL;
 +		st_sel_cfg = 0x10;
-+		dpll_cfg = MAX96724_DPLL_2000MBPS;
++		dpll_cfg = MAX96724_DPLL_1300MBPS;
 +	}
 +
 +	/* 
@@ -2360,9 +2359,8 @@ index 0000000..22bfb47
 +	max96724_apply_porta_subset(dev, priv);
 +
 +	/*
-+	 * CSI-output DPLL data rate = 2000 Mbps on ALL controllers.
-+	 * This matches the device-tree serdes_pix_clk_hz values:
-+	 * 500 MHz for 16-bit modes and 1000 MHz for 8-bit modes.
++	 * CSI-output DPLL data rate = 1300 Mbps on ALL
++	 * FOUR controllers, matching the device-tree serdes_pix_clk_hz (325 MHz).
 +	 * reset_oneshot is called by the sensor after setup_streaming, so it must
 +	 * mirror the same DPLL values.
 +	 */

--- a/nvidia-oot/6.1/0011-Add-MAX96717-serializer-and-MAX96724-deserializer-dr.patch
+++ b/nvidia-oot/6.1/0011-Add-MAX96717-serializer-and-MAX96724-deserializer-dr.patch
@@ -23,11 +23,11 @@ MAX96724 quad deserializer features:
 Signed-off-by: RealSense AI <realsense@realsenseai.com>
 ---
  drivers/media/i2c/Makefile   |    2 +
- drivers/media/i2c/max96717.c |  836 ++++++++++++++
+ drivers/media/i2c/max96717.c |  835 ++++++++++++++
  drivers/media/i2c/max96724.c | 1916 ++++++++++++++++++++++++++++++++++
  include/media/max96717.h     |  151 ++
  include/media/max96724.h     |  183 +++
- 4 files changed, 3086 insertions(+)
+ 4 files changed, 3085 insertions(+)
  create mode 100644 drivers/media/i2c/max96717.c
  create mode 100644 drivers/media/i2c/max96724.c
  create mode 100644 include/media/max96717.h
@@ -38,7 +38,7 @@ new file mode 100644
 index 0000000..70d25a3
 --- /dev/null
 +++ b/drivers/media/i2c/max96717.c
-@@ -0,0 +1,836 @@
+@@ -0,0 +1,835 @@
 +/*
 + * max96717.c - MAX96717 GMSL2 Serializer driver (Tunnel Mode)
 + *
@@ -68,9 +68,8 @@ index 0000000..70d25a3
 +#define MAX96717_DEV_ADDR		0x00
 +
 +/* 
-+ *   REG1: GMSL2 link rate
-+ *   TX_RATE[3:2]: 01=3Gbps, 10=6Gbps
-+ *   RX_RATE[1:0]: 00=187.5Mbps reverse
++ *   REG1: Link Speed
++ *   bit[3]=1: 3 Gbps, bit[4]=1: 6 Gbps
 + */
 +#define MAX96717_REG1_ADDR		0x01
 +
@@ -217,10 +216,10 @@ index 0000000..70d25a3
 +/* MIPI_RX0: Normal operation */
 +#define MAX96717_MIPI_RX0_NORMAL	0x00
 +
-+/* REG1: TX_RATE[3:2]=01, RX_RATE[1:0]=00 */
-+#define MAX96717_LINK_SPEED_3GBPS	0x04
-+/* REG1: TX_RATE[3:2]=10, RX_RATE[1:0]=00 */
-+#define MAX96717_LINK_SPEED_6GBPS	0x08
++/* REG1: 3 Gbps link speed, bit[3]=1 */
++#define MAX96717_LINK_SPEED_3GBPS	0x08
++/* REG1: 6 Gbps link speed, bit[4]=1 */
++#define MAX96717_LINK_SPEED_6GBPS	0x10
 +
 +/* EXT11 tunnel mode pre-config (0x0383=0x80) */
 +#define MAX96717_EXT11_TUN_PRE		0x80
@@ -1246,10 +1245,10 @@ index 0000000..22bfb47
 +#define MAX96724_DPLL_700MBPS_CTRL0	0x27
 +
 +/* 
-+ *   CSI-output DPLL data rate = 2000 Mbps.
-+ *   bits[4:0] = data-rate / 100 MHz -> 2000/100 = 20 = 0x14. bit[5] = DPLL en.
++ *   CSI-output DPLL data rate = 1300 Mbps.
++ *   bits[4:0] = data-rate / 100 MHz -> 1300/100 = 13 = 0x0D. bit[5] = DPLL en.
 + */
-+#define MAX96724_DPLL_2000MBPS		0x34
++#define MAX96724_DPLL_1300MBPS		0x2D
 +
 +/* One-shot reset: all links */
 +#define MAX96724_ONESHOT_ALL		0x0F
@@ -2090,14 +2089,14 @@ index 0000000..22bfb47
 +		vid_rx0_cfg = MAX96724_VID_RX0_PIXEL_VAL;
 +		vid_rx6_cfg = MAX96724_VID_RX6_PIXEL_VAL;
 +		st_sel_cfg = 0x00;
-+		dpll_cfg = MAX96724_DPLL_2000MBPS;
++		dpll_cfg = MAX96724_DPLL_1300MBPS;
 +	} else {
 +		pipe_sel0 = MAX96724_PIPE_SEL0_PIXEL;
 +		pipe_sel1 = MAX96724_PIPE_SEL1_PIXEL;
 +		vid_rx0_cfg = MAX96724_VID_RX0_CFG_VAL;
 +		vid_rx6_cfg = MAX96724_VID_RX6_CFG_VAL;
 +		st_sel_cfg = 0x10;
-+		dpll_cfg = MAX96724_DPLL_2000MBPS;
++		dpll_cfg = MAX96724_DPLL_1300MBPS;
 +	}
 +
 +	/*
@@ -2117,7 +2116,7 @@ index 0000000..22bfb47
 +	max96724_apply_porta_subset(dev, priv);
 +
 +	/*
-+	 * CSI-output DPLL data rate = 2000 Mbps
++	 * CSI-output DPLL data rate = 1300 Mbps
 +	 * on ALL FOUR controller freq registers
 +	 */
 +	if (!priv->lane_setup) {
@@ -2336,14 +2335,14 @@ index 0000000..22bfb47
 +		vid_rx0_cfg = MAX96724_VID_RX0_PIXEL_VAL;
 +		vid_rx6_cfg = MAX96724_VID_RX6_PIXEL_VAL;
 +		st_sel_cfg = 0x00;
-+		dpll_cfg = MAX96724_DPLL_2000MBPS;
++		dpll_cfg = MAX96724_DPLL_1300MBPS;
 +	} else {
 +		pipe_sel0 = MAX96724_PIPE_SEL0_PIXEL;
 +		pipe_sel1 = MAX96724_PIPE_SEL1_PIXEL;
 +		vid_rx0_cfg = MAX96724_VID_RX0_CFG_VAL;
 +		vid_rx6_cfg = MAX96724_VID_RX6_CFG_VAL;
 +		st_sel_cfg = 0x10;
-+		dpll_cfg = MAX96724_DPLL_2000MBPS;
++		dpll_cfg = MAX96724_DPLL_1300MBPS;
 +	}
 +
 +	/* 
@@ -2360,9 +2359,8 @@ index 0000000..22bfb47
 +	max96724_apply_porta_subset(dev, priv);
 +
 +	/*
-+	 * CSI-output DPLL data rate = 2000 Mbps on ALL controllers.
-+	 * This matches the device-tree serdes_pix_clk_hz values:
-+	 * 500 MHz for 16-bit modes and 1000 MHz for 8-bit modes.
++	 * CSI-output DPLL data rate = 1300 Mbps on ALL
++	 * FOUR controllers, matching the device-tree serdes_pix_clk_hz (325 MHz).
 +	 * reset_oneshot is called by the sensor after setup_streaming, so it must
 +	 * mirror the same DPLL values.
 +	 */

--- a/nvidia-oot/7.0/0011-Add-MAX96717-serializer-and-MAX96724-deserializer-dr.patch
+++ b/nvidia-oot/7.0/0011-Add-MAX96717-serializer-and-MAX96724-deserializer-dr.patch
@@ -23,11 +23,11 @@ MAX96724 quad deserializer features:
 Signed-off-by: RealSense AI <realsense@realsenseai.com>
 ---
  drivers/media/i2c/Makefile   |    2 +
- drivers/media/i2c/max96717.c |  836 ++++++++++++++
+ drivers/media/i2c/max96717.c |  835 ++++++++++++++
  drivers/media/i2c/max96724.c | 1916 ++++++++++++++++++++++++++++++++++
  include/media/max96717.h     |  151 ++
  include/media/max96724.h     |  183 +++
- 4 files changed, 3086 insertions(+)
+ 4 files changed, 3085 insertions(+)
  create mode 100644 drivers/media/i2c/max96717.c
  create mode 100644 drivers/media/i2c/max96724.c
  create mode 100644 include/media/max96717.h
@@ -38,7 +38,7 @@ new file mode 100644
 index 0000000..70d25a3
 --- /dev/null
 +++ b/drivers/media/i2c/max96717.c
-@@ -0,0 +1,836 @@
+@@ -0,0 +1,835 @@
 +/*
 + * max96717.c - MAX96717 GMSL2 Serializer driver (Tunnel Mode)
 + *
@@ -68,9 +68,8 @@ index 0000000..70d25a3
 +#define MAX96717_DEV_ADDR		0x00
 +
 +/* 
-+ *   REG1: GMSL2 link rate
-+ *   TX_RATE[3:2]: 01=3Gbps, 10=6Gbps
-+ *   RX_RATE[1:0]: 00=187.5Mbps reverse
++ *   REG1: Link Speed
++ *   bit[3]=1: 3 Gbps, bit[4]=1: 6 Gbps
 + */
 +#define MAX96717_REG1_ADDR		0x01
 +
@@ -217,10 +216,10 @@ index 0000000..70d25a3
 +/* MIPI_RX0: Normal operation */
 +#define MAX96717_MIPI_RX0_NORMAL	0x00
 +
-+/* REG1: TX_RATE[3:2]=01, RX_RATE[1:0]=00 */
-+#define MAX96717_LINK_SPEED_3GBPS	0x04
-+/* REG1: TX_RATE[3:2]=10, RX_RATE[1:0]=00 */
-+#define MAX96717_LINK_SPEED_6GBPS	0x08
++/* REG1: 3 Gbps link speed, bit[3]=1 */
++#define MAX96717_LINK_SPEED_3GBPS	0x08
++/* REG1: 6 Gbps link speed, bit[4]=1 */
++#define MAX96717_LINK_SPEED_6GBPS	0x10
 +
 +/* EXT11 tunnel mode pre-config (0x0383=0x80) */
 +#define MAX96717_EXT11_TUN_PRE		0x80
@@ -1246,10 +1245,10 @@ index 0000000..22bfb47
 +#define MAX96724_DPLL_700MBPS_CTRL0	0x27
 +
 +/* 
-+ *   CSI-output DPLL data rate = 2000 Mbps.
-+ *   bits[4:0] = data-rate / 100 MHz -> 2000/100 = 20 = 0x14. bit[5] = DPLL en.
++ *   CSI-output DPLL data rate = 1300 Mbps.
++ *   bits[4:0] = data-rate / 100 MHz -> 1300/100 = 13 = 0x0D. bit[5] = DPLL en.
 + */
-+#define MAX96724_DPLL_2000MBPS		0x34
++#define MAX96724_DPLL_1300MBPS		0x2D
 +
 +/* One-shot reset: all links */
 +#define MAX96724_ONESHOT_ALL		0x0F
@@ -2090,14 +2089,14 @@ index 0000000..22bfb47
 +		vid_rx0_cfg = MAX96724_VID_RX0_PIXEL_VAL;
 +		vid_rx6_cfg = MAX96724_VID_RX6_PIXEL_VAL;
 +		st_sel_cfg = 0x00;
-+		dpll_cfg = MAX96724_DPLL_2000MBPS;
++		dpll_cfg = MAX96724_DPLL_1300MBPS;
 +	} else {
 +		pipe_sel0 = MAX96724_PIPE_SEL0_PIXEL;
 +		pipe_sel1 = MAX96724_PIPE_SEL1_PIXEL;
 +		vid_rx0_cfg = MAX96724_VID_RX0_CFG_VAL;
 +		vid_rx6_cfg = MAX96724_VID_RX6_CFG_VAL;
 +		st_sel_cfg = 0x10;
-+		dpll_cfg = MAX96724_DPLL_2000MBPS;
++		dpll_cfg = MAX96724_DPLL_1300MBPS;
 +	}
 +
 +	/*
@@ -2117,7 +2116,7 @@ index 0000000..22bfb47
 +	max96724_apply_porta_subset(dev, priv);
 +
 +	/*
-+	 * CSI-output DPLL data rate = 2000 Mbps
++	 * CSI-output DPLL data rate = 1300 Mbps
 +	 * on ALL FOUR controller freq registers
 +	 */
 +	if (!priv->lane_setup) {
@@ -2336,14 +2335,14 @@ index 0000000..22bfb47
 +		vid_rx0_cfg = MAX96724_VID_RX0_PIXEL_VAL;
 +		vid_rx6_cfg = MAX96724_VID_RX6_PIXEL_VAL;
 +		st_sel_cfg = 0x00;
-+		dpll_cfg = MAX96724_DPLL_2000MBPS;
++		dpll_cfg = MAX96724_DPLL_1300MBPS;
 +	} else {
 +		pipe_sel0 = MAX96724_PIPE_SEL0_PIXEL;
 +		pipe_sel1 = MAX96724_PIPE_SEL1_PIXEL;
 +		vid_rx0_cfg = MAX96724_VID_RX0_CFG_VAL;
 +		vid_rx6_cfg = MAX96724_VID_RX6_CFG_VAL;
 +		st_sel_cfg = 0x10;
-+		dpll_cfg = MAX96724_DPLL_2000MBPS;
++		dpll_cfg = MAX96724_DPLL_1300MBPS;
 +	}
 +
 +	/* 
@@ -2360,9 +2359,8 @@ index 0000000..22bfb47
 +	max96724_apply_porta_subset(dev, priv);
 +
 +	/*
-+	 * CSI-output DPLL data rate = 2000 Mbps on ALL controllers.
-+	 * This matches the device-tree serdes_pix_clk_hz values:
-+	 * 500 MHz for 16-bit modes and 1000 MHz for 8-bit modes.
++	 * CSI-output DPLL data rate = 1300 Mbps on ALL
++	 * FOUR controllers, matching the device-tree serdes_pix_clk_hz (325 MHz).
 +	 * reset_oneshot is called by the sensor after setup_streaming, so it must
 +	 * mirror the same DPLL values.
 +	 */

--- a/nvidia-oot/7.1/0011-Add-MAX96717-serializer-and-MAX96724-deserializer-dr.patch
+++ b/nvidia-oot/7.1/0011-Add-MAX96717-serializer-and-MAX96724-deserializer-dr.patch
@@ -23,11 +23,11 @@ MAX96724 quad deserializer features:
 Signed-off-by: RealSense AI <realsense@realsenseai.com>
 ---
  drivers/media/i2c/Makefile   |    2 +
- drivers/media/i2c/max96717.c |  836 ++++++++++++++
+ drivers/media/i2c/max96717.c |  835 ++++++++++++++
  drivers/media/i2c/max96724.c | 1916 ++++++++++++++++++++++++++++++++++
  include/media/max96717.h     |  151 ++
  include/media/max96724.h     |  183 +++
- 4 files changed, 3086 insertions(+)
+ 4 files changed, 3085 insertions(+)
  create mode 100644 drivers/media/i2c/max96717.c
  create mode 100644 drivers/media/i2c/max96724.c
  create mode 100644 include/media/max96717.h
@@ -38,7 +38,7 @@ new file mode 100644
 index 0000000..70d25a3
 --- /dev/null
 +++ b/drivers/media/i2c/max96717.c
-@@ -0,0 +1,836 @@
+@@ -0,0 +1,835 @@
 +/*
 + * max96717.c - MAX96717 GMSL2 Serializer driver (Tunnel Mode)
 + *
@@ -68,9 +68,8 @@ index 0000000..70d25a3
 +#define MAX96717_DEV_ADDR		0x00
 +
 +/* 
-+ *   REG1: GMSL2 link rate
-+ *   TX_RATE[3:2]: 01=3Gbps, 10=6Gbps
-+ *   RX_RATE[1:0]: 00=187.5Mbps reverse
++ *   REG1: Link Speed
++ *   bit[3]=1: 3 Gbps, bit[4]=1: 6 Gbps
 + */
 +#define MAX96717_REG1_ADDR		0x01
 +
@@ -217,10 +216,10 @@ index 0000000..70d25a3
 +/* MIPI_RX0: Normal operation */
 +#define MAX96717_MIPI_RX0_NORMAL	0x00
 +
-+/* REG1: TX_RATE[3:2]=01, RX_RATE[1:0]=00 */
-+#define MAX96717_LINK_SPEED_3GBPS	0x04
-+/* REG1: TX_RATE[3:2]=10, RX_RATE[1:0]=00 */
-+#define MAX96717_LINK_SPEED_6GBPS	0x08
++/* REG1: 3 Gbps link speed, bit[3]=1 */
++#define MAX96717_LINK_SPEED_3GBPS	0x08
++/* REG1: 6 Gbps link speed, bit[4]=1 */
++#define MAX96717_LINK_SPEED_6GBPS	0x10
 +
 +/* EXT11 tunnel mode pre-config (0x0383=0x80) */
 +#define MAX96717_EXT11_TUN_PRE		0x80
@@ -1246,10 +1245,10 @@ index 0000000..22bfb47
 +#define MAX96724_DPLL_700MBPS_CTRL0	0x27
 +
 +/* 
-+ *   CSI-output DPLL data rate = 2000 Mbps.
-+ *   bits[4:0] = data-rate / 100 MHz -> 2000/100 = 20 = 0x14. bit[5] = DPLL en.
++ *   CSI-output DPLL data rate = 1300 Mbps.
++ *   bits[4:0] = data-rate / 100 MHz -> 1300/100 = 13 = 0x0D. bit[5] = DPLL en.
 + */
-+#define MAX96724_DPLL_2000MBPS		0x34
++#define MAX96724_DPLL_1300MBPS		0x2D
 +
 +/* One-shot reset: all links */
 +#define MAX96724_ONESHOT_ALL		0x0F
@@ -2090,14 +2089,14 @@ index 0000000..22bfb47
 +		vid_rx0_cfg = MAX96724_VID_RX0_PIXEL_VAL;
 +		vid_rx6_cfg = MAX96724_VID_RX6_PIXEL_VAL;
 +		st_sel_cfg = 0x00;
-+		dpll_cfg = MAX96724_DPLL_2000MBPS;
++		dpll_cfg = MAX96724_DPLL_1300MBPS;
 +	} else {
 +		pipe_sel0 = MAX96724_PIPE_SEL0_PIXEL;
 +		pipe_sel1 = MAX96724_PIPE_SEL1_PIXEL;
 +		vid_rx0_cfg = MAX96724_VID_RX0_CFG_VAL;
 +		vid_rx6_cfg = MAX96724_VID_RX6_CFG_VAL;
 +		st_sel_cfg = 0x10;
-+		dpll_cfg = MAX96724_DPLL_2000MBPS;
++		dpll_cfg = MAX96724_DPLL_1300MBPS;
 +	}
 +
 +	/*
@@ -2117,7 +2116,7 @@ index 0000000..22bfb47
 +	max96724_apply_porta_subset(dev, priv);
 +
 +	/*
-+	 * CSI-output DPLL data rate = 2000 Mbps
++	 * CSI-output DPLL data rate = 1300 Mbps
 +	 * on ALL FOUR controller freq registers
 +	 */
 +	if (!priv->lane_setup) {
@@ -2336,14 +2335,14 @@ index 0000000..22bfb47
 +		vid_rx0_cfg = MAX96724_VID_RX0_PIXEL_VAL;
 +		vid_rx6_cfg = MAX96724_VID_RX6_PIXEL_VAL;
 +		st_sel_cfg = 0x00;
-+		dpll_cfg = MAX96724_DPLL_2000MBPS;
++		dpll_cfg = MAX96724_DPLL_1300MBPS;
 +	} else {
 +		pipe_sel0 = MAX96724_PIPE_SEL0_PIXEL;
 +		pipe_sel1 = MAX96724_PIPE_SEL1_PIXEL;
 +		vid_rx0_cfg = MAX96724_VID_RX0_CFG_VAL;
 +		vid_rx6_cfg = MAX96724_VID_RX6_CFG_VAL;
 +		st_sel_cfg = 0x10;
-+		dpll_cfg = MAX96724_DPLL_2000MBPS;
++		dpll_cfg = MAX96724_DPLL_1300MBPS;
 +	}
 +
 +	/* 
@@ -2360,9 +2359,8 @@ index 0000000..22bfb47
 +	max96724_apply_porta_subset(dev, priv);
 +
 +	/*
-+	 * CSI-output DPLL data rate = 2000 Mbps on ALL controllers.
-+	 * This matches the device-tree serdes_pix_clk_hz values:
-+	 * 500 MHz for 16-bit modes and 1000 MHz for 8-bit modes.
++	 * CSI-output DPLL data rate = 1300 Mbps on ALL
++	 * FOUR controllers, matching the device-tree serdes_pix_clk_hz (325 MHz).
 +	 * reset_oneshot is called by the sensor after setup_streaming, so it must
 +	 * mirror the same DPLL values.
 +	 */


### PR DESCRIPTION
Follow-up for PR #480 review feedback.

Summary:
- Scope D5x GMSL SER/DES 2Gbps and deskew work to JetPack 6.2 / 6.2.2 only.
- Revert the non-6.2 MAX96717/MAX96724 patch files for 6.0, 6.1, 7.0, and 7.1 back to their pre-PR #480 behavior.
- Avoid carrying unverified D5x GMSL DPLL/SER/DES behavior into JetPack targets where we do not currently have target hardware validation.

Review context:
- The PR #480 review finding is valid: the non-6.2 patches had partial cross-version changes, which made their behavior inconsistent with the 6.2 design note.
- Instead of propagating the full 6.2 SER/DES programming to unvalidated JetPack targets, this follow-up takes the safer option requested in the review: make the D5x GMSL change effectively 6.2-only and drop the cross-version edits.
- Future JetPack 6.0, 6.1, 7.0, or 7.1 support should be handled as an explicit porting task with matching target hardware validation.

Validation:
- git diff --check: pass.
- Temporary nvidia-oot worktree patch-stack checks: nvidia-oot/6.0 on jetson_36.3 pass; nvidia-oot/6.1 on jetson_36.4 pass; nvidia-oot/7.0 on jetson_38.2 pass; nvidia-oot/7.1 on jetson_38.4 pass.

Notes:
- Existing trailing whitespace warnings remain inside generated patch payloads during git apply; patch application succeeds.
- This PR does not change the validated 6.2 / 6.2.2 path and does not attempt to fix the remaining 1500M streaming frame corruption issue.