### PR TITLE
apply_patches_ext.sh: add JP7/noble (7.x) support for ext-source builds

### DIFF
--- a/apply_patches_ext.sh
+++ b/apply_patches_ext.sh
@@ -54,6 +54,18 @@ if [[ "$JETPACK_VERSION" == "6.x" ]]; then
     cp hardware/realsense/tegra234-camera-d4xx-overlay*.dts "$TARGET/hardware/nvidia/t23x/nv-public/overlay/"
     # max96712 header
     cp nvidia-oot/max96712.h "$TARGET/nvidia-oot/include/media/"
+elif [[ "$JETPACK_VERSION" == "7.x" ]]; then
+    # max96712 header
+    cp nvidia-oot/max96712.h "$TARGET/nvidia-oot/include/media/"
+    # tegra264-gpio.h for Thor overlay compilation if not already present
+    if [[ ! -f "$TARGET/$KERNEL_DIR/include/dt-bindings/gpio/tegra264-gpio.h" ]]; then
+        cp "$TARGET/$KERNEL_DIR/3rdparty/canonical/linux-noble/include/dt-bindings/gpio/tegra264-gpio.h" \
+            "$TARGET/$KERNEL_DIR/include/dt-bindings/gpio/" 2>/dev/null || true
+    fi
+    # JP7 D4XX device-tree overlays (noble uses .dtso, built in the kernel tree):
+    # Thor (tegra264) + single-camera Orin (tegra234) Fangzhu overlay
+    cp hardware/realsense/tegra264-camera-d4xx-overlay*.dtso "$TARGET/$KERNEL_DIR/arch/arm64/boot/dts/nvidia/"
+    cp hardware/realsense/tegra234-camera-d4xx-overlay-fg12-16ch-cams-0.dtso "$TARGET/$KERNEL_DIR/arch/arm64/boot/dts/nvidia/"
 elif [[ "$JETPACK_VERSION" == "5.x" ]]; then
     cp "hardware/realsense/${JP5_D4XX_DTSI}" "$TARGET/hardware/nvidia/platform/t19x/galen/kernel-dts/common/tegra194-camera-d4xx.dtsi"
     # max96712 header


### PR DESCRIPTION
## What
Add a `7.x` branch to `apply_patches_ext.sh` so the **external-source** patch flow works on JetPack 7 (noble / L4T R39.x).

## Why
`apply_patches_ext.sh` is the variant used by the Artifactory-based Jenkins pipeline (it patches an externally-supplied source tree via `patch -p1`, rather than the git-clone tree that `apply_patches.sh` uses with `git apply`). It only handled `5.x`/`6.x`: for `7.x` it copied `d4xx.c` but **skipped all the noble-specific steps**, so a JP7.2 ext build had no `max96712.h` and no D4XX device-tree overlays.

This is the prerequisite for building **JP7.2 in Jenkins via the Artifactory source flow** (companion PR in `librealsense-deploy`: `LRS_Jetson_mipi_driver` → JP7.2).

## Change
Mirrors the existing `7.x` block of `apply_patches.sh`, but `cp`s into the external source tree (`$TARGET`) instead of `ln`-ing into the git-clone tree:
- `max96712.h` → `nvidia-oot/include/media/`
- `tegra264-gpio.h` dt-binding (for Thor overlay compilation), if missing
- tegra264 (Thor) + tegra234 (Orin Fangzhu) `.dtso` overlays → noble kernel `arch/arm64/boot/dts/nvidia/`

## Notes / review asks
- Assumes the R39.2 `public_sources.tbz2` extracts to the same internal layout as the git-clone flow (`kernel/kernel-noble-src`, `nvidia-oot`, `3rdparty/canonical/linux-noble`). Please confirm against the actual Artifactory bundle.
- No effect on 5.x/6.x paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)