### PR TITLE
[Host][GMSL] Support D5xx flat NV12 over RAW8

### DIFF
--- a/kernel/realsense/d5xx.c
+++ b/kernel/realsense/d5xx.c
@@ -1315,7 +1315,7 @@ static const struct d5x_format d5x_y_formats_d58x[] = {
 
 static const struct d5x_format d5x_rgb_formats_d58x[] = {
 	{
-		/* MC-FCVT uses UYVY bytes on DT 0x1E; V4L2 exposes YUYV. */
+		/* CSI2_DT 0x1E uses MC-FCVT UYVY bytes; V4L2 exposes YUYV. */
 		.data_type = GMSL_CSI_DT_YUV422_8,
 		.mbus_code = MEDIA_BUS_FMT_YUYV8_1X16,
 		.n_resolutions = ARRAY_SIZE(d58x_rgb_sizes),

--- a/kernel/realsense/d5xx.c
+++ b/kernel/realsense/d5xx.c
@@ -1313,13 +1313,21 @@ static const struct d5x_format d5x_y_formats_d58x[] = {
 	},
 };
 
-static const struct d5x_format d5x_d58x_rgb_format = {
-	.data_type = GMSL_CSI_DT_YUV422_8,	/* UYVY */
-	.mbus_code = MEDIA_BUS_FMT_YUYV8_1X16,
-	.n_resolutions = ARRAY_SIZE(d58x_rgb_sizes),
-	.resolutions = d58x_rgb_sizes,
+static const struct d5x_format d5x_rgb_formats_d58x[] = {
+	{
+		/* MC-FCVT uses UYVY bytes on DT 0x1E; V4L2 exposes YUYV. */
+		.data_type = GMSL_CSI_DT_YUV422_8,
+		.mbus_code = MEDIA_BUS_FMT_YUYV8_1X16,
+		.n_resolutions = ARRAY_SIZE(d58x_rgb_sizes),
+		.resolutions = d58x_rgb_sizes,
+	}, {
+		/* Flat NV12 surface carried as width x (height * 3 / 2) RAW8. */
+		.data_type = GMSL_CSI_DT_RAW_8,
+		.mbus_code = MEDIA_BUS_FMT_UYYVYY8_0_5X24,
+		.n_resolutions = ARRAY_SIZE(d58x_rgb_sizes),
+		.resolutions = d58x_rgb_sizes,
+	},
 };
-#define D5X_D58X_RGB_N_FORMATS 1
 
 static const struct d5x_variant d5x_variants[] = {
 	[D5X_DS5U] = {
@@ -1613,6 +1621,69 @@ static const struct d5x_format *d5x_sensor_find_format(
 /* 1-8 */
 #define MIPI_CSI2_TYPE_USER_DEF(i)	(0x30 + (i) - 1)
 
+#ifdef CONFIG_TEGRA_CAMERA_PLATFORM
+static void d5x_tegra_update_mipi_clock(struct sensor_signal_properties *signal,
+					u32 bit_depth)
+{
+	u64 rate;
+
+	if (!signal || !signal->num_lanes)
+		return;
+
+	rate = signal->serdes_pixel_clock.val ?
+		signal->serdes_pixel_clock.val : signal->pixel_clock.val;
+	rate = div_u64(rate * bit_depth, signal->num_lanes);
+
+	if (signal->phy_mode == CSI_PHY_MODE_DPHY)
+		signal->mipi_clock.val = div_u64(rate, 2);
+	else if (signal->phy_mode == CSI_PHY_MODE_CPHY)
+		signal->mipi_clock.val = div_u64(rate * 7, 16);
+	else
+		signal->mipi_clock.val = rate;
+}
+
+static void d5x_tegra_update_rgb_mode(struct d5x *state,
+				      const struct d5x_sensor *sensor)
+{
+	struct sensor_mode_properties *mode;
+	struct sensor_image_properties *image;
+	u32 pixel_format;
+	u32 bit_depth;
+
+	if (!state->mux.sd.sensor_props.sensor_modes ||
+	    !sensor->config.format || !sensor->config.resolution)
+		return;
+
+	switch (sensor->config.format->mbus_code) {
+	case MEDIA_BUS_FMT_UYYVYY8_0_5X24:
+		pixel_format = V4L2_PIX_FMT_NV12;
+		bit_depth = 12;
+		break;
+	case MEDIA_BUS_FMT_YUYV8_1X16:
+		pixel_format = V4L2_PIX_FMT_YUYV;
+		bit_depth = 16;
+		break;
+	default:
+		return;
+	}
+
+	mode = &state->mux.sd.sensor_props.sensor_modes[0];
+	image = &mode->image_properties;
+	image->width = sensor->format.width;
+	image->height = sensor->format.height;
+	image->line_length = sensor->format.width;
+	image->pixel_format = pixel_format;
+	image->embedded_metadata_height = state->metadata_enabled ? 1 : 0;
+
+	d5x_tegra_update_mipi_clock(&mode->signal_properties, bit_depth);
+
+	state->mux.sd.mode_prop_idx = 0;
+	state->mux.sd.mode = state->mux.sd.def_mode;
+	state->mux.sd.fmt_width = image->width;
+	state->mux.sd.fmt_height = image->height;
+}
+#endif
+
 static int __d5x_sensor_set_fmt(struct d5x *state, struct d5x_sensor *sensor,
 #if LINUX_VERSION_CODE < KERNEL_VERSION(5, 15, 10)
 		struct v4l2_subdev_pad_config *cfg,
@@ -1660,12 +1731,9 @@ static int __d5x_sensor_set_fmt(struct d5x *state, struct d5x_sensor *sensor,
 	else {
 		sensor->format = *mf;
 #ifdef CONFIG_TEGRA_CAMERA_PLATFORM
-		/* Update mode_prop_idx so the Tegra framework uses the correct
-		 * DT mode (pixel_t) for NVCSI/VI pixel parser configuration.
-		 * Only the IR sensor has multiple DT modes (mode0=grey_y8, mode1=grey_y16).
-		 * Other sensors (depth/rgb/imu) have a single mode0 and must stay at 0.
-		 */
-		if (state->is_y8) {
+		if (state->is_rgb) {
+			d5x_tegra_update_rgb_mode(state, sensor);
+		} else if (state->is_y8) {
 			if (sensor->config.format->mbus_code == MEDIA_BUS_FMT_Y8_1X8)
 				state->mux.sd.mode_prop_idx = 0;
 			else
@@ -5983,8 +6051,8 @@ static int d5x_fixed_configuration(struct i2c_client *client, struct d5x *state)
 	switch (dev_type) {
 	case D5X_DEVICE_TYPE_D58X:
 	default:
-		sensor->formats = &d5x_d58x_rgb_format;
-		sensor->n_formats = D5X_D58X_RGB_N_FORMATS;
+		sensor->formats = d5x_rgb_formats_d58x;
+		sensor->n_formats = ARRAY_SIZE(d5x_rgb_formats_d58x);
 	}
 	sensor->mux_pad = D5X_MUX_PAD_RGB;
 

--- a/nvidia-oot/6.0/0014-Add-flat-NV12-RAW8-capture-format.patch
+++ b/nvidia-oot/6.0/0014-Add-flat-NV12-RAW8-capture-format.patch
@@ -1,0 +1,76 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: zhou <shengyong.zhou@realsenseai.com>
+Date: Fri, 17 Jul 2026 18:00:00 +0800
+Subject: [PATCH] media: tegra: add flat NV12 RAW8 capture format
+
+Add D5xx flat NV12 capture over a RAW8 carrier: VI5 matches CSI DT 0x2A
+and writes width x (height * 3 / 2) byte rows into one V4L2 NV12 buffer.
+The 3/2 sizeimage accounting remains standard NV12, while the transport
+avoids native CSI YUV420 line interpretation and does not reorder bytes.
+
+Formats are selected at STREAMON through the VI5 format table, so
+sensors can add these formats without device-tree mode changes.
+
+Signed-off-by: zhou <shengyong.zhou@realsenseai.com>
+---
+diff --git a/drivers/media/platform/tegra/camera/vi/channel.c b/drivers/media/platform/tegra/camera/vi/channel.c
+index 3ee83f5a..9fc6e9be 100644
+--- a/drivers/media/platform/tegra/camera/vi/channel.c
++++ b/drivers/media/platform/tegra/camera/vi/channel.c
+@@ -295,6 +295,9 @@ static void tegra_channel_update_format(struct tegra_channel *chan,
+ 
+ 	if (fourcc == V4L2_PIX_FMT_NV16)
+ 		chan->format.sizeimage *= 2;
++	else if (fourcc == V4L2_PIX_FMT_NV12)
++		/* NV12 V4L2 buffer: Y plane + half-height UV plane */
++		chan->format.sizeimage = chan->format.sizeimage * 3 / 2;
+ }
+ 
+ static void tegra_channel_fmts_bitmap_init(struct tegra_channel *chan)
+@@ -2131,6 +2134,9 @@ __tegra_channel_try_format(struct tegra_channel *chan,
+ 			pix->bytesperline, pix->height);
+ 	if (chan->fmtinfo->fourcc == V4L2_PIX_FMT_NV16)
+ 		pix->sizeimage *= 2;
++	else if (chan->fmtinfo->fourcc == V4L2_PIX_FMT_NV12)
++		/* NV12 V4L2 buffer: Y plane + half-height UV plane */
++		pix->sizeimage = pix->sizeimage * 3 / 2;
+ 
+ 	return ret;
+ }
+diff --git a/drivers/media/platform/tegra/camera/vi/vi5_fops.c b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
+index b2aa7fc7..079b5865 100644
+--- a/drivers/media/platform/tegra/camera/vi/vi5_fops.c
++++ b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
+@@ -393,6 +393,7 @@ static void vi5_setup_surface(struct tegra_channel *chan,
+ 	u32 format = chan->fmtinfo->img_fmt;
+ 	u32 bpl = chan->format.bytesperline;
+ 	u32 data_type = chan->fmtinfo->img_dt;
++	bool flat_nv12 = chan->fmtinfo->fourcc == V4L2_PIX_FMT_NV12;
+ 	u32 nvcsi_stream = chan->port[vi_port];
+ 	struct capture_descriptor_memoryinfo *desc_memoryinfo =
+ 		&chan->tegra_vi_channel[vi_port]->
+@@ -405,5 +406,9 @@ static void vi5_setup_surface(struct tegra_channel *chan,
+ 		offset = buf->addr + chan->buffer_offset[1 - vi_port];
+ 	}
+ 
++	/* D5xx carries flat NV12 bytes as W x (H * 3 / 2) RAW8 rows. */
++	if (flat_nv12)
++		height = height * 3 / 2;
++
+ 	memcpy(desc, &capture_template, sizeof(capture_template));
+ 	memset(desc_memoryinfo, 0, sizeof(*desc_memoryinfo));
+diff --git a/drivers/media/platform/tegra/camera/vi/vi5_formats.h b/drivers/media/platform/tegra/camera/vi/vi5_formats.h
+index afa1a2c6..fb07cfd2 100644
+--- a/drivers/media/platform/tegra/camera/vi/vi5_formats.h
++++ b/drivers/media/platform/tegra/camera/vi/vi5_formats.h
+@@ -166,6 +166,10 @@ static const struct tegra_video_format vi5_video_formats[] = {
+ 	TEGRA_VIDEO_FORMAT(RGB888, 24, RGB888_1X24, 4, 1, T_A8R8G8B8,
+ 				RGB888, Y12I, "Y12I 24"),
+ 
++	/* D5xx NV12: HKR sends flat bytes as RAW8, W x (H * 3 / 2). */
++	TEGRA_VIDEO_FORMAT(RAW8, 8, UYYVYY8_0_5X24, 1, 1, T_R8,
++				RAW8, NV12, "YUV 4:2:0 NV12"),
++
+ };
+ 
+ #endif

--- a/nvidia-oot/6.1/0014-Add-flat-NV12-RAW8-capture-format.patch
+++ b/nvidia-oot/6.1/0014-Add-flat-NV12-RAW8-capture-format.patch
@@ -1,0 +1,77 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: zhou <shengyong.zhou@realsenseai.com>
+Date: Fri, 17 Jul 2026 18:00:00 +0800
+Subject: [PATCH] media: tegra: add flat NV12 RAW8 capture format
+
+Add D5xx flat NV12 capture over a RAW8 carrier: VI5 matches CSI DT 0x2A
+and writes width x (height * 3 / 2) byte rows into one V4L2 NV12 buffer.
+The 3/2 sizeimage accounting remains standard NV12, while the transport
+avoids native CSI YUV420 line interpretation and does not reorder bytes.
+
+Formats are selected at STREAMON through the VI5 format table, so
+sensors can add these formats without device-tree mode changes.
+
+Signed-off-by: zhou <shengyong.zhou@realsenseai.com>
+---
+diff --git a/drivers/media/platform/tegra/camera/vi/channel.c b/drivers/media/platform/tegra/camera/vi/channel.c
+index 11f75d7..ca37919 100644
+--- a/drivers/media/platform/tegra/camera/vi/channel.c
++++ b/drivers/media/platform/tegra/camera/vi/channel.c
+@@ -295,6 +295,9 @@ static void tegra_channel_update_format(struct tegra_channel *chan,
+ 
+ 	if (fourcc == V4L2_PIX_FMT_NV16)
+ 		chan->format.sizeimage *= 2;
++	else if (fourcc == V4L2_PIX_FMT_NV12)
++		/* NV12 V4L2 buffer: Y plane + half-height UV plane */
++		chan->format.sizeimage = chan->format.sizeimage * 3 / 2;
+ }
+ 
+ static void tegra_channel_fmts_bitmap_init(struct tegra_channel *chan)
+@@ -2128,6 +2131,9 @@ __tegra_channel_try_format(struct tegra_channel *chan,
+ 			pix->bytesperline, pix->height);
+ 	if (chan->fmtinfo->fourcc == V4L2_PIX_FMT_NV16)
+ 		pix->sizeimage *= 2;
++	else if (chan->fmtinfo->fourcc == V4L2_PIX_FMT_NV12)
++		/* NV12 V4L2 buffer: Y plane + half-height UV plane */
++		pix->sizeimage = pix->sizeimage * 3 / 2;
+ 
+ 	return ret;
+ }
+diff --git a/drivers/media/platform/tegra/camera/vi/vi5_fops.c b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
+index b2aa7fc7..079b5865 100644
+--- a/drivers/media/platform/tegra/camera/vi/vi5_fops.c
++++ b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
+@@ -393,6 +393,7 @@ static void vi5_setup_surface(struct tegra_channel *chan,
+ 	u32 format = chan->fmtinfo->img_fmt;
+ 	u32 bpl = chan->format.bytesperline;
+ 	u32 data_type = chan->fmtinfo->img_dt;
++	bool flat_nv12 = chan->fmtinfo->fourcc == V4L2_PIX_FMT_NV12;
+ 	u32 nvcsi_stream = chan->port[vi_port];
+ 	struct capture_descriptor_memoryinfo *desc_memoryinfo =
+ 		&chan->tegra_vi_channel[vi_port]->
+@@ -405,5 +406,9 @@ static void vi5_setup_surface(struct tegra_channel *chan,
+ 		offset = buf->addr + chan->buffer_offset[1 - vi_port];
+ 	}
+ 
++	/* D5xx carries flat NV12 bytes as W x (H * 3 / 2) RAW8 rows. */
++	if (flat_nv12)
++		height = height * 3 / 2;
++
+ 	memcpy(desc, &capture_template, sizeof(capture_template));
+ 	memset(desc_memoryinfo, 0, sizeof(*desc_memoryinfo));
+ 
+diff --git a/drivers/media/platform/tegra/camera/vi/vi5_formats.h b/drivers/media/platform/tegra/camera/vi/vi5_formats.h
+index 1d375de..7ae1ea4 100644
+--- a/drivers/media/platform/tegra/camera/vi/vi5_formats.h
++++ b/drivers/media/platform/tegra/camera/vi/vi5_formats.h
+@@ -150,6 +150,10 @@ static const struct tegra_video_format vi5_video_formats[] = {
+ 	TEGRA_VIDEO_FORMAT(RGB888, 24, RGB888_1X24, 4, 1, T_A8R8G8B8,
+ 				RGB888, Y12I, "Y12I 24"),
+ 
++	/* D5xx NV12: HKR sends flat bytes as RAW8, W x (H * 3 / 2). */
++	TEGRA_VIDEO_FORMAT(RAW8, 8, UYYVYY8_0_5X24, 1, 1, T_R8,
++				RAW8, NV12, "YUV 4:2:0 NV12"),
++
+ };
+ 
+ #endif

--- a/nvidia-oot/6.2/0014-Add-flat-NV12-RAW8-capture-format.patch
+++ b/nvidia-oot/6.2/0014-Add-flat-NV12-RAW8-capture-format.patch
@@ -1,0 +1,76 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: zhou <shengyong.zhou@realsenseai.com>
+Date: Fri, 17 Jul 2026 18:00:00 +0800
+Subject: [PATCH] media: tegra: add flat NV12 RAW8 capture format
+
+Add D5xx flat NV12 capture over a RAW8 carrier: VI5 matches CSI DT 0x2A
+and writes width x (height * 3 / 2) byte rows into one V4L2 NV12 buffer.
+The 3/2 sizeimage accounting remains standard NV12, while the transport
+avoids native CSI YUV420 line interpretation and does not reorder bytes.
+
+Formats are selected at STREAMON through the VI5 format table, so
+sensors can add these formats without device-tree mode changes.
+
+Signed-off-by: zhou <shengyong.zhou@realsenseai.com>
+---
+diff --git a/drivers/media/platform/tegra/camera/vi/channel.c b/drivers/media/platform/tegra/camera/vi/channel.c
+index 3ee83f5a..9fc6e9be 100644
+--- a/drivers/media/platform/tegra/camera/vi/channel.c
++++ b/drivers/media/platform/tegra/camera/vi/channel.c
+@@ -295,6 +295,9 @@ static void tegra_channel_update_format(struct tegra_channel *chan,
+ 
+ 	if (fourcc == V4L2_PIX_FMT_NV16)
+ 		chan->format.sizeimage *= 2;
++	else if (fourcc == V4L2_PIX_FMT_NV12)
++		/* NV12 V4L2 buffer: Y plane + half-height UV plane */
++		chan->format.sizeimage = chan->format.sizeimage * 3 / 2;
+ }
+ 
+ static void tegra_channel_fmts_bitmap_init(struct tegra_channel *chan)
+@@ -2131,6 +2134,9 @@ __tegra_channel_try_format(struct tegra_channel *chan,
+ 			pix->bytesperline, pix->height);
+ 	if (chan->fmtinfo->fourcc == V4L2_PIX_FMT_NV16)
+ 		pix->sizeimage *= 2;
++	else if (chan->fmtinfo->fourcc == V4L2_PIX_FMT_NV12)
++		/* NV12 V4L2 buffer: Y plane + half-height UV plane */
++		pix->sizeimage = pix->sizeimage * 3 / 2;
+ 
+ 	return ret;
+ }
+diff --git a/drivers/media/platform/tegra/camera/vi/vi5_fops.c b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
+index b2aa7fc7..079b5865 100644
+--- a/drivers/media/platform/tegra/camera/vi/vi5_fops.c
++++ b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
+@@ -393,6 +393,7 @@ static void vi5_setup_surface(struct tegra_channel *chan,
+ 	u32 format = chan->fmtinfo->img_fmt;
+ 	u32 bpl = chan->format.bytesperline;
+ 	u32 data_type = chan->fmtinfo->img_dt;
++	bool flat_nv12 = chan->fmtinfo->fourcc == V4L2_PIX_FMT_NV12;
+ 	u32 nvcsi_stream = chan->port[vi_port];
+ 	struct capture_descriptor_memoryinfo *desc_memoryinfo =
+ 		&chan->tegra_vi_channel[vi_port]->
+@@ -405,5 +406,9 @@ static void vi5_setup_surface(struct tegra_channel *chan,
+ 		offset = buf->addr + chan->buffer_offset[1 - vi_port];
+ 	}
+ 
++	/* D5xx carries flat NV12 bytes as W x (H * 3 / 2) RAW8 rows. */
++	if (flat_nv12)
++		height = height * 3 / 2;
++
+ 	memcpy(desc, &capture_template, sizeof(capture_template));
+ 	memset(desc_memoryinfo, 0, sizeof(*desc_memoryinfo));
+diff --git a/drivers/media/platform/tegra/camera/vi/vi5_formats.h b/drivers/media/platform/tegra/camera/vi/vi5_formats.h
+index afa1a2c6..fb07cfd2 100644
+--- a/drivers/media/platform/tegra/camera/vi/vi5_formats.h
++++ b/drivers/media/platform/tegra/camera/vi/vi5_formats.h
+@@ -166,6 +166,10 @@ static const struct tegra_video_format vi5_video_formats[] = {
+ 	TEGRA_VIDEO_FORMAT(RGB888, 24, RGB888_1X24, 4, 1, T_A8R8G8B8,
+ 				RGB888, Y12I, "Y12I 24"),
+ 
++	/* D5xx NV12: HKR sends flat bytes as RAW8, W x (H * 3 / 2). */
++	TEGRA_VIDEO_FORMAT(RAW8, 8, UYYVYY8_0_5X24, 1, 1, T_R8,
++				RAW8, NV12, "YUV 4:2:0 NV12"),
++
+ };
+ 
+ #endif

--- a/nvidia-oot/7.0/0014-Add-flat-NV12-RAW8-capture-format.patch
+++ b/nvidia-oot/7.0/0014-Add-flat-NV12-RAW8-capture-format.patch
@@ -1,0 +1,77 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: zhou <shengyong.zhou@realsenseai.com>
+Date: Fri, 17 Jul 2026 18:00:00 +0800
+Subject: [PATCH] media: tegra: add flat NV12 RAW8 capture format
+
+Add D5xx flat NV12 capture over a RAW8 carrier: VI5 matches CSI DT 0x2A and writes width x (height * 3 / 2) byte rows into one V4L2 NV12 buffer. The 3/2 sizeimage accounting remains standard NV12, while the transport avoids native CSI YUV420 line interpretation and does not reorder bytes.
+
+Formats are selected at STREAMON through the VI5 format table, so sensors can add these formats without device-tree mode changes.
+
+Signed-off-by: zhou <shengyong.zhou@realsenseai.com>
+
+diff --git a/drivers/media/platform/tegra/camera/vi/channel.c b/drivers/media/platform/tegra/camera/vi/channel.c
+index 88cf075..340afb6 100644
+--- a/drivers/media/platform/tegra/camera/vi/channel.c
++++ b/drivers/media/platform/tegra/camera/vi/channel.c
+@@ -329,6 +329,9 @@ static void tegra_channel_update_format(struct tegra_channel *chan,
+ 
+ 	if (fourcc == V4L2_PIX_FMT_NV16)
+ 		chan->format.sizeimage *= 2;
++	else if (fourcc == V4L2_PIX_FMT_NV12)
++		/* NV12 V4L2 buffer: Y plane + half-height UV plane */
++		chan->format.sizeimage = chan->format.sizeimage * 3 / 2;
+ }
+ 
+ static void tegra_channel_fmts_bitmap_init(struct tegra_channel *chan)
+@@ -2225,6 +2228,13 @@ __tegra_channel_try_format(struct tegra_channel *chan,
+ 			__func__);
+ 			return -EOVERFLOW;
+ 		}
++	} else if (chan->fmtinfo->fourcc == V4L2_PIX_FMT_NV12) {
++		if (__builtin_umul_overflow(pix->sizeimage, 3, &pix->sizeimage)) {
++			dev_err(chan->vi->dev, "%s: update size image failed due to an overflow\n",
++				__func__);
++			return -EOVERFLOW;
++		}
++		pix->sizeimage /= 2;
+ 	}
+ 
+ 	return ret;
+diff --git a/drivers/media/platform/tegra/camera/vi/vi5_fops.c b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
+index aad0669..952e3bc 100644
+--- a/drivers/media/platform/tegra/camera/vi/vi5_fops.c
++++ b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
+@@ -391,6 +391,7 @@ static void vi5_setup_surface(struct tegra_channel *chan,
+ 	u32 format = chan->fmtinfo->img_fmt;
+ 	u32 bpl = chan->format.bytesperline;
+ 	u32 data_type = chan->fmtinfo->img_dt;
++	bool flat_nv12 = chan->fmtinfo->fourcc == V4L2_PIX_FMT_NV12;
+ 	u32 nvcsi_stream = chan->port[vi_port];
+ 	unsigned int range = 0;
+ 	struct capture_descriptor_memoryinfo *desc_memoryinfo =
+@@ -419,6 +420,10 @@ static void vi5_setup_surface(struct tegra_channel *chan,
+ 		}
+ 	}
+ 
++	/* D5xx carries flat NV12 bytes as W x (H * 3 / 2) RAW8 rows. */
++	if (flat_nv12)
++		height = height * 3 / 2;
++
+ 	memcpy(desc, &capture_template, sizeof(capture_template));
+ 	memset(desc_memoryinfo, 0, sizeof(*desc_memoryinfo));
+ 
+diff --git a/drivers/media/platform/tegra/camera/vi/vi5_formats.h b/drivers/media/platform/tegra/camera/vi/vi5_formats.h
+index afa1a2c..5674df8 100644
+--- a/drivers/media/platform/tegra/camera/vi/vi5_formats.h
++++ b/drivers/media/platform/tegra/camera/vi/vi5_formats.h
+@@ -166,6 +166,10 @@ static const struct tegra_video_format vi5_video_formats[] = {
+ 	TEGRA_VIDEO_FORMAT(RGB888, 24, RGB888_1X24, 4, 1, T_A8R8G8B8,
+ 				RGB888, Y12I, "Y12I 24"),
+ 
++	/* D5xx NV12: HKR sends flat bytes as RAW8, W x (H * 3 / 2). */
++	TEGRA_VIDEO_FORMAT(RAW8, 8, UYYVYY8_0_5X24, 1, 1, T_R8,
++				RAW8, NV12, "YUV 4:2:0 NV12"),
++
+ };
+ 
+ #endif

--- a/nvidia-oot/7.1/0014-Add-flat-NV12-RAW8-capture-format.patch
+++ b/nvidia-oot/7.1/0014-Add-flat-NV12-RAW8-capture-format.patch
@@ -1,0 +1,77 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: zhou <shengyong.zhou@realsenseai.com>
+Date: Fri, 17 Jul 2026 18:00:00 +0800
+Subject: [PATCH] media: tegra: add flat NV12 RAW8 capture format
+
+Add D5xx flat NV12 capture over a RAW8 carrier: VI5 matches CSI DT 0x2A and writes width x (height * 3 / 2) byte rows into one V4L2 NV12 buffer. The 3/2 sizeimage accounting remains standard NV12, while the transport avoids native CSI YUV420 line interpretation and does not reorder bytes.
+
+Formats are selected at STREAMON through the VI5 format table, so sensors can add these formats without device-tree mode changes.
+
+Signed-off-by: zhou <shengyong.zhou@realsenseai.com>
+
+diff --git a/drivers/media/platform/tegra/camera/vi/channel.c b/drivers/media/platform/tegra/camera/vi/channel.c
+index 98a7bba..c033092 100644
+--- a/drivers/media/platform/tegra/camera/vi/channel.c
++++ b/drivers/media/platform/tegra/camera/vi/channel.c
+@@ -338,6 +338,9 @@ static void tegra_channel_update_format(struct tegra_channel *chan,
+ 
+ 	if (fourcc == V4L2_PIX_FMT_NV16)
+ 		chan->format.sizeimage *= 2;
++	else if (fourcc == V4L2_PIX_FMT_NV12)
++		/* NV12 V4L2 buffer: Y plane + half-height UV plane */
++		chan->format.sizeimage = chan->format.sizeimage * 3 / 2;
+ }
+ 
+ static void tegra_channel_fmts_bitmap_init(struct tegra_channel *chan)
+@@ -2241,6 +2244,13 @@ __tegra_channel_try_format(struct tegra_channel *chan,
+ 			__func__);
+ 			return -EOVERFLOW;
+ 		}
++	} else if (chan->fmtinfo->fourcc == V4L2_PIX_FMT_NV12) {
++		if (__builtin_umul_overflow(pix->sizeimage, 3, &pix->sizeimage)) {
++			dev_err(chan->vi->dev, "%s: update size image failed due to an overflow\n",
++				__func__);
++			return -EOVERFLOW;
++		}
++		pix->sizeimage /= 2;
+ 	}
+ 
+ 	return ret;
+diff --git a/drivers/media/platform/tegra/camera/vi/vi5_fops.c b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
+index dac37f9..117a304 100644
+--- a/drivers/media/platform/tegra/camera/vi/vi5_fops.c
++++ b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
+@@ -391,6 +391,7 @@ static void vi5_setup_surface(struct tegra_channel *chan,
+ 	u32 format = chan->fmtinfo->img_fmt;
+ 	u32 bpl = chan->format.bytesperline;
+ 	u32 data_type = chan->fmtinfo->img_dt;
++	bool flat_nv12 = chan->fmtinfo->fourcc == V4L2_PIX_FMT_NV12;
+ 	u32 nvcsi_stream = chan->port[vi_port];
+ 	unsigned int range = 0;
+ 	struct capture_descriptor_memoryinfo *desc_memoryinfo =
+@@ -419,6 +420,10 @@ static void vi5_setup_surface(struct tegra_channel *chan,
+ 		}
+ 	}
+ 
++	/* D5xx carries flat NV12 bytes as W x (H * 3 / 2) RAW8 rows. */
++	if (flat_nv12)
++		height = height * 3 / 2;
++
+ 	memcpy(desc, &capture_template, sizeof(capture_template));
+ 	memset(desc_memoryinfo, 0, sizeof(*desc_memoryinfo));
+ 
+diff --git a/drivers/media/platform/tegra/camera/vi/vi5_formats.h b/drivers/media/platform/tegra/camera/vi/vi5_formats.h
+index bd22b58..0cfa550 100644
+--- a/drivers/media/platform/tegra/camera/vi/vi5_formats.h
++++ b/drivers/media/platform/tegra/camera/vi/vi5_formats.h
+@@ -176,6 +176,10 @@ static const struct tegra_video_format vi5_video_formats[] = {
+ 	TEGRA_VIDEO_FORMAT(RGB888, 24, RGB888_1X24, 4, 1, T_A8R8G8B8,
+ 				RGB888, Y12I, "Y12I 24"),
+ 
++	/* D5xx NV12: HKR sends flat bytes as RAW8, W x (H * 3 / 2). */
++	TEGRA_VIDEO_FORMAT(RAW8, 8, UYYVYY8_0_5X24, 1, 1, T_R8,
++				RAW8, NV12, "YUV 4:2:0 NV12"),
++
+ };
+ 
+ #endif


### PR DESCRIPTION
## Summary

Add the D5xx product path for a flat NV12 surface carried over CSI-2 RAW8 without changing the existing stream-control register protocol.

- Keep the existing RGB `YUYV` format.
- Add `NV12` as the second RGB V4L2 format.
- Selecting NV12 uses the existing RGB stream DT field with packet DT `0x2A`.
- Capture `width x (height * 3 / 2)` RAW8 byte rows into one standard NV12 V4L2 buffer without app-side repacking.

No input-format I2C field or new control register is added.

## Layer contract

| Layer | Contract |
| --- | --- |
| HKR RGB surface | NV12 1280x960@60 |
| HIF MIPI packet | CSI2_DT `0x2A` RAW8, VC1 |
| Wire geometry | 1280 x 1440 byte rows, WC=1280 |
| Payload order | 960 Y rows followed by 480 interleaved-UV rows |
| Tegra VI | Match RAW8 and write all 1440 rows without byte reordering |
| Host V4L2 API | `V4L2_PIX_FMT_NV12` 1280x960, bytesperline=1280, sizeimage=1,843,200 |

For the separate CSI2_DT `0x1E` color path, HKR MC-FCVT and the Tegra receive layout use UYVY bytes, while the Host RGB video node continues to expose `YUYV`. The Host node therefore remains fixed to `YUYV / NV12`; this PR does not expose UYVY as a V4L2 format.

## Scope

- Update only the D5xx RGB format selection needed for YUYV/NV12.
- Add flat NV12 RAW8 capture patches for JetPack 6.0, 6.1, 6.2, 7.0, and 7.1.
- Do not change RAW10/BA10, Y12I, depth, IR, IMU, serializer, deserializer, device tree, deskew, or deployment scripts.

## Validation

- JetPack 6.2.2 full build: PASS.
- Jetson67 loaded `d5xx.ko` srcversion `574F511E6885E27482BEB02`.
- RGB V4L2 inventory: `YUYV` and `NV12`; no UYVY or BA10 is added by this PR.
- Complete enabled D5xx GMSL regression: PASS.
- Existing Depth Z16, IR Y8I, RGB YUYV, IMU 38x1, three-stream, and four-stream cases passed strict counters.
- RGB NV12 RAW8 1280x960@60 passed strict counters.

Artifacts: `/tmp/d5xx_full_nv12_only_pr516`

## Dependencies

- HKR HIF: https://github.com/RealSenseAI-Internal/soc-rs-soc-io-drivers/pull/460
- HKR tests/app: https://github.com/RealSenseAI-Internal/soc-rs-hkr-test/pull/325
