### PR TITLE
Fix MAX96712 two-lane MIPI output rate

### DIFF
--- a/nvidia-oot/6.0/0003-Adding-max96712-support-for-D4xx.patch
+++ b/nvidia-oot/6.0/0003-Adding-max96712-support-for-D4xx.patch
@@ -47,7 +47,7 @@ index 8e237eef..293dcc8a 100644
 +
 +#define MAX96712_BACKTOP25_ADDR 0x418
 +#define MAX96712_BACKTOP25_PHY1_SW_OVRR_OFFS 0x5
-+#define MAX96712_BACKTOP25_2500Mbps 0x19
++#define MAX96712_BACKTOP25_1500Mbps 0x0f
 +#define MAX96712_BACKTOP25_1100Mbps 0xb
 +
 +#define MAX96712_MIPI_TX_EXT0_ADDR 0x800
@@ -781,8 +781,8 @@ index 8e237eef..293dcc8a 100644
 +		{MAX96712_VIDEO_PIPE_EN_ADDR, 0x00}, //0xF4, Disable all pipes for now
 +	};
 +
-+	/* 1100Mbps per lane for 4 lanes, 2500Mbps per lane for 2 lanes */
-+	uint8_t lane_rate = (priv->lane_cnt == 4) ? MAX96712_BACKTOP25_1100Mbps : MAX96712_BACKTOP25_2500Mbps;
++	/* 1100Mbps per lane for 4 lanes, 1500Mbps per lane for 2 lanes */
++	uint8_t lane_rate = (priv->lane_cnt == 4) ? MAX96712_BACKTOP25_1100Mbps : MAX96712_BACKTOP25_1500Mbps;
 +
 +	struct reg_pair map_phy_opt[] =
 +	{


### PR DESCRIPTION
## Summary

- Configure the MAX96712 two-lane MIPI output for 1500 Mbps per lane instead of 2500 Mbps per lane.
- Rename the lane-rate constant and update the selection comment to match the programmed value.

## Root cause

The two-lane MAX96712 path programmed register `0x0418` for 2500 Mbps per lane. On the Orin NX FG12-4CH setup this caused Tegra VI capture collisions and repeated frame discards (`err_data 0x40000`) for both RGB and Depth streams.

Programming the documented 1500 Mbps per-lane value (`0x0418 = 0x2f`) removes the VI errors without changing the device-tree VC, port, or PHY mapping.

## Validation

- Cross-compiled the MAX96712 and D4xx camera modules for JetPack 6.2.1 / kernel 5.15.148-tegra.
- Deployed the modules and rebooted the Orin NX; verified `0x0418` initializes automatically to `0x2f`.
- RGB: 1280x720 YUYV at 30 fps, 5/5 consecutive frames, 29.99 fps, no error buffers, VI discards, or `corr_err`.
- Depth: 1280x720 Z16 at 30 fps, 5/5 consecutive frames, 30.02 fps, no error buffers, VI discards, or `corr_err`.
- `git diff --check` passes.
