### PR TITLE
Fix D5xx FSYNC GPIO tunneling

### DIFF
--- a/kernel/realsense/d5xx.c
+++ b/kernel/realsense/d5xx.c
@@ -56,6 +56,10 @@ struct dser_interface {
 	int (*setup_link)(struct device *dev, struct device *s_dev);
 	int (*setup_control)(struct device *dev, struct device *s_dev);
 	int (*reset_control)(struct device *dev, struct device *s_dev);
+
+	/* Frame sync (multi-camera).  fps is the V4L2-negotiated frame rate. */
+	int (*setup_fsync)(struct device *dev, u32 fps);
+	int (*disable_fsync)(struct device *dev);
 	
 	/* Device registration */
 	int (*sdev_register)(struct device *dev, struct gmsl_link_ctx *g_ctx);
@@ -182,7 +186,7 @@ struct dser_interface {
 #define DS5_STATUS_INVALID_RES		0x4
 #define DS5_STATUS_INVALID_FPS		0x8
 
-#define MIPI_LANE_RATE				1000
+#define MIPI_LANE_RATE				1300
 
 #define MAX_DEPTH_EXP				200000
 #define MAX_RGB_EXP					10000
@@ -555,6 +559,7 @@ struct ds5_dev {
 	/* Pointer to the primary DS5 struct */
 	struct ds5 *ds5_primary;
 
+	int sync_mode;
 	bool depth_streaming;
 	bool ir_streaming;
 	bool rgb_streaming;
@@ -622,6 +627,8 @@ static const struct dser_interface max96724_interface = {
 	.setup_link = max96724_setup_link,
 	.setup_control = max96724_setup_control,
 	.reset_control = max96724_reset_control,
+	.setup_fsync = max96724_setup_fsync,
+	.disable_fsync = max96724_disable_fsync,
 	.sdev_register = max96724_sdev_register,
 	.sdev_unregister = max96724_sdev_unregister,
 	.power_on = max96724_power_on,
@@ -1248,9 +1255,6 @@ static int __ds5_sensor_set_fmt(struct ds5 *state, struct ds5_sensor *sensor,
 		struct v4l2_subdev_format *fmt)
 {
 	struct v4l2_mbus_framefmt *mf;// = &fmt->format;
-	u32 req_code;
-	u32 req_width;
-	u32 req_height;
 	int ret = 0;
 	//unsigned r;
 
@@ -1259,9 +1263,6 @@ static int __ds5_sensor_set_fmt(struct ds5 *state, struct ds5_sensor *sensor,
 		__func__, state, sensor, fmt,  &fmt->format);
 
 	mf = &fmt->format;
-	req_code = mf->code;
-	req_width = mf->width;
-	req_height = mf->height;
 
 	if (fmt->pad)
 		return -EINVAL;
@@ -1307,15 +1308,6 @@ static int __ds5_sensor_set_fmt(struct ds5 *state, struct ds5_sensor *sensor,
 	}
 
 	state->mux.last_set = sensor;
-
-	dev_info(sensor->sd.dev,
-		"ds5_set_fmt: sensor=%s request=%ux%u code=0x%x selected=%ux%u code=0x%x dt=0x%x fps=%u\n",
-		ds5_get_sensor_name(state), req_width, req_height, req_code,
-		sensor->config.resolution ? sensor->config.resolution->width : 0,
-		sensor->config.resolution ? sensor->config.resolution->height : 0,
-		sensor->config.format ? sensor->config.format->mbus_code : 0,
-		sensor->config.format ? sensor->config.format->data_type : 0,
-		sensor->config.framerate);
 
 	mutex_unlock(&state->lock);
 	return ret;
@@ -1412,7 +1404,6 @@ static int ds5_configure(struct ds5 *state)
 	u16 dt_addr, md_addr, override_addr, fps_addr, width_addr, height_addr;
 	u16 dt_value = 0;
 	u16 md_value = 0;
-	u16 override_value = 0;
 	u16 fps_value = 0;
 	u16 width_value = 0;
 	u16 height_value = 0;
@@ -1472,13 +1463,8 @@ static int ds5_configure(struct ds5 *state)
 
 	vc_id = state->g_ctx.dst_vc;
 	dev_info(&state->client->dev,
-		"ds5_configure: sensor=%s %ux%u@%u code=0x%x dt1=0x%x dt2=0x%x vc=%u pipe_id=%d\n",
-		ds5_get_sensor_name(state),
-		sensor->config.resolution ? sensor->config.resolution->width : 0,
-		sensor->config.resolution ? sensor->config.resolution->height : 0,
-		sensor->config.framerate,
-		sensor->config.format ? sensor->config.format->mbus_code : 0,
-		data_type1, data_type2, vc_id, sensor->pipe_id);
+		"ds5_configure: sensor=%s dt1=0x%x dt2=0x%x vc=%u pipe_id=%d\n",
+		ds5_get_sensor_name(state), data_type1, data_type2, vc_id, sensor->pipe_id);
     if (PIPE_NOT_CONFIGURED == sensor->pipe_id ||
 			sensor->pipe_data_type1 != data_type1 ||
 			sensor->pipe_data_type2 != data_type2 ||
@@ -1546,19 +1532,6 @@ static int ds5_configure(struct ds5 *state)
 	else if (state->is_y8 && dt_value == GMSL_CSI_DT_YUV422_8)
 		dt_value = 0x32;
 
-	md_value = (vc_id << 8) | md_fmt;
-	if (override_addr != 0)
-		override_value = sensor->config.format->data_type;
-	fps_value = sensor->config.framerate;
-	width_value = sensor->config.resolution->width;
-	height_value = sensor->config.resolution->height;
-
-	dev_info(&state->client->dev,
-		"ds5_configure: stream cfg sensor=%s dt=0x%04x meta_dt=0x%04x override_dt=0x%04x res=%ux%u fps=%u regs(dt=0x%04x md=0x%04x override=0x%04x width=0x%04x height=0x%04x fps=0x%04x)\n",
-		ds5_get_sensor_name(state), dt_value, md_value, override_value,
-		width_value, height_value, fps_value, dt_addr, md_addr,
-		override_addr, width_addr, height_addr, fps_addr);
-
 	dev_dbg(&state->client->dev,
 		"sensor %p: dt_value=0x%x, cached_dt_value=0x%x, cached_fps_value=%u, framerate=%u\n",
 		sensor, dt_value, sensor->cached_dt_value, sensor->cached_fps_value, sensor->config.framerate);
@@ -1570,6 +1543,7 @@ static int ds5_configure(struct ds5 *state)
 		sensor->cached_dt_value = dt_value;
 	}
 
+	md_value = (vc_id << 8) | md_fmt;
 	if (sensor->cached_md_value != md_value) {
 		ret = ds5_write(state, md_addr, md_value);
 		if (ret < 0)
@@ -1578,14 +1552,16 @@ static int ds5_configure(struct ds5 *state)
 	}
 
 	if (override_addr != 0) {
-		if (sensor->cached_override_value != override_value) {
-			ret = ds5_write(state, override_addr, override_value);
+		dt_value = sensor->config.format->data_type;
+		if (sensor->cached_override_value != dt_value) {
+			ret = ds5_write(state, override_addr, dt_value);
 			if (ret < 0)
 				return ret;
-			sensor->cached_override_value = override_value;
+			sensor->cached_override_value = dt_value;
 		}
 	}
 
+	fps_value = sensor->config.framerate;
 	if (sensor->cached_fps_value != fps_value) {
 		ret = ds5_write(state, fps_addr, fps_value);
 		if (ret < 0)
@@ -1593,6 +1569,7 @@ static int ds5_configure(struct ds5 *state)
 		sensor->cached_fps_value = fps_value;
 	}
 
+	width_value = sensor->config.resolution->width;
 	if (sensor->cached_width_value != width_value) {
 		ret = ds5_write(state, width_addr, width_value);
 		if (ret < 0)
@@ -1600,6 +1577,7 @@ static int ds5_configure(struct ds5 *state)
 		sensor->cached_width_value = width_value;
 	}
 
+	height_value = sensor->config.resolution->height;
 	if (sensor->cached_height_value != height_value) {
 		ret = ds5_write(state, height_addr, height_value);
 		if (ret < 0)
@@ -2065,35 +2043,105 @@ static void ds5_reset_streaming_flags(struct ds5_dev *ds5_dev)
 static int ds5_set_ser_esync_tunneling(struct ds5 *state, bool enable)
 {
 #ifdef CONFIG_VIDEO_D5XX_SERDES
+	struct ds5 *owner;
 	int ret;
 
-	if (!state || !state->ser_dev)
+	if (!state || !state->client || !state->ds5_dev)
 		return -EINVAL;
-	if (state->dser_ops != &max96724_interface)
+
+	owner = state->ds5_dev->ds5_primary ? state->ds5_dev->ds5_primary : state;
+	if (!owner || !owner->client || !owner->ser_dev || !owner->dser_ops)
+		return -EINVAL;
+	if (owner->dser_ops != &max96724_interface)
 		return 0;
 
-	dev_dbg(&state->client->dev,
-		"%s(): serializer ESYNC %s requested\n",
-		__func__, enable ? "enable" : "disable");
+	dev_info(&state->client->dev,
+		"%s(): serializer GPIO tunnel %s requested via %s owner %s\n",
+		__func__, enable ? "enable" : "disable",
+		dev_name(&state->client->dev), dev_name(&owner->client->dev));
 
 	if (enable)
-		ret = max96717_setup_gpio_tunneling(state->ser_dev);
+		ret = max96717_setup_gpio_tunneling(owner->ser_dev);
 	else
-		ret = 0; /* MAX96717 GPIO tunneling has no disable */
+		ret = max96717_disable_gpio_tunneling(owner->ser_dev);
 
 	if (ret)
 		dev_warn(&state->client->dev,
-			"%s(): serializer ESYNC %s failed (%d)\n",
+			"%s(): serializer GPIO tunnel %s failed (%d)\n",
 			__func__, enable ? "enable" : "disable", ret);
 	else
-		dev_dbg(&state->client->dev,
-			"%s(): serializer ESYNC %s OK\n",
+		dev_info(&state->client->dev,
+			"%s(): serializer GPIO tunnel %s OK\n",
 			__func__, enable ? "enable" : "disable");
 
 	return ret;
 #else
 	return 0;
 #endif
+}
+
+static int ds5_set_des_fsync(struct ds5 *state, bool enable)
+{
+#ifdef CONFIG_VIDEO_D5XX_SERDES
+	struct ds5 *owner;
+	u32 fps = 0;
+	int ret = 0;
+
+	if (!state || !state->client || !state->ds5_dev)
+		return -EINVAL;
+
+	owner = state->ds5_dev->ds5_primary ? state->ds5_dev->ds5_primary : state;
+	if (!owner || !owner->client || !owner->dser_dev || !owner->dser_ops)
+		return -EINVAL;
+	if (owner->dser_ops != &max96724_interface)
+		return 0;
+
+	if (state->mux.last_set)
+		fps = state->mux.last_set->config.framerate;
+	if (!fps)
+		fps = state->depth.sensor.config.framerate;
+
+	dev_info(&state->client->dev,
+		"%s(): deserializer internal FSYNC %s requested via %s owner %s, fps=%u\n",
+		__func__, enable ? "enable" : "disable",
+		dev_name(&state->client->dev), dev_name(&owner->client->dev), fps);
+
+	if (enable) {
+		if (owner->dser_ops->setup_fsync)
+			ret = owner->dser_ops->setup_fsync(owner->dser_dev, fps);
+	} else if (owner->dser_ops->disable_fsync) {
+		ret = owner->dser_ops->disable_fsync(owner->dser_dev);
+	}
+
+	if (ret)
+		dev_warn(&state->client->dev,
+			"%s(): deserializer internal FSYNC %s failed (%d)\n",
+			__func__, enable ? "enable" : "disable", ret);
+	else
+		dev_info(&state->client->dev,
+			"%s(): deserializer internal FSYNC %s OK\n",
+			__func__, enable ? "enable" : "disable");
+
+	return ret;
+#else
+	return 0;
+#endif
+}
+
+static bool ds5_sync_mode_uses_esync(struct ds5 *state)
+{
+	int sync_mode = DS5_SYNC_MODE_DEFAULT;
+
+	if (!state)
+		return false;
+
+	if (state->ds5_dev)
+		sync_mode = READ_ONCE(state->ds5_dev->sync_mode);
+	if (sync_mode == DS5_SYNC_MODE_DEFAULT && state->ctrls.sync_mode)
+		sync_mode = state->ctrls.sync_mode->cur.val;
+
+	return sync_mode == DS5_SYNC_MODE_SLAVE ||
+	       sync_mode == DS5_SYNC_MODE_FULL_SLAVE;
 }
 
 /*
@@ -2303,18 +2351,12 @@ static int ds5_hw_reset_with_recovery(struct ds5 *state)
 		(state->fw_version >> 8) & 0xff, state->fw_version & 0xff,
 		(state->fw_build >> 8) & 0xff, state->fw_build & 0xff);
 
-	/* Re-apply ESYNC tunneling to match cached sync_mode control */
-	if (state->ctrls.sync_mode) {
-		int sync_val = state->ctrls.sync_mode->cur.val;
-		bool need_esync = (sync_val == DS5_SYNC_MODE_SLAVE ||
-				   sync_val == DS5_SYNC_MODE_FULL_SLAVE);
-
-		ret = ds5_set_ser_esync_tunneling(state, need_esync);
-		if (ret)
-			dev_warn(&state->client->dev,
-				"%s(): serializer ESYNC %s after HW reset failed (%d)\n",
-				__func__, need_esync ? "enable" : "disable", ret);
-	}
+	/*
+	 * ESYNC / FSYNC hardware is NOT re-applied here after a HW
+	 * reset.  The cached sync_mode control is a pure policy flag;
+	 * the actual SERDES programming happens at the next
+	 * stream-on boundary (ds5_mux_s_stream).
+	 */
 
 	WRITE_ONCE(state->ds5_dev->last_reset_jiffies, jiffies);
 
@@ -2654,11 +2696,19 @@ static int ds5_s_ctrl(struct v4l2_ctrl *ctrl)
 				bool need_esync = (ctrl->val == DS5_SYNC_MODE_SLAVE ||
 						   ctrl->val == DS5_SYNC_MODE_FULL_SLAVE);
 
-				dev_dbg(&state->client->dev,
-					"%s(): sync_mode=%d -> serializer ESYNC %s\n",
-					__func__, ctrl->val,
-					need_esync ? "enable" : "disable");
+				if (state->ds5_dev)
+					WRITE_ONCE(state->ds5_dev->sync_mode, ctrl->val);
+
+				/*
+				 * Match D4xx behavior for the serializer side:
+				 * make GPIO tunneling visible immediately after
+				 * camera_sync_mode changes.  The DES internal
+				 * FSYNC generator still starts at stream-on so it
+				 * can use the negotiated FPS.
+				 */
 				ret = ds5_set_ser_esync_tunneling(state, need_esync);
+				if (!ret && !need_esync)
+					ret = ds5_set_des_fsync(state, false);
 			}
 		}
 		break;
@@ -3268,6 +3318,7 @@ static void ds5_init_ds5_dev(struct ds5 *state, struct ds5_dev *ds5_dev)
 	mutex_lock(&ds5_dev->lock);
 	ds5_dev->ds5_primary = state;
 	ds5_dev->cached_device_type = DS5_DEVICE_TYPE_UNKNOWN;
+	ds5_dev->sync_mode = DS5_SYNC_MODE_DEFAULT;
 	mutex_unlock(&ds5_dev->lock);
 	ds5_reset_streaming_flags(ds5_dev);
 }
@@ -4572,6 +4623,17 @@ static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on)
 			mutex_unlock(&state->ds5_dev->lock);
 			return ret;
 		}
+#ifdef CONFIG_VIDEO_D5XX_SERDES
+		/*
+		 * The control callback enables serializer GPIO tunneling
+		 * immediately.  Re-assert it here after reset/recovery, then
+		 * start the DES internal FSYNC source at the negotiated FPS.
+		 */
+		if (ds5_sync_mode_uses_esync(state)) {
+			ds5_set_ser_esync_tunneling(state, true);
+			ds5_set_des_fsync(state, true);
+		}
+#endif
 	} else {
 		/* On stream off, release SERDES pipe */
 #ifdef CONFIG_VIDEO_D5XX_SERDES
@@ -4583,6 +4645,17 @@ static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on)
 				sensor->pipe_id = PIPE_NOT_CONFIGURED;
 			mutex_unlock(&serdes_lock__);
 		}
+		/*
+		 * Tear down the DES FSYNC generator when the last stream
+		 * stops.  Serializer GPIO tunneling remains tied to
+		 * camera_sync_mode and is disabled by the control callback.
+		 */
+		if (ds5_sync_mode_uses_esync(state) &&
+		    !state->ds5_dev->depth_streaming &&
+		    !state->ds5_dev->rgb_streaming &&
+		    !state->ds5_dev->ir_streaming &&
+		    !state->ds5_dev->imu_streaming)
+			ds5_set_des_fsync(state, false);
 #endif
 	}
 	return 0;
@@ -4668,15 +4741,6 @@ static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on)
 		expected_streaming_state = DS5_STREAM_IDLE;
 		status = DS5_STATUS_STREAMING;
 	}
-
-	dev_info(&state->client->dev,
-		"ds5_s_stream: sensor=%s on=%d stream_id=%u cmd=0x%04x vc=%u res=%ux%u fps=%u code=0x%x dt=0x%x\n",
-		ds5_get_sensor_name(state), on, stream_id, stream_cmd, vc_id,
-		sensor->config.resolution ? sensor->config.resolution->width : 0,
-		sensor->config.resolution ? sensor->config.resolution->height : 0,
-		sensor->config.framerate,
-		sensor->config.format ? sensor->config.format->mbus_code : 0,
-		sensor->config.format ? sensor->config.format->data_type : 0);
 
 	/* Verify stream is in the expected state before issuing command */
 	ts = jiffies;
