### PR TITLE
Fix JetPack 5.1.6 streaming: G_PARM EINVAL + D457 color-path panic/recovery

### DIFF
--- a/kernel/nvidia/5.1.6/0003-vi-channel-verify-s-g-callbacks.patch
+++ b/kernel/nvidia/5.1.6/0003-vi-channel-verify-s-g-callbacks.patch
@@ -1,0 +1,52 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Yogev Modlin <yogev.modlin@realsenseai.com>
+Date: Wed, 2 Jul 2026 15:30:00 +0300
+Subject: [PATCH] vi: channel: verify s/g callbacks
+
+Port of 5.1.2/0003-vi-channel-verify-s-g-callbacks.patch to the 5.1.6
+patch set, where it was lost when the directory was created from 5.1.2
+(0001 absorbed the wrapped v4l2_subdev_call() but dropped the direct-op
+fallback).
+
+Without the fallback, VIDIOC_G_PARM always fails with EINVAL on kernel
+5.10: the on-stack v4l2_subdev_frame_interval is passed to
+v4l2_subdev_call() with an uninitialized pad field, and the subdev-call
+wrapper's check_pad() rejects it before the sensor op is ever invoked.
+librealsense cannot start any stream on JP 5.1.6 as a result
+(rs2_pipeline_start() -> "xioctl(VIDIOC_G_PARM) failed").
+
+Signed-off-by: Yogev Modlin <yogev.modlin@realsenseai.com>
+---
+ drivers/media/platform/tegra/camera/vi/channel.c | 10 +++++++++-
+ 1 file changed, 9 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/media/platform/tegra/camera/vi/channel.c b/drivers/media/platform/tegra/camera/vi/channel.c
+index e01ef8665..10dc73681 100644
+--- a/drivers/media/platform/tegra/camera/vi/channel.c
++++ b/drivers/media/platform/tegra/camera/vi/channel.c
+@@ -2263,7 +2263,10 @@ __tegra_channel_get_parm(struct tegra_channel *chan,
+ 
+ 	/* dmipx: fixing G_PARM EINVAL error */
+ 	ret = v4l2_subdev_call(sd, video, g_frame_interval, &interval);
+-
++	if (ret) {
++		if (sd && sd->ops->video && sd->ops->video->g_frame_interval)
++			ret = sd->ops->video->g_frame_interval(sd, &interval);
++	}
+ 	a->parm.capture.timeperframe.numerator = interval.interval.numerator;
+ 	a->parm.capture.timeperframe.denominator = interval.interval.denominator;
+ 
+@@ -2293,6 +2296,11 @@ __tegra_channel_set_parm(struct tegra_channel *chan,
+ 	interval.interval.denominator = a->parm.capture.timeperframe.denominator;
+ 
+ 	ret = v4l2_subdev_call(sd, video, s_frame_interval, &interval);
++	if (ret) {
++		if (sd && sd->ops->video && sd->ops->video->s_frame_interval)
++			ret = sd->ops->video->s_frame_interval(sd, &interval);
++	}
++
+ 	if (ret == -ENOIOCTLCMD)
+ 			return -ENOTTY;
+ 
+-- 
+2.34.1

--- a/kernel/nvidia/5.1.6/0012-csi5-do-not-override-rce-error-config-on-v4l2-path.patch
+++ b/kernel/nvidia/5.1.6/0012-csi5-do-not-override-rce-error-config-on-v4l2-path.patch
@@ -1,0 +1,35 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Yogev Modlin <yogev.modlin@realsenseai.com>
+Date: Wed, 2 Jul 2026 16:10:00 +0300
+Subject: [PATCH] csi5: do not override RCE error config on the v4l2 path
+
+L4T 35.5 ("csi5: add error config", bug 4499208) makes the v4l2 path
+send NVCSI_CONFIG_FLAG_ERROR with a zeroed nvcsi_error_config on every
+stream start, replacing the RCE default error handling that JetPack
+5.1.2 used. With the override, the D457 first-color-frame corruption is
+reported as CHANSEL err_data 0x100, which the D457 recovery mask in
+vi5_fops.c does not cover - every color frame is discarded and the
+stream never starts. Drop the flag so the RCE defaults are used again
+and the corruption is reported as err_data 0x20000, which triggers the
+existing D457 channel recovery (JetPack 5.1.2 behavior).
+
+Signed-off-by: Yogev Modlin <yogev.modlin@realsenseai.com>
+---
+ drivers/media/platform/tegra/camera/nvcsi/csi5_fops.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/media/platform/tegra/camera/nvcsi/csi5_fops.c b/drivers/media/platform/tegra/camera/nvcsi/csi5_fops.c
+index fab8be2ec..0380d61c8 100644
+--- a/drivers/media/platform/tegra/camera/nvcsi/csi5_fops.c
++++ b/drivers/media/platform/tegra/camera/nvcsi/csi5_fops.c
+@@ -302,7 +302,7 @@ static int csi5_stream_set_config(struct tegra_csi_channel *chan, u32 stream_id,
+ 	msg.csi_stream_set_config_req.cil_config = cil_config;
+ 	msg.csi_stream_set_config_req.error_config = err_config;
+ 	msg.csi_stream_set_config_req.config_flags = NVCSI_CONFIG_FLAG_BRICK |
+-						NVCSI_CONFIG_FLAG_CIL | NVCSI_CONFIG_FLAG_ERROR;
++						NVCSI_CONFIG_FLAG_CIL;
+ 
+ 	if (tegra_chan->valid_ports > 1)
+ 		vi_port = (stream_id > 0) ? 1 : 0;
+-- 
+2.34.1

--- a/kernel/nvidia/5.1.6/0013-vi5-port-d457-error-recovery-to-filp-lifecycle.patch
+++ b/kernel/nvidia/5.1.6/0013-vi5-port-d457-error-recovery-to-filp-lifecycle.patch
@@ -1,0 +1,80 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Yogev Modlin <yogev.modlin@realsenseai.com>
+Date: Wed, 2 Jul 2026 16:11:00 +0300
+Subject: [PATCH] vi5: port D457 channel error recovery to filp-based lifecycle
+
+L4T 35.6.x ("camera: vi5: fix stream on/off memory leakage", bug
+4206070) rewrote the VI channel lifecycle: channels are tracked as
+struct file in chan->fp[] and all close paths use filp_close().
+vi5_channel_error_recover_internal() still used the old sequence
+(vi_channel_close_ex + vi_channel_open_ex), which bypasses chan->fp[]
+bookkeeping. On the first D457 color-frame corruption (err_data
+0x20000) the recovery left chan->fp[] pointing at freed private_data;
+closing the stream then oopsed in vi_capture_shutdown ->
+tegra_camrtc_reboot (NULL deref) and panicked the whole system, with a
+secondary Oops in tegra_capture_ivc_worker during the RTCPU teardown
+race.
+
+Port the recovery to the new lifecycle: reset the RCE-side channel
+first (vi_capture_release with CAPTURE_CHANNEL_RESET_FLAG_IMMEDIATE,
+while the handle is still valid - this is what actually frees the CSI
+channel-match configuration in the RCE; without it the reopen fails
+with "match configuration is already in use"), then filp_close(), then
+reopen through vi5_channel_open() so chan->fp[] stays consistent.
+
+Validated on Jetson AGX Xavier + D457 GMSL (L4T 35.6.4): color streams
+at 5-90 fps with the first-frame corruption recovered transparently; no
+panic on stream close.
+
+Signed-off-by: Yogev Modlin <yogev.modlin@realsenseai.com>
+---
+ drivers/media/platform/tegra/camera/vi/vi5_fops.c | 25 ++++++++++-----------
+ 1 file changed, 12 insertions(+), 13 deletions(-)
+
+diff --git a/drivers/media/platform/tegra/camera/vi/vi5_fops.c b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
+index 845d0cedf..a1c6e5bc5 100644
+--- a/drivers/media/platform/tegra/camera/vi/vi5_fops.c
++++ b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
+@@ -539,15 +539,16 @@ static int vi5_channel_error_recover_internal(struct tegra_channel *chan)
+ 	struct v4l2_subdev *csi_subdev;
+ 	dev_dbg(chan->vi->dev, "%s() vc: %d\n", __func__, chan->virtual_channel);
+ 
+-	/* stop vi channel */
++	/* stop vi channel (filp-based lifecycle on 35.6.x base).
++	 * Reset the RCE-side channel FIRST (frees the CSI match config)
++	 * while the VI channel handle is still valid, then close the filp.
++	 */
+ 	for(vi_port = 0; vi_port < chan->valid_ports; vi_port++) {
+ 		err = vi_capture_release(chan->tegra_vi_channel[vi_port],
+ 			CAPTURE_CHANNEL_RESET_FLAG_IMMEDIATE);
+-		if (err) {
+-			dev_err(&chan->video->dev, "vi capture release failed\n");
+-			goto done;
+-		}
+-		vi_channel_close_ex(chan->id, chan->tegra_vi_channel[vi_port]);
++		if (err)
++			dev_err(chan->vi->dev, "vi capture release failed\n");
++		filp_close(chan->fp[vi_port], NULL);
+ 		chan->tegra_vi_channel[vi_port] = NULL;
+ 	}
+ 
+@@ -583,14 +584,11 @@ static int vi5_channel_error_recover_internal(struct tegra_channel *chan)
+ 	v4l2_subdev_call(csi_subdev, core, sync,
+ 		V4L2_SYNC_EVENT_SUBDEV_ERROR_RECOVER);
+ 
+-	/* restart vi channel */
++	/* restart vi channel (filp-based lifecycle on 35.6.x base) */
+ 	for(vi_port = 0; vi_port < chan->valid_ports; vi_port++) {
+-		chan->tegra_vi_channel[vi_port] = vi_channel_open_ex(chan->id + vi_port, false);
+-		if (IS_ERR(chan->tegra_vi_channel[vi_port])) {
+-			err = PTR_ERR(chan->tegra_vi_channel[vi_port]);
+-			chan->tegra_vi_channel[vi_port] = NULL;
++		err = vi5_channel_open(chan, vi_port);
++		if (err < 0)
+ 			goto done;
+-		}
+ 		err = tegra_channel_capture_setup(chan, vi_port);
+ 		if (err < 0)
+ 			goto done;
+-- 
+2.34.1

--- a/kernel/nvidia/5.1.6/0013-vi5-port-d457-error-recovery-to-filp-lifecycle.patch
+++ b/kernel/nvidia/5.1.6/0013-vi5-port-d457-error-recovery-to-filp-lifecycle.patch
@@ -22,23 +22,33 @@ channel-match configuration in the RCE; without it the reopen fails
 with "match configuration is already in use"), then filp_close(), then
 reopen through vi5_channel_open() so chan->fp[] stays consistent.
 
+Keep the bail-out (goto done) on a failed vi_capture_release instead of
+falling through to filp_close(): force-closing a channel whose release
+just failed drives vi_capture_shutdown against inconsistent state - the
+exact NULL-deref path this patch exists to avoid - and matches the
+upstream vi5_channel_error_recover behaviour on the JP6.2 base. Also
+NULL chan->fp[] right after filp_close(), alongside the tegra_vi_channel
+reset: vi5_channel_stop_streaming() filp_close()es chan->fp[] again on
+the real stop, so a stale (freed) pointer left by a partial recovery
+would be a use-after-free.
+
 Validated on Jetson AGX Xavier + D457 GMSL (L4T 35.6.4): color streams
 at 5-90 fps with the first-frame corruption recovered transparently; no
 panic on stream close.
 
 Signed-off-by: Yogev Modlin <yogev.modlin@realsenseai.com>
 ---
- drivers/media/platform/tegra/camera/vi/vi5_fops.c | 25 ++++++++++-----------
- 1 file changed, 12 insertions(+), 13 deletions(-)
+ drivers/media/platform/tegra/camera/vi/vi5_fops.c | 19 ++++++++++---------
+ 1 file changed, 10 insertions(+), 9 deletions(-)
 
 diff --git a/drivers/media/platform/tegra/camera/vi/vi5_fops.c b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
-index 845d0cedf..a1c6e5bc5 100644
+index 845d0cedf..7d15d64a2 100644
 --- a/drivers/media/platform/tegra/camera/vi/vi5_fops.c
 +++ b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
-@@ -539,15 +539,16 @@ static int vi5_channel_error_recover_internal(struct tegra_channel *chan)
+@@ -539,15 +539,19 @@ static int vi5_channel_error_recover_internal(struct tegra_channel *chan)
  	struct v4l2_subdev *csi_subdev;
  	dev_dbg(chan->vi->dev, "%s() vc: %d\n", __func__, chan->virtual_channel);
- 
+
 -	/* stop vi channel */
 +	/* stop vi channel (filp-based lifecycle on 35.6.x base).
 +	 * Reset the RCE-side channel FIRST (frees the CSI match config)
@@ -47,21 +57,21 @@ index 845d0cedf..a1c6e5bc5 100644
  	for(vi_port = 0; vi_port < chan->valid_ports; vi_port++) {
  		err = vi_capture_release(chan->tegra_vi_channel[vi_port],
  			CAPTURE_CHANNEL_RESET_FLAG_IMMEDIATE);
--		if (err) {
+ 		if (err) {
 -			dev_err(&chan->video->dev, "vi capture release failed\n");
--			goto done;
--		}
--		vi_channel_close_ex(chan->id, chan->tegra_vi_channel[vi_port]);
-+		if (err)
 +			dev_err(chan->vi->dev, "vi capture release failed\n");
+ 			goto done;
+ 		}
+-		vi_channel_close_ex(chan->id, chan->tegra_vi_channel[vi_port]);
 +		filp_close(chan->fp[vi_port], NULL);
++		chan->fp[vi_port] = NULL;
  		chan->tegra_vi_channel[vi_port] = NULL;
  	}
- 
-@@ -583,14 +584,11 @@ static int vi5_channel_error_recover_internal(struct tegra_channel *chan)
+
+@@ -583,14 +587,11 @@ static int vi5_channel_error_recover_internal(struct tegra_channel *chan)
  	v4l2_subdev_call(csi_subdev, core, sync,
  		V4L2_SYNC_EVENT_SUBDEV_ERROR_RECOVER);
- 
+
 -	/* restart vi channel */
 +	/* restart vi channel (filp-based lifecycle on 35.6.x base) */
  	for(vi_port = 0; vi_port < chan->valid_ports; vi_port++) {
@@ -76,5 +86,5 @@ index 845d0cedf..a1c6e5bc5 100644
  		err = tegra_channel_capture_setup(chan, vi_port);
  		if (err < 0)
  			goto done;
--- 
+--
 2.34.1


### PR DESCRIPTION
## Fix JetPack 5.1.6 (L4T R35.6.x) streaming regression on D457 GMSL

Upgrading a D457 GMSL rig from JetPack 5.0.2 / 5.1.2 to **5.1.6** broke streaming: `VIDIOC_G_PARM` returned `EINVAL`, and starting the **color** stream hard-hung the box (panic → watchdog reboot). Depth/IR alone worked; color and multi-stream did not. These three patches restore full streaming — each stream alone and all combinations in parallel.

### Root cause
JP5.1.6 pulled in two NVIDIA L4T changes that the RealSense D457 color path was never adapted to:
- **VI channel lifecycle rewrite** — L4T 35.6.x *"camera: vi5: fix stream on/off memory leakage"* (bug 4206070): channels are now tracked as `struct file` in `chan->fp[]` and every close path goes through `filp_close()`.
- **CSI error-config change** — L4T 35.5 *"csi5: add error config"* (bug 4499208): the v4l2 path now sends `NVCSI_CONFIG_FLAG_ERROR` with a zeroed `nvcsi_error_config`, replacing the RCE default error handling used on 5.1.2.

Three resulting failures:
1. **G_PARM `EINVAL`** — the 5.1.6 patch set (created from 5.1.2) dropped the direct-op G/S_PARM fallback: `0001` kept the wrapped `v4l2_subdev_call()` but not the fallback. `__tegra_channel_get_parm` passes an on-stack `v4l2_subdev_frame_interval` with an uninitialized `pad`, so kernel 5.10's `check_pad()` rejects the call before the sensor op runs — librealsense can't start any stream (`rs2_pipeline_start()` → `G_PARM` failed). (`S_PARM` set `pad` explicitly, so it worked — the diagnostic tell.)
2. **Color-path panic** — D457 color frame 0 always arrives corrupted (`err_data 0x20000`; expected, also on 5.1.2). The RS `vi5` error recovery still used the old `vi_channel_close_ex`/`open_ex` sequence, which bypasses `chan->fp[]`; after recovery `chan->fp[]` was left pointing at freed `private_data`, so closing the stream NULL-deref'd in `vi_capture_shutdown` → panic. *(This mechanism is the working diagnosis from the crash signature plus on-HW behavior; the 35.6.x `vi_capture_shutdown` internals were not independently source-reviewed — see Notes.)*
3. **No recovery** — with the new `NVCSI_CONFIG_FLAG_ERROR` override the same corruption is reported as `err_data 0x100`, which the D457 recovery mask in `vi5_fops.c` does not cover → corr_err flood, no recovery, no frames.

### Fix (3 patches under `kernel/nvidia/5.1.6/`)
- **`0003-vi-channel-verify-s-g-callbacks.patch`** — restore the direct-op `g_frame_interval` fallback lost from 5.1.2, so `G_PARM` succeeds.
- **`0012-csi5-do-not-override-rce-error-config-on-v4l2-path.patch`** — drop `NVCSI_CONFIG_FLAG_ERROR` so the RCE defaults apply and the corruption is reported as `err_data 0x20000` (covered by the existing recovery mask) instead of `0x100`.
- **`0013-vi5-port-d457-error-recovery-to-filp-lifecycle.patch`** — port the D457 recovery to the filp lifecycle:
  - `vi_capture_release(CAPTURE_CHANNEL_RESET_FLAG_IMMEDIATE)` **before** `filp_close()` (this frees the RCE channel-match configuration; without it the reopen fails with *"match configuration is already in use"*), then reopen via `vi5_channel_open()` so `chan->fp[]` stays consistent.
  - On a **failed** `vi_capture_release`, **bail (`goto done`)** rather than force-closing — force-closing a channel whose release just failed drives `vi_capture_shutdown` against inconsistent state (the NULL-deref this patch avoids), and it matches NVIDIA's `vi5_channel_error_recover` on the JP6.2 base.
  - **NULL `chan->fp[vi_port]` right after `filp_close()`** (alongside the `tegra_vi_channel` reset), so a partial recovery can't leave a freed pointer for the real stream-stop to `filp_close()` a second time.

### Validation — hardware (D457 GMSL, Jetson AGX Xavier, L4T R35.6.4, FW 5.17.3.21)
Kernel with all three patches, via librealsense (callback-based), no panic, `pstore` clean:

| Permutation | Result |
|---|---|
| depth / color / ir (each alone) | ✅ 30 fps |
| depth+color, depth+ir, color+ir | ✅ 30 + 30 fps |
| depth+color+ir (all parallel) | ✅ 30 + 30 + 30 fps |

Color frame-0 recovery fires as designed (channel reset + re-arm) and streaming continues through it; also consistent with the LibCI fps test (depth+color, 5–90 fps).

### Notes
- Raw `v4l2-ctl` color-standalone still needs the SDK/driver-coordinated frame-0 recovery-retry (depth/IR work under raw v4l2); use librealsense to exercise color. Out of scope here.
- **Verification method:** the patches were reviewed against the JP6.2 filp-model reference (`vi5_channel_open` / `vi5_channel_error_recover`) plus on-HW behavior; a 35.6.x kernel source tree was not available for line-level confirmation of the `vi_capture_shutdown` path, so the frame-0-panic mechanism above is the working diagnosis rather than a source-verified claim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
