### PR TITLE
overlay: add seeed 3-camera (links 0-1-2) config

### DIFF
--- a/.claude/skills/build/SKILL.md
+++ b/.claude/skills/build/SKILL.md
@@ -59,6 +59,36 @@ Flags:
 
 Output directory: `images/$VERSION/` (normalized: `images/6.x/` for JP 6.x, `images/5.x/` for JP 5.x).
 
+### Step 3 (optional): Overlay-only rebuild
+
+When only a device-tree overlay changed (new/edited `tegra234-camera-d4xx-overlay*.dts`) and the kernel/modules are already built, skip the full `build_all.sh` and rebuild just the DTBs — far faster, and it does NOT recompile `d4xx.c` (safe when the build tree sits on an unrelated WIP branch).
+
+Prerequisite: the workspace was built at least once (`out` symlink + kernel image present in `sources_$VERSION/`).
+
+1. If the overlay is **new**, link it into the tree and add it to the enumeration (mirrors what `apply_patches.sh` does):
+   ```bash
+   ov=sources_$VERSION/hardware/nvidia/t23x/nv-public/overlay
+   ln -f hardware/realsense/<new-overlay>.dts "$ov/"
+   grep -q "<new-overlay>.dtbo" "$ov/Makefile" || \
+     sed -i "/<sibling-overlay>.dtbo/i dtbo-y += <new-overlay>.dtbo" "$ov/Makefile"
+   ```
+   Also add the same `dtbo-y +=` line to `hardware/nvidia/t23x/nv-public/6.x/0001-overlay-*.patch` so a clean `apply_patches.sh` keeps building it (bump the hunk `@@` count + diffstat).
+
+2. Build only the DTBs (same env `build_all.sh` uses):
+   ```bash
+   . scripts/setup-common $VERSION
+   export DEVDIR=$(pwd) TEGRA_KERNEL_OUT="$DEVDIR/images/$VERSION" ARCH=arm64
+   export CROSS_COMPILE=$DEVDIR/l4t-gcc/6.x/bin/aarch64-buildroot-linux-gnu-
+   export KERNEL_HEADERS="$DEVDIR/sources_$VERSION/kernel/kernel-jammy-src"
+   cd sources_$VERSION && make dtbs
+   ```
+   Output: `sources_$VERSION/nvidia-oot/device-tree/platform/generic-dts/dtbs/<overlay>.dtbo`
+
+3. Validate before deploy:
+   ```bash
+   dtc -I dtb -O dts <overlay>.dtbo | grep -E "overlay-name|num-channels|max9295"
+   ```
+
 ## Build Architecture Details
 
 ### What gets built per JetPack generation

--- a/.claude/skills/deploy/SKILL.md
+++ b/.claude/skills/deploy/SKILL.md
@@ -47,6 +47,27 @@ v4l2-ctl -d0 --stream-mmap      # Verify streaming works
 
 If `dmesg` shows no d4xx messages or `/dev/video*` devices are missing, the driver did not load — check for patch/build version mismatch or missing DTB overlay.
 
+### Alternate deploy — carriers that boot via extlinux OVERLAYS (overlay-only)
+
+Some GMSL carriers boot a **custom base FDT + boot-time device-tree overlays** chosen in `/boot/extlinux/extlinux.conf`, not the standard NVIDIA kernel/DTB layout. `deploy_kernel.sh` does not model this. For an overlay-only change on such a rig:
+
+1. Copy the built `.dtbo` to the Jetson `/boot` (two hops if build host and Jetson aren't directly reachable):
+   ```bash
+   scp <build-host>:.../generic-dts/dtbs/<overlay>.dtbo <local>
+   scp <local> <user>@<jetson>:/tmp/
+   ssh <user>@<jetson> "sudo cp /tmp/<overlay>.dtbo /boot/"
+   ```
+2. Point a boot label at the overlay in `/boot/extlinux/extlinux.conf` (back it up first). Each `LABEL` block has `LINUX/INITRD/APPEND/FDT` + an `OVERLAYS /boot/<overlay>.dtbo` line; mirror an existing camera label, change only `OVERLAYS` and the menu text, then set `DEFAULT <label>`.
+3. Reboot — GMSL is boot-probe only, no hotplug:
+   ```bash
+   ssh <user>@<jetson> "sudo reboot"
+   ```
+4. After reboot verify (per verify-deploy) and confirm the links: i2c groups `2-00N[abcd]` (link N), `/dev/video-rs-*` symlinks, and **no `-121`** (serdes no-response) in `dmesg` for links that should be empty.
+
+Notes:
+- Non-interactive sudo with a payload file: `echo $PW | sudo -S bash -c 'cmd < /tmp/file'`. Do NOT pipe file content into `sudo -S tee` — sudo eats the first line as the password.
+- The base FDT name and camera-count labels are rig-specific — keep them in the rig's own notes, not in this skill.
+
 ## Deploy Details
 
 ### What gets deployed

--- a/README_JP6.0.md
+++ b/README_JP6.0.md
@@ -189,6 +189,7 @@ sudo ln -s /boot/initrd.img-5.15.136-tegra /boot/initrd
     | `tegra234-camera-d4xx-overlay-seeed.dtbo` | Seeed reComputer board with one camera connected to top right link |
     | `tegra234-camera-d4xx-overlay-seeed-d5xx.dtbo` | Seeed reComputer board with one D5xx camera (max96717 serializer, 4-lane) connected to top right link |
     | `tegra234-camera-d4xx-overlay-seeed-cams-0-1.dtbo` | Seeed reComputer board with two cameras connected to top two links |
+    | `tegra234-camera-d4xx-overlay-seeed-cams-0-1-2.dtbo` | Seeed reComputer board with three cameras connected to slots 0,1,2 — top-right, top-left, bottom-left (slot 3 / bottom-right empty) |
     | `tegra234-camera-d4xx-overlay-seeed-cams-0-1-2-3.dtbo` | Seeed reComputer board with four cameras connected |
 
 6. Modify bootloader configuration:

--- a/README_JP6.2.md
+++ b/README_JP6.2.md
@@ -189,6 +189,7 @@ sudo ln -s /boot/initrd.img-5.15.148-tegra /boot/initrd
     | `tegra234-camera-d4xx-overlay-seeed.dtbo` | Seeed reComputer board with one camera connected to top right link |
     | `tegra234-camera-d4xx-overlay-seeed-d5xx.dtbo` | Seeed reComputer board with one D5xx camera (max96717 serializer, 4-lane) connected to top right link |
     | `tegra234-camera-d4xx-overlay-seeed-cams-0-1.dtbo` | Seeed reComputer board with two cameras connected to top two links |
+    | `tegra234-camera-d4xx-overlay-seeed-cams-0-1-2.dtbo` | Seeed reComputer board with three cameras connected to slots 0,1,2 — top-right, top-left, bottom-left (slot 3 / bottom-right empty) |
     | `tegra234-camera-d4xx-overlay-seeed-cams-0-1-2-3.dtbo` | Seeed reComputer board with four cameras connected |
 
 6. Modify bootloader configuration:

--- a/hardware/nvidia/t23x/nv-public/6.x/0001-overlay-enable-d4xx-camera-for-Orin-jp6.patch
+++ b/hardware/nvidia/t23x/nv-public/6.x/0001-overlay-enable-d4xx-camera-for-Orin-jp6.patch
@@ -5,14 +5,14 @@ Subject: [PATCH] overlay: enable d4xx camera for Orin jp6
 
 Signed-off-by: ejgoldik <ehud.joseph.goldik@realsenseai.com>
 ---
- overlay/Makefile | 22 ++++++++++++++++++++++
- 1 file changed, 22 insertions(+)
+ overlay/Makefile | 23 +++++++++++++++++++++++
+ 1 file changed, 23 insertions(+)
 
 diff --git a/overlay/Makefile b/overlay/Makefile
 index c88bbe2..cdd125f 100644
 --- a/overlay/Makefile
 +++ b/overlay/Makefile
-@@ -60,6 +60,28 @@ dtbo-y += tegra234-p3767-camera-p3768-imx219-A.dtbo
+@@ -60,6 +60,29 @@ dtbo-y += tegra234-p3767-camera-p3768-imx219-A.dtbo
  dtbo-y += tegra234-p3767-camera-p3768-imx219-imx477.dtbo
  dtbo-y += tegra234-p3767-camera-p3768-imx477-C.dtbo
  dtbo-y += tegra234-p3767-camera-p3768-imx477-A.dtbo
@@ -35,6 +35,7 @@ index c88bbe2..cdd125f 100644
 +dtbo-y += tegra234-camera-d4xx-overlay-seeed.dtbo
 +dtbo-y += tegra234-camera-d4xx-overlay-seeed-d5xx.dtbo
 +dtbo-y += tegra234-camera-d4xx-overlay-seeed-cams-0-1.dtbo
++dtbo-y += tegra234-camera-d4xx-overlay-seeed-cams-0-1-2.dtbo
 +dtbo-y += tegra234-camera-d4xx-overlay-seeed-cams-0-1-2-3.dtbo
 +dtbo-y += tegra234-camera-d4xx-overlay-d5xx.dtbo
 +dtbo-y += tegra234-camera-d4xx-overlay-fg24-4ch-d5xx.dtbo

--- a/hardware/realsense/tegra234-camera-d4xx-overlay-seeed-cams-0-1-2.dts
+++ b/hardware/realsense/tegra234-camera-d4xx-overlay-seeed-cams-0-1-2.dts
@@ -1,0 +1,1228 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// SPDX-FileCopyrightText: Copyright (c) 2018-2023, INTEL CORPORATION.  All rights reserved.
+
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/clock/tegra234-clock.h>
+#include <dt-bindings/gpio/tegra234-gpio.h>
+#include <dt-bindings/tegra234-p3737-0000+p3701-0000.h>
+
+/* camera control gpio definitions */
+/ {
+	overlay-name = "Jetson Three RealSense D4xx Cameras with max96712 for Seeed studio Orin nano (Top two + bottom left)";
+	jetson-header-name = "Jetson AGX CSI Connector";
+	compatible = JETSON_COMPATIBLE;
+
+	fragment@0 {
+		target-path = "/";
+		__overlay__ {
+			tegra-capture-vi {
+				num-channels = <12>;
+				ports {
+					status = "okay";
+					port@0 {
+						status = "okay";
+						reg = <0>;
+						d4xx_vi_in0: endpoint {
+							status = "okay";
+							vc-id = <0>;
+							port-index = <2>;
+							bus-width = <2>;
+							remote-endpoint = <&d4xx_csi_out0>;
+						};
+					};
+					port@1 {
+						status = "okay";
+						reg = <1>;
+						d4xx_vi_in1: endpoint {
+							status = "okay";
+							vc-id = <1>;
+							port-index = <2>;
+							bus-width = <2>;
+							remote-endpoint = <&d4xx_csi_out1>;
+						};
+					};
+					port@2 {
+						status = "okay";
+						reg = <2>;
+						d4xx_vi_in2: endpoint {
+							status = "okay";
+							vc-id = <2>;
+							port-index = <2>;
+							bus-width = <2>;
+							remote-endpoint = <&d4xx_csi_out2>;
+						};
+					};
+					port@3 {
+						status = "okay";
+						reg = <3>;
+						d4xx_vi_in3: endpoint {
+							status = "okay";
+							vc-id = <3>;
+							port-index = <2>;
+							bus-width = <2>;
+							remote-endpoint = <&d4xx_csi_out3>;
+						};
+					};
+					port@4 {
+						status = "okay";
+						reg = <4>;
+						d4xx_vi_in4: endpoint {
+							status = "okay";
+							vc-id = <4>;
+							port-index = <2>;
+							bus-width = <2>;
+							remote-endpoint = <&d4xx_csi_out4>;
+						};
+					};
+					port@5 {
+						status = "okay";
+						reg = <5>;
+						d4xx_vi_in5: endpoint {
+							status = "okay";
+							vc-id = <5>;
+							port-index = <2>;
+							bus-width = <2>;
+							remote-endpoint = <&d4xx_csi_out5>;
+						};
+					};
+					port@6 {
+						status = "okay";
+						reg = <6>;
+						d4xx_vi_in6: endpoint {
+							status = "okay";
+							vc-id = <6>;
+							port-index = <2>;
+							bus-width = <2>;
+							remote-endpoint = <&d4xx_csi_out6>;
+						};
+					};
+					port@7 {
+						status = "okay";
+						reg = <7>;
+						d4xx_vi_in7: endpoint {
+							status = "okay";
+							vc-id = <7>;
+							port-index = <2>;
+							bus-width = <2>;
+							remote-endpoint = <&d4xx_csi_out7>;
+						};
+					};
+					port@8 {
+						status = "okay";
+						reg = <8>;
+						d4xx_vi_in8: endpoint {
+							status = "okay";
+							vc-id = <8>;
+							port-index = <2>;
+							bus-width = <2>;
+							remote-endpoint = <&d4xx_csi_out8>;
+						};
+					};
+					port@9 {
+						status = "okay";
+						reg = <9>;
+						d4xx_vi_in9: endpoint {
+							status = "okay";
+							vc-id = <9>;
+							port-index = <2>;
+							bus-width = <2>;
+							remote-endpoint = <&d4xx_csi_out9>;
+						};
+					};
+					port@10 {
+						status = "okay";
+						reg = <10>;
+						d4xx_vi_in10: endpoint {
+							status = "okay";
+							vc-id = <10>;
+							port-index = <2>;
+							bus-width = <2>;
+							remote-endpoint = <&d4xx_csi_out10>;
+						};
+					};
+					port@11 {
+						status = "okay";
+						reg = <11>;
+						d4xx_vi_in11: endpoint {
+							status = "okay";
+							vc-id = <11>;
+							port-index = <2>;
+							bus-width = <2>;
+							remote-endpoint = <&d4xx_csi_out11>;
+						};
+					};
+				};
+			};
+			tegra-camera-platform {
+				compatible = "nvidia, tegra-camera-platform";
+				status = "okay";
+				num_csi_lanes = <2>;
+				max_lane_speed = <1500000>;
+				min_bits_per_pixel = <8>;
+				vi_peak_byte_per_pixel = <2>;
+				vi_bw_margin_pct = <25>;
+				max_pixel_rate = <160000>;
+				isp_peak_byte_per_pixel = <5>;
+				isp_bw_margin_pct = <25>;
+				modules {
+					status = "okay";
+					module0 {
+						status = "okay";
+						badge = "d4xx_depth";
+						position = "left";
+						orientation = "1";
+						drivernode0 {
+							status = "okay";
+							pcl_id = "v4l2_sensor";
+							devname = "DS5 mux 2-001a";
+							sysfs-device-tree = "/sys/firmware/devicetree/base/bus@0/i2c@3180000/ds5@1a";
+						};
+					};
+					module1 {
+						status = "okay";
+						badge = "d4xx_rgb";
+						position = "left";
+						orientation = "1";
+						drivernode0 {
+							status = "okay";
+							pcl_id = "v4l2_sensor";
+							devname = "DS5 mux 2-001b";
+							sysfs-device-tree = "/sys/firmware/devicetree/base/bus@0/i2c@3180000/ds5@1b";
+						};
+					};
+					module2 {
+						status = "okay";
+						badge = "d4xx_Y8";
+						position = "left";
+						orientation = "1";
+						drivernode0 {
+							status = "okay";
+							pcl_id = "v4l2_sensor";
+							devname = "DS5 mux 2-001c";
+							sysfs-device-tree = "/sys/firmware/devicetree/base/bus@0/i2c@3180000/ds5@1c";
+						};
+					};
+					module3 {
+						status = "okay";
+						badge = "d4xx_imu";
+						position = "left";
+						orientation = "1";
+						drivernode0 {
+							status = "okay";
+							pcl_id = "v4l2_sensor";
+							devname = "DS5 mux 2-001d";
+							sysfs-device-tree = "/sys/firmware/devicetree/base/bus@0/i2c@3180000/ds5@1d";
+						};
+					};
+					module4 {
+						status = "okay";
+						badge = "d4xx_depth";
+						position = "left";
+						orientation = "1";
+						drivernode0 {
+							status = "okay";
+							pcl_id = "v4l2_sensor";
+							devname = "DS5 mux 2-002a";
+							sysfs-device-tree = "/sys/firmware/devicetree/base/bus@0/i2c@3180000/ds5@2a";
+						};
+					};
+					module5 {
+						status = "okay";
+						badge = "d4xx_rgb";
+						position = "left";
+						orientation = "1";
+						drivernode0 {
+							status = "okay";
+							pcl_id = "v4l2_sensor";
+							devname = "DS5 mux 2-002b";
+							sysfs-device-tree = "/sys/firmware/devicetree/base/bus@0/i2c@3180000/ds5@2b";
+						};
+					};
+					module6 {
+						status = "okay";
+						badge = "d4xx_Y8";
+						position = "left";
+						orientation = "1";
+						drivernode0 {
+							status = "okay";
+							pcl_id = "v4l2_sensor";
+							devname = "DS5 mux 2-002c";
+							sysfs-device-tree = "/sys/firmware/devicetree/base/bus@0/i2c@3180000/ds5@2c";
+						};
+					};
+					module7 {
+						status = "okay";
+						badge = "d4xx_imu";
+						position = "left";
+						orientation = "1";
+						drivernode0 {
+							status = "okay";
+							pcl_id = "v4l2_sensor";
+							devname = "DS5 mux 2-002d";
+							sysfs-device-tree = "/sys/firmware/devicetree/base/bus@0/i2c@3180000/ds5@2d";
+						};
+					};
+					module8 {
+						status = "okay";
+						badge = "d4xx_depth";
+						position = "left";
+						orientation = "1";
+						drivernode0 {
+							status = "okay";
+							pcl_id = "v4l2_sensor";
+							devname = "DS5 mux 2-003a";
+							sysfs-device-tree = "/sys/firmware/devicetree/base/bus@0/i2c@3180000/ds5@3a";
+						};
+					};
+					module9 {
+						status = "okay";
+						badge = "d4xx_rgb";
+						position = "left";
+						orientation = "1";
+						drivernode0 {
+							status = "okay";
+							pcl_id = "v4l2_sensor";
+							devname = "DS5 mux 2-003b";
+							sysfs-device-tree = "/sys/firmware/devicetree/base/bus@0/i2c@3180000/ds5@3b";
+						};
+					};
+					module10 {
+						status = "okay";
+						badge = "d4xx_Y8";
+						position = "left";
+						orientation = "1";
+						drivernode0 {
+							status = "okay";
+							pcl_id = "v4l2_sensor";
+							devname = "DS5 mux 2-003c";
+							sysfs-device-tree = "/sys/firmware/devicetree/base/bus@0/i2c@3180000/ds5@3c";
+						};
+					};
+					module11 {
+						status = "okay";
+						badge = "d4xx_imu";
+						position = "left";
+						orientation = "1";
+						drivernode0 {
+							status = "okay";
+							pcl_id = "v4l2_sensor";
+							devname = "DS5 mux 2-003d";
+							sysfs-device-tree = "/sys/firmware/devicetree/base/bus@0/i2c@3180000/ds5@3d";
+						};
+					};
+				};
+			};
+			bus@0 {
+				host1x@13e00000 {
+					nvcsi@15a00000 {
+						num-channels = <12>;
+						channel@0 {
+							status = "okay";
+							reg = <0>;
+							ports {
+								status = "okay";
+								port@0 {
+									status = "okay";
+									reg = <0>;
+									d4xx_csi_in0: endpoint@0 {
+										status = "okay";
+										port-index = <2>;
+										bus-width = <2>;
+										remote-endpoint = <&ds5_0_out>;
+									};
+								};
+								port@1 {
+									status = "okay";
+									reg = <1>;
+									d4xx_csi_out0: endpoint@1 {
+										status = "okay";
+										remote-endpoint = <&d4xx_vi_in0>;
+									};
+								};
+							};
+						};
+						channel@1 {
+							status = "okay";
+							reg = <1>;
+							ports {
+								status = "okay";
+								port@0 {
+									status = "okay";
+									reg = <0>;
+									d4xx_csi_in1: endpoint@2 {
+										status = "okay";
+										port-index = <2>;
+										bus-width = <2>;
+										remote-endpoint = <&ds5_1_out>;
+									};
+								};
+								port@1 {
+									status = "okay";
+									reg = <1>;
+									d4xx_csi_out1: endpoint@3 {
+										status = "okay";
+										remote-endpoint = <&d4xx_vi_in1>;
+									};
+								};
+							};
+						};
+						channel@2 {
+							status = "okay";
+							reg = <2>;
+							ports {
+								status = "okay";
+								port@0 {
+									status = "okay";
+									reg = <0>;
+									d4xx_csi_in2: endpoint@4 {
+										status = "okay";
+										port-index = <2>;
+										bus-width = <2>;
+										remote-endpoint = <&ds5_2_out>;
+									};
+								};
+								port@1 {
+									status = "okay";
+									reg = <1>;
+									d4xx_csi_out2: endpoint@5 {
+										status = "okay";
+										remote-endpoint = <&d4xx_vi_in2>;
+									};
+								};
+							};
+						};
+						channel@3 {
+							status = "okay";
+							reg = <3>;
+							ports {
+								status = "okay";
+								port@0 {
+									status = "okay";
+									reg = <0>;
+									d4xx_csi_in3: endpoint@6 {
+										status = "okay";
+										port-index = <2>;
+										bus-width = <2>;
+										remote-endpoint = <&ds5_3_out>;
+									};
+								};
+								port@1 {
+									status = "okay";
+									reg = <1>;
+									d4xx_csi_out3: endpoint@7 {
+										status = "okay";
+										remote-endpoint = <&d4xx_vi_in3>;
+									};
+								};
+							};
+						};
+						channel@4 {
+							status = "okay";
+							reg = <4>;
+							ports {
+								status = "okay";
+								port@0 {
+									status = "okay";
+									reg = <0>;
+									d4xx_csi_in4: endpoint@8 {
+										status = "okay";
+										port-index = <2>;
+										bus-width = <2>;
+										remote-endpoint = <&ds5_4_out>;
+									};
+								};
+								port@1 {
+									status = "okay";
+									reg = <1>;
+									d4xx_csi_out4: endpoint@9 {
+										status = "okay";
+										remote-endpoint = <&d4xx_vi_in4>;
+									};
+								};
+							};
+						};
+						channel@5 {
+							status = "okay";
+							reg = <5>;
+							ports {
+								status = "okay";
+								port@0 {
+									status = "okay";
+									reg = <0>;
+									d4xx_csi_in5: endpoint@10 {
+										status = "okay";
+										port-index = <2>;
+										bus-width = <2>;
+										remote-endpoint = <&ds5_5_out>;
+									};
+								};
+								port@1 {
+									status = "okay";
+									reg = <1>;
+									d4xx_csi_out5: endpoint@11 {
+										status = "okay";
+										remote-endpoint = <&d4xx_vi_in5>;
+									};
+								};
+							};
+						};
+						channel@6 {
+							status = "okay";
+							reg = <6>;
+							ports {
+								status = "okay";
+								port@0 {
+									status = "okay";
+									reg = <0>;
+									d4xx_csi_in6: endpoint@12 {
+										status = "okay";
+										port-index = <2>;
+										bus-width = <2>;
+										remote-endpoint = <&ds5_6_out>;
+									};
+								};
+								port@1 {
+									status = "okay";
+									reg = <1>;
+									d4xx_csi_out6: endpoint@13 {
+										status = "okay";
+										remote-endpoint = <&d4xx_vi_in6>;
+									};
+								};
+							};
+						};
+						channel@7 {
+							status = "okay";
+							reg = <7>;
+							ports {
+								status = "okay";
+								port@0 {
+									status = "okay";
+									reg = <0>;
+									d4xx_csi_in7: endpoint@14 {
+										status = "okay";
+										port-index = <2>;
+										bus-width = <2>;
+										remote-endpoint = <&ds5_7_out>;
+									};
+								};
+								port@1 {
+									status = "okay";
+									reg = <1>;
+									d4xx_csi_out7: endpoint@15 {
+										status = "okay";
+										remote-endpoint = <&d4xx_vi_in7>;
+									};
+								};
+							};
+						};
+						channel@8 {
+							status = "okay";
+							reg = <8>;
+							ports {
+								status = "okay";
+								port@0 {
+									status = "okay";
+									reg = <0>;
+									d4xx_csi_in8: endpoint@16 {
+										status = "okay";
+										port-index = <2>;
+										bus-width = <2>;
+										remote-endpoint = <&ds5_8_out>;
+									};
+								};
+								port@1 {
+									status = "okay";
+									reg = <1>;
+									d4xx_csi_out8: endpoint@17 {
+										status = "okay";
+										remote-endpoint = <&d4xx_vi_in8>;
+									};
+								};
+							};
+						};
+						channel@9 {
+							status = "okay";
+							reg = <9>;
+							ports {
+								status = "okay";
+								port@0 {
+									status = "okay";
+									reg = <0>;
+									d4xx_csi_in9: endpoint@18 {
+										status = "okay";
+										port-index = <2>;
+										bus-width = <2>;
+										remote-endpoint = <&ds5_9_out>;
+									};
+								};
+								port@1 {
+									status = "okay";
+									reg = <1>;
+									d4xx_csi_out9: endpoint@19 {
+										status = "okay";
+										remote-endpoint = <&d4xx_vi_in9>;
+									};
+								};
+							};
+						};
+						channel@10 {
+							status = "okay";
+							reg = <10>;
+							ports {
+								status = "okay";
+								port@0 {
+									status = "okay";
+									reg = <0>;
+									d4xx_csi_in10: endpoint@20 {
+										status = "okay";
+										port-index = <2>;
+										bus-width = <2>;
+										remote-endpoint = <&ds5_10_out>;
+									};
+								};
+								port@1 {
+									status = "okay";
+									reg = <1>;
+									d4xx_csi_out10: endpoint@21 {
+										status = "okay";
+										remote-endpoint = <&d4xx_vi_in10>;
+									};
+								};
+							};
+						};
+						channel@11 {
+							status = "okay";
+							reg = <11>;
+							ports {
+								status = "okay";
+								port@0 {
+									status = "okay";
+									reg = <0>;
+									d4xx_csi_in11: endpoint@22 {
+										status = "okay";
+										port-index = <2>;
+										bus-width = <2>;
+										remote-endpoint = <&ds5_11_out>;
+									};
+								};
+								port@1 {
+									status = "okay";
+									reg = <1>;
+									d4xx_csi_out11: endpoint@23 {
+										status = "okay";
+										remote-endpoint = <&d4xx_vi_in11>;
+									};
+								};
+							};
+						};
+					};
+				};
+
+				i2c@3180000 {
+					clock-frequency = <100000>;
+
+					dser: max96712@29 {
+						status = "okay";
+						reg = <0x29>;
+						compatible = "maxim,max96712";
+						csi-mode = "2x4";
+						link-mask = <0x7>;
+						channel = "a";
+						force_clk0;
+					};
+
+					ser_a: max9295_a@40 {
+						status = "okay";
+						compatible = "maxim,max9295";
+						reg = <0x40>;
+						maxim,gmsl-dser-device = <&dser>;
+						external_addr_reassign;
+					};
+
+					ser_b: max9295_b@41 {
+						status = "okay";
+						compatible = "maxim,max9295";
+						reg = <0x41>;
+						maxim,gmsl-dser-device = <&dser>;
+						external_addr_reassign;
+					};
+
+					ser_c: max9295_c@42 {
+						status = "okay";
+						compatible = "maxim,max9295";
+						reg = <0x42>;
+						maxim,gmsl-dser-device = <&dser>;
+						external_addr_reassign;
+					};
+
+					ds5_11: ds5@3d {
+						status = "okay";
+						def-addr = <0x10>;
+						reg = <0x3d>;
+						override_reg = <0x3a>;
+						compatible = "intel,d4xx";
+						use_sensor_mode_id = "true";
+						cam-type = "IMU";
+						nvidia,gmsl-ser-device = <&ser_c>;
+						nvidia,gmsl-dser-device = <&dser>;
+						ports {
+							#address-cells = <1>;
+							#size-cells = <0>;
+
+							port@0 {
+								reg = <0>;
+								ds5_11_out: endpoint {
+									vc-id = <11>;
+									port-index = <11>;
+									bus-width = <2>;
+									remote-endpoint = <&d4xx_csi_in11>;
+								};
+							};
+						};
+						mode0 {
+							pixel_t = "grey_y16";
+							num_lanes = "2";
+							csi_pixel_bit_depth = "16";
+							active_w = "640";
+							active_h = "480";
+							tegra_sinterface = "serial_b";
+							mclk_khz = "24000";
+							pix_clk_hz = "74250000";
+							line_length = "1280"; /* 2200 */
+							embedded_metadata_height = "0";
+						};
+						gmsl-link {
+							src-csi-port = "b";
+							dst-csi-port = "a";
+							serdes-csi-link = "a";
+							csi-mode = "1x4";
+							st-vc = <0>;
+							vc-id = <11>;
+							num-lanes = <2>;
+						};
+					};
+
+					ds5_10: ds5@3c {
+						status = "okay";
+						def-addr = <0x10>;
+						reg = <0x3c>;
+						override_reg = <0x3a>;
+						compatible = "intel,d4xx";
+						use_sensor_mode_id = "true";
+						cam-type = "Y8";
+						nvidia,gmsl-ser-device = <&ser_c>;
+						nvidia,gmsl-dser-device = <&dser>;
+						ports {
+							#address-cells = <1>;
+							#size-cells = <0>;
+
+							port@0 {
+								reg = <0>;
+								ds5_10_out: endpoint {
+									vc-id = <10>;
+									port-index = <10>;
+									bus-width = <2>;
+									remote-endpoint = <&d4xx_csi_in10>;
+								};
+							};
+						};
+						/* mode0: Y8, mode1: depth D16 */
+						mode0 {
+							pixel_t = "grey_y16";
+							num_lanes = "2";
+							csi_pixel_bit_depth = "16";
+							active_w = "1280";
+							active_h = "720";
+							tegra_sinterface = "serial_b";
+							mclk_khz = "24000";
+							pix_clk_hz = "74250000";
+							line_length = "1280"; /* 2200 */
+							embedded_metadata_height = "1";
+						};
+						gmsl-link {
+							src-csi-port = "b";
+							dst-csi-port = "a";
+							serdes-csi-link = "a";
+							csi-mode = "1x4";
+							st-vc = <0>;
+							vc-id = <10>;
+							num-lanes = <2>;
+						};
+					};
+
+					ds5_9: ds5@3b {
+						status = "okay";
+						def-addr = <0x10>;
+						reg = <0x3b>;
+						override_reg = <0x3a>;
+						compatible = "intel,d4xx";
+						use_sensor_mode_id = "true";
+						cam-type = "RGB";
+						nvidia,gmsl-ser-device = <&ser_c>;
+						nvidia,gmsl-dser-device = <&dser>;
+						ports {
+							#address-cells = <1>;
+							#size-cells = <0>;
+
+							port@0 {
+								reg = <0>;
+								ds5_9_out: endpoint {
+									vc-id = <9>;
+									port-index = <9>;
+									bus-width = <2>;
+									remote-endpoint = <&d4xx_csi_in9>;
+								};
+							};
+						};
+						mode0 {
+							pixel_t = "grey_y16";
+							num_lanes = "2";
+							csi_pixel_bit_depth = "16";
+							active_w = "1920";
+							active_h = "1080";
+							tegra_sinterface = "serial_e";
+							mclk_khz = "24000";
+							pix_clk_hz = "74250000";
+							line_length = "1280"; /* 2200 */
+							embedded_metadata_height = "1";
+						};
+						gmsl-link {
+							src-csi-port = "b";
+							dst-csi-port = "a";
+							serdes-csi-link = "a";
+							csi-mode = "1x4";
+							st-vc = <0>;
+							vc-id = <9>;
+							num-lanes = <2>;
+						};
+					};
+
+					ds5_8: ds5@3a {
+						status = "okay";
+						def-addr = <0x10>;
+						reg = <0x3a>;
+						compatible = "intel,d4xx";
+						use_sensor_mode_id = "true";
+						cam-type = "Depth";
+						nvidia,gmsl-ser-device = <&ser_c>;
+						nvidia,gmsl-dser-device = <&dser>;
+						ports {
+							#address-cells = <1>;
+							#size-cells = <0>;
+
+							port@0 {
+								reg = <0>;
+								ds5_8_out: endpoint {
+									vc-id = <8>;
+									port-index = <8>;
+									bus-width = <2>;
+									remote-endpoint = <&d4xx_csi_in8>;
+								};
+							};
+						};
+						mode0 {
+							pixel_t = "grey_y16";
+							num_lanes = "2";
+							csi_pixel_bit_depth = "16";
+							active_w = "1280";
+							active_h = "720";
+							tegra_sinterface = "serial_a";
+							mclk_khz = "24000";
+							pix_clk_hz = "74250000";
+							line_length = "1280"; /* 2200 */
+							embedded_metadata_height = "1";
+						};
+						gmsl-link {
+							src-csi-port = "b";
+							dst-csi-port = "a";
+							serdes-csi-link = "a";
+							csi-mode = "1x4";
+							st-vc = <0>;
+							vc-id = <8>;
+							num-lanes = <2>;
+						};
+					};
+
+					ds5_7: ds5@2d {
+						status = "okay";
+						def-addr = <0x10>;
+						reg = <0x2d>;
+						override_reg = <0x2a>;
+						compatible = "intel,d4xx";
+						use_sensor_mode_id = "true";
+						cam-type = "IMU";
+						nvidia,gmsl-ser-device = <&ser_b>;
+						nvidia,gmsl-dser-device = <&dser>;
+						ports {
+							#address-cells = <1>;
+							#size-cells = <0>;
+
+							port@0 {
+								reg = <0>;
+								ds5_7_out: endpoint {
+									vc-id = <7>;
+									port-index = <7>;
+									bus-width = <2>;
+									remote-endpoint = <&d4xx_csi_in7>;
+								};
+							};
+						};
+						mode0 {
+							pixel_t = "grey_y16";
+							num_lanes = "2";
+							csi_pixel_bit_depth = "16";
+							active_w = "640";
+							active_h = "480";
+							tegra_sinterface = "serial_b";
+							mclk_khz = "24000";
+							pix_clk_hz = "74250000";
+							line_length = "1280"; /* 2200 */
+							embedded_metadata_height = "0";
+						};
+						gmsl-link {
+							src-csi-port = "b";
+							dst-csi-port = "a";
+							serdes-csi-link = "a";
+							csi-mode = "1x4";
+							st-vc = <0>;
+							vc-id = <7>;
+							num-lanes = <2>;
+						};
+					};
+
+					ds5_6: ds5@2c {
+						status = "okay";
+						def-addr = <0x10>;
+						reg = <0x2c>;
+						override_reg = <0x2a>;
+						compatible = "intel,d4xx";
+						use_sensor_mode_id = "true";
+						cam-type = "Y8";
+						nvidia,gmsl-ser-device = <&ser_b>;
+						nvidia,gmsl-dser-device = <&dser>;
+						ports {
+							#address-cells = <1>;
+							#size-cells = <0>;
+
+							port@0 {
+								reg = <0>;
+								ds5_6_out: endpoint {
+									vc-id = <6>;
+									port-index = <6>;
+									bus-width = <2>;
+									remote-endpoint = <&d4xx_csi_in6>;
+								};
+							};
+						};
+						/* mode0: Y8, mode1: depth D16 */
+						mode0 {
+							pixel_t = "grey_y16";
+							num_lanes = "2";
+							csi_pixel_bit_depth = "16";
+							active_w = "1280";
+							active_h = "720";
+							tegra_sinterface = "serial_b";
+							mclk_khz = "24000";
+							pix_clk_hz = "74250000";
+							line_length = "1280"; /* 2200 */
+							embedded_metadata_height = "1";
+						};
+						gmsl-link {
+							src-csi-port = "b";
+							dst-csi-port = "a";
+							serdes-csi-link = "a";
+							csi-mode = "1x4";
+							st-vc = <0>;
+							vc-id = <6>;
+							num-lanes = <2>;
+						};
+					};
+
+					ds5_5: ds5@2b {
+						status = "okay";
+						def-addr = <0x10>;
+						reg = <0x2b>;
+						override_reg = <0x2a>;
+						compatible = "intel,d4xx";
+						use_sensor_mode_id = "true";
+						cam-type = "RGB";
+						nvidia,gmsl-ser-device = <&ser_b>;
+						nvidia,gmsl-dser-device = <&dser>;
+						ports {
+							#address-cells = <1>;
+							#size-cells = <0>;
+
+							port@0 {
+								reg = <0>;
+								ds5_5_out: endpoint {
+									vc-id = <5>;
+									port-index = <5>;
+									bus-width = <2>;
+									remote-endpoint = <&d4xx_csi_in5>;
+								};
+							};
+						};
+						mode0 {
+							pixel_t = "grey_y16";
+							num_lanes = "2";
+							csi_pixel_bit_depth = "16";
+							active_w = "1920";
+							active_h = "1080";
+							tegra_sinterface = "serial_e";
+							mclk_khz = "24000";
+							pix_clk_hz = "74250000";
+							line_length = "1280"; /* 2200 */
+							embedded_metadata_height = "1";
+						};
+						gmsl-link {
+							src-csi-port = "b";
+							dst-csi-port = "a";
+							serdes-csi-link = "a";
+							csi-mode = "1x4";
+							st-vc = <0>;
+							vc-id = <5>;
+							num-lanes = <2>;
+						};
+					};
+
+					ds5_4: ds5@2a {
+						status = "okay";
+						def-addr = <0x10>;
+						reg = <0x2a>;
+						compatible = "intel,d4xx";
+						use_sensor_mode_id = "true";
+						cam-type = "Depth";
+						nvidia,gmsl-ser-device = <&ser_b>;
+						nvidia,gmsl-dser-device = <&dser>;
+						ports {
+							#address-cells = <1>;
+							#size-cells = <0>;
+
+							port@0 {
+								reg = <0>;
+								ds5_4_out: endpoint {
+									vc-id = <4>;
+									port-index = <4>;
+									bus-width = <2>;
+									remote-endpoint = <&d4xx_csi_in4>;
+								};
+							};
+						};
+						mode0 {
+							pixel_t = "grey_y16";
+							num_lanes = "2";
+							csi_pixel_bit_depth = "16";
+							active_w = "1280";
+							active_h = "720";
+							tegra_sinterface = "serial_a";
+							mclk_khz = "24000";
+							pix_clk_hz = "74250000";
+							line_length = "1280"; /* 2200 */
+							embedded_metadata_height = "1";
+						};
+						gmsl-link {
+							src-csi-port = "b";
+							dst-csi-port = "a";
+							serdes-csi-link = "a";
+							csi-mode = "1x4";
+							st-vc = <0>;
+							vc-id = <4>;
+							num-lanes = <2>;
+						};
+					};
+
+					ds5_3: ds5@1d {
+						status = "okay";
+						def-addr = <0x10>;
+						reg = <0x1d>;
+						override_reg = <0x1a>;
+						compatible = "intel,d4xx";
+						use_sensor_mode_id = "true";
+						cam-type = "IMU";
+						nvidia,gmsl-ser-device = <&ser_a>;
+						nvidia,gmsl-dser-device = <&dser>;
+						ports {
+							#address-cells = <1>;
+							#size-cells = <0>;
+
+							port@0 {
+								reg = <0>;
+								ds5_3_out: endpoint {
+									vc-id = <3>;
+									port-index = <3>;
+									bus-width = <2>;
+									remote-endpoint = <&d4xx_csi_in3>;
+								};
+							};
+						};
+						mode0 {
+							pixel_t = "grey_y16";
+							num_lanes = "2";
+							csi_pixel_bit_depth = "16";
+							active_w = "640";
+							active_h = "480";
+							tegra_sinterface = "serial_b";
+							mclk_khz = "24000";
+							pix_clk_hz = "74250000";
+							line_length = "1280"; /* 2200 */
+							embedded_metadata_height = "0";
+						};
+						gmsl-link {
+							src-csi-port = "b";
+							dst-csi-port = "a";
+							serdes-csi-link = "a";
+							csi-mode = "1x4";
+							st-vc = <0>;
+							vc-id = <3>;
+							num-lanes = <2>;
+						};
+					};
+
+					ds5_2: ds5@1c {
+						status = "okay";
+						def-addr = <0x10>;
+						reg = <0x1c>;
+						override_reg = <0x1a>;
+						compatible = "intel,d4xx";
+						use_sensor_mode_id = "true";
+						cam-type = "Y8";
+						nvidia,gmsl-ser-device = <&ser_a>;
+						nvidia,gmsl-dser-device = <&dser>;
+						ports {
+							#address-cells = <1>;
+							#size-cells = <0>;
+
+							port@0 {
+								reg = <0>;
+								ds5_2_out: endpoint {
+									vc-id = <2>;
+									port-index = <2>;
+									bus-width = <2>;
+									remote-endpoint = <&d4xx_csi_in2>;
+								};
+							};
+						};
+						/* mode0: Y8, mode1: depth D16 */
+						mode0 {
+							pixel_t = "grey_y16";
+							num_lanes = "2";
+							csi_pixel_bit_depth = "16";
+							active_w = "1280";
+							active_h = "720";
+							tegra_sinterface = "serial_b";
+							mclk_khz = "24000";
+							pix_clk_hz = "74250000";
+							line_length = "1280"; /* 2200 */
+							embedded_metadata_height = "1";
+						};
+						gmsl-link {
+							src-csi-port = "b";
+							dst-csi-port = "a";
+							serdes-csi-link = "a";
+							csi-mode = "1x4";
+							st-vc = <0>;
+							vc-id = <2>;
+							num-lanes = <2>;
+						};
+					};
+
+					ds5_1: ds5@1b {
+						status = "okay";
+						def-addr = <0x10>;
+						reg = <0x1b>;
+						override_reg = <0x1a>;
+						compatible = "intel,d4xx";
+						use_sensor_mode_id = "true";
+						cam-type = "RGB";
+						nvidia,gmsl-ser-device = <&ser_a>;
+						nvidia,gmsl-dser-device = <&dser>;
+						ports {
+							#address-cells = <1>;
+							#size-cells = <0>;
+
+							port@0 {
+								reg = <0>;
+								ds5_1_out: endpoint {
+									vc-id = <1>;
+									port-index = <1>;
+									bus-width = <2>;
+									remote-endpoint = <&d4xx_csi_in1>;
+								};
+							};
+						};
+						mode0 {
+							pixel_t = "grey_y16";
+							num_lanes = "2";
+							csi_pixel_bit_depth = "16";
+							active_w = "1920";
+							active_h = "1080";
+							tegra_sinterface = "serial_e";
+							mclk_khz = "24000";
+							pix_clk_hz = "74250000";
+							line_length = "1280"; /* 2200 */
+							embedded_metadata_height = "1";
+						};
+						gmsl-link {
+							src-csi-port = "b";
+							dst-csi-port = "a";
+							serdes-csi-link = "a";
+							csi-mode = "1x4";
+							st-vc = <0>;
+							vc-id = <1>;
+							num-lanes = <2>;
+						};
+					};
+
+					ds5_0: ds5@1a {
+						status = "okay";
+						def-addr = <0x10>;
+						reg = <0x1a>;
+						compatible = "intel,d4xx";
+						use_sensor_mode_id = "true";
+						cam-type = "Depth";
+						nvidia,gmsl-ser-device = <&ser_a>;
+						nvidia,gmsl-dser-device = <&dser>;
+						ports {
+							#address-cells = <1>;
+							#size-cells = <0>;
+
+							port@0 {
+								reg = <0>;
+								ds5_0_out: endpoint {
+									vc-id = <0>;
+									port-index = <0>;
+									bus-width = <2>;
+									remote-endpoint = <&d4xx_csi_in0>;
+								};
+							};
+						};
+						mode0 {
+							pixel_t = "grey_y16";
+							num_lanes = "2";
+							csi_pixel_bit_depth = "16";
+							active_w = "1280";
+							active_h = "720";
+							tegra_sinterface = "serial_a";
+							mclk_khz = "24000";
+							pix_clk_hz = "74250000";
+							line_length = "1280"; /* 2200 */
+							embedded_metadata_height = "1";
+						};
+						gmsl-link {
+							src-csi-port = "b";
+							dst-csi-port = "a";
+							serdes-csi-link = "a";
+							csi-mode = "1x4";
+							st-vc = <0>;
+							vc-id = <0>;
+							num-lanes = <2>;
+						};
+					};
+				};
+			};
+		};
+	};
+};


### PR DESCRIPTION
## Summary
Adds a 3-camera Seeed Orin nano overlay (`tegra234-camera-d4xx-overlay-seeed-cams-0-1-2`) — 3× D4xx on GMSL links 0-1-2, slot 3 (bottom-right) left empty. For the `fw-orin-nano-2` CI rig (D457 + D401 + D415).

## Changes
- **New overlay** `hardware/realsense/tegra234-camera-d4xx-overlay-seeed-cams-0-1-2.dts`, derived from the 4-cam overlay minus link 3: `num-channels` 16→12, `link-mask` 0xf→0x7, `ser_d` + `ds5@4a-4d` removed. `overlay-name = "…(Top two + bottom left)"`.
- **Overlay Makefile patch** (`hardware/nvidia/t23x/nv-public/6.x/0001-overlay-enable-d4xx-camera-for-Orin-jp6.patch`): added the `dtbo-y +=` line so a clean `apply_patches.sh` + `build_all.sh` produces the `.dtbo`.
- **README device tables** (`README_JP6.0.md`, `README_JP6.2.md`): new row with the slot→corner mapping.

## Slot mapping
| slot | link / serializer | corner |
|---|---|---|
| 0 | link0 / ser_a | top-right |
| 1 | link1 / ser_b | top-left |
| 2 | link2 / ser_c | bottom-left |
| 3 | link3 / ser_d | bottom-right (empty — not in DT) |

## Validation
- Built on JP6.2 (`sources_6.2.1`) via `make dtbs`. Decompiled `.dtbo` verified: 12 `ds5` nodes (1a–3d), 3 serializers (a/b/c), no link-3 references.
- Makefile patch verified with `git apply --check` against the pristine base.
- Deployed + booted on `fw-orin-nano-2` (`dev_triple` extlinux label): all 3 cameras probe on links 0-1-2 (slot 2 = D415 FW 5.17.4.6; slots 0/1 = FW 5.17.3.7); slot 3 empty; **no `-121`/probe errors**.
