### PR TITLE
[Host][GMSL]: Support D5xx CSI metadata

### DIFF
--- a/kernel/realsense/d5xx.c
+++ b/kernel/realsense/d5xx.c
@@ -192,6 +192,8 @@ struct dser_interface {
 #define DS5_STATUS_UNAVAILABLE		0xffff
 
 #define MIPI_LANE_RATE				1300
+#define DS5_CSI_METADATA_DEPTH_IR_WC	256	/* csi header 20 + depth/IR metadata 236 */
+#define DS5_CSI_METADATA_RGB_WC		263	/* csi header 20 + RGB metadata 243 */
 
 #define MAX_DEPTH_EXP				200000
 #define MAX_RGB_EXP					10000
@@ -5496,7 +5498,10 @@ static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on)
 static int ds5_mux_get_frame_desc(struct v4l2_subdev *sd,
 	unsigned int pad, struct v4l2_mbus_frame_desc *desc)
 {
+	struct ds5 *state = container_of(sd, struct ds5, mux.sd.subdev);
 	unsigned int i;
+	unsigned int metadata_len = state->is_rgb ?
+		DS5_CSI_METADATA_RGB_WC : DS5_CSI_METADATA_DEPTH_IR_WC;
 
 	desc->num_entries = V4L2_FRAME_DESC_ENTRY_MAX;
 
@@ -5506,7 +5511,7 @@ static int ds5_mux_get_frame_desc(struct v4l2_subdev *sd,
 		desc->entry[i].length = 0;
 		if (i == desc->num_entries - 1) {
 			desc->entry[i].pixelcode = 0x12;
-			desc->entry[i].length = 68;
+			desc->entry[i].length = metadata_len;
 		}
 	}
 	return 0;

--- a/kernel/realsense/d5xx.c
+++ b/kernel/realsense/d5xx.c
@@ -192,8 +192,7 @@ struct dser_interface {
 #define DS5_STATUS_UNAVAILABLE		0xffff
 
 #define MIPI_LANE_RATE				1300
-#define DS5_CSI_METADATA_DEPTH_IR_WC	256	/* csi header 20 + depth/IR metadata 236 */
-#define DS5_CSI_METADATA_RGB_WC		263	/* csi header 20 + RGB metadata 243 */
+#define DS5_CSI_METADATA_MAX_WC		4096
 
 #define MAX_DEPTH_EXP				200000
 #define MAX_RGB_EXP					10000
@@ -5498,10 +5497,7 @@ static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on)
 static int ds5_mux_get_frame_desc(struct v4l2_subdev *sd,
 	unsigned int pad, struct v4l2_mbus_frame_desc *desc)
 {
-	struct ds5 *state = container_of(sd, struct ds5, mux.sd.subdev);
 	unsigned int i;
-	unsigned int metadata_len = state->is_rgb ?
-		DS5_CSI_METADATA_RGB_WC : DS5_CSI_METADATA_DEPTH_IR_WC;
 
 	desc->num_entries = V4L2_FRAME_DESC_ENTRY_MAX;
 
@@ -5511,7 +5507,7 @@ static int ds5_mux_get_frame_desc(struct v4l2_subdev *sd,
 		desc->entry[i].length = 0;
 		if (i == desc->num_entries - 1) {
 			desc->entry[i].pixelcode = 0x12;
-			desc->entry[i].length = metadata_len;
+			desc->entry[i].length = DS5_CSI_METADATA_MAX_WC;
 		}
 	}
 	return 0;

--- a/nvidia-oot/6.0/0001-Porting-nvidia-driver-patches-to-jetpack-6.0.patch
+++ b/nvidia-oot/6.0/0001-Porting-nvidia-driver-patches-to-jetpack-6.0.patch
@@ -602,20 +602,20 @@ index 91f8d5f8..d9be2677 100644
 +	memset(fmt, 0, sizeof(*fmt));
 +
 +	fmt->dataformat = V4L2_META_FMT_D4XX;
-+	fmt->buffersize = 255;
++	fmt->buffersize = 4096;
 +
 +	return 0;
 +}
 +static int tegra_metadata_set_format(struct file *file, void *fh,
 +                                    struct v4l2_format *format)
 +{
-+   return 0;
++	return tegra_metadata_get_format(file, fh, format);
 +}
 +
 +static int tegra_metadata_try_format(struct file *file, void *fh,
 +                                    struct v4l2_format *format)
 +{
-+    return 0;
++	return tegra_metadata_get_format(file, fh, format);
 +}
 +static const struct v4l2_ioctl_ops tegra_metadata_ioctl_ops = {
 +	.vidioc_querycap                = tegra_metadata_querycap,
@@ -643,14 +643,14 @@ index 91f8d5f8..d9be2677 100644
 +		if (*nplanes != 1)
 +			return -EINVAL;
 +
-+		if (sizes[0] < 255)
++		if (sizes[0] < 4096)
 +			return -EINVAL;
 +
 +		return 0;
 +	}
 +
 +	*nplanes = 1;
-+	sizes[0] = 255;
++	sizes[0] = 4096;
 +	alloc_devs[0] = chan->vi->dev;
 +
 +
@@ -662,7 +662,7 @@ index 91f8d5f8..d9be2677 100644
 +	if (vb->num_planes != 1)
 +		return -EINVAL;
 +
-+	if (vb2_plane_size(vb, 0) < 255)
++	if (vb2_plane_size(vb, 0) < 4096)
 +		return -EINVAL;
 +
 +	return 0;
@@ -990,16 +990,42 @@ diff --git a/drivers/media/platform/tegra/camera/vi/vi5_fops.c b/drivers/media/p
 index 7b16dcaf..487ae44b 100644
 --- a/drivers/media/platform/tegra/camera/vi/vi5_fops.c
 +++ b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
-@@ -426,6 +426,39 @@ static void vi5_setup_surface(struct tegra_channel *chan,
+@@ -426,6 +426,76 @@ static void vi5_setup_surface(struct tegra_channel *chan,
  		chan->capture_descr_sequence += 1;
  }
  
++static unsigned int vi5_metadata_bytesused(struct tegra_channel *chan,
++	unsigned int copy_size)
++{
++	u8 *meta = chan->emb_buf_addr;
++	u32 magic;
++	u16 payload_size;
++	unsigned int bytesused;
++
++	if (!meta || copy_size < 20)
++		return copy_size;
++
++	/* HKRM csi_metadata_header: magic, version, stream, reserved, payload_size. */
++	memcpy(&magic, meta, sizeof(magic));
++	if (magic != 0x484B524D)
++		return copy_size;
++
++	memcpy(&payload_size, meta + 8, sizeof(payload_size));
++	bytesused = 20 + payload_size;
++	if (payload_size && bytesused <= copy_size && bytesused <= 4096)
++		return bytesused;
++
++	return copy_size;
++}
++
 +static void vi5_release_metadata_buffer(struct tegra_channel *chan,
 +	struct vb2_v4l2_buffer *vbuf)
 +{
 +	struct vb2_buffer *evb = NULL;
 +	struct vb2_v4l2_buffer *evbuf;
-+	void* frm_buffer;
++	void *frm_buffer;
++	unsigned int copy_size;
++	unsigned int bytesused;
 +
 +	spin_lock(&chan->embedded.spin_lock);
 +	if (0 < chan->embedded.num_buffers) {
@@ -1019,10 +1045,21 @@ index 7b16dcaf..487ae44b 100644
 +	if (!frm_buffer)
 +		return;
 +
-+	memcpy(frm_buffer, chan->emb_buf_addr, 255);
++	copy_size = min_t(unsigned int, 4096, vb2_plane_size(evb, 0));
++	if (chan->embedded_data_width && chan->embedded_data_height)
++		copy_size = min_t(unsigned int, copy_size,
++			chan->embedded_data_width * chan->embedded_data_height *
++			BPP_MEM);
++	if (chan->emb_buf_size)
++		copy_size = min_t(unsigned int, copy_size, chan->emb_buf_size);
++	if (!copy_size)
++		return;
++
++	bytesused = vi5_metadata_bytesused(chan, copy_size);
++	memcpy(frm_buffer, chan->emb_buf_addr, bytesused);
 +	evbuf = to_vb2_v4l2_buffer(evb);
 +	evbuf->sequence = vbuf->sequence;
-+	vb2_set_plane_payload(evb, 0, 68);
++	vb2_set_plane_payload(evb, 0, bytesused);
 +	evb->timestamp = vbuf->vb2_buf.timestamp;
 +	vb2_buffer_done(evb, VB2_BUF_STATE_DONE);
 +}
@@ -1264,4 +1301,3 @@ index e6d9a2b1..38634b77 100644
  /* Supported CSI to VI Data Formats */
 -- 
 2.34.1
-

--- a/nvidia-oot/6.0/0001-Porting-nvidia-driver-patches-to-jetpack-6.0.patch
+++ b/nvidia-oot/6.0/0001-Porting-nvidia-driver-patches-to-jetpack-6.0.patch
@@ -4,6 +4,7 @@ Date: Mon, 20 May 2024 18:08:02 +0300
 Subject: [PATCH] Porting nvidia driver patches to jetpack 6.0
 
 Signed-off-by: Dmitry Perchanov <dmitry.perchanov@intel.com>
+Signed-off-by: zhou <shengyong.zhou@realsenseai.com>
 ---
 drivers/media/i2c/Makefile                    |   7 +++++++
  drivers/media/i2c/max9295.c                   | 139 ++++++
@@ -990,7 +991,7 @@ diff --git a/drivers/media/platform/tegra/camera/vi/vi5_fops.c b/drivers/media/p
 index 7b16dcaf..487ae44b 100644
 --- a/drivers/media/platform/tegra/camera/vi/vi5_fops.c
 +++ b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
-@@ -426,6 +426,76 @@ static void vi5_setup_surface(struct tegra_channel *chan,
+@@ -426,6 +426,124 @@ static void vi5_setup_surface(struct tegra_channel *chan,
  		chan->capture_descr_sequence += 1;
  }
  
@@ -1115,7 +1116,7 @@ index 7b16dcaf..487ae44b 100644
  static void vi5_release_buffer(struct tegra_channel *chan,
  	struct tegra_channel_buffer *buf)
  {
-@@ -436,6 +469,9 @@ static void vi5_release_buffer(struct tegra_channel *chan,
+@@ -436,6 +554,9 @@ static void vi5_release_buffer(struct tegra_channel *chan,
  	vb2_set_plane_payload(&vbuf->vb2_buf, 0, chan->format.sizeimage);
  
  	vb2_buffer_done(&vbuf->vb2_buf, buf->vb2_state);

--- a/nvidia-oot/6.0/0001-Porting-nvidia-driver-patches-to-jetpack-6.0.patch
+++ b/nvidia-oot/6.0/0001-Porting-nvidia-driver-patches-to-jetpack-6.0.patch
@@ -994,28 +994,75 @@ index 7b16dcaf..487ae44b 100644
  		chan->capture_descr_sequence += 1;
  }
  
++#define VI5_CSI_METADATA_MAGIC		0x484B524D
++#define VI5_CSI_METADATA_HEADER_SIZE	20
++#define VI5_CSI_METADATA_VERSION	2
++#define VI5_CSI_METADATA_MAX_SIZE	4096
++#define VI5_CSI_METADATA_LEGACY_SIZE	68
++#define VI5_CSI_METADATA_VERSION_OFFSET	4
++#define VI5_CSI_METADATA_STREAM_OFFSET	6
++#define VI5_CSI_METADATA_PAYLOAD_OFFSET	8
++
++static bool vi5_metadata_stream_valid(u8 stream_type)
++{
++	switch (stream_type) {
++	case 2:
++	case 3:
++	case 4:
++	case 5:
++	case 8:
++	case 12:
++		return true;
++	default:
++		return false;
++	}
++}
++
++static unsigned int vi5_metadata_legacy_bytesused(unsigned int copy_size)
++{
++	return min_t(unsigned int, copy_size, VI5_CSI_METADATA_LEGACY_SIZE);
++}
++
 +static unsigned int vi5_metadata_bytesused(struct tegra_channel *chan,
 +	unsigned int copy_size)
 +{
 +	u8 *meta = chan->emb_buf_addr;
 +	u32 magic;
++	u16 version;
++	u8 stream_type;
 +	u16 payload_size;
++	unsigned int max_payload_size;
 +	unsigned int bytesused;
 +
-+	if (!meta || copy_size < 20)
-+		return copy_size;
++	if (!meta || copy_size < VI5_CSI_METADATA_HEADER_SIZE)
++		return vi5_metadata_legacy_bytesused(copy_size);
 +
-+	/* HKRM csi_metadata_header: magic, version, stream, reserved, payload_size. */
 +	memcpy(&magic, meta, sizeof(magic));
-+	if (magic != 0x484B524D)
-+		return copy_size;
++	if (magic != VI5_CSI_METADATA_MAGIC)
++		return vi5_metadata_legacy_bytesused(copy_size);
 +
-+	memcpy(&payload_size, meta + 8, sizeof(payload_size));
-+	bytesused = 20 + payload_size;
-+	if (payload_size && bytesused <= copy_size && bytesused <= 4096)
++	memcpy(&version, meta + VI5_CSI_METADATA_VERSION_OFFSET,
++		sizeof(version));
++	if (version != VI5_CSI_METADATA_VERSION)
++		return vi5_metadata_legacy_bytesused(copy_size);
++
++	memcpy(&stream_type, meta + VI5_CSI_METADATA_STREAM_OFFSET,
++		sizeof(stream_type));
++	if (!vi5_metadata_stream_valid(stream_type))
++		return vi5_metadata_legacy_bytesused(copy_size);
++
++	memcpy(&payload_size, meta + VI5_CSI_METADATA_PAYLOAD_OFFSET,
++		sizeof(payload_size));
++	max_payload_size = VI5_CSI_METADATA_MAX_SIZE -
++		VI5_CSI_METADATA_HEADER_SIZE;
++	if (!payload_size || payload_size > max_payload_size)
++		return vi5_metadata_legacy_bytesused(copy_size);
++
++	bytesused = VI5_CSI_METADATA_HEADER_SIZE + payload_size;
++	if (bytesused <= copy_size)
 +		return bytesused;
 +
-+	return copy_size;
++	return vi5_metadata_legacy_bytesused(copy_size);
 +}
 +
 +static void vi5_release_metadata_buffer(struct tegra_channel *chan,
@@ -1045,7 +1092,8 @@ index 7b16dcaf..487ae44b 100644
 +	if (!frm_buffer)
 +		return;
 +
-+	copy_size = min_t(unsigned int, 4096, vb2_plane_size(evb, 0));
++	copy_size = min_t(unsigned int, VI5_CSI_METADATA_MAX_SIZE,
++		vb2_plane_size(evb, 0));
 +	if (chan->embedded_data_width && chan->embedded_data_height)
 +		copy_size = min_t(unsigned int, copy_size,
 +			chan->embedded_data_width * chan->embedded_data_height *

--- a/nvidia-oot/6.2/0001-Porting-nvidia-driver-patches-to-jetpack-6.0.patch
+++ b/nvidia-oot/6.2/0001-Porting-nvidia-driver-patches-to-jetpack-6.0.patch
@@ -602,20 +602,20 @@ index 91f8d5f8..d9be2677 100644
 +	memset(fmt, 0, sizeof(*fmt));
 +
 +	fmt->dataformat = V4L2_META_FMT_D4XX;
-+	fmt->buffersize = 255;
++	fmt->buffersize = 4096;
 +
 +	return 0;
 +}
 +static int tegra_metadata_set_format(struct file *file, void *fh,
 +                                    struct v4l2_format *format)
 +{
-+   return 0;
++	return tegra_metadata_get_format(file, fh, format);
 +}
 +
 +static int tegra_metadata_try_format(struct file *file, void *fh,
 +                                    struct v4l2_format *format)
 +{
-+    return 0;
++	return tegra_metadata_get_format(file, fh, format);
 +}
 +static const struct v4l2_ioctl_ops tegra_metadata_ioctl_ops = {
 +	.vidioc_querycap                = tegra_metadata_querycap,
@@ -643,14 +643,14 @@ index 91f8d5f8..d9be2677 100644
 +		if (*nplanes != 1)
 +			return -EINVAL;
 +
-+		if (sizes[0] < 255)
++		if (sizes[0] < 4096)
 +			return -EINVAL;
 +
 +		return 0;
 +	}
 +
 +	*nplanes = 1;
-+	sizes[0] = 255;
++	sizes[0] = 4096;
 +	alloc_devs[0] = chan->vi->dev;
 +
 +
@@ -662,7 +662,7 @@ index 91f8d5f8..d9be2677 100644
 +	if (vb->num_planes != 1)
 +		return -EINVAL;
 +
-+	if (vb2_plane_size(vb, 0) < 255)
++	if (vb2_plane_size(vb, 0) < 4096)
 +		return -EINVAL;
 +
 +	return 0;
@@ -990,16 +990,42 @@ diff --git a/drivers/media/platform/tegra/camera/vi/vi5_fops.c b/drivers/media/p
 index 7b16dcaf..487ae44b 100644
 --- a/drivers/media/platform/tegra/camera/vi/vi5_fops.c
 +++ b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
-@@ -426,6 +426,39 @@ static void vi5_setup_surface(struct tegra_channel *chan,
+@@ -426,6 +426,76 @@ static void vi5_setup_surface(struct tegra_channel *chan,
  		chan->capture_descr_sequence += 1;
  }
  
++static unsigned int vi5_metadata_bytesused(struct tegra_channel *chan,
++	unsigned int copy_size)
++{
++	u8 *meta = chan->emb_buf_addr;
++	u32 magic;
++	u16 payload_size;
++	unsigned int bytesused;
++
++	if (!meta || copy_size < 20)
++		return copy_size;
++
++	/* HKRM csi_metadata_header: magic, version, stream, reserved, payload_size. */
++	memcpy(&magic, meta, sizeof(magic));
++	if (magic != 0x484B524D)
++		return copy_size;
++
++	memcpy(&payload_size, meta + 8, sizeof(payload_size));
++	bytesused = 20 + payload_size;
++	if (payload_size && bytesused <= copy_size && bytesused <= 4096)
++		return bytesused;
++
++	return copy_size;
++}
++
 +static void vi5_release_metadata_buffer(struct tegra_channel *chan,
 +	struct vb2_v4l2_buffer *vbuf)
 +{
 +	struct vb2_buffer *evb = NULL;
 +	struct vb2_v4l2_buffer *evbuf;
-+	void* frm_buffer;
++	void *frm_buffer;
++	unsigned int copy_size;
++	unsigned int bytesused;
 +
 +	spin_lock(&chan->embedded.spin_lock);
 +	if (0 < chan->embedded.num_buffers) {
@@ -1019,10 +1045,21 @@ index 7b16dcaf..487ae44b 100644
 +	if (!frm_buffer)
 +		return;
 +
-+	memcpy(frm_buffer, chan->emb_buf_addr, 255);
++	copy_size = min_t(unsigned int, 4096, vb2_plane_size(evb, 0));
++	if (chan->embedded_data_width && chan->embedded_data_height)
++		copy_size = min_t(unsigned int, copy_size,
++			chan->embedded_data_width * chan->embedded_data_height *
++			BPP_MEM);
++	if (chan->emb_buf_size)
++		copy_size = min_t(unsigned int, copy_size, chan->emb_buf_size);
++	if (!copy_size)
++		return;
++
++	bytesused = vi5_metadata_bytesused(chan, copy_size);
++	memcpy(frm_buffer, chan->emb_buf_addr, bytesused);
 +	evbuf = to_vb2_v4l2_buffer(evb);
 +	evbuf->sequence = vbuf->sequence;
-+	vb2_set_plane_payload(evb, 0, 68);
++	vb2_set_plane_payload(evb, 0, bytesused);
 +	evb->timestamp = vbuf->vb2_buf.timestamp;
 +	vb2_buffer_done(evb, VB2_BUF_STATE_DONE);
 +}
@@ -1264,4 +1301,3 @@ index e6d9a2b1..38634b77 100644
  /* Supported CSI to VI Data Formats */
 -- 
 2.34.1
-

--- a/nvidia-oot/6.2/0001-Porting-nvidia-driver-patches-to-jetpack-6.0.patch
+++ b/nvidia-oot/6.2/0001-Porting-nvidia-driver-patches-to-jetpack-6.0.patch
@@ -4,6 +4,7 @@ Date: Mon, 20 May 2024 18:08:02 +0300
 Subject: [PATCH] Porting nvidia driver patches to jetpack 6.0
 
 Signed-off-by: Dmitry Perchanov <dmitry.perchanov@intel.com>
+Signed-off-by: zhou <shengyong.zhou@realsenseai.com>
 ---
 drivers/media/i2c/Makefile                    |   7 +++++++
  drivers/media/i2c/max9295.c                   | 139 ++++++
@@ -990,7 +991,7 @@ diff --git a/drivers/media/platform/tegra/camera/vi/vi5_fops.c b/drivers/media/p
 index 7b16dcaf..487ae44b 100644
 --- a/drivers/media/platform/tegra/camera/vi/vi5_fops.c
 +++ b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
-@@ -426,6 +426,76 @@ static void vi5_setup_surface(struct tegra_channel *chan,
+@@ -426,6 +426,124 @@ static void vi5_setup_surface(struct tegra_channel *chan,
  		chan->capture_descr_sequence += 1;
  }
  
@@ -1115,7 +1116,7 @@ index 7b16dcaf..487ae44b 100644
  static void vi5_release_buffer(struct tegra_channel *chan,
  	struct tegra_channel_buffer *buf)
  {
-@@ -436,6 +469,9 @@ static void vi5_release_buffer(struct tegra_channel *chan,
+@@ -436,6 +554,9 @@ static void vi5_release_buffer(struct tegra_channel *chan,
  	vb2_set_plane_payload(&vbuf->vb2_buf, 0, chan->format.sizeimage);
  
  	vb2_buffer_done(&vbuf->vb2_buf, buf->vb2_state);

--- a/nvidia-oot/6.2/0001-Porting-nvidia-driver-patches-to-jetpack-6.0.patch
+++ b/nvidia-oot/6.2/0001-Porting-nvidia-driver-patches-to-jetpack-6.0.patch
@@ -994,28 +994,75 @@ index 7b16dcaf..487ae44b 100644
  		chan->capture_descr_sequence += 1;
  }
  
++#define VI5_CSI_METADATA_MAGIC		0x484B524D
++#define VI5_CSI_METADATA_HEADER_SIZE	20
++#define VI5_CSI_METADATA_VERSION	2
++#define VI5_CSI_METADATA_MAX_SIZE	4096
++#define VI5_CSI_METADATA_LEGACY_SIZE	68
++#define VI5_CSI_METADATA_VERSION_OFFSET	4
++#define VI5_CSI_METADATA_STREAM_OFFSET	6
++#define VI5_CSI_METADATA_PAYLOAD_OFFSET	8
++
++static bool vi5_metadata_stream_valid(u8 stream_type)
++{
++	switch (stream_type) {
++	case 2:
++	case 3:
++	case 4:
++	case 5:
++	case 8:
++	case 12:
++		return true;
++	default:
++		return false;
++	}
++}
++
++static unsigned int vi5_metadata_legacy_bytesused(unsigned int copy_size)
++{
++	return min_t(unsigned int, copy_size, VI5_CSI_METADATA_LEGACY_SIZE);
++}
++
 +static unsigned int vi5_metadata_bytesused(struct tegra_channel *chan,
 +	unsigned int copy_size)
 +{
 +	u8 *meta = chan->emb_buf_addr;
 +	u32 magic;
++	u16 version;
++	u8 stream_type;
 +	u16 payload_size;
++	unsigned int max_payload_size;
 +	unsigned int bytesused;
 +
-+	if (!meta || copy_size < 20)
-+		return copy_size;
++	if (!meta || copy_size < VI5_CSI_METADATA_HEADER_SIZE)
++		return vi5_metadata_legacy_bytesused(copy_size);
 +
-+	/* HKRM csi_metadata_header: magic, version, stream, reserved, payload_size. */
 +	memcpy(&magic, meta, sizeof(magic));
-+	if (magic != 0x484B524D)
-+		return copy_size;
++	if (magic != VI5_CSI_METADATA_MAGIC)
++		return vi5_metadata_legacy_bytesused(copy_size);
 +
-+	memcpy(&payload_size, meta + 8, sizeof(payload_size));
-+	bytesused = 20 + payload_size;
-+	if (payload_size && bytesused <= copy_size && bytesused <= 4096)
++	memcpy(&version, meta + VI5_CSI_METADATA_VERSION_OFFSET,
++		sizeof(version));
++	if (version != VI5_CSI_METADATA_VERSION)
++		return vi5_metadata_legacy_bytesused(copy_size);
++
++	memcpy(&stream_type, meta + VI5_CSI_METADATA_STREAM_OFFSET,
++		sizeof(stream_type));
++	if (!vi5_metadata_stream_valid(stream_type))
++		return vi5_metadata_legacy_bytesused(copy_size);
++
++	memcpy(&payload_size, meta + VI5_CSI_METADATA_PAYLOAD_OFFSET,
++		sizeof(payload_size));
++	max_payload_size = VI5_CSI_METADATA_MAX_SIZE -
++		VI5_CSI_METADATA_HEADER_SIZE;
++	if (!payload_size || payload_size > max_payload_size)
++		return vi5_metadata_legacy_bytesused(copy_size);
++
++	bytesused = VI5_CSI_METADATA_HEADER_SIZE + payload_size;
++	if (bytesused <= copy_size)
 +		return bytesused;
 +
-+	return copy_size;
++	return vi5_metadata_legacy_bytesused(copy_size);
 +}
 +
 +static void vi5_release_metadata_buffer(struct tegra_channel *chan,
@@ -1045,7 +1092,8 @@ index 7b16dcaf..487ae44b 100644
 +	if (!frm_buffer)
 +		return;
 +
-+	copy_size = min_t(unsigned int, 4096, vb2_plane_size(evb, 0));
++	copy_size = min_t(unsigned int, VI5_CSI_METADATA_MAX_SIZE,
++		vb2_plane_size(evb, 0));
 +	if (chan->embedded_data_width && chan->embedded_data_height)
 +		copy_size = min_t(unsigned int, copy_size,
 +			chan->embedded_data_width * chan->embedded_data_height *

--- a/nvidia-oot/7.0/0001-Porting-nvidia-driver-patches-to-jetpack-6.0.patch
+++ b/nvidia-oot/7.0/0001-Porting-nvidia-driver-patches-to-jetpack-6.0.patch
@@ -606,20 +606,20 @@ index 91f8d5f8..d9be2677 100644
 +	memset(fmt, 0, sizeof(*fmt));
 +
 +	fmt->dataformat = V4L2_META_FMT_D4XX;
-+	fmt->buffersize = 255;
++	fmt->buffersize = 4096;
 +
 +	return 0;
 +}
 +static int tegra_metadata_set_format(struct file *file, void *fh,
 +                                    struct v4l2_format *format)
 +{
-+   return 0;
++	return tegra_metadata_get_format(file, fh, format);
 +}
 +
 +static int tegra_metadata_try_format(struct file *file, void *fh,
 +                                    struct v4l2_format *format)
 +{
-+    return 0;
++	return tegra_metadata_get_format(file, fh, format);
 +}
 +static const struct v4l2_ioctl_ops tegra_metadata_ioctl_ops = {
 +	.vidioc_querycap                = tegra_metadata_querycap,
@@ -647,14 +647,14 @@ index 91f8d5f8..d9be2677 100644
 +		if (*nplanes != 1)
 +			return -EINVAL;
 +
-+		if (sizes[0] < 255)
++		if (sizes[0] < 4096)
 +			return -EINVAL;
 +
 +		return 0;
 +	}
 +
 +	*nplanes = 1;
-+	sizes[0] = 255;
++	sizes[0] = 4096;
 +	alloc_devs[0] = chan->vi->dev;
 +
 +
@@ -666,7 +666,7 @@ index 91f8d5f8..d9be2677 100644
 +	if (vb->num_planes != 1)
 +		return -EINVAL;
 +
-+	if (vb2_plane_size(vb, 0) < 255)
++	if (vb2_plane_size(vb, 0) < 4096)
 +		return -EINVAL;
 +
 +	return 0;
@@ -994,16 +994,42 @@ diff --git a/drivers/media/platform/tegra/camera/vi/vi5_fops.c b/drivers/media/p
 index 7b16dcaf..487ae44b 100644
 --- a/drivers/media/platform/tegra/camera/vi/vi5_fops.c
 +++ b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
-@@ -426,6 +426,39 @@ static void vi5_setup_surface(struct tegra_channel *chan,
+@@ -426,6 +426,76 @@ static void vi5_setup_surface(struct tegra_channel *chan,
  		chan->capture_descr_sequence += 1;
  }
  
++static unsigned int vi5_metadata_bytesused(struct tegra_channel *chan,
++	unsigned int copy_size)
++{
++	u8 *meta = chan->emb_buf_addr;
++	u32 magic;
++	u16 payload_size;
++	unsigned int bytesused;
++
++	if (!meta || copy_size < 20)
++		return copy_size;
++
++	/* HKRM csi_metadata_header: magic, version, stream, reserved, payload_size. */
++	memcpy(&magic, meta, sizeof(magic));
++	if (magic != 0x484B524D)
++		return copy_size;
++
++	memcpy(&payload_size, meta + 8, sizeof(payload_size));
++	bytesused = 20 + payload_size;
++	if (payload_size && bytesused <= copy_size && bytesused <= 4096)
++		return bytesused;
++
++	return copy_size;
++}
++
 +static void vi5_release_metadata_buffer(struct tegra_channel *chan,
 +	struct vb2_v4l2_buffer *vbuf)
 +{
 +	struct vb2_buffer *evb = NULL;
 +	struct vb2_v4l2_buffer *evbuf;
-+	void* frm_buffer;
++	void *frm_buffer;
++	unsigned int copy_size;
++	unsigned int bytesused;
 +
 +	spin_lock(&chan->embedded.spin_lock);
 +	if (0 < chan->embedded.num_buffers) {
@@ -1023,10 +1049,21 @@ index 7b16dcaf..487ae44b 100644
 +	if (!frm_buffer)
 +		return;
 +
-+	memcpy(frm_buffer, chan->emb_buf_addr, 255);
++	copy_size = min_t(unsigned int, 4096, vb2_plane_size(evb, 0));
++	if (chan->embedded_data_width && chan->embedded_data_height)
++		copy_size = min_t(unsigned int, copy_size,
++			chan->embedded_data_width * chan->embedded_data_height *
++			BPP_MEM);
++	if (chan->emb_buf_size)
++		copy_size = min_t(unsigned int, copy_size, chan->emb_buf_size);
++	if (!copy_size)
++		return;
++
++	bytesused = vi5_metadata_bytesused(chan, copy_size);
++	memcpy(frm_buffer, chan->emb_buf_addr, bytesused);
 +	evbuf = to_vb2_v4l2_buffer(evb);
 +	evbuf->sequence = vbuf->sequence;
-+	vb2_set_plane_payload(evb, 0, 68);
++	vb2_set_plane_payload(evb, 0, bytesused);
 +	evb->timestamp = vbuf->vb2_buf.timestamp;
 +	vb2_buffer_done(evb, VB2_BUF_STATE_DONE);
 +}
@@ -1268,4 +1305,3 @@ index e6d9a2b1..38634b77 100644
  /* Supported CSI to VI Data Formats */
 -- 
 2.34.1
-

--- a/nvidia-oot/7.0/0001-Porting-nvidia-driver-patches-to-jetpack-6.0.patch
+++ b/nvidia-oot/7.0/0001-Porting-nvidia-driver-patches-to-jetpack-6.0.patch
@@ -4,6 +4,7 @@ Date: Mon, 20 May 2024 18:08:02 +0300
 Subject: [PATCH] Porting nvidia driver patches to jetpack 6.0
 
 Signed-off-by: Dmitry Perchanov <dmitry.perchanov@intel.com>
+Signed-off-by: zhou <shengyong.zhou@realsenseai.com>
 ---
 drivers/media/i2c/Makefile                    |   7 +++++++
  drivers/media/i2c/max9295.c                   | 139 ++++++
@@ -994,7 +995,7 @@ diff --git a/drivers/media/platform/tegra/camera/vi/vi5_fops.c b/drivers/media/p
 index 7b16dcaf..487ae44b 100644
 --- a/drivers/media/platform/tegra/camera/vi/vi5_fops.c
 +++ b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
-@@ -426,6 +426,76 @@ static void vi5_setup_surface(struct tegra_channel *chan,
+@@ -426,6 +426,124 @@ static void vi5_setup_surface(struct tegra_channel *chan,
  		chan->capture_descr_sequence += 1;
  }
  
@@ -1119,7 +1120,7 @@ index 7b16dcaf..487ae44b 100644
  static void vi5_release_buffer(struct tegra_channel *chan,
  	struct tegra_channel_buffer *buf)
  {
-@@ -436,6 +469,9 @@ static void vi5_release_buffer(struct tegra_channel *chan,
+@@ -436,6 +554,9 @@ static void vi5_release_buffer(struct tegra_channel *chan,
  	vb2_set_plane_payload(&vbuf->vb2_buf, 0, chan->format.sizeimage);
  
  	vb2_buffer_done(&vbuf->vb2_buf, buf->vb2_state);

--- a/nvidia-oot/7.0/0001-Porting-nvidia-driver-patches-to-jetpack-6.0.patch
+++ b/nvidia-oot/7.0/0001-Porting-nvidia-driver-patches-to-jetpack-6.0.patch
@@ -998,28 +998,75 @@ index 7b16dcaf..487ae44b 100644
  		chan->capture_descr_sequence += 1;
  }
  
++#define VI5_CSI_METADATA_MAGIC		0x484B524D
++#define VI5_CSI_METADATA_HEADER_SIZE	20
++#define VI5_CSI_METADATA_VERSION	2
++#define VI5_CSI_METADATA_MAX_SIZE	4096
++#define VI5_CSI_METADATA_LEGACY_SIZE	68
++#define VI5_CSI_METADATA_VERSION_OFFSET	4
++#define VI5_CSI_METADATA_STREAM_OFFSET	6
++#define VI5_CSI_METADATA_PAYLOAD_OFFSET	8
++
++static bool vi5_metadata_stream_valid(u8 stream_type)
++{
++	switch (stream_type) {
++	case 2:
++	case 3:
++	case 4:
++	case 5:
++	case 8:
++	case 12:
++		return true;
++	default:
++		return false;
++	}
++}
++
++static unsigned int vi5_metadata_legacy_bytesused(unsigned int copy_size)
++{
++	return min_t(unsigned int, copy_size, VI5_CSI_METADATA_LEGACY_SIZE);
++}
++
 +static unsigned int vi5_metadata_bytesused(struct tegra_channel *chan,
 +	unsigned int copy_size)
 +{
 +	u8 *meta = chan->emb_buf_addr;
 +	u32 magic;
++	u16 version;
++	u8 stream_type;
 +	u16 payload_size;
++	unsigned int max_payload_size;
 +	unsigned int bytesused;
 +
-+	if (!meta || copy_size < 20)
-+		return copy_size;
++	if (!meta || copy_size < VI5_CSI_METADATA_HEADER_SIZE)
++		return vi5_metadata_legacy_bytesused(copy_size);
 +
-+	/* HKRM csi_metadata_header: magic, version, stream, reserved, payload_size. */
 +	memcpy(&magic, meta, sizeof(magic));
-+	if (magic != 0x484B524D)
-+		return copy_size;
++	if (magic != VI5_CSI_METADATA_MAGIC)
++		return vi5_metadata_legacy_bytesused(copy_size);
 +
-+	memcpy(&payload_size, meta + 8, sizeof(payload_size));
-+	bytesused = 20 + payload_size;
-+	if (payload_size && bytesused <= copy_size && bytesused <= 4096)
++	memcpy(&version, meta + VI5_CSI_METADATA_VERSION_OFFSET,
++		sizeof(version));
++	if (version != VI5_CSI_METADATA_VERSION)
++		return vi5_metadata_legacy_bytesused(copy_size);
++
++	memcpy(&stream_type, meta + VI5_CSI_METADATA_STREAM_OFFSET,
++		sizeof(stream_type));
++	if (!vi5_metadata_stream_valid(stream_type))
++		return vi5_metadata_legacy_bytesused(copy_size);
++
++	memcpy(&payload_size, meta + VI5_CSI_METADATA_PAYLOAD_OFFSET,
++		sizeof(payload_size));
++	max_payload_size = VI5_CSI_METADATA_MAX_SIZE -
++		VI5_CSI_METADATA_HEADER_SIZE;
++	if (!payload_size || payload_size > max_payload_size)
++		return vi5_metadata_legacy_bytesused(copy_size);
++
++	bytesused = VI5_CSI_METADATA_HEADER_SIZE + payload_size;
++	if (bytesused <= copy_size)
 +		return bytesused;
 +
-+	return copy_size;
++	return vi5_metadata_legacy_bytesused(copy_size);
 +}
 +
 +static void vi5_release_metadata_buffer(struct tegra_channel *chan,
@@ -1049,7 +1096,8 @@ index 7b16dcaf..487ae44b 100644
 +	if (!frm_buffer)
 +		return;
 +
-+	copy_size = min_t(unsigned int, 4096, vb2_plane_size(evb, 0));
++	copy_size = min_t(unsigned int, VI5_CSI_METADATA_MAX_SIZE,
++		vb2_plane_size(evb, 0));
 +	if (chan->embedded_data_width && chan->embedded_data_height)
 +		copy_size = min_t(unsigned int, copy_size,
 +			chan->embedded_data_width * chan->embedded_data_height *

--- a/nvidia-oot/7.1/0001-Porting-nvidia-driver-patches-to-jetpack-6.0.patch
+++ b/nvidia-oot/7.1/0001-Porting-nvidia-driver-patches-to-jetpack-6.0.patch
@@ -606,20 +606,20 @@ index 91f8d5f8..d9be2677 100644
 +	memset(fmt, 0, sizeof(*fmt));
 +
 +	fmt->dataformat = V4L2_META_FMT_D4XX;
-+	fmt->buffersize = 255;
++	fmt->buffersize = 4096;
 +
 +	return 0;
 +}
 +static int tegra_metadata_set_format(struct file *file, void *fh,
 +                                    struct v4l2_format *format)
 +{
-+   return 0;
++	return tegra_metadata_get_format(file, fh, format);
 +}
 +
 +static int tegra_metadata_try_format(struct file *file, void *fh,
 +                                    struct v4l2_format *format)
 +{
-+    return 0;
++	return tegra_metadata_get_format(file, fh, format);
 +}
 +static const struct v4l2_ioctl_ops tegra_metadata_ioctl_ops = {
 +	.vidioc_querycap                = tegra_metadata_querycap,
@@ -647,14 +647,14 @@ index 91f8d5f8..d9be2677 100644
 +		if (*nplanes != 1)
 +			return -EINVAL;
 +
-+		if (sizes[0] < 255)
++		if (sizes[0] < 4096)
 +			return -EINVAL;
 +
 +		return 0;
 +	}
 +
 +	*nplanes = 1;
-+	sizes[0] = 255;
++	sizes[0] = 4096;
 +	alloc_devs[0] = chan->vi->dev;
 +
 +
@@ -666,7 +666,7 @@ index 91f8d5f8..d9be2677 100644
 +	if (vb->num_planes != 1)
 +		return -EINVAL;
 +
-+	if (vb2_plane_size(vb, 0) < 255)
++	if (vb2_plane_size(vb, 0) < 4096)
 +		return -EINVAL;
 +
 +	return 0;
@@ -994,16 +994,42 @@ diff --git a/drivers/media/platform/tegra/camera/vi/vi5_fops.c b/drivers/media/p
 index 7b16dcaf..487ae44b 100644
 --- a/drivers/media/platform/tegra/camera/vi/vi5_fops.c
 +++ b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
-@@ -426,6 +426,39 @@ static void vi5_setup_surface(struct tegra_channel *chan,
+@@ -426,6 +426,76 @@ static void vi5_setup_surface(struct tegra_channel *chan,
  		chan->capture_descr_sequence += 1;
  }
  
++static unsigned int vi5_metadata_bytesused(struct tegra_channel *chan,
++	unsigned int copy_size)
++{
++	u8 *meta = chan->emb_buf_addr;
++	u32 magic;
++	u16 payload_size;
++	unsigned int bytesused;
++
++	if (!meta || copy_size < 20)
++		return copy_size;
++
++	/* HKRM csi_metadata_header: magic, version, stream, reserved, payload_size. */
++	memcpy(&magic, meta, sizeof(magic));
++	if (magic != 0x484B524D)
++		return copy_size;
++
++	memcpy(&payload_size, meta + 8, sizeof(payload_size));
++	bytesused = 20 + payload_size;
++	if (payload_size && bytesused <= copy_size && bytesused <= 4096)
++		return bytesused;
++
++	return copy_size;
++}
++
 +static void vi5_release_metadata_buffer(struct tegra_channel *chan,
 +	struct vb2_v4l2_buffer *vbuf)
 +{
 +	struct vb2_buffer *evb = NULL;
 +	struct vb2_v4l2_buffer *evbuf;
-+	void* frm_buffer;
++	void *frm_buffer;
++	unsigned int copy_size;
++	unsigned int bytesused;
 +
 +	spin_lock(&chan->embedded.spin_lock);
 +	if (0 < chan->embedded.num_buffers) {
@@ -1023,10 +1049,21 @@ index 7b16dcaf..487ae44b 100644
 +	if (!frm_buffer)
 +		return;
 +
-+	memcpy(frm_buffer, chan->emb_buf_addr, 255);
++	copy_size = min_t(unsigned int, 4096, vb2_plane_size(evb, 0));
++	if (chan->embedded_data_width && chan->embedded_data_height)
++		copy_size = min_t(unsigned int, copy_size,
++			chan->embedded_data_width * chan->embedded_data_height *
++			BPP_MEM);
++	if (chan->emb_buf_size)
++		copy_size = min_t(unsigned int, copy_size, chan->emb_buf_size);
++	if (!copy_size)
++		return;
++
++	bytesused = vi5_metadata_bytesused(chan, copy_size);
++	memcpy(frm_buffer, chan->emb_buf_addr, bytesused);
 +	evbuf = to_vb2_v4l2_buffer(evb);
 +	evbuf->sequence = vbuf->sequence;
-+	vb2_set_plane_payload(evb, 0, 68);
++	vb2_set_plane_payload(evb, 0, bytesused);
 +	evb->timestamp = vbuf->vb2_buf.timestamp;
 +	vb2_buffer_done(evb, VB2_BUF_STATE_DONE);
 +}
@@ -1268,4 +1305,3 @@ index e6d9a2b1..38634b77 100644
  /* Supported CSI to VI Data Formats */
 -- 
 2.34.1
-

--- a/nvidia-oot/7.1/0001-Porting-nvidia-driver-patches-to-jetpack-6.0.patch
+++ b/nvidia-oot/7.1/0001-Porting-nvidia-driver-patches-to-jetpack-6.0.patch
@@ -4,6 +4,7 @@ Date: Mon, 20 May 2024 18:08:02 +0300
 Subject: [PATCH] Porting nvidia driver patches to jetpack 6.0
 
 Signed-off-by: Dmitry Perchanov <dmitry.perchanov@intel.com>
+Signed-off-by: zhou <shengyong.zhou@realsenseai.com>
 ---
 drivers/media/i2c/Makefile                    |   7 +++++++
  drivers/media/i2c/max9295.c                   | 139 ++++++
@@ -994,7 +995,7 @@ diff --git a/drivers/media/platform/tegra/camera/vi/vi5_fops.c b/drivers/media/p
 index 7b16dcaf..487ae44b 100644
 --- a/drivers/media/platform/tegra/camera/vi/vi5_fops.c
 +++ b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
-@@ -426,6 +426,76 @@ static void vi5_setup_surface(struct tegra_channel *chan,
+@@ -426,6 +426,124 @@ static void vi5_setup_surface(struct tegra_channel *chan,
  		chan->capture_descr_sequence += 1;
  }
  
@@ -1119,7 +1120,7 @@ index 7b16dcaf..487ae44b 100644
  static void vi5_release_buffer(struct tegra_channel *chan,
  	struct tegra_channel_buffer *buf)
  {
-@@ -436,6 +469,9 @@ static void vi5_release_buffer(struct tegra_channel *chan,
+@@ -436,6 +554,9 @@ static void vi5_release_buffer(struct tegra_channel *chan,
  	vb2_set_plane_payload(&vbuf->vb2_buf, 0, chan->format.sizeimage);
  
  	vb2_buffer_done(&vbuf->vb2_buf, buf->vb2_state);

--- a/nvidia-oot/7.1/0001-Porting-nvidia-driver-patches-to-jetpack-6.0.patch
+++ b/nvidia-oot/7.1/0001-Porting-nvidia-driver-patches-to-jetpack-6.0.patch
@@ -998,28 +998,75 @@ index 7b16dcaf..487ae44b 100644
  		chan->capture_descr_sequence += 1;
  }
  
++#define VI5_CSI_METADATA_MAGIC		0x484B524D
++#define VI5_CSI_METADATA_HEADER_SIZE	20
++#define VI5_CSI_METADATA_VERSION	2
++#define VI5_CSI_METADATA_MAX_SIZE	4096
++#define VI5_CSI_METADATA_LEGACY_SIZE	68
++#define VI5_CSI_METADATA_VERSION_OFFSET	4
++#define VI5_CSI_METADATA_STREAM_OFFSET	6
++#define VI5_CSI_METADATA_PAYLOAD_OFFSET	8
++
++static bool vi5_metadata_stream_valid(u8 stream_type)
++{
++	switch (stream_type) {
++	case 2:
++	case 3:
++	case 4:
++	case 5:
++	case 8:
++	case 12:
++		return true;
++	default:
++		return false;
++	}
++}
++
++static unsigned int vi5_metadata_legacy_bytesused(unsigned int copy_size)
++{
++	return min_t(unsigned int, copy_size, VI5_CSI_METADATA_LEGACY_SIZE);
++}
++
 +static unsigned int vi5_metadata_bytesused(struct tegra_channel *chan,
 +	unsigned int copy_size)
 +{
 +	u8 *meta = chan->emb_buf_addr;
 +	u32 magic;
++	u16 version;
++	u8 stream_type;
 +	u16 payload_size;
++	unsigned int max_payload_size;
 +	unsigned int bytesused;
 +
-+	if (!meta || copy_size < 20)
-+		return copy_size;
++	if (!meta || copy_size < VI5_CSI_METADATA_HEADER_SIZE)
++		return vi5_metadata_legacy_bytesused(copy_size);
 +
-+	/* HKRM csi_metadata_header: magic, version, stream, reserved, payload_size. */
 +	memcpy(&magic, meta, sizeof(magic));
-+	if (magic != 0x484B524D)
-+		return copy_size;
++	if (magic != VI5_CSI_METADATA_MAGIC)
++		return vi5_metadata_legacy_bytesused(copy_size);
 +
-+	memcpy(&payload_size, meta + 8, sizeof(payload_size));
-+	bytesused = 20 + payload_size;
-+	if (payload_size && bytesused <= copy_size && bytesused <= 4096)
++	memcpy(&version, meta + VI5_CSI_METADATA_VERSION_OFFSET,
++		sizeof(version));
++	if (version != VI5_CSI_METADATA_VERSION)
++		return vi5_metadata_legacy_bytesused(copy_size);
++
++	memcpy(&stream_type, meta + VI5_CSI_METADATA_STREAM_OFFSET,
++		sizeof(stream_type));
++	if (!vi5_metadata_stream_valid(stream_type))
++		return vi5_metadata_legacy_bytesused(copy_size);
++
++	memcpy(&payload_size, meta + VI5_CSI_METADATA_PAYLOAD_OFFSET,
++		sizeof(payload_size));
++	max_payload_size = VI5_CSI_METADATA_MAX_SIZE -
++		VI5_CSI_METADATA_HEADER_SIZE;
++	if (!payload_size || payload_size > max_payload_size)
++		return vi5_metadata_legacy_bytesused(copy_size);
++
++	bytesused = VI5_CSI_METADATA_HEADER_SIZE + payload_size;
++	if (bytesused <= copy_size)
 +		return bytesused;
 +
-+	return copy_size;
++	return vi5_metadata_legacy_bytesused(copy_size);
 +}
 +
 +static void vi5_release_metadata_buffer(struct tegra_channel *chan,
@@ -1049,7 +1096,8 @@ index 7b16dcaf..487ae44b 100644
 +	if (!frm_buffer)
 +		return;
 +
-+	copy_size = min_t(unsigned int, 4096, vb2_plane_size(evb, 0));
++	copy_size = min_t(unsigned int, VI5_CSI_METADATA_MAX_SIZE,
++		vb2_plane_size(evb, 0));
 +	if (chan->embedded_data_width && chan->embedded_data_height)
 +		copy_size = min_t(unsigned int, copy_size,
 +			chan->embedded_data_width * chan->embedded_data_height *


### PR DESCRIPTION
## Summary

This PR replaces #492 with an upstream branch based directly on `d500_gmsl_dev`.

It adds host-side D5xx CSI metadata support by reporting metadata sidecar `bytesused` from the runtime HKRM CSI metadata header instead of relying on a fixed 68-byte legacy payload size. The runtime path validates the metadata header magic, version, stream type, and payload size before using it, and keeps invalid or legacy metadata on the existing 68-byte fallback path for compatibility with older firmware.

The NVIDIA OOT patch hunk ranges are also corrected for the expanded metadata helper so the JetPack 6.x/7.x patch stack applies cleanly.

## Validation

- `git diff --check origin/d500_gmsl_dev..HEAD`
- `git apply --check --verbose` for the JetPack 6.2 NVIDIA OOT patch against the JetPack 6.2.2 source tree
- Full Orin GMSL build and deploy to Jetson 67 was previously completed for this change set; `orin-gmsl verify --require-loaded` passed with `d5xx`, `max96717`, and `max96724` loaded and deployed artifacts matching by SHA256.