@@ -4864,8 +4928,32 @@ static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on)
 		}
 		mutex_unlock(&serdes_lock__);
 		msleep_range(100);
+
+		/*
+		 * Tear down the DES FSYNC generator when the last stream stops.
+		 * Check the ds5_dev-level streaming flags (already
+		 * cleared for *this* sensor before we entered the polling
+		 * loop) to decide whether any stream is still active.
+		 */
+		if (ds5_sync_mode_uses_esync(state) &&
+		    !state->ds5_dev->depth_streaming &&
+		    !state->ds5_dev->rgb_streaming &&
+		    !state->ds5_dev->ir_streaming &&
+		    !state->ds5_dev->imu_streaming)
+			ds5_set_des_fsync(state, false);
 #endif
 	}
+#ifdef CONFIG_VIDEO_D5XX_SERDES
+	/*
+	 * Stream-on success path (neither timeout nor stream-off).
+	 * Re-assert serializer GPIO tunneling after reset/recovery and
+	 * start the DES internal FSYNC source at the negotiated FPS.
+	 */
+	if (on && ds5_sync_mode_uses_esync(state)) {
+		ds5_set_ser_esync_tunneling(state, true);
+		ds5_set_des_fsync(state, true);
+	}
+#endif
 	return ret;
 #endif /* !DS5_BYPASS_CAMERA_I2C */
 }

--- a/nvidia-oot/files/6.2/drivers/media/i2c/max96717.c
+++ b/nvidia-oot/files/6.2/drivers/media/i2c/max96717.c
@@ -432,31 +432,140 @@ EXPORT_SYMBOL(max96717_setup_control);
 /* ===== GPIO Tunneling ===== */
 
 /*
- * max96717_setup_gpio_tunneling - GPIO-over-GMSL no-op hook
+ * GPIO-over-GMSL tunneling for external frame sync (FSYNC/ESYNC).
  *
- *   GPIO Signal Mapping:
- *   MFP0 → GPIO0: FSIN (DES→SER, frame sync in)
- *   MFP1 → GPIO1: FOUT/STROBE (SER→DES, frame sync out)
- *   MFP4 → GPIO4: RESET_N (DES→SER, hard reset)
- *   MFP5 → GPIO5: IRQ (SER→DES, interrupt request)
- *   MFP6 → GPIO6: ZV_SYNC (DES→SER, IR stereo sync)
+ * The MAX96717 GPIO_n registers form a 3-byte group (A/B/C) at 0x02BE + 3*n:
+ *   GPIO_n_A: GPIO_OUT_DIS / GPIO_TX_EN / GPIO_RX_EN / TX_COMP_EN
+ *   GPIO_n_B: GPIO_TX_ID[4:0]  - GMSL channel this pin transmits on
+ *   GPIO_n_C: GPIO_RX_ID[4:0]  - GMSL channel this pin receives from
  *
+ * Schematic signal mapping on the D585/D580 board:
+ *   H_VSYNC_TRIG    → MFP0  (PIN 2) = GPIO0  (DES→SER, host sync trigger)
+ *   RGB_FSYNC       → CFG0  (PIN 3) = GPIO1  (DES→SER, RGB frame sync; note
+ *                          CFG0 is output-only after boot, so GPIO1 must be
+ *                          RX-from-link driving the pin, not input)
+ *   H_STROBE_OUT_1V8 → MFP6 (PIN22) = GPIO6  (SER→DES, camera strobe/EOF
+ *                          feedback for host-side frame timing)
+ *
+ * GMSL2 GPIO channel assignment (mirrors validated MAX9295 ESYNC scheme):
+ *   ch23: Host→Camera  sync edge (GPIO0 + GPIO1 both RX from ch23)
+ *   ch31: Camera→Host  strobe/EOF (GPIO6 TX on ch31)
+ */
+#define MAX96717_GPIO0_A_ADDR		0x02BE
+#define MAX96717_GPIO0_B_ADDR		0x02BF
+#define MAX96717_GPIO0_C_ADDR		0x02C0
+#define MAX96717_GPIO1_A_ADDR		0x02C1
+#define MAX96717_GPIO1_B_ADDR		0x02C2
+#define MAX96717_GPIO1_C_ADDR		0x02C3
+#define MAX96717_GPIO6_A_ADDR		0x02D0
+#define MAX96717_GPIO6_B_ADDR		0x02D1
+#define MAX96717_GPIO6_C_ADDR		0x02D2
+
+/* Enable: GPIO0 (H_VSYNC_TRIG) — RX from ch23, drives camera pin. */
+#define MAX96717_GPIO0_A_ESYNC		0x24	/* RX_EN=1, OUT_DIS=0, TX_COMP_EN=1 */
+#define MAX96717_GPIO0_B_ESYNC		0x77	/* TX_ID=23, push-pull, pull-up */
+#define MAX96717_GPIO0_C_ESYNC		0x57	/* RX_ID=23 */
+/* Enable: GPIO1 (RGB_FSYNC) — RX from ch23, drives camera pin (CFG0=output only). */
+#define MAX96717_GPIO1_A_ESYNC		0x05	/* OUT_DIS=1*, RX_EN=1, TX_EN=0 */
+#define MAX96717_GPIO1_B_ESYNC		0x1F	/* TX_ID=31 (unused, TX_EN=0) */
+#define MAX96717_GPIO1_C_ESYNC		0x57	/* RX_ID=23 */
+/* Enable: GPIO6 (H_STROBE_OUT_1V8) — TX on ch31, reads camera strobe pin. */
+#define MAX96717_GPIO6_A_ESYNC		0x27	/* TX_EN=1, RX_EN=0, OUT_DIS=1, TX_COMP_EN=1 */
+#define MAX96717_GPIO6_B_ESYNC		0x1F	/* TX_ID=31, push-pull, no pull */
+#define MAX96717_GPIO6_C_ESYNC		0x00	/* RX_ID=0 (unused, RX_EN=0) */
+
+/* Disable: restore power-up reset values (datasheet GPIO_n reset column). */
+#define MAX96717_GPIO0_A_RESET		0x99
+#define MAX96717_GPIO0_B_RESET		0xA0
+#define MAX96717_GPIO0_C_RESET		0x40
+#define MAX96717_GPIO1_A_RESET		0x81
+#define MAX96717_GPIO1_B_RESET		0x21
+#define MAX96717_GPIO1_C_RESET		0x41
+#define MAX96717_GPIO6_A_RESET		0x99
+#define MAX96717_GPIO6_B_RESET		0xA6
+#define MAX96717_GPIO6_C_RESET		0x46
+
+/*
+ * max96717_setup_gpio_tunneling - enable sync/strobe GPIO tunneling
+ *
+ * Configures three GPIOs for external frame sync:
+ *   GPIO0 (H_VSYNC_TRIG):  RX from ch23, drives camera MFP0 pin
+ *   GPIO1 (RGB_FSYNC):     RX from ch23, drives camera CFG0/MFP1 pin
+ *   GPIO6 (H_STROBE_OUT_1V8): TX on ch31, reads camera strobe for host timing
+ *
+ * Used for external sync (FSYNC/trigger).  The register values mirror the
+ * validated MAX9295 ESYNC configuration.
  */
 int max96717_setup_gpio_tunneling(struct device *dev)
 {
 	struct max96717 *priv = dev_get_drvdata(dev);
-	int err = 0;
+	struct reg_pair map[] = {
+		{MAX96717_GPIO0_A_ADDR, MAX96717_GPIO0_A_ESYNC},
+		{MAX96717_GPIO0_B_ADDR, MAX96717_GPIO0_B_ESYNC},
+		{MAX96717_GPIO0_C_ADDR, MAX96717_GPIO0_C_ESYNC},
+		{MAX96717_GPIO1_A_ADDR, MAX96717_GPIO1_A_ESYNC},
+		{MAX96717_GPIO1_B_ADDR, MAX96717_GPIO1_B_ESYNC},
+		{MAX96717_GPIO1_C_ADDR, MAX96717_GPIO1_C_ESYNC},
+		{MAX96717_GPIO6_A_ADDR, MAX96717_GPIO6_A_ESYNC},
+		{MAX96717_GPIO6_B_ADDR, MAX96717_GPIO6_B_ESYNC},
+		{MAX96717_GPIO6_C_ADDR, MAX96717_GPIO6_C_ESYNC},
+	};
+	int err;
 
 	mutex_lock(&priv->lock);
 
-	dev_info(dev, "%s: GPIO tunneling hook is a no-op; MFP_CFG values are not defined yet\n",
-		 __func__);
+	err = max96717_set_registers(dev, map, ARRAY_SIZE(map));
+	if (err)
+		dev_err(dev, "%s: GPIO tunneling enable failed (%d)\n",
+			__func__, err);
+	else
+		dev_info(dev, "%s: GPIO tunneling enabled (sync ch23, strobe ch31)\n",
+			 __func__);
 
 	mutex_unlock(&priv->lock);
 
 	return err;
 }
 EXPORT_SYMBOL(max96717_setup_gpio_tunneling);
+
+/*
+ * max96717_disable_gpio_tunneling - disable sync/strobe GPIO tunneling
+ *
+ * Restores GPIO0/GPIO1/GPIO6 to their power-up reset state so the
+ * serializer no longer tunnels frame-sync or strobe transitions.
+ * Counterpart to max96717_setup_gpio_tunneling().
+ */
+int max96717_disable_gpio_tunneling(struct device *dev)
+{
+	struct max96717 *priv = dev_get_drvdata(dev);
+	struct reg_pair map[] = {
+		{MAX96717_GPIO0_A_ADDR, MAX96717_GPIO0_A_RESET},
+		{MAX96717_GPIO0_B_ADDR, MAX96717_GPIO0_B_RESET},
+		{MAX96717_GPIO0_C_ADDR, MAX96717_GPIO0_C_RESET},
+		{MAX96717_GPIO1_A_ADDR, MAX96717_GPIO1_A_RESET},
+		{MAX96717_GPIO1_B_ADDR, MAX96717_GPIO1_B_RESET},
+		{MAX96717_GPIO1_C_ADDR, MAX96717_GPIO1_C_RESET},
+		{MAX96717_GPIO6_A_ADDR, MAX96717_GPIO6_A_RESET},
+		{MAX96717_GPIO6_B_ADDR, MAX96717_GPIO6_B_RESET},
+		{MAX96717_GPIO6_C_ADDR, MAX96717_GPIO6_C_RESET},
+	};
+	int err;
+
+	mutex_lock(&priv->lock);
+
+	err = max96717_set_registers(dev, map, ARRAY_SIZE(map));
+	if (err)
+		dev_err(dev, "%s: GPIO tunneling disable failed (%d)\n",
+			__func__, err);
+	else
+		dev_dbg(dev, "%s: GPIO tunneling disabled (pins restored)\n",
+			__func__);
+
+	mutex_unlock(&priv->lock);
+
+	return err;
+}
+EXPORT_SYMBOL(max96717_disable_gpio_tunneling);
 
 /* ===== Reset Control ===== */
 
@@ -498,13 +607,8 @@ int max96717_sdev_pair(struct device *dev, struct gmsl_link_ctx *g_ctx)
 	struct max96717 *priv;
 	int err = 0;
 
-	if (!dev) {
-		pr_err("%s: invalid device\n", __func__);
-		return -EINVAL;
-	}
-
-	if (!g_ctx || !g_ctx->s_dev) {
-		dev_err(dev, "%s: invalid input params\n", __func__);
+	if (!dev || !g_ctx || !g_ctx->s_dev) {
+		pr_err("%s: invalid input params\n", __func__);
 		return -EINVAL;
 	}
 
@@ -534,13 +638,8 @@ int max96717_sdev_unpair(struct device *dev, struct device *s_dev)
 	struct max96717 *priv = NULL;
 	int err = 0;
 
-	if (!dev) {
-		pr_err("%s: invalid device\n", __func__);
-		return -EINVAL;
-	}
-
-	if (!s_dev) {
-		dev_err(dev, "%s: invalid input params\n", __func__);
+	if (!dev || !s_dev) {
+		pr_err("%s: invalid input params\n", __func__);
 		return -EINVAL;
 	}
 
@@ -817,6 +916,8 @@ static int max96717_remove(struct i2c_client *client)
 
 	if (client != NULL) {
 		priv = dev_get_drvdata(&client->dev);
+		if (priv == prim_priv__)
+			prim_priv__ = NULL;
 		mutex_destroy(&priv->lock);
 		i2c_unregister_device(client);
 		client = NULL;

--- a/nvidia-oot/files/6.2/drivers/media/i2c/max96724.c
+++ b/nvidia-oot/files/6.2/drivers/media/i2c/max96724.c
@@ -1135,12 +1135,7 @@ int max96724_sdev_register(struct device *dev, struct gmsl_link_ctx *g_ctx)
 	unsigned int i;
 	int err = 0;
 
-	if (!dev) {
-		pr_err("%s: invalid device\n", __func__);
-		return -EINVAL;
-	}
-
-	if (!g_ctx || !g_ctx->s_dev) {
+	if (!dev || !g_ctx || !g_ctx->s_dev) {
 		dev_err(dev, "%s: invalid input params\n", __func__);
 		return -EINVAL;
 	}
@@ -1203,12 +1198,7 @@ int max96724_sdev_unregister(struct device *dev, struct device *s_dev)
 	int err = 0;
 	unsigned int i = 0;
 
-	if (!dev) {
-		pr_err("%s: invalid device\n", __func__);
-		return -EINVAL;
-	}
-
-	if (!s_dev) {
+	if (!dev || !s_dev) {
 		dev_err(dev, "%s: invalid input params\n", __func__);
 		return -EINVAL;
 	}
@@ -1801,6 +1791,151 @@ int max96724_set_pipe(struct device *dev, int pipe_id,
 	return err;
 }
 EXPORT_SYMBOL(max96724_set_pipe);
+
+/* ================================================================
+ * Frame Sync (FSYNC) — internal generator, broadcast to all links
+ * ================================================================ */
+
+/*
+ * Multi-camera frame synchronization.
+ *
+ * The MAX96724 generates the FSYNC signal internally from its on-board
+ * 25MHz crystal and broadcasts it over the GMSL2 reverse channel to
+ * every serializer on GPIO channel 23.  Each MAX96717 already receives
+ * ch23 on GPIO0 (H_VSYNC_TRIG) and GPIO1 (RGB_FSYNC) — see
+ * max96717_setup_gpio_tunneling() — so all cameras are driven by the
+ * same deserializer-generated edge with zero inter-camera skew.  No
+ * camera strobe loop-back and no SoC sync pin are required.
+ *
+ * Register sequence validated against the MAX96724 User Guide
+ * "Internal FSYNC (GMSL2)" programming example.
+ */
+#define MAX96724_FSYNC_0_ADDR		0x04A0	/* mode / method / enable      */
+#define MAX96724_FSYNC_PER_L_ADDR	0x04A5	/* FSYNC_PERIOD[7:0]           */
+#define MAX96724_FSYNC_PER_M_ADDR	0x04A6	/* FSYNC_PERIOD[15:8]          */
+#define MAX96724_FSYNC_PER_H_ADDR	0x04A7	/* FSYNC_PERIOD[23:16]         */
+#define MAX96724_FSYNC_15_ADDR		0x04AF	/* link select / XTAL time base*/
+#define MAX96724_FSYNC_TXID_ADDR	0x04B1	/* FSYNC_TX_ID[7:3]            */
+
+/* FSYNC time base = on-board 25MHz crystal. */
+#define MAX96724_FSYNC_XTAL_HZ		25000000U
+/* Fallback frame rate (Hz) if the caller passes fps == 0 (unknown). */
+#define MAX96724_FSYNC_FPS_DEFAULT	30U
+/* FSYNC_PERIOD is a 24-bit field (0x04A5..0x04A7). */
+#define MAX96724_FSYNC_PERIOD_MAX	0x00FFFFFFU
+
+/* GMSL2 GPIO channel the serializers receive sync on
+ * (matches MAX96717 GPIO0/GPIO1 RX_ID=23). */
+#define MAX96724_FSYNC_TX_CH		23
+
+/*
+ * 0x04AF: GMSL2-type FSYNC output (bit7=1), use 25MHz XTAL as the time
+ * base (bit6=1), select links via FS_LINK_x rather than "all enabled"
+ * (bit4=0), and include all four video pipes (bits[3:0]=1111).
+ */
+#define MAX96724_FSYNC_15_ALL		0xCF
+/* 0x04B1: FSYNC_TX_ID in bits[7:3]; FSYNC_ERR_THR[2:0] left at 0. */
+#define MAX96724_FSYNC_TXID_VAL		(MAX96724_FSYNC_TX_CH << 3)
+/*
+ * 0x04A0: FSYNC_MODE=01 (master deserializer — drives subordinates over
+ * the GMSL reverse channel) | FSYNC_METH=00 (manual / internal period).
+ * Must be written last to start the FSYNC state machine.
+ */
+#define MAX96724_FSYNC_0_ENABLE		0x04
+/* 0x04A0 disable: FSYNC_MODE=11 (off / power-up reset state). */
+#define MAX96724_FSYNC_0_DISABLE	0x0C
+
+/*
+ * max96724_setup_fsync - enable internal FSYNC broadcast (multi-camera sync)
+ * @dev: deserializer device handle
+ * @fps: desired frame rate in Hz, normally the V4L2-negotiated value
+ *       (VIDIOC_S_PARM / frame interval); pass 0 to use the default.
+ *
+ * Programs the MAX96724 as the FSYNC master: it generates a frame-sync
+ * pulse internally from the 25MHz crystal and transmits it on GMSL GPIO
+ * channel 23 to all four links.  Every camera's serializer receives the
+ * same edge (via max96717_setup_gpio_tunneling()), giving frame-locked,
+ * skew-free multi-camera capture.  The FSYNC period is computed at
+ * runtime as XTAL / fps so the sync rate tracks the active V4L2 mode.
+ */
+int max96724_setup_fsync(struct device *dev, u32 fps)
+{
+	struct max96724 *priv = dev_get_drvdata(dev);
+	struct reg_pair map[6];
+	u32 period;
+	int err;
+
+	if (!fps)
+		fps = MAX96724_FSYNC_FPS_DEFAULT;
+
+	/* Convert frame rate to a 24-bit period in 25MHz XTAL cycles. */
+	period = MAX96724_FSYNC_XTAL_HZ / fps;
+	if (!period || period > MAX96724_FSYNC_PERIOD_MAX) {
+		dev_err(dev, "%s: fps %u out of range (period %u)\n",
+			__func__, fps, period);
+		return -EINVAL;
+	}
+
+	/* Link select + 25MHz XTAL time base (all 4 links). */
+	map[0].addr = MAX96724_FSYNC_15_ADDR;
+	map[0].val  = MAX96724_FSYNC_15_ALL;
+	/* FSYNC period (24-bit, in XTAL cycles). */
+	map[1].addr = MAX96724_FSYNC_PER_L_ADDR;
+	map[1].val  = period & 0xFF;
+	map[2].addr = MAX96724_FSYNC_PER_M_ADDR;
+	map[2].val  = (period >> 8) & 0xFF;
+	map[3].addr = MAX96724_FSYNC_PER_H_ADDR;
+	map[3].val  = (period >> 16) & 0xFF;
+	/* Transmit FSYNC over GMSL reverse channel 23 to all SERs. */
+	map[4].addr = MAX96724_FSYNC_TXID_ADDR;
+	map[4].val  = MAX96724_FSYNC_TXID_VAL;
+	/* Enable internal FSYNC, manual mode (must be written last). */
+	map[5].addr = MAX96724_FSYNC_0_ADDR;
+	map[5].val  = MAX96724_FSYNC_0_ENABLE;
+
+	mutex_lock(&priv->lock);
+
+	err = max96724_set_registers(dev, map, ARRAY_SIZE(map));
+	if (err)
+		dev_err(dev, "%s: FSYNC setup failed (%d)\n", __func__, err);
+	else
+		dev_info(dev,
+			 "%s: internal FSYNC enabled (%u Hz, period %u, broadcast ch%u to all links)\n",
+			 __func__, fps, period, MAX96724_FSYNC_TX_CH);
+
+	mutex_unlock(&priv->lock);
+
+	return err;
+}
+EXPORT_SYMBOL(max96724_setup_fsync);
+
+/*
+ * max96724_disable_fsync - disable internal FSYNC generation
+ *
+ * Turns the FSYNC state machine off (FSYNC_MODE=11/off).  Counterpart to
+ * max96724_setup_fsync().
+ */
+int max96724_disable_fsync(struct device *dev)
+{
+	struct max96724 *priv = dev_get_drvdata(dev);
+	struct reg_pair map[] = {
+		{MAX96724_FSYNC_0_ADDR, MAX96724_FSYNC_0_DISABLE},
+	};
+	int err;
+
+	mutex_lock(&priv->lock);
+
+	err = max96724_set_registers(dev, map, ARRAY_SIZE(map));
+	if (err)
+		dev_err(dev, "%s: FSYNC disable failed (%d)\n", __func__, err);
+	else
+		dev_dbg(dev, "%s: internal FSYNC disabled\n", __func__);
+
+	mutex_unlock(&priv->lock);
+
+	return err;
+}
+EXPORT_SYMBOL(max96724_disable_fsync);
 
 /* ================================================================
  * Device Tree Parsing

--- a/nvidia-oot/files/6.2/include/media/max96717.h
+++ b/nvidia-oot/files/6.2/include/media/max96717.h
@@ -146,6 +146,17 @@ int max96717_init_settings(struct device *dev);
  */
 int max96717_setup_gpio_tunneling(struct device *dev);
 
+/**
+ * @brief  Disables GPIO-over-GMSL tunneling for FSIN/FOUT signals.
+ *
+ * Restores the serializer GPIOs to their default non-tunneled function.
+ *
+ * @param  [in]  dev          The serializer device handle.
+ *
+ * @return  0 for success, or negative error code.
+ */
+int max96717_disable_gpio_tunneling(struct device *dev);
+
 /** @} */
 
 #endif  /* __MAX96717_H__ */

--- a/nvidia-oot/files/6.2/include/media/max96724.h
+++ b/nvidia-oot/files/6.2/include/media/max96724.h
@@ -163,6 +163,28 @@ void max96724_power_off(struct device *dev);
 int max96724_init_settings(struct device *dev);
 
 /**
+ * @brief  Enables the MAX96724 internal FSYNC generator.
+ *
+ * Programs the deserializer as the FSYNC master and broadcasts the
+ * generated sync signal over the configured GMSL GPIO channel.
+ *
+ * @param  [in]  dev          The deserializer device handle.
+ * @param  [in]  fps          Desired frame-sync rate in Hz.
+ *
+ * @return  0 for success, or negative error code.
+ */
+int max96724_setup_fsync(struct device *dev, u32 fps);
+
+/**
+ * @brief  Disables the MAX96724 internal FSYNC generator.
+ *
+ * @param  [in]  dev          The deserializer device handle.
+ *
+ * @return  0 for success, or negative error code.
+ */
+int max96724_disable_fsync(struct device *dev);
+
+/**
  * @brief  Maps deserializer pipe ID to serializer pipe ID.
  *
  * In tunnel mode with MAX96717, all data flows through a single pipe


### PR DESCRIPTION
## Summary
- Route D5xx serializer GPIO tunnel and MAX96724 FSYNC operations through the SERDES owner instance when the sync control is set from a peer subdev.
- Match D4xx behavior by applying MAX96717 GPIO tunneling immediately from the depth `camera_sync_mode` callback.
- Start/stop the MAX96724 internal FSYNC generator at stream boundaries using the negotiated FPS, and use the correct FSYNC disable mode value.

## Root Cause
On D5xx, the depth subdev receives `camera_sync_mode`, but the SERDES devices may be owned by a different primary instance. On the tested system, `9-001a` received the depth control while `9-001d` owned the MAX96717/MAX96724 setup. This prevented the sync path from reliably programming the intended hardware owner.

The MAX96724 FSYNC disable path also wrote `0x04A0 = 0x00`; hardware validation showed FSYNC output kept toggling until `0x04A0 = 0x0c` was written.

## Validation
- `git diff --cached --check` passed before commit.
- Built and deployed by hardware owner on Jetson.
- Verified stream-on logs show:
  - `max96717_setup_gpio_tunneling: GPIO tunneling enabled`
  - `max96724_setup_fsync: internal FSYNC enabled (60 Hz, period 416666, broadcast ch23 to all links)`
- Verified stream-off calls `deserializer internal FSYNC disable OK`.
- Verified manual write of `0x04A0 = 0x0c` stops HKR GPIO 78 interrupts after streams are closed.