### PR TITLE
install_to_kernel.sh: block JetPack-mismatched kernel on JP5

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,8 @@ The `--one-cam`/`--dual-cam` options only apply to JetPack 5.0.2.
 ./scripts/deploy_kernel_6.2.sh    # For JP 6.2+
 ```
 
+On JetPack 5.x, `install_to_kernel.sh` refuses to install a kernel `Image` whose embedded `Linux version` differs from the running `uname -r` (JP5 installs only a few `.ko`, so a mismatched-JetPack Image boots with no modules and can latch the bootloader into recovery); `SKIP_KERNEL_CHECK=1` overrides. Keep this guard when editing the deploy scripts.
+
 ## Testing
 
 Tests run on-device using pytest (Python 3). Located in `test/`.

--- a/scripts/install_to_kernel.sh
+++ b/scripts/install_to_kernel.sh
@@ -37,6 +37,20 @@ if [ "${JETPACK_VERSION}" = "5.0.2" ] || [ "${JETPACK_VERSION}" = "5.1.2" ]; the
     fi
 fi
 
+# JetPack 5.x installs only a few .ko into /lib/modules/$(uname -r), so the new
+# Image must match the running kernel; a mismatched-JetPack Image boots without
+# modules and can latch the bootloader into recovery. Override: SKIP_KERNEL_CHECK=1.
+if [ "${JETPACK_VERSION}" = "5.0.2" ] || [ "${JETPACK_VERSION}" = "5.1.2" ]; then
+    NEW_IMAGE=$(ls boot/Image Image 2>/dev/null | head -n1)
+    if [ -n "${NEW_IMAGE}" ] && [ "${SKIP_KERNEL_CHECK:-0}" != "1" ]; then
+        NEW_KVER=$(grep -a -m1 -oE 'Linux version [0-9][^ ]+' "${NEW_IMAGE}" | awk '{print $3}')
+        if [ "${NEW_KVER}" != "$(uname -r)" ]; then
+            echo "Error: new Image kernel (${NEW_KVER:-unknown}) != running kernel ($(uname -r)); wrong JetPack build. Set SKIP_KERNEL_CHECK=1 to override."
+            exit 1
+        fi
+    fi
+fi
+
 echo "Copying kernel files for JetPack ${JETPACK_VERSION}..."
 if [ "${JETPACK_VERSION}" = "5.0.2" ]; then
     echo "sudo cp tegra194-p2888-0001-p2822-0000.dtb /boot/${FOLDER}/"


### PR DESCRIPTION
## What
On JetPack 5.x, `install_to_kernel.sh` now refuses to install a kernel `Image` whose embedded `Linux version` differs from the running kernel (`uname -r`). `SKIP_KERNEL_CHECK=1` overrides.

## Why
The JP5 install path copies only the `Image` plus a handful of `.ko` files into `/lib/modules/$(uname -r)/updates/`, so it relies on the new Image matching the running kernel. Deploying a kernel built for a **different JetPack** (e.g. a 5.1.2 `5.10.120` build onto a 5.0.2 `5.10.104` box) boots a kernel with **no matching module tree** → no display/network → repeated failed boots **latch the UEFI L4TLauncher into recovery boot**. This happened on a lab CI box and required wiping the UEFI variable store to recover.

## Details
- Scoped to **JP 5.0.2 / 5.1.2 only** (JP6/7 replace the full module tree and are unaffected — verified).
- Reads the version baked into the Image about to be installed, compares to `uname -r`, and `exit 1` **before copying anything** on mismatch.
- Fails safe: if the version can't be read, it blocks (override still available).

## Testing (real JP5.0.2 AGX Xavier + unit tests)
- **BLOCK:** ran against a `5.10.120` (JP5.1.2) build → refused, `exit 1`, nothing copied, box untouched.
- **ALLOW + full deploy:** matching `5.10.104` build → copied, `depmod`, rebooted, D457 camera streaming after reboot.
- **JP 6.0/6.1/6.2/6.2.1/7.0/7.1/7.2** → guard correctly skipped.

Complements #494 (JP5.1.2 module copy) — independent change, different hunks, no conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
