### PR TITLE
scripts: install/deploy handle JP 5.1.2 module copy

### DIFF
--- a/scripts/deploy_kernel.sh
+++ b/scripts/deploy_kernel.sh
@@ -45,12 +45,12 @@ if [ "$(ls -A ${LOCAL_DIR}/kernel_mod/${JETPACK_VERSION} 2>/dev/null)" ]; then
 fi
 
 
-# Copy specific kernel files for compatibility with legacy scripts (only for 5.0.2)
+# Copy specific kernel files for compatibility with legacy scripts (5.0.2 / 5.1.2)
 IMG_DIR="images/${JETPACK_VERSION}"
 DEST_DIR="${LOCAL_DIR}/kernel_mod/${JETPACK_VERSION}"
 
-if [ "${JETPACK_VERSION}" = "5.0.2" ]; then
-    echo "Copying kernel files to ${DEST_DIR} (5.0.2 only)..."
+if [ "${JETPACK_VERSION}" = "5.0.2" ] || [ "${JETPACK_VERSION}" = "5.1.2" ]; then
+    echo "Copying kernel files to ${DEST_DIR} (5.0.2/5.1.2)..."
     cp "${IMG_DIR}/arch/arm64/boot/Image" "${DEST_DIR}/" 2>/dev/null || true
     cp "${IMG_DIR}/arch/arm64/boot/dts/nvidia/tegra194-p2888-0001-p2822-0000.dtb" "${DEST_DIR}/" 2>/dev/null || true
     cp "${IMG_DIR}/drivers/media/i2c/d4xx.ko" "${DEST_DIR}/" 2>/dev/null || true

--- a/scripts/install_to_kernel.sh
+++ b/scripts/install_to_kernel.sh
@@ -38,7 +38,7 @@ if [ "${JETPACK_VERSION}" = "5.0.2" ] || [ "${JETPACK_VERSION}" = "5.1.2" ]; the
 fi
 
 echo "Copying kernel files for JetPack ${JETPACK_VERSION}..."
-if [ "${JETPACK_VERSION}" = "5.0.2" ]; then
+if [ "${JETPACK_VERSION}" = "5.0.2" ] || [ "${JETPACK_VERSION}" = "5.1.2" ]; then
     echo "sudo cp tegra194-p2888-0001-p2822-0000.dtb /boot/${FOLDER}/"
           sudo cp tegra194-p2888-0001-p2822-0000.dtb /boot/${FOLDER}/
     echo "sudo cp d4xx.ko /lib/modules/$(uname -r)/updates/"


### PR DESCRIPTION
## Problem
The MIPI Driver Release Page has users download the per-version JP5.1.2 package from Artifactory (`Image`, `d4xx.ko`, `.dtb`, `uvcvideo.ko`, `videobuf-*.ko`) and install it with `scripts/install_to_kernel.sh`. But the file-copy branch in both `install_to_kernel.sh` and `deploy_kernel.sh` is gated on `JETPACK_VERSION == "5.0.2"` only — **`5.1.2` matches neither branch**, so `d4xx.ko` (and companions) is never copied. `install_to_kernel.sh 5.1.2` still overwrites the kernel `Image`, so the install *appears* to succeed but the device reboots running the **old** driver.

## Fix
Add `5.1.2` to the existing `5.0.2` file-copy branch in both scripts (the JP5.1.2 Artifactory artifacts already use the exact filenames that branch copies).

## Validation (real hardware)
D457 GMSL on JP5.1.2 (L4T R35.4.1, kernel 5.10.120-tegra):
- **Before:** `install_to_kernel.sh 5.1.2` left `updates/d4xx.ko` unchanged (no copy) — silent broken install.
- **After:** downloading + installing the Artifactory **1.0.3.18** and **1.0.4.9** JP5.1.2 packages loads the matching `d4xx.ko` and streams depth (30 frames) after reboot; `ds5_probe` reports the installed version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)