### PR TITLE
[D585][GMSL][RGB Calib] Expose RAW16 Bayer10 surfaces

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -46,6 +46,7 @@ Each camera registers four sensor subdevices: Depth, RGB, IR (Y8/Y8I/Y12I), and 
 
 A deserializer abstraction layer (`struct dser_interface`) provides function pointer tables for MAX9296 vs MAX96712 variants.
 
+- **D5xx frame postprocessing errors**: A `tegra_frame_postprocess_ops` callback returns `0` only after a required buffer transform succeeds. Return a negative error when the VB2 plane has no CPU mapping or the frame geometry is invalid; the VI `buf_finish` adapter reports that buffer with `V4L2_BUF_FLAG_ERROR` instead of exposing unconverted bytes under the advertised FourCC.
 - **SerDes pipe configuration**: the **driver** configures all four SerDes pipes (Depth, RGB, IR, IMU) at stream start via `ds5_configure()`. The D457 firmware does **not** configure any pipes. Do not add probe-time pipe setup or special-case individual pipes (e.g. IMU) in `ds5_probe()`.
 - **Device tree assumptions**: all supported device trees include all four sensor instances (Depth, RGB, IR, IMU). Do not add DT-scanning logic to check for the presence of individual sensor types.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,7 @@ RealSense D4XX camera module
 
 - **`kernel/realsense/d4xx.c`** — The main driver. Single-file V4L2 subdevice driver handling I2C communication, MIPI CSI-2 stream config, firmware control (DFU), calibration data, metadata capture, and V4L2 controls (exposure, laser power, AE ROI, etc.). Registers four sensor subdevices per camera: Depth, RGB, IR (Y8/Y8I/Y12I), and IMU.
 - **D4xx/D5xx naming** — Keep `ds5_*`/`DS5_*` for `d4xx.c` and use `d5x_*`/`D5X_*` for `d5xx.c`, including D5xx diagnostic sysfs attributes. Preserve shared ABI names required by existing character devices, media graph discovery, and DT matching unless an ABI migration is explicitly required.
+- **D5xx frame postprocessing errors** — A `tegra_frame_postprocess_ops` callback returns `0` only after a required buffer transform succeeds. Return a negative error when the VB2 plane has no CPU mapping or the frame geometry is invalid; the VI `buf_finish` adapter reports that buffer with `V4L2_BUF_FLAG_ERROR` instead of exposing unconverted bytes under the advertised FourCC.
 - **`kernel/kernel-4.9/`, `kernel/kernel-5.10/`, `kernel/kernel-jammy-src/`** — Kernel patches organized by JetPack generation: 4.6.1 uses kernel 4.9, 5.x uses kernel 5.10, 6.x uses kernel-jammy-src.
 - **`kernel/nvidia/`** — NVIDIA driver patches (max9295/max9296 SerDes, VI capture engine) organized by JetPack version.
 - **`nvidia-oot/`** — Out-of-tree NVIDIA module patches for JetPack 6.x/7.x. New SERDES source overlays live under `nvidia-oot/files/<version>/...`; non-6.2 selectors currently link to the shared 6.2 overlay.

--- a/kernel/realsense/d5xx.c
+++ b/kernel/realsense/d5xx.c
@@ -562,11 +562,6 @@ struct d5x {
 	u16 fw_build;
 	u16 control_base;
 	u16 control_status_reg;
-#ifdef CONFIG_TEGRA_CAMERA_PLATFORM
-	struct mutex frame_postprocess_lock;
-	void *frame_postprocess_scratch;
-	size_t frame_postprocess_scratch_size;
-#endif
 #ifdef CONFIG_VIDEO_D5XX_SERDES
 	struct gmsl_link_ctx g_ctx;
 	struct device *ser_dev;
@@ -582,58 +577,52 @@ struct d5x {
 };
 
 #ifdef CONFIG_TEGRA_CAMERA_PLATFORM
-static void d5x_copy_raw16_to_ba10(void *dst, const void *src,
-				   size_t bytesused)
+static void d5x_swap_raw16_to_ba10(void *data, size_t bytesused)
 {
-	const u64 *src_quadwords = src;
-	u64 *dst_quadwords = dst;
-	size_t quadword_count = bytesused / sizeof(*src_quadwords);
-	size_t remainder;
-	const u8 *src_tail;
-	u8 *dst_tail;
+	u8 *cursor = data;
 
-	while (quadword_count--) {
-		u64 value = *src_quadwords++;
+	while (bytesused >= sizeof(u64)) {
+		u64 value = get_unaligned_le64(cursor);
 
-		*dst_quadwords++ =
-			((value & 0x00ff00ff00ff00ffULL) << 8) |
+		value = ((value & 0x00ff00ff00ff00ffULL) << 8) |
 			((value & 0xff00ff00ff00ff00ULL) >> 8);
+		put_unaligned_le64(value, cursor);
+		cursor += sizeof(value);
+		bytesused -= sizeof(value);
 	}
+	if (bytesused >= sizeof(u32)) {
+		u32 value = get_unaligned_le32(cursor);
 
-	remainder = bytesused & (sizeof(*src_quadwords) - 1U);
-	src_tail = (const u8 *)src_quadwords;
-	dst_tail = (u8 *)dst_quadwords;
-	if (remainder >= sizeof(u32)) {
-		u32 value = *(const u32 *)src_tail;
-
-		*(u32 *)dst_tail = swahb32(value);
-		src_tail += sizeof(value);
-		dst_tail += sizeof(value);
-		remainder -= sizeof(value);
+		put_unaligned_le32(swahb32(value), cursor);
+		cursor += sizeof(value);
+		bytesused -= sizeof(value);
 	}
-	if (remainder)
-		*(u16 *)dst_tail = swab16(*(const u16 *)src_tail);
+	if (bytesused)
+		put_unaligned_le16(swab16(get_unaligned_le16(cursor)), cursor);
 }
 
-static void d5x_pack_raw16_to_sgrbg10p(void *dst_data, const void *src_data,
-				       size_t bytesused,
-				       u32 width, u32 height,
-				       u32 bytesperline)
+static int d5x_pack_raw16_to_sgrbg10p(void *data, size_t bytesused,
+				      u32 width, u32 height,
+				      u32 bytesperline)
 {
-	const u8 *src_frame = src_data;
-	u8 *dst_frame = dst_data;
+	u8 *frame = data;
 	u32 y;
 
 	if (WARN_ON_ONCE(width & 3U) ||
 	    WARN_ON_ONCE(bytesperline < width * sizeof(u16)) ||
 	    WARN_ON_ONCE(bytesused < (size_t)bytesperline * height))
-		return;
+		return -EINVAL;
 
 	for (y = 0; y < height; y++) {
-		const u8 *src = src_frame + (size_t)y * bytesperline;
-		u8 *dst = dst_frame + (size_t)y * bytesperline;
+		const u8 *src = frame + (size_t)y * bytesperline;
+		u8 *dst = frame + (size_t)y * bytesperline;
 		u32 x;
 
+		/*
+		 * Each 8-byte source group is loaded before its 5-byte output is
+		 * stored. The destination cursor never advances beyond the source
+		 * cursor, so the forward transform cannot overwrite unread input.
+		 */
 		for (x = 0; x < width; x += 4) {
 			u64 raw = get_unaligned_le64(src);
 			u64 lanes =
@@ -654,65 +643,35 @@ static void d5x_pack_raw16_to_sgrbg10p(void *dst_data, const void *src_data,
 			dst += 5;
 		}
 	}
+
+	return 0;
 }
 
-static bool d5x_prepare_frame_postprocess_scratch(struct d5x *state,
-						   size_t bytesused)
-{
-	void *scratch;
-
-	if (state->frame_postprocess_scratch_size >= bytesused)
-		return true;
-
-	scratch = kvmalloc(bytesused, GFP_KERNEL);
-	if (!scratch) {
-		dev_err_ratelimited(&state->client->dev,
-				    "failed to allocate frame postprocess buffer\n");
-		return false;
-	}
-
-	kvfree(state->frame_postprocess_scratch);
-	state->frame_postprocess_scratch = scratch;
-	state->frame_postprocess_scratch_size = bytesused;
-	return true;
-}
-
-static void d5x_postprocess_csi_frame(struct camera_common_data *s_data,
-				     void *data, size_t bytesused,
-				     u32 mbus_code)
+static int d5x_postprocess_csi_frame(struct camera_common_data *s_data,
+				    void *data, size_t bytesused,
+				    u32 mbus_code)
 {
 	struct d5x *state = container_of(s_data, struct d5x, mux.sd);
 
 	if (mbus_code != MEDIA_BUS_FMT_RS_SGRBG10_1X16 &&
 	    mbus_code != MEDIA_BUS_FMT_RS_SGRBG10P_RAW16_1X16)
-		return;
-	if (WARN_ON_ONCE(bytesused & 1U))
-		return;
-
-	mutex_lock(&state->frame_postprocess_lock);
-	if (!d5x_prepare_frame_postprocess_scratch(state, bytesused))
-		goto unlock;
-
-	memcpy(state->frame_postprocess_scratch, data, bytesused);
+		return 0;
+	if (!data || !bytesused || WARN_ON_ONCE(bytesused & 1U))
+		return -EFAULT;
 
 	switch (mbus_code) {
 	case MEDIA_BUS_FMT_RS_SGRBG10_1X16:
-		d5x_copy_raw16_to_ba10(
-			data, state->frame_postprocess_scratch, bytesused);
-		break;
+		d5x_swap_raw16_to_ba10(data, bytesused);
+		return 0;
 	case MEDIA_BUS_FMT_RS_SGRBG10P_RAW16_1X16:
-		d5x_pack_raw16_to_sgrbg10p(
-			data, state->frame_postprocess_scratch, bytesused,
+		return d5x_pack_raw16_to_sgrbg10p(
+			data, bytesused,
 			state->rgb.sensor.format.width,
 			state->rgb.sensor.format.height,
 			state->rgb.sensor.format.width * sizeof(u16));
-		break;
 	default:
-		break;
+		return 0;
 	}
-
-unlock:
-	mutex_unlock(&state->frame_postprocess_lock);
 }
 
 static const struct tegra_frame_postprocess_ops d5x_frame_postprocess_ops = {
@@ -7097,9 +7056,6 @@ static int d5x_probe(struct i2c_client *c
 		return -ENOMEM;
 
 	mutex_init(&state->lock);
-#ifdef CONFIG_TEGRA_CAMERA_PLATFORM
-	mutex_init(&state->frame_postprocess_lock);
-#endif
 	state->client = c;
 
 	dev_warn(&c->dev, "Probing driver for D5xx\n");
@@ -7346,10 +7302,6 @@ static void d5x_remove(struct i2c_client *c)
 	if (state->is_depth && state->dfu_dev.d5x_class) {
 		d5x_chrdev_remove(state);
 	}
-
-#ifdef CONFIG_TEGRA_CAMERA_PLATFORM
-	kvfree(state->frame_postprocess_scratch);
-#endif
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(6, 8, 12)
 	return 0;

--- a/kernel/realsense/d5xx.c
+++ b/kernel/realsense/d5xx.c
@@ -28,6 +28,7 @@
 #include <linux/regulator/consumer.h>
 #include <linux/slab.h>
 #include <linux/string.h>
+#include <linux/swab.h>
 #include <linux/videodev2.h>
 #include <linux/version.h>
 #include <linux/mutex.h>
@@ -90,8 +91,16 @@ struct dser_interface {
 #define GMSL_CSI_DT_RAW_10          0x2B
 #endif
 
+#ifndef GMSL_CSI_DT_RAW_16
+#define GMSL_CSI_DT_RAW_16          0x2E
+#endif
+
 #ifndef GMSL_CSI_DT_USER_1
 #define GMSL_CSI_DT_USER_1          0x30
+#endif
+
+#ifndef MEDIA_BUS_FMT_RS_SGRBG10_1X16
+#define MEDIA_BUS_FMT_RS_SGRBG10_1X16 0x5003
 #endif
 
 /*
@@ -545,6 +554,11 @@ struct d5x {
 	u16 fw_build;
 	u16 control_base;
 	u16 control_status_reg;
+#ifdef CONFIG_TEGRA_CAMERA_PLATFORM
+	struct mutex frame_postprocess_lock;
+	void *frame_postprocess_scratch;
+	size_t frame_postprocess_scratch_size;
+#endif
 #ifdef CONFIG_VIDEO_D5XX_SERDES
 	struct gmsl_link_ctx g_ctx;
 	struct device *ser_dev;
@@ -558,6 +572,70 @@ struct d5x {
 #endif
 	struct d5x_dev *d5x_dev; /* D5xx device state */
 };
+
+#ifdef CONFIG_TEGRA_CAMERA_PLATFORM
+static void d5x_postprocess_csi_frame(struct camera_common_data *s_data,
+				     void *data, size_t bytesused,
+				     u32 mbus_code)
+{
+	struct d5x *state = container_of(s_data, struct d5x, mux.sd);
+	u64 *quadwords;
+	size_t quadword_count;
+	size_t remainder;
+	u8 *tail;
+
+	if (mbus_code != MEDIA_BUS_FMT_RS_SGRBG10_1X16)
+		return;
+	if (WARN_ON_ONCE(bytesused & 1U))
+		return;
+
+	mutex_lock(&state->frame_postprocess_lock);
+	if (state->frame_postprocess_scratch_size < bytesused) {
+		void *scratch = kvmalloc(bytesused, GFP_KERNEL);
+
+		if (!scratch) {
+			dev_err_ratelimited(&state->client->dev,
+					    "failed to allocate BA10 postprocess buffer\n");
+			goto unlock;
+		}
+
+		kvfree(state->frame_postprocess_scratch);
+		state->frame_postprocess_scratch = scratch;
+		state->frame_postprocess_scratch_size = bytesused;
+	}
+
+	memcpy(state->frame_postprocess_scratch, data, bytesused);
+	quadwords = state->frame_postprocess_scratch;
+	quadword_count = bytesused / sizeof(*quadwords);
+	while (quadword_count--) {
+		u64 value = *quadwords;
+
+		*quadwords++ = ((value & 0x00ff00ff00ff00ffULL) << 8) |
+			       ((value & 0xff00ff00ff00ff00ULL) >> 8);
+	}
+
+	remainder = bytesused & (sizeof(*quadwords) - 1U);
+	tail = (u8 *)quadwords;
+	if (remainder >= sizeof(u32)) {
+		u32 *word = (u32 *)tail;
+
+		*word = swahb32(*word);
+		tail += sizeof(*word);
+		remainder -= sizeof(*word);
+	}
+	if (remainder)
+		swab16s((u16 *)tail);
+
+	memcpy(data, state->frame_postprocess_scratch, bytesused);
+
+unlock:
+	mutex_unlock(&state->frame_postprocess_lock);
+}
+
+static const struct tegra_frame_postprocess_ops d5x_frame_postprocess_ops = {
+	.process = d5x_postprocess_csi_frame,
+};
+#endif
 
 struct d5x_dev {
 	struct mutex lock;
@@ -1349,6 +1427,15 @@ static const struct d5x_format d5x_rgb_formats_d58x[] = {
 		.resolutions = d58x_rgb_sizes,
 	}, {
 		/*
+		 * HKR emits one 10-bit GRBG sample in each 16-bit container.
+		 * RAW16 preserves those containers on wire; V4L2 exposes BA10.
+		 */
+		.data_type = GMSL_CSI_DT_RAW_16,
+		.mbus_code = MEDIA_BUS_FMT_RS_SGRBG10_1X16,
+		.n_resolutions = ARRAY_SIZE(d58x_rgb_raw_sizes),
+		.resolutions = d58x_rgb_raw_sizes,
+	}, {
+		/*
 		 * HKR FMT_SGRBG10P bytes are carried unchanged as CSI DT 0x30.
 		 * The private mbus code prevents this surface from being exposed
 		 * as standard BA10 or V4L2 IPU3 SGRBG10.
@@ -1692,6 +1779,11 @@ static void d5x_tegra_update_rgb_mode(struct d5x *state,
 		break;
 	case MEDIA_BUS_FMT_YUYV8_1X16:
 		pixel_format = V4L2_PIX_FMT_YUYV;
+		bit_depth = 16;
+		break;
+	case MEDIA_BUS_FMT_RS_SGRBG10_1X16:
+		pixel_format = V4L2_PIX_FMT_SGRBG10;
+		/* The CSI carrier transmits the complete 16-bit container. */
 		bit_depth = 16;
 		break;
 	case MEDIA_BUS_FMT_RS_SGRBG10P_1X10:
@@ -4916,6 +5008,27 @@ static int d5x_mux_enum_mbus_code(struct v4l2_subdev *sd,
 		remote_sd = &state->imu.sensor.sd;
 		break;
 	case D5X_MUX_PAD_EXTERNAL:
+		/*
+		 * A stream-specific mux enumerates that stream's complete format
+		 * table. Only the shared legacy mux combines IR and depth indices.
+		 */
+		if (state->is_rgb) {
+			remote_sd = &state->rgb.sensor.sd;
+			break;
+		}
+		if (state->is_depth) {
+			remote_sd = &state->depth.sensor.sd;
+			break;
+		}
+		if (state->is_y8) {
+			remote_sd = &state->ir.sensor.sd;
+			break;
+		}
+		if (state->is_imu) {
+			remote_sd = &state->imu.sensor.sd;
+			break;
+		}
+
 		if (mce->index >= state->ir.sensor.n_formats +
 				state->depth.sensor.n_formats)
 			return -EINVAL;
@@ -5989,6 +6102,9 @@ static int d5x_mux_init(struct i2c_client *c, struct d5x *state)
 #if defined(CONFIG_TEGRA_CAMERA_PLATFORM) && defined(CONFIG_TEGRA_EMBEDDED_METADATA_OPS)
 	state->mux.sd.embedded_metadata_ops = &d5x_csi_metadata_ops;
 #endif
+#ifdef CONFIG_TEGRA_CAMERA_PLATFORM
+	state->mux.sd.frame_postprocess_ops = &d5x_frame_postprocess_ops;
+#endif
 	ret = camera_common_initialize(&state->mux.sd, "d5xx");
 	if (ret) {
 		dev_err(&c->dev, "Failed to initialize d5xx.\n");
@@ -6884,6 +7000,9 @@ static int d5x_probe(struct i2c_client *c
 		return -ENOMEM;
 
 	mutex_init(&state->lock);
+#ifdef CONFIG_TEGRA_CAMERA_PLATFORM
+	mutex_init(&state->frame_postprocess_lock);
+#endif
 
 	state->client = c;
 
@@ -7131,6 +7250,10 @@ static void d5x_remove(struct i2c_client *c)
 	if (state->is_depth && state->dfu_dev.d5x_class) {
 		d5x_chrdev_remove(state);
 	}
+
+#ifdef CONFIG_TEGRA_CAMERA_PLATFORM
+	kvfree(state->frame_postprocess_scratch);
+#endif
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(6, 8, 12)
 	return 0;

--- a/kernel/realsense/d5xx.c
+++ b/kernel/realsense/d5xx.c
@@ -103,6 +103,10 @@ struct dser_interface {
 #define MEDIA_BUS_FMT_RS_SGRBG10_1X16 0x5003
 #endif
 
+#ifndef MEDIA_BUS_FMT_RS_SGRBG10P_RAW16_1X16
+#define MEDIA_BUS_FMT_RS_SGRBG10P_RAW16_1X16 0x5004
+#endif
+
 /*
  * D5x RGB ISYS stores GRBG10P as 50 little-endian 10-bit pixels per
  * 64-byte cache line. This is neither standard CSI RAW10, V4L2 IPU3
@@ -114,6 +118,10 @@ struct dser_interface {
 
 #ifndef V4L2_PIX_FMT_RS_SGRBG10P
 #define V4L2_PIX_FMT_RS_SGRBG10P v4l2_fourcc('G', 'R', '0', 'P')
+#endif
+
+#ifndef V4L2_PIX_FMT_SGRBG10P
+#define V4L2_PIX_FMT_SGRBG10P v4l2_fourcc('p', 'g', 'A', 'A')
 #endif
 
 /*
@@ -574,59 +582,134 @@ struct d5x {
 };
 
 #ifdef CONFIG_TEGRA_CAMERA_PLATFORM
+static void d5x_copy_raw16_to_ba10(void *dst, const void *src,
+				   size_t bytesused)
+{
+	const u64 *src_quadwords = src;
+	u64 *dst_quadwords = dst;
+	size_t quadword_count = bytesused / sizeof(*src_quadwords);
+	size_t remainder;
+	const u8 *src_tail;
+	u8 *dst_tail;
+
+	while (quadword_count--) {
+		u64 value = *src_quadwords++;
+
+		*dst_quadwords++ =
+			((value & 0x00ff00ff00ff00ffULL) << 8) |
+			((value & 0xff00ff00ff00ff00ULL) >> 8);
+	}
+
+	remainder = bytesused & (sizeof(*src_quadwords) - 1U);
+	src_tail = (const u8 *)src_quadwords;
+	dst_tail = (u8 *)dst_quadwords;
+	if (remainder >= sizeof(u32)) {
+		u32 value = *(const u32 *)src_tail;
+
+		*(u32 *)dst_tail = swahb32(value);
+		src_tail += sizeof(value);
+		dst_tail += sizeof(value);
+		remainder -= sizeof(value);
+	}
+	if (remainder)
+		*(u16 *)dst_tail = swab16(*(const u16 *)src_tail);
+}
+
+static void d5x_pack_raw16_to_sgrbg10p(void *dst_data, const void *src_data,
+				       size_t bytesused,
+				       u32 width, u32 height,
+				       u32 bytesperline)
+{
+	const u8 *src_frame = src_data;
+	u8 *dst_frame = dst_data;
+	u32 y;
+
+	if (WARN_ON_ONCE(width & 3U) ||
+	    WARN_ON_ONCE(bytesperline < width * sizeof(u16)) ||
+	    WARN_ON_ONCE(bytesused < (size_t)bytesperline * height))
+		return;
+
+	for (y = 0; y < height; y++) {
+		const u8 *src = src_frame + (size_t)y * bytesperline;
+		u8 *dst = dst_frame + (size_t)y * bytesperline;
+		u32 x;
+
+		for (x = 0; x < width; x += 4) {
+			u64 raw = get_unaligned_le64(src);
+			u64 lanes =
+				((raw & 0x00ff00ff00ff00ffULL) << 8) |
+				((raw & 0xff00ff00ff00ff00ULL) >> 8);
+			u32 high =
+				((lanes >> 2) & 0x000000ff) |
+				((lanes >> 10) & 0x0000ff00) |
+				((lanes >> 18) & 0x00ff0000) |
+				((lanes >> 26) & 0xff000000);
+
+			put_unaligned_le32(high, dst);
+			dst[4] = (lanes & 0x03) |
+				 ((lanes >> 14) & 0x0c) |
+				 ((lanes >> 28) & 0x30) |
+				 ((lanes >> 42) & 0xc0);
+			src += 4 * sizeof(u16);
+			dst += 5;
+		}
+	}
+}
+
+static bool d5x_prepare_frame_postprocess_scratch(struct d5x *state,
+						   size_t bytesused)
+{
+	void *scratch;
+
+	if (state->frame_postprocess_scratch_size >= bytesused)
+		return true;
+
+	scratch = kvmalloc(bytesused, GFP_KERNEL);
+	if (!scratch) {
+		dev_err_ratelimited(&state->client->dev,
+				    "failed to allocate frame postprocess buffer\n");
+		return false;
+	}
+
+	kvfree(state->frame_postprocess_scratch);
+	state->frame_postprocess_scratch = scratch;
+	state->frame_postprocess_scratch_size = bytesused;
+	return true;
+}
+
 static void d5x_postprocess_csi_frame(struct camera_common_data *s_data,
 				     void *data, size_t bytesused,
 				     u32 mbus_code)
 {
 	struct d5x *state = container_of(s_data, struct d5x, mux.sd);
-	u64 *quadwords;
-	size_t quadword_count;
-	size_t remainder;
-	u8 *tail;
 
-	if (mbus_code != MEDIA_BUS_FMT_RS_SGRBG10_1X16)
+	if (mbus_code != MEDIA_BUS_FMT_RS_SGRBG10_1X16 &&
+	    mbus_code != MEDIA_BUS_FMT_RS_SGRBG10P_RAW16_1X16)
 		return;
 	if (WARN_ON_ONCE(bytesused & 1U))
 		return;
 
 	mutex_lock(&state->frame_postprocess_lock);
-	if (state->frame_postprocess_scratch_size < bytesused) {
-		void *scratch = kvmalloc(bytesused, GFP_KERNEL);
-
-		if (!scratch) {
-			dev_err_ratelimited(&state->client->dev,
-					    "failed to allocate BA10 postprocess buffer\n");
-			goto unlock;
-		}
-
-		kvfree(state->frame_postprocess_scratch);
-		state->frame_postprocess_scratch = scratch;
-		state->frame_postprocess_scratch_size = bytesused;
-	}
+	if (!d5x_prepare_frame_postprocess_scratch(state, bytesused))
+		goto unlock;
 
 	memcpy(state->frame_postprocess_scratch, data, bytesused);
-	quadwords = state->frame_postprocess_scratch;
-	quadword_count = bytesused / sizeof(*quadwords);
-	while (quadword_count--) {
-		u64 value = *quadwords;
 
-		*quadwords++ = ((value & 0x00ff00ff00ff00ffULL) << 8) |
-			       ((value & 0xff00ff00ff00ff00ULL) >> 8);
+	switch (mbus_code) {
+	case MEDIA_BUS_FMT_RS_SGRBG10_1X16:
+		d5x_copy_raw16_to_ba10(
+			data, state->frame_postprocess_scratch, bytesused);
+		break;
+	case MEDIA_BUS_FMT_RS_SGRBG10P_RAW16_1X16:
+		d5x_pack_raw16_to_sgrbg10p(
+			data, state->frame_postprocess_scratch, bytesused,
+			state->rgb.sensor.format.width,
+			state->rgb.sensor.format.height,
+			state->rgb.sensor.format.width * sizeof(u16));
+		break;
+	default:
+		break;
 	}
-
-	remainder = bytesused & (sizeof(*quadwords) - 1U);
-	tail = (u8 *)quadwords;
-	if (remainder >= sizeof(u32)) {
-		u32 *word = (u32 *)tail;
-
-		*word = swahb32(*word);
-		tail += sizeof(*word);
-		remainder -= sizeof(*word);
-	}
-	if (remainder)
-		swab16s((u16 *)tail);
-
-	memcpy(data, state->frame_postprocess_scratch, bytesused);
 
 unlock:
 	mutex_unlock(&state->frame_postprocess_lock);
@@ -1436,6 +1519,15 @@ static const struct d5x_format d5x_rgb_formats_d58x[] = {
 		.resolutions = d58x_rgb_raw_sizes,
 	}, {
 		/*
+		 * This Host-output option reuses the same RAW16 transport as
+		 * BA10, then packs each completed T_R16 row into standard pgAA.
+		 */
+		.data_type = GMSL_CSI_DT_RAW_16,
+		.mbus_code = MEDIA_BUS_FMT_RS_SGRBG10P_RAW16_1X16,
+		.n_resolutions = ARRAY_SIZE(d58x_rgb_raw_sizes),
+		.resolutions = d58x_rgb_raw_sizes,
+	}, {
+		/*
 		 * HKR FMT_SGRBG10P bytes are carried unchanged as CSI DT 0x30.
 		 * The private mbus code prevents this surface from being exposed
 		 * as standard BA10 or V4L2 IPU3 SGRBG10.
@@ -1784,6 +1876,11 @@ static void d5x_tegra_update_rgb_mode(struct d5x *state,
 	case MEDIA_BUS_FMT_RS_SGRBG10_1X16:
 		pixel_format = V4L2_PIX_FMT_SGRBG10;
 		/* The CSI carrier transmits the complete 16-bit container. */
+		bit_depth = 16;
+		break;
+	case MEDIA_BUS_FMT_RS_SGRBG10P_RAW16_1X16:
+		pixel_format = V4L2_PIX_FMT_SGRBG10P;
+		/* pgAA is packed after VI; the CSI carrier remains RAW16. */
 		bit_depth = 16;
 		break;
 	case MEDIA_BUS_FMT_RS_SGRBG10P_1X10:
@@ -7003,7 +7100,6 @@ static int d5x_probe(struct i2c_client *c
 #ifdef CONFIG_TEGRA_CAMERA_PLATFORM
 	mutex_init(&state->frame_postprocess_lock);
 #endif
-
 	state->client = c;
 
 	dev_warn(&c->dev, "Probing driver for D5xx\n");

--- a/kernel/realsense/d5xx.c
+++ b/kernel/realsense/d5xx.c
@@ -86,6 +86,27 @@ struct dser_interface {
 #define GMSL_CSI_DT_EMBED           0x12
 #endif
 
+#ifndef GMSL_CSI_DT_RAW_10
+#define GMSL_CSI_DT_RAW_10          0x2B
+#endif
+
+#ifndef GMSL_CSI_DT_USER_1
+#define GMSL_CSI_DT_USER_1          0x30
+#endif
+
+/*
+ * D5x RGB ISYS stores GRBG10P as 50 little-endian 10-bit pixels per
+ * 64-byte cache line. This is neither standard CSI RAW10, V4L2 IPU3
+ * SGRBG10, nor 10-bit-in-16 BA10.
+ */
+#ifndef MEDIA_BUS_FMT_RS_SGRBG10P_1X10
+#define MEDIA_BUS_FMT_RS_SGRBG10P_1X10 0x5002
+#endif
+
+#ifndef V4L2_PIX_FMT_RS_SGRBG10P
+#define V4L2_PIX_FMT_RS_SGRBG10P v4l2_fourcc('G', 'R', '0', 'P')
+#endif
+
 /*
  * D5X_BYPASS_CAMERA_I2C: Bypass all I2C communication to the D5XX camera
  * sensor while keeping GMSL SERDES (MAX96717/MAX96724) fully operational.
@@ -1198,8 +1219,8 @@ static const u16 d5x_framerate_to_60[] = {5, 15, 30, 60};
 static const u16 d5x_framerate_to_90[] = {5, 15, 30, 60, 90};
 static const u16 d5x_framerate_15_30[] = {15, 30};
 static const u16 d5x_framerate_15_25[] = {15, 25};
+static const u16 d5x_framerate_25[] = {25};
 static const u16 d5x_framerate_90[] = {90};
-static const u16 d5x_framerate_9_30[] = {9, 30};
 static const u16 d5x_imu_framerates[] = {100, 200, 400};
 
 /* Helper macro to define resolution entries concisely. */
@@ -1248,9 +1269,9 @@ static const struct d5x_resolution d58x_rgb_sizes[] = {
 	D5X_RES(424, 240, d5x_framerate_to_90)
 };
 
-/* D58x COLOR_RAW resolutions: RAW16 */
+/* D58x packed Bayer RGB profile carried as an opaque CSI-2 UD30 byte stream. */
 static const struct d5x_resolution d58x_rgb_raw_sizes[] = {
-	D5X_RES(1600, 1300, d5x_framerate_9_30)
+	D5X_RES(1600, 1300, d5x_framerate_25)
 };
 
 static const struct d5x_resolution d5x_size_imu[] = {
@@ -1326,6 +1347,16 @@ static const struct d5x_format d5x_rgb_formats_d58x[] = {
 		.mbus_code = MEDIA_BUS_FMT_UYYVYY8_0_5X24,
 		.n_resolutions = ARRAY_SIZE(d58x_rgb_sizes),
 		.resolutions = d58x_rgb_sizes,
+	}, {
+		/*
+		 * HKR FMT_SGRBG10P bytes are carried unchanged as CSI DT 0x30.
+		 * The private mbus code prevents this surface from being exposed
+		 * as standard BA10 or V4L2 IPU3 SGRBG10.
+		 */
+		.data_type = GMSL_CSI_DT_USER_1,
+		.mbus_code = MEDIA_BUS_FMT_RS_SGRBG10P_1X10,
+		.n_resolutions = ARRAY_SIZE(d58x_rgb_raw_sizes),
+		.resolutions = d58x_rgb_raw_sizes,
 	},
 };
 
@@ -1662,6 +1693,10 @@ static void d5x_tegra_update_rgb_mode(struct d5x *state,
 	case MEDIA_BUS_FMT_YUYV8_1X16:
 		pixel_format = V4L2_PIX_FMT_YUYV;
 		bit_depth = 16;
+		break;
+	case MEDIA_BUS_FMT_RS_SGRBG10P_1X10:
+		pixel_format = V4L2_PIX_FMT_RS_SGRBG10P;
+		bit_depth = 10;
 		break;
 	default:
 		return;

--- a/kernel/realsense/d5xx.c
+++ b/kernel/realsense/d5xx.c
@@ -562,6 +562,11 @@ struct d5x {
 	u16 fw_build;
 	u16 control_base;
 	u16 control_status_reg;
+#ifdef CONFIG_TEGRA_CAMERA_PLATFORM
+	struct mutex frame_postprocess_lock;
+	void *frame_postprocess_scratch;
+	size_t frame_postprocess_scratch_size;
+#endif
 #ifdef CONFIG_VIDEO_D5XX_SERDES
 	struct gmsl_link_ctx g_ctx;
 	struct device *ser_dev;
@@ -577,35 +582,41 @@ struct d5x {
 };
 
 #ifdef CONFIG_TEGRA_CAMERA_PLATFORM
-static void d5x_swap_raw16_to_ba10(void *data, size_t bytesused)
+static void d5x_copy_raw16_to_ba10(void *dst_data, const void *src_data,
+				   size_t bytesused)
 {
-	u8 *cursor = data;
+	const u8 *src = src_data;
+	u8 *dst = dst_data;
 
 	while (bytesused >= sizeof(u64)) {
-		u64 value = get_unaligned_le64(cursor);
+		u64 value = get_unaligned_le64(src);
 
 		value = ((value & 0x00ff00ff00ff00ffULL) << 8) |
 			((value & 0xff00ff00ff00ff00ULL) >> 8);
-		put_unaligned_le64(value, cursor);
-		cursor += sizeof(value);
+		put_unaligned_le64(value, dst);
+		src += sizeof(value);
+		dst += sizeof(value);
 		bytesused -= sizeof(value);
 	}
 	if (bytesused >= sizeof(u32)) {
-		u32 value = get_unaligned_le32(cursor);
+		u32 value = get_unaligned_le32(src);
 
-		put_unaligned_le32(swahb32(value), cursor);
-		cursor += sizeof(value);
+		put_unaligned_le32(swahb32(value), dst);
+		src += sizeof(value);
+		dst += sizeof(value);
 		bytesused -= sizeof(value);
 	}
 	if (bytesused)
-		put_unaligned_le16(swab16(get_unaligned_le16(cursor)), cursor);
+		put_unaligned_le16(swab16(get_unaligned_le16(src)), dst);
 }
 
-static int d5x_pack_raw16_to_sgrbg10p(void *data, size_t bytesused,
+static int d5x_pack_raw16_to_sgrbg10p(void *dst_data, const void *src_data,
+				      size_t bytesused,
 				      u32 width, u32 height,
 				      u32 bytesperline)
 {
-	u8 *frame = data;
+	const u8 *src_frame = src_data;
+	u8 *dst_frame = dst_data;
 	u32 y;
 
 	if (WARN_ON_ONCE(width & 3U) ||
@@ -614,15 +625,10 @@ static int d5x_pack_raw16_to_sgrbg10p(void *data, size_t bytesused,
 		return -EINVAL;
 
 	for (y = 0; y < height; y++) {
-		const u8 *src = frame + (size_t)y * bytesperline;
-		u8 *dst = frame + (size_t)y * bytesperline;
+		const u8 *src = src_frame + (size_t)y * bytesperline;
+		u8 *dst = dst_frame + (size_t)y * bytesperline;
 		u32 x;
 
-		/*
-		 * Each 8-byte source group is loaded before its 5-byte output is
-		 * stored. The destination cursor never advances beyond the source
-		 * cursor, so the forward transform cannot overwrite unread input.
-		 */
 		for (x = 0; x < width; x += 4) {
 			u64 raw = get_unaligned_le64(src);
 			u64 lanes =
@@ -647,11 +653,33 @@ static int d5x_pack_raw16_to_sgrbg10p(void *data, size_t bytesused,
 	return 0;
 }
 
+static int d5x_prepare_frame_postprocess_scratch(struct d5x *state,
+						  size_t bytesused)
+{
+	void *scratch;
+
+	if (state->frame_postprocess_scratch_size >= bytesused)
+		return 0;
+
+	scratch = kvmalloc(bytesused, GFP_KERNEL);
+	if (!scratch) {
+		dev_err_ratelimited(&state->client->dev,
+				    "failed to allocate frame postprocess buffer\n");
+		return -ENOMEM;
+	}
+
+	kvfree(state->frame_postprocess_scratch);
+	state->frame_postprocess_scratch = scratch;
+	state->frame_postprocess_scratch_size = bytesused;
+	return 0;
+}
+
 static int d5x_postprocess_csi_frame(struct camera_common_data *s_data,
 				    void *data, size_t bytesused,
 				    u32 mbus_code)
 {
 	struct d5x *state = container_of(s_data, struct d5x, mux.sd);
+	int ret;
 
 	if (mbus_code != MEDIA_BUS_FMT_RS_SGRBG10_1X16 &&
 	    mbus_code != MEDIA_BUS_FMT_RS_SGRBG10P_RAW16_1X16)
@@ -659,19 +687,34 @@ static int d5x_postprocess_csi_frame(struct camera_common_data *s_data,
 	if (!data || !bytesused || WARN_ON_ONCE(bytesused & 1U))
 		return -EFAULT;
 
+	mutex_lock(&state->frame_postprocess_lock);
+	ret = d5x_prepare_frame_postprocess_scratch(state, bytesused);
+	if (ret)
+		goto unlock;
+
+	memcpy(state->frame_postprocess_scratch, data, bytesused);
+
 	switch (mbus_code) {
 	case MEDIA_BUS_FMT_RS_SGRBG10_1X16:
-		d5x_swap_raw16_to_ba10(data, bytesused);
-		return 0;
+		d5x_copy_raw16_to_ba10(
+			data, state->frame_postprocess_scratch, bytesused);
+		ret = 0;
+		break;
 	case MEDIA_BUS_FMT_RS_SGRBG10P_RAW16_1X16:
-		return d5x_pack_raw16_to_sgrbg10p(
-			data, bytesused,
+		ret = d5x_pack_raw16_to_sgrbg10p(
+			data, state->frame_postprocess_scratch, bytesused,
 			state->rgb.sensor.format.width,
 			state->rgb.sensor.format.height,
 			state->rgb.sensor.format.width * sizeof(u16));
+		break;
 	default:
-		return 0;
+		ret = 0;
+		break;
 	}
+
+unlock:
+	mutex_unlock(&state->frame_postprocess_lock);
+	return ret;
 }
 
 static const struct tegra_frame_postprocess_ops d5x_frame_postprocess_ops = {
@@ -7056,6 +7099,9 @@ static int d5x_probe(struct i2c_client *c
 		return -ENOMEM;
 
 	mutex_init(&state->lock);
+#ifdef CONFIG_TEGRA_CAMERA_PLATFORM
+	mutex_init(&state->frame_postprocess_lock);
+#endif
 	state->client = c;
 
 	dev_warn(&c->dev, "Probing driver for D5xx\n");
@@ -7302,6 +7348,10 @@ static void d5x_remove(struct i2c_client *c)
 	if (state->is_depth && state->dfu_dev.d5x_class) {
 		d5x_chrdev_remove(state);
 	}
+
+#ifdef CONFIG_TEGRA_CAMERA_PLATFORM
+	kvfree(state->frame_postprocess_scratch);
+#endif
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(6, 8, 12)
 	return 0;

--- a/nvidia-oot/6.0/0015-Add-D5x-GRBG10P-byte-surface.patch
+++ b/nvidia-oot/6.0/0015-Add-D5x-GRBG10P-byte-surface.patch
@@ -1,17 +1,20 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: zhou <shengyong.zhou@realsenseai.com>
 Date: Fri, 24 Jul 2026 19:30:00 +0800
-Subject: [PATCH] media: tegra: receive D5x GRBG10P over UD30
+Subject: [PATCH] media: tegra: receive D5x RGB Bayer surfaces
 
 D5x RGB ISYS stores FMT_SGRBG10P as 50 little-endian 10-bit pixels
 in each 64-byte cache line. HIF MIPI preserves the complete aligned
 row in a CSI User Defined 1 packet so the receiver treats the payload
 as an opaque byte stream.
 
-Add a private mbus/fourcc tuple for this product surface. VI matches
-wire DT 0x30, maps the User Defined byte stream to RAW8/T_R8, and writes
-the payload unchanged. The visible V4L2 geometry remains 1600x1300 while
-bytesperline and capture frame_x use the 2048-byte HKR stride.
+The optional unpacked path stores one 10-bit sample in each 16-bit
+container and sends those containers unchanged using CSI RAW16.
+
+Add separate internal mbus tuples for both transports. The packed path
+keeps its private GR0P ABI. The unpacked RAW16 path uses T_R16 and exposes
+the standard V4L2 SGRBG10/BA10 surface. Prefer formats advertised by the
+active subdevice when two transport tuples share a standard FourCC.
 
 Signed-off-by: zhou <shengyong.zhou@realsenseai.com>
 ---
@@ -67,14 +70,118 @@ index 6dc16c9f..58f80bd4 100644
  	return 0;
  }
  
+diff --git a/drivers/media/platform/tegra/camera/vi/core.c b/drivers/media/platform/tegra/camera/vi/core.c
+index 4923d9b6..6ec75573 100644
+--- a/drivers/media/platform/tegra/camera/vi/core.c
++++ b/drivers/media/platform/tegra/camera/vi/core.c
+@@ -94,13 +94,19 @@ int tegra_core_get_code_by_fourcc(struct tegra_channel *chan,
+-		unsigned int fourcc, unsigned offset)
++		unsigned int fourcc, unsigned offset)
+ {
+-	unsigned int i;
+-
+-	for (i = offset; i < chan->num_video_formats; ++i) {
+-		if (chan->video_formats[i]->fourcc == fourcc)
+-			return chan->video_formats[i]->code;
+-	}
+-	spec_bar();
+-
+-	return -1;
++	unsigned int i;
++	int fallback = -1;
++
++	for (i = offset; i < chan->num_video_formats; ++i) {
++		if (chan->video_formats[i]->fourcc != fourcc)
++			continue;
++
++		if (fallback < 0)
++			fallback = chan->video_formats[i]->code;
++		if (test_bit(i, chan->fmts_bitmap))
++			return chan->video_formats[i]->code;
++	}
++	spec_bar();
++
++	return fallback;
+ }
+ EXPORT_SYMBOL(tegra_core_get_code_by_fourcc);
+@@ -154,13 +160,19 @@ const struct tegra_video_format *
+ tegra_core_get_format_by_fourcc(struct tegra_channel *chan, u32 fourcc)
+ {
+-	unsigned int i;
+-
+-	for (i = 0; i < chan->num_video_formats; ++i) {
+-		if (chan->video_formats[i]->fourcc == fourcc)
+-			return chan->video_formats[i];
+-	}
+-	spec_bar();
+-
+-	return NULL;
++	unsigned int i;
++	const struct tegra_video_format *fallback = NULL;
++
++	for (i = 0; i < chan->num_video_formats; ++i) {
++		if (chan->video_formats[i]->fourcc != fourcc)
++			continue;
++
++		if (!fallback)
++			fallback = chan->video_formats[i];
++		if (test_bit(i, chan->fmts_bitmap))
++			return chan->video_formats[i];
++	}
++	spec_bar();
++
++	return fallback;
+ }
+ EXPORT_SYMBOL(tegra_core_get_format_by_fourcc);
+diff --git a/include/media/tegra_camera_core.h b/include/media/tegra_camera_core.h
+index 43d5316b..d9e459b8 100644
+--- a/include/media/tegra_camera_core.h
++++ b/include/media/tegra_camera_core.h
+@@ -49,16 +49,17 @@ enum tegra_image_dt {
+-
+-	TEGRA_IMAGE_DT_RAW6 = 40,
+-	TEGRA_IMAGE_DT_RAW7,
+-	TEGRA_IMAGE_DT_RAW8,
+-	TEGRA_IMAGE_DT_RAW10,
+-	TEGRA_IMAGE_DT_RAW12,
+-	TEGRA_IMAGE_DT_RAW14,
+-
+-	TEGRA_IMAGE_DT_USER_1 = 48,
+-	TEGRA_IMAGE_DT_USER_2,
+-	TEGRA_IMAGE_DT_USER_3,
+-	TEGRA_IMAGE_DT_USER_4,
+-
+-};
+-
++
++	TEGRA_IMAGE_DT_RAW6 = 40,
++	TEGRA_IMAGE_DT_RAW7,
++	TEGRA_IMAGE_DT_RAW8,
++	TEGRA_IMAGE_DT_RAW10,
++	TEGRA_IMAGE_DT_RAW12,
++	TEGRA_IMAGE_DT_RAW14,
++	TEGRA_IMAGE_DT_RAW16,
++
++	TEGRA_IMAGE_DT_USER_1 = 48,
++	TEGRA_IMAGE_DT_USER_2,
++	TEGRA_IMAGE_DT_USER_3,
++	TEGRA_IMAGE_DT_USER_4,
++
++};
++
+ /* Supported CSI to VI Data Formats */
 diff --git a/drivers/media/platform/tegra/camera/vi/vi5_formats.h b/drivers/media/platform/tegra/camera/vi/vi5_formats.h
 index fb07cfd2..1cb54ba8 100644
 --- a/drivers/media/platform/tegra/camera/vi/vi5_formats.h
 +++ b/drivers/media/platform/tegra/camera/vi/vi5_formats.h
-@@ -76,6 +76,14 @@ enum tegra_image_format {
+@@ -76,6 +76,18 @@ enum tegra_image_format {
  	TEGRA_IMAGE_FORMAT_T_DPCM_RAW20,
  };
  
++#ifndef MEDIA_BUS_FMT_RS_SGRBG10_1X16
++#define MEDIA_BUS_FMT_RS_SGRBG10_1X16 0x5003
++#endif
++
 +#ifndef MEDIA_BUS_FMT_RS_SGRBG10P_1X10
 +#define MEDIA_BUS_FMT_RS_SGRBG10P_1X10 0x5002
 +#endif
@@ -86,10 +193,17 @@ index fb07cfd2..1cb54ba8 100644
  static const struct tegra_video_format vi5_video_formats[] = {
  	/* RAW 6: TODO */
  
-@@ -170,6 +178,13 @@ static const struct tegra_video_format vi5_video_formats[] = {
+@@ -170,6 +182,20 @@ static const struct tegra_video_format vi5_video_formats[] = {
  	TEGRA_VIDEO_FORMAT(RAW8, 8, UYYVYY8_0_5X24, 1, 1, T_R8,
  				RAW8, NV12, "YUV 4:2:0 NV12"),
  
++	/*
++	 * D5x unpacked GRBG10: CSI RAW16 carries one complete 16-bit
++	 * container per sample. Expose the standard V4L2 BA10 surface.
++	 */
++	TEGRA_VIDEO_FORMAT(RAW10, 10, RS_SGRBG10_1X16, 2, 1, T_R16,
++				RAW16, SGRBG10, "GRBG10 in 16-bit containers"),
++
 +	/*
 +	 * D5x FMT_SGRBG10P: 50 little-endian 10-bit pixels per 64-byte
 +	 * cache line. Receive CSI UD30 and preserve every byte in T_R8.
@@ -100,3 +214,65 @@ index fb07cfd2..1cb54ba8 100644
  };
  
  #endif
+diff --git a/include/media/camera_common.h b/include/media/camera_common.h
+--- a/include/media/camera_common.h
++++ b/include/media/camera_common.h
+@@ -164,6 +164,11 @@ struct camera_common_framesync {
+ struct tegracam_device ;
+ struct camera_common_data;
+ 
++struct tegra_frame_postprocess_ops {
++	void (*process)(struct camera_common_data *s_data, void *data,
++			size_t bytesused, u32 mbus_code);
++};
++
+ struct camera_common_sensor_ops {
+ 	u32 numfrmfmts;
+ 	const struct camera_common_frmfmt *frmfmt_table;
+@@ -258,6 +263,7 @@ struct camera_common_data {
+ 	bool	use_sensor_mode_id;
+ 	bool	override_enable;
+ 	const struct tegra_embedded_metadata_ops *embedded_metadata_ops;
++	const struct tegra_frame_postprocess_ops *frame_postprocess_ops;
+ 	u32	version;
+ };
+ 
+diff --git a/drivers/media/platform/tegra/camera/vi/channel.c b/drivers/media/platform/tegra/camera/vi/channel.c
+--- a/drivers/media/platform/tegra/camera/vi/channel.c
++++ b/drivers/media/platform/tegra/camera/vi/channel.c
+@@ -1068,10 +1068,35 @@ static void tegra_channel_stop_streaming(struct vb2_queue *vq)
+ 	queue_init_ts = 0;
+ }
+ 
++static void tegra_channel_buffer_finish(struct vb2_buffer *vb)
++{
++	struct tegra_channel *chan = vb2_get_drv_priv(vb->vb2_queue);
++	struct camera_common_data *s_data;
++	void *data;
++	size_t bytesused;
++
++	if (!chan->subdev_on_csi)
++		return;
++
++	s_data = to_camera_common_data(chan->subdev_on_csi->dev);
++	if (!s_data || !s_data->frame_postprocess_ops ||
++	    !s_data->frame_postprocess_ops->process)
++		return;
++
++	data = vb2_plane_vaddr(vb, 0);
++	bytesused = vb2_get_plane_payload(vb, 0);
++	if (!data || !bytesused)
++		return;
++
++	s_data->frame_postprocess_ops->process(s_data, data, bytesused,
++					      chan->fmtinfo->code);
++}
++
+ static const struct vb2_ops tegra_channel_queue_qops = {
+ 	.queue_setup = tegra_channel_queue_setup,
+ 	.buf_prepare = tegra_channel_buffer_prepare,
+ 	.buf_queue = tegra_channel_buffer_queue,
++	.buf_finish = tegra_channel_buffer_finish,
+ 	.wait_prepare = vb2_ops_wait_prepare,
+ 	.wait_finish = vb2_ops_wait_finish,
+ 	.start_streaming = tegra_channel_start_streaming,

--- a/nvidia-oot/6.0/0015-Add-D5x-GRBG10P-byte-surface.patch
+++ b/nvidia-oot/6.0/0015-Add-D5x-GRBG10P-byte-surface.patch
@@ -1,0 +1,102 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: zhou <shengyong.zhou@realsenseai.com>
+Date: Fri, 24 Jul 2026 19:30:00 +0800
+Subject: [PATCH] media: tegra: receive D5x GRBG10P over UD30
+
+D5x RGB ISYS stores FMT_SGRBG10P as 50 little-endian 10-bit pixels
+in each 64-byte cache line. HIF MIPI preserves the complete aligned
+row in a CSI User Defined 1 packet so the receiver treats the payload
+as an opaque byte stream.
+
+Add a private mbus/fourcc tuple for this product surface. VI matches
+wire DT 0x30, maps the User Defined byte stream to RAW8/T_R8, and writes
+the payload unchanged. The visible V4L2 geometry remains 1600x1300 while
+bytesperline and capture frame_x use the 2048-byte HKR stride.
+
+Signed-off-by: zhou <shengyong.zhou@realsenseai.com>
+---
+diff --git a/drivers/media/platform/tegra/camera/vi/vi5_fops.c b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
+index 079b5865..fa0acd21 100644
+--- a/drivers/media/platform/tegra/camera/vi/vi5_fops.c
++++ b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
+@@ -394,6 +394,8 @@ static void vi5_setup_surface(struct tegra_channel *chan,
+ 	u32 bpl = chan->format.bytesperline;
+ 	u32 data_type = chan->fmtinfo->img_dt;
+ 	bool flat_nv12 = chan->fmtinfo->fourcc == V4L2_PIX_FMT_NV12;
++	bool d5x_sgrbg10p =
++		chan->fmtinfo->fourcc == V4L2_PIX_FMT_RS_SGRBG10P;
+ 	u32 nvcsi_stream = chan->port[vi_port];
+ 	struct capture_descriptor_memoryinfo *desc_memoryinfo =
+ 		&chan->tegra_vi_channel[vi_port]->
+@@ -409,6 +411,9 @@ static void vi5_setup_surface(struct tegra_channel *chan,
+ 	/* D5xx carries flat NV12 bytes as W x (H * 3 / 2) RAW8 rows. */
+ 	if (flat_nv12)
+ 		height = height * 3 / 2;
++	else if (d5x_sgrbg10p)
++		/* RAW8 parser width is the byte-identical HKR DDR stride. */
++		width = bpl;
+ 
+ 	memcpy(desc, &capture_template, sizeof(capture_template));
+ 	memset(desc_memoryinfo, 0, sizeof(*desc_memoryinfo));
+@@ -421,6 +426,14 @@ static void vi5_setup_surface(struct tegra_channel *chan,
+ 	desc->ch_cfg.frame.frame_y = height;
+ 	desc->ch_cfg.match.datatype = data_type;
+ 	desc->ch_cfg.match.datatype_mask = 0x3f;
++	if (d5x_sgrbg10p) {
++		/*
++		 * UD30 is an opaque byte stream. Map it to RAW8 only inside VI
++		 * so each packet payload byte reaches the V4L2 surface unchanged.
++		 */
++		desc->ch_cfg.dt_enable = 1;
++		desc->ch_cfg.dt_override = TEGRA_IMAGE_DT_RAW8;
++	}
+ 	desc->ch_cfg.pixfmt_enable = 1;
+ 	desc->ch_cfg.pixfmt.format = format;
+ 
+diff --git a/drivers/media/platform/tegra/camera/vi/channel.c b/drivers/media/platform/tegra/camera/vi/channel.c
+index 6dc16c9f..58f80bd4 100644
+--- a/drivers/media/platform/tegra/camera/vi/channel.c
++++ b/drivers/media/platform/tegra/camera/vi/channel.c
+@@ -1156,6 +1156,9 @@ tegra_channel_enum_format(struct file *file, void *fh, struct v4l2_fmtdesc *f)
+ 	index -= 1;
+ 	f->pixelformat = tegra_core_get_fourcc_by_idx(chan, index);
+ 
++	if (f->pixelformat == v4l2_fourcc('G', 'R', '0', 'P'))
++		strscpy(f->description, "RealSense GRBG10P CL64", sizeof(f->description));
++
+ 	return 0;
+ }
+ 
+diff --git a/drivers/media/platform/tegra/camera/vi/vi5_formats.h b/drivers/media/platform/tegra/camera/vi/vi5_formats.h
+index fb07cfd2..1cb54ba8 100644
+--- a/drivers/media/platform/tegra/camera/vi/vi5_formats.h
++++ b/drivers/media/platform/tegra/camera/vi/vi5_formats.h
+@@ -76,6 +76,14 @@ enum tegra_image_format {
+ 	TEGRA_IMAGE_FORMAT_T_DPCM_RAW20,
+ };
+ 
++#ifndef MEDIA_BUS_FMT_RS_SGRBG10P_1X10
++#define MEDIA_BUS_FMT_RS_SGRBG10P_1X10 0x5002
++#endif
++
++#ifndef V4L2_PIX_FMT_RS_SGRBG10P
++#define V4L2_PIX_FMT_RS_SGRBG10P v4l2_fourcc('G', 'R', '0', 'P')
++#endif
++
+ static const struct tegra_video_format vi5_video_formats[] = {
+ 	/* RAW 6: TODO */
+ 
+@@ -170,6 +178,13 @@ static const struct tegra_video_format vi5_video_formats[] = {
+ 	TEGRA_VIDEO_FORMAT(RAW8, 8, UYYVYY8_0_5X24, 1, 1, T_R8,
+ 				RAW8, NV12, "YUV 4:2:0 NV12"),
+ 
++	/*
++	 * D5x FMT_SGRBG10P: 50 little-endian 10-bit pixels per 64-byte
++	 * cache line. Receive CSI UD30 and preserve every byte in T_R8.
++	 */
++	TEGRA_VIDEO_FORMAT(RAW10, 10, RS_SGRBG10P_1X10, 32, 25, T_R8,
++				USER_1, RS_SGRBG10P, "RealSense GRBG10P CL64"),
++
+ };
+ 
+ #endif

--- a/nvidia-oot/6.0/0015-Add-D5x-GRBG10P-byte-surface.patch
+++ b/nvidia-oot/6.0/0015-Add-D5x-GRBG10P-byte-surface.patch
@@ -13,8 +13,10 @@ container and sends those containers unchanged using CSI RAW16.
 
 Add separate internal mbus tuples for both transports. The packed path
 keeps its private GR0P ABI. The unpacked RAW16 path uses T_R16 and exposes
-the standard V4L2 SGRBG10/BA10 surface. Prefer formats advertised by the
-active subdevice when two transport tuples share a standard FourCC.
+the standard V4L2 SGRBG10/BA10 surface or, through a D5x frame-finish
+callback, the associated standard packed SGRBG10P/pgAA surface. Prefer
+formats advertised by the active subdevice when transport tuples share
+a standard FourCC.
 
 Signed-off-by: zhou <shengyong.zhou@realsenseai.com>
 ---
@@ -174,12 +176,16 @@ diff --git a/drivers/media/platform/tegra/camera/vi/vi5_formats.h b/drivers/medi
 index fb07cfd2..1cb54ba8 100644
 --- a/drivers/media/platform/tegra/camera/vi/vi5_formats.h
 +++ b/drivers/media/platform/tegra/camera/vi/vi5_formats.h
-@@ -76,6 +76,18 @@ enum tegra_image_format {
+@@ -76,6 +76,26 @@ enum tegra_image_format {
  	TEGRA_IMAGE_FORMAT_T_DPCM_RAW20,
  };
  
 +#ifndef MEDIA_BUS_FMT_RS_SGRBG10_1X16
 +#define MEDIA_BUS_FMT_RS_SGRBG10_1X16 0x5003
++#endif
++
++#ifndef MEDIA_BUS_FMT_RS_SGRBG10P_RAW16_1X16
++#define MEDIA_BUS_FMT_RS_SGRBG10P_RAW16_1X16 0x5004
 +#endif
 +
 +#ifndef MEDIA_BUS_FMT_RS_SGRBG10P_1X10
@@ -190,10 +196,14 @@ index fb07cfd2..1cb54ba8 100644
 +#define V4L2_PIX_FMT_RS_SGRBG10P v4l2_fourcc('G', 'R', '0', 'P')
 +#endif
 +
++#ifndef V4L2_PIX_FMT_SGRBG10P
++#define V4L2_PIX_FMT_SGRBG10P v4l2_fourcc('p', 'g', 'A', 'A')
++#endif
++
  static const struct tegra_video_format vi5_video_formats[] = {
  	/* RAW 6: TODO */
  
-@@ -170,6 +182,20 @@ static const struct tegra_video_format vi5_video_formats[] = {
+@@ -170,6 +190,27 @@ static const struct tegra_video_format vi5_video_formats[] = {
  	TEGRA_VIDEO_FORMAT(RAW8, 8, UYYVYY8_0_5X24, 1, 1, T_R8,
  				RAW8, NV12, "YUV 4:2:0 NV12"),
  
@@ -203,6 +213,13 @@ index fb07cfd2..1cb54ba8 100644
 +	 */
 +	TEGRA_VIDEO_FORMAT(RAW10, 10, RS_SGRBG10_1X16, 2, 1, T_R16,
 +				RAW16, SGRBG10, "GRBG10 in 16-bit containers"),
++
++	/*
++	 * Associated Host-output option for the same D5x RAW16/T_R16
++	 * transport. The D5x frame-finish callback packs each row to pgAA.
++	 */
++	TEGRA_VIDEO_FORMAT(RAW10, 10, RS_SGRBG10P_RAW16_1X16, 2, 1, T_R16,
++				RAW16, SGRBG10P, "Packed GRBG10 from RAW16"),
 +
 +	/*
 +	 * D5x FMT_SGRBG10P: 50 little-endian 10-bit pixels per 64-byte

--- a/nvidia-oot/6.0/0015-Add-D5x-GRBG10P-byte-surface.patch
+++ b/nvidia-oot/6.0/0015-Add-D5x-GRBG10P-byte-surface.patch
@@ -239,8 +239,8 @@ diff --git a/include/media/camera_common.h b/include/media/camera_common.h
  struct camera_common_data;
  
 +struct tegra_frame_postprocess_ops {
-+	void (*process)(struct camera_common_data *s_data, void *data,
-+			size_t bytesused, u32 mbus_code);
++	int (*process)(struct camera_common_data *s_data, void *data,
++		       size_t bytesused, u32 mbus_code);
 +};
 +
  struct camera_common_sensor_ops {
@@ -257,7 +257,7 @@ diff --git a/include/media/camera_common.h b/include/media/camera_common.h
 diff --git a/drivers/media/platform/tegra/camera/vi/channel.c b/drivers/media/platform/tegra/camera/vi/channel.c
 --- a/drivers/media/platform/tegra/camera/vi/channel.c
 +++ b/drivers/media/platform/tegra/camera/vi/channel.c
-@@ -1068,10 +1068,35 @@ static void tegra_channel_stop_streaming(struct vb2_queue *vq)
+@@ -1068,10 +1068,33 @@ static void tegra_channel_stop_streaming(struct vb2_queue *vq)
  	queue_init_ts = 0;
  }
  
@@ -276,13 +276,11 @@ diff --git a/drivers/media/platform/tegra/camera/vi/channel.c b/drivers/media/pl
 +	    !s_data->frame_postprocess_ops->process)
 +		return;
 +
-+	data = vb2_plane_vaddr(vb, 0);
 +	bytesused = vb2_get_plane_payload(vb, 0);
-+	if (!data || !bytesused)
-+		return;
-+
-+	s_data->frame_postprocess_ops->process(s_data, data, bytesused,
-+					      chan->fmtinfo->code);
++	data = vb2_plane_vaddr(vb, 0);
++	if (s_data->frame_postprocess_ops->process(s_data, data, bytesused,
++						  chan->fmtinfo->code))
++		to_vb2_v4l2_buffer(vb)->flags |= V4L2_BUF_FLAG_ERROR;
 +}
 +
  static const struct vb2_ops tegra_channel_queue_qops = {

--- a/nvidia-oot/6.1/0015-Add-D5x-GRBG10P-byte-surface.patch
+++ b/nvidia-oot/6.1/0015-Add-D5x-GRBG10P-byte-surface.patch
@@ -1,17 +1,20 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: zhou <shengyong.zhou@realsenseai.com>
 Date: Fri, 24 Jul 2026 19:30:00 +0800
-Subject: [PATCH] media: tegra: receive D5x GRBG10P over UD30
+Subject: [PATCH] media: tegra: receive D5x RGB Bayer surfaces
 
 D5x RGB ISYS stores FMT_SGRBG10P as 50 little-endian 10-bit pixels
 in each 64-byte cache line. HIF MIPI preserves the complete aligned
 row in a CSI User Defined 1 packet so the receiver treats the payload
 as an opaque byte stream.
 
-Add a private mbus/fourcc tuple for this product surface. VI matches
-wire DT 0x30, maps the User Defined byte stream to RAW8/T_R8, and writes
-the payload unchanged. The visible V4L2 geometry remains 1600x1300 while
-bytesperline and capture frame_x use the 2048-byte HKR stride.
+The optional unpacked path stores one 10-bit sample in each 16-bit
+container and sends those containers unchanged using CSI RAW16.
+
+Add separate internal mbus tuples for both transports. The packed path
+keeps its private GR0P ABI. The unpacked RAW16 path uses T_R16 and exposes
+the standard V4L2 SGRBG10/BA10 surface. Prefer formats advertised by the
+active subdevice when two transport tuples share a standard FourCC.
 
 Signed-off-by: zhou <shengyong.zhou@realsenseai.com>
 ---
@@ -67,14 +70,118 @@ index 6dc16c9f..58f80bd4 100644
  	return 0;
  }
  
+diff --git a/drivers/media/platform/tegra/camera/vi/core.c b/drivers/media/platform/tegra/camera/vi/core.c
+index 4923d9b6..6ec75573 100644
+--- a/drivers/media/platform/tegra/camera/vi/core.c
++++ b/drivers/media/platform/tegra/camera/vi/core.c
+@@ -94,13 +94,19 @@ int tegra_core_get_code_by_fourcc(struct tegra_channel *chan,
+-		unsigned int fourcc, unsigned offset)
++		unsigned int fourcc, unsigned offset)
+ {
+-	unsigned int i;
+-
+-	for (i = offset; i < chan->num_video_formats; ++i) {
+-		if (chan->video_formats[i]->fourcc == fourcc)
+-			return chan->video_formats[i]->code;
+-	}
+-	spec_bar();
+-
+-	return -1;
++	unsigned int i;
++	int fallback = -1;
++
++	for (i = offset; i < chan->num_video_formats; ++i) {
++		if (chan->video_formats[i]->fourcc != fourcc)
++			continue;
++
++		if (fallback < 0)
++			fallback = chan->video_formats[i]->code;
++		if (test_bit(i, chan->fmts_bitmap))
++			return chan->video_formats[i]->code;
++	}
++	spec_bar();
++
++	return fallback;
+ }
+ EXPORT_SYMBOL(tegra_core_get_code_by_fourcc);
+@@ -154,13 +160,19 @@ const struct tegra_video_format *
+ tegra_core_get_format_by_fourcc(struct tegra_channel *chan, u32 fourcc)
+ {
+-	unsigned int i;
+-
+-	for (i = 0; i < chan->num_video_formats; ++i) {
+-		if (chan->video_formats[i]->fourcc == fourcc)
+-			return chan->video_formats[i];
+-	}
+-	spec_bar();
+-
+-	return NULL;
++	unsigned int i;
++	const struct tegra_video_format *fallback = NULL;
++
++	for (i = 0; i < chan->num_video_formats; ++i) {
++		if (chan->video_formats[i]->fourcc != fourcc)
++			continue;
++
++		if (!fallback)
++			fallback = chan->video_formats[i];
++		if (test_bit(i, chan->fmts_bitmap))
++			return chan->video_formats[i];
++	}
++	spec_bar();
++
++	return fallback;
+ }
+ EXPORT_SYMBOL(tegra_core_get_format_by_fourcc);
+diff --git a/include/media/tegra_camera_core.h b/include/media/tegra_camera_core.h
+index 43d5316b..d9e459b8 100644
+--- a/include/media/tegra_camera_core.h
++++ b/include/media/tegra_camera_core.h
+@@ -49,16 +49,17 @@ enum tegra_image_dt {
+-
+-	TEGRA_IMAGE_DT_RAW6 = 40,
+-	TEGRA_IMAGE_DT_RAW7,
+-	TEGRA_IMAGE_DT_RAW8,
+-	TEGRA_IMAGE_DT_RAW10,
+-	TEGRA_IMAGE_DT_RAW12,
+-	TEGRA_IMAGE_DT_RAW14,
+-
+-	TEGRA_IMAGE_DT_USER_1 = 48,
+-	TEGRA_IMAGE_DT_USER_2,
+-	TEGRA_IMAGE_DT_USER_3,
+-	TEGRA_IMAGE_DT_USER_4,
+-
+-};
+-
++
++	TEGRA_IMAGE_DT_RAW6 = 40,
++	TEGRA_IMAGE_DT_RAW7,
++	TEGRA_IMAGE_DT_RAW8,
++	TEGRA_IMAGE_DT_RAW10,
++	TEGRA_IMAGE_DT_RAW12,
++	TEGRA_IMAGE_DT_RAW14,
++	TEGRA_IMAGE_DT_RAW16,
++
++	TEGRA_IMAGE_DT_USER_1 = 48,
++	TEGRA_IMAGE_DT_USER_2,
++	TEGRA_IMAGE_DT_USER_3,
++	TEGRA_IMAGE_DT_USER_4,
++
++};
++
+ /* Supported CSI to VI Data Formats */
 diff --git a/drivers/media/platform/tegra/camera/vi/vi5_formats.h b/drivers/media/platform/tegra/camera/vi/vi5_formats.h
 index fb07cfd2..1cb54ba8 100644
 --- a/drivers/media/platform/tegra/camera/vi/vi5_formats.h
 +++ b/drivers/media/platform/tegra/camera/vi/vi5_formats.h
-@@ -76,6 +76,14 @@ enum tegra_image_format {
+@@ -76,6 +76,18 @@ enum tegra_image_format {
  	TEGRA_IMAGE_FORMAT_T_DPCM_RAW20,
  };
  
++#ifndef MEDIA_BUS_FMT_RS_SGRBG10_1X16
++#define MEDIA_BUS_FMT_RS_SGRBG10_1X16 0x5003
++#endif
++
 +#ifndef MEDIA_BUS_FMT_RS_SGRBG10P_1X10
 +#define MEDIA_BUS_FMT_RS_SGRBG10P_1X10 0x5002
 +#endif
@@ -86,10 +193,17 @@ index fb07cfd2..1cb54ba8 100644
  static const struct tegra_video_format vi5_video_formats[] = {
  	/* RAW 6: TODO */
  
-@@ -170,6 +178,13 @@ static const struct tegra_video_format vi5_video_formats[] = {
+@@ -170,6 +182,20 @@ static const struct tegra_video_format vi5_video_formats[] = {
  	TEGRA_VIDEO_FORMAT(RAW8, 8, UYYVYY8_0_5X24, 1, 1, T_R8,
  				RAW8, NV12, "YUV 4:2:0 NV12"),
  
++	/*
++	 * D5x unpacked GRBG10: CSI RAW16 carries one complete 16-bit
++	 * container per sample. Expose the standard V4L2 BA10 surface.
++	 */
++	TEGRA_VIDEO_FORMAT(RAW10, 10, RS_SGRBG10_1X16, 2, 1, T_R16,
++				RAW16, SGRBG10, "GRBG10 in 16-bit containers"),
++
 +	/*
 +	 * D5x FMT_SGRBG10P: 50 little-endian 10-bit pixels per 64-byte
 +	 * cache line. Receive CSI UD30 and preserve every byte in T_R8.
@@ -100,3 +214,65 @@ index fb07cfd2..1cb54ba8 100644
  };
  
  #endif
+diff --git a/include/media/camera_common.h b/include/media/camera_common.h
+--- a/include/media/camera_common.h
++++ b/include/media/camera_common.h
+@@ -164,6 +164,11 @@ struct camera_common_framesync {
+ struct tegracam_device ;
+ struct camera_common_data;
+ 
++struct tegra_frame_postprocess_ops {
++	void (*process)(struct camera_common_data *s_data, void *data,
++			size_t bytesused, u32 mbus_code);
++};
++
+ struct camera_common_sensor_ops {
+ 	u32 numfrmfmts;
+ 	const struct camera_common_frmfmt *frmfmt_table;
+@@ -258,6 +263,7 @@ struct camera_common_data {
+ 	bool	use_sensor_mode_id;
+ 	bool	override_enable;
+ 	const struct tegra_embedded_metadata_ops *embedded_metadata_ops;
++	const struct tegra_frame_postprocess_ops *frame_postprocess_ops;
+ 	u32	version;
+ };
+ 
+diff --git a/drivers/media/platform/tegra/camera/vi/channel.c b/drivers/media/platform/tegra/camera/vi/channel.c
+--- a/drivers/media/platform/tegra/camera/vi/channel.c
++++ b/drivers/media/platform/tegra/camera/vi/channel.c
+@@ -1068,10 +1068,35 @@ static void tegra_channel_stop_streaming(struct vb2_queue *vq)
+ 	queue_init_ts = 0;
+ }
+ 
++static void tegra_channel_buffer_finish(struct vb2_buffer *vb)
++{
++	struct tegra_channel *chan = vb2_get_drv_priv(vb->vb2_queue);
++	struct camera_common_data *s_data;
++	void *data;
++	size_t bytesused;
++
++	if (!chan->subdev_on_csi)
++		return;
++
++	s_data = to_camera_common_data(chan->subdev_on_csi->dev);
++	if (!s_data || !s_data->frame_postprocess_ops ||
++	    !s_data->frame_postprocess_ops->process)
++		return;
++
++	data = vb2_plane_vaddr(vb, 0);
++	bytesused = vb2_get_plane_payload(vb, 0);
++	if (!data || !bytesused)
++		return;
++
++	s_data->frame_postprocess_ops->process(s_data, data, bytesused,
++					      chan->fmtinfo->code);
++}
++
+ static const struct vb2_ops tegra_channel_queue_qops = {
+ 	.queue_setup = tegra_channel_queue_setup,
+ 	.buf_prepare = tegra_channel_buffer_prepare,
+ 	.buf_queue = tegra_channel_buffer_queue,
++	.buf_finish = tegra_channel_buffer_finish,
+ 	.wait_prepare = vb2_ops_wait_prepare,
+ 	.wait_finish = vb2_ops_wait_finish,
+ 	.start_streaming = tegra_channel_start_streaming,

--- a/nvidia-oot/6.1/0015-Add-D5x-GRBG10P-byte-surface.patch
+++ b/nvidia-oot/6.1/0015-Add-D5x-GRBG10P-byte-surface.patch
@@ -1,0 +1,102 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: zhou <shengyong.zhou@realsenseai.com>
+Date: Fri, 24 Jul 2026 19:30:00 +0800
+Subject: [PATCH] media: tegra: receive D5x GRBG10P over UD30
+
+D5x RGB ISYS stores FMT_SGRBG10P as 50 little-endian 10-bit pixels
+in each 64-byte cache line. HIF MIPI preserves the complete aligned
+row in a CSI User Defined 1 packet so the receiver treats the payload
+as an opaque byte stream.
+
+Add a private mbus/fourcc tuple for this product surface. VI matches
+wire DT 0x30, maps the User Defined byte stream to RAW8/T_R8, and writes
+the payload unchanged. The visible V4L2 geometry remains 1600x1300 while
+bytesperline and capture frame_x use the 2048-byte HKR stride.
+
+Signed-off-by: zhou <shengyong.zhou@realsenseai.com>
+---
+diff --git a/drivers/media/platform/tegra/camera/vi/vi5_fops.c b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
+index 079b5865..fa0acd21 100644
+--- a/drivers/media/platform/tegra/camera/vi/vi5_fops.c
++++ b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
+@@ -394,6 +394,8 @@ static void vi5_setup_surface(struct tegra_channel *chan,
+ 	u32 bpl = chan->format.bytesperline;
+ 	u32 data_type = chan->fmtinfo->img_dt;
+ 	bool flat_nv12 = chan->fmtinfo->fourcc == V4L2_PIX_FMT_NV12;
++	bool d5x_sgrbg10p =
++		chan->fmtinfo->fourcc == V4L2_PIX_FMT_RS_SGRBG10P;
+ 	u32 nvcsi_stream = chan->port[vi_port];
+ 	struct capture_descriptor_memoryinfo *desc_memoryinfo =
+ 		&chan->tegra_vi_channel[vi_port]->
+@@ -409,6 +411,9 @@ static void vi5_setup_surface(struct tegra_channel *chan,
+ 	/* D5xx carries flat NV12 bytes as W x (H * 3 / 2) RAW8 rows. */
+ 	if (flat_nv12)
+ 		height = height * 3 / 2;
++	else if (d5x_sgrbg10p)
++		/* RAW8 parser width is the byte-identical HKR DDR stride. */
++		width = bpl;
+ 
+ 	memcpy(desc, &capture_template, sizeof(capture_template));
+ 	memset(desc_memoryinfo, 0, sizeof(*desc_memoryinfo));
+@@ -421,6 +426,14 @@ static void vi5_setup_surface(struct tegra_channel *chan,
+ 	desc->ch_cfg.frame.frame_y = height;
+ 	desc->ch_cfg.match.datatype = data_type;
+ 	desc->ch_cfg.match.datatype_mask = 0x3f;
++	if (d5x_sgrbg10p) {
++		/*
++		 * UD30 is an opaque byte stream. Map it to RAW8 only inside VI
++		 * so each packet payload byte reaches the V4L2 surface unchanged.
++		 */
++		desc->ch_cfg.dt_enable = 1;
++		desc->ch_cfg.dt_override = TEGRA_IMAGE_DT_RAW8;
++	}
+ 	desc->ch_cfg.pixfmt_enable = 1;
+ 	desc->ch_cfg.pixfmt.format = format;
+ 
+diff --git a/drivers/media/platform/tegra/camera/vi/channel.c b/drivers/media/platform/tegra/camera/vi/channel.c
+index 6dc16c9f..58f80bd4 100644
+--- a/drivers/media/platform/tegra/camera/vi/channel.c
++++ b/drivers/media/platform/tegra/camera/vi/channel.c
+@@ -1156,6 +1156,9 @@ tegra_channel_enum_format(struct file *file, void *fh, struct v4l2_fmtdesc *f)
+ 	index -= 1;
+ 	f->pixelformat = tegra_core_get_fourcc_by_idx(chan, index);
+ 
++	if (f->pixelformat == v4l2_fourcc('G', 'R', '0', 'P'))
++		strscpy(f->description, "RealSense GRBG10P CL64", sizeof(f->description));
++
+ 	return 0;
+ }
+ 
+diff --git a/drivers/media/platform/tegra/camera/vi/vi5_formats.h b/drivers/media/platform/tegra/camera/vi/vi5_formats.h
+index fb07cfd2..1cb54ba8 100644
+--- a/drivers/media/platform/tegra/camera/vi/vi5_formats.h
++++ b/drivers/media/platform/tegra/camera/vi/vi5_formats.h
+@@ -76,6 +76,14 @@ enum tegra_image_format {
+ 	TEGRA_IMAGE_FORMAT_T_DPCM_RAW20,
+ };
+ 
++#ifndef MEDIA_BUS_FMT_RS_SGRBG10P_1X10
++#define MEDIA_BUS_FMT_RS_SGRBG10P_1X10 0x5002
++#endif
++
++#ifndef V4L2_PIX_FMT_RS_SGRBG10P
++#define V4L2_PIX_FMT_RS_SGRBG10P v4l2_fourcc('G', 'R', '0', 'P')
++#endif
++
+ static const struct tegra_video_format vi5_video_formats[] = {
+ 	/* RAW 6: TODO */
+ 
+@@ -170,6 +178,13 @@ static const struct tegra_video_format vi5_video_formats[] = {
+ 	TEGRA_VIDEO_FORMAT(RAW8, 8, UYYVYY8_0_5X24, 1, 1, T_R8,
+ 				RAW8, NV12, "YUV 4:2:0 NV12"),
+ 
++	/*
++	 * D5x FMT_SGRBG10P: 50 little-endian 10-bit pixels per 64-byte
++	 * cache line. Receive CSI UD30 and preserve every byte in T_R8.
++	 */
++	TEGRA_VIDEO_FORMAT(RAW10, 10, RS_SGRBG10P_1X10, 32, 25, T_R8,
++				USER_1, RS_SGRBG10P, "RealSense GRBG10P CL64"),
++
+ };
+ 
+ #endif

--- a/nvidia-oot/6.1/0015-Add-D5x-GRBG10P-byte-surface.patch
+++ b/nvidia-oot/6.1/0015-Add-D5x-GRBG10P-byte-surface.patch
@@ -13,8 +13,10 @@ container and sends those containers unchanged using CSI RAW16.
 
 Add separate internal mbus tuples for both transports. The packed path
 keeps its private GR0P ABI. The unpacked RAW16 path uses T_R16 and exposes
-the standard V4L2 SGRBG10/BA10 surface. Prefer formats advertised by the
-active subdevice when two transport tuples share a standard FourCC.
+the standard V4L2 SGRBG10/BA10 surface or, through a D5x frame-finish
+callback, the associated standard packed SGRBG10P/pgAA surface. Prefer
+formats advertised by the active subdevice when transport tuples share
+a standard FourCC.
 
 Signed-off-by: zhou <shengyong.zhou@realsenseai.com>
 ---
@@ -174,12 +176,16 @@ diff --git a/drivers/media/platform/tegra/camera/vi/vi5_formats.h b/drivers/medi
 index fb07cfd2..1cb54ba8 100644
 --- a/drivers/media/platform/tegra/camera/vi/vi5_formats.h
 +++ b/drivers/media/platform/tegra/camera/vi/vi5_formats.h
-@@ -76,6 +76,18 @@ enum tegra_image_format {
+@@ -76,6 +76,26 @@ enum tegra_image_format {
  	TEGRA_IMAGE_FORMAT_T_DPCM_RAW20,
  };
  
 +#ifndef MEDIA_BUS_FMT_RS_SGRBG10_1X16
 +#define MEDIA_BUS_FMT_RS_SGRBG10_1X16 0x5003
++#endif
++
++#ifndef MEDIA_BUS_FMT_RS_SGRBG10P_RAW16_1X16
++#define MEDIA_BUS_FMT_RS_SGRBG10P_RAW16_1X16 0x5004
 +#endif
 +
 +#ifndef MEDIA_BUS_FMT_RS_SGRBG10P_1X10
@@ -190,10 +196,14 @@ index fb07cfd2..1cb54ba8 100644
 +#define V4L2_PIX_FMT_RS_SGRBG10P v4l2_fourcc('G', 'R', '0', 'P')
 +#endif
 +
++#ifndef V4L2_PIX_FMT_SGRBG10P
++#define V4L2_PIX_FMT_SGRBG10P v4l2_fourcc('p', 'g', 'A', 'A')
++#endif
++
  static const struct tegra_video_format vi5_video_formats[] = {
  	/* RAW 6: TODO */
  
-@@ -170,6 +182,20 @@ static const struct tegra_video_format vi5_video_formats[] = {
+@@ -170,6 +190,27 @@ static const struct tegra_video_format vi5_video_formats[] = {
  	TEGRA_VIDEO_FORMAT(RAW8, 8, UYYVYY8_0_5X24, 1, 1, T_R8,
  				RAW8, NV12, "YUV 4:2:0 NV12"),
  
@@ -203,6 +213,13 @@ index fb07cfd2..1cb54ba8 100644
 +	 */
 +	TEGRA_VIDEO_FORMAT(RAW10, 10, RS_SGRBG10_1X16, 2, 1, T_R16,
 +				RAW16, SGRBG10, "GRBG10 in 16-bit containers"),
++
++	/*
++	 * Associated Host-output option for the same D5x RAW16/T_R16
++	 * transport. The D5x frame-finish callback packs each row to pgAA.
++	 */
++	TEGRA_VIDEO_FORMAT(RAW10, 10, RS_SGRBG10P_RAW16_1X16, 2, 1, T_R16,
++				RAW16, SGRBG10P, "Packed GRBG10 from RAW16"),
 +
 +	/*
 +	 * D5x FMT_SGRBG10P: 50 little-endian 10-bit pixels per 64-byte

--- a/nvidia-oot/6.1/0015-Add-D5x-GRBG10P-byte-surface.patch
+++ b/nvidia-oot/6.1/0015-Add-D5x-GRBG10P-byte-surface.patch
@@ -239,8 +239,8 @@ diff --git a/include/media/camera_common.h b/include/media/camera_common.h
  struct camera_common_data;
  
 +struct tegra_frame_postprocess_ops {
-+	void (*process)(struct camera_common_data *s_data, void *data,
-+			size_t bytesused, u32 mbus_code);
++	int (*process)(struct camera_common_data *s_data, void *data,
++		       size_t bytesused, u32 mbus_code);
 +};
 +
  struct camera_common_sensor_ops {
@@ -257,7 +257,7 @@ diff --git a/include/media/camera_common.h b/include/media/camera_common.h
 diff --git a/drivers/media/platform/tegra/camera/vi/channel.c b/drivers/media/platform/tegra/camera/vi/channel.c
 --- a/drivers/media/platform/tegra/camera/vi/channel.c
 +++ b/drivers/media/platform/tegra/camera/vi/channel.c
-@@ -1068,10 +1068,35 @@ static void tegra_channel_stop_streaming(struct vb2_queue *vq)
+@@ -1068,10 +1068,33 @@ static void tegra_channel_stop_streaming(struct vb2_queue *vq)
  	queue_init_ts = 0;
  }
  
@@ -276,13 +276,11 @@ diff --git a/drivers/media/platform/tegra/camera/vi/channel.c b/drivers/media/pl
 +	    !s_data->frame_postprocess_ops->process)
 +		return;
 +
-+	data = vb2_plane_vaddr(vb, 0);
 +	bytesused = vb2_get_plane_payload(vb, 0);
-+	if (!data || !bytesused)
-+		return;
-+
-+	s_data->frame_postprocess_ops->process(s_data, data, bytesused,
-+					      chan->fmtinfo->code);
++	data = vb2_plane_vaddr(vb, 0);
++	if (s_data->frame_postprocess_ops->process(s_data, data, bytesused,
++						  chan->fmtinfo->code))
++		to_vb2_v4l2_buffer(vb)->flags |= V4L2_BUF_FLAG_ERROR;
 +}
 +
  static const struct vb2_ops tegra_channel_queue_qops = {

--- a/nvidia-oot/6.2/0015-Add-D5x-GRBG10P-byte-surface.patch
+++ b/nvidia-oot/6.2/0015-Add-D5x-GRBG10P-byte-surface.patch
@@ -1,17 +1,20 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: zhou <shengyong.zhou@realsenseai.com>
 Date: Fri, 24 Jul 2026 19:30:00 +0800
-Subject: [PATCH] media: tegra: receive D5x GRBG10P over UD30
+Subject: [PATCH] media: tegra: receive D5x RGB Bayer surfaces
 
 D5x RGB ISYS stores FMT_SGRBG10P as 50 little-endian 10-bit pixels
 in each 64-byte cache line. HIF MIPI preserves the complete aligned
 row in a CSI User Defined 1 packet so the receiver treats the payload
 as an opaque byte stream.
 
-Add a private mbus/fourcc tuple for this product surface. VI matches
-wire DT 0x30, maps the User Defined byte stream to RAW8/T_R8, and writes
-the payload unchanged. The visible V4L2 geometry remains 1600x1300 while
-bytesperline and capture frame_x use the 2048-byte HKR stride.
+The optional unpacked path stores one 10-bit sample in each 16-bit
+container and sends those containers unchanged using CSI RAW16.
+
+Add separate internal mbus tuples for both transports. The packed path
+keeps its private GR0P ABI. The unpacked RAW16 path uses T_R16 and exposes
+the standard V4L2 SGRBG10/BA10 surface. Prefer formats advertised by the
+active subdevice when two transport tuples share a standard FourCC.
 
 Signed-off-by: zhou <shengyong.zhou@realsenseai.com>
 ---
@@ -67,14 +70,118 @@ index 6dc16c9f..58f80bd4 100644
  	return 0;
  }
  
+diff --git a/drivers/media/platform/tegra/camera/vi/core.c b/drivers/media/platform/tegra/camera/vi/core.c
+index 4923d9b6..6ec75573 100644
+--- a/drivers/media/platform/tegra/camera/vi/core.c
++++ b/drivers/media/platform/tegra/camera/vi/core.c
+@@ -94,13 +94,19 @@ int tegra_core_get_code_by_fourcc(struct tegra_channel *chan,
+-		unsigned int fourcc, unsigned offset)
++		unsigned int fourcc, unsigned offset)
+ {
+-	unsigned int i;
+-
+-	for (i = offset; i < chan->num_video_formats; ++i) {
+-		if (chan->video_formats[i]->fourcc == fourcc)
+-			return chan->video_formats[i]->code;
+-	}
+-	spec_bar();
+-
+-	return -1;
++	unsigned int i;
++	int fallback = -1;
++
++	for (i = offset; i < chan->num_video_formats; ++i) {
++		if (chan->video_formats[i]->fourcc != fourcc)
++			continue;
++
++		if (fallback < 0)
++			fallback = chan->video_formats[i]->code;
++		if (test_bit(i, chan->fmts_bitmap))
++			return chan->video_formats[i]->code;
++	}
++	spec_bar();
++
++	return fallback;
+ }
+ EXPORT_SYMBOL(tegra_core_get_code_by_fourcc);
+@@ -154,13 +160,19 @@ const struct tegra_video_format *
+ tegra_core_get_format_by_fourcc(struct tegra_channel *chan, u32 fourcc)
+ {
+-	unsigned int i;
+-
+-	for (i = 0; i < chan->num_video_formats; ++i) {
+-		if (chan->video_formats[i]->fourcc == fourcc)
+-			return chan->video_formats[i];
+-	}
+-	spec_bar();
+-
+-	return NULL;
++	unsigned int i;
++	const struct tegra_video_format *fallback = NULL;
++
++	for (i = 0; i < chan->num_video_formats; ++i) {
++		if (chan->video_formats[i]->fourcc != fourcc)
++			continue;
++
++		if (!fallback)
++			fallback = chan->video_formats[i];
++		if (test_bit(i, chan->fmts_bitmap))
++			return chan->video_formats[i];
++	}
++	spec_bar();
++
++	return fallback;
+ }
+ EXPORT_SYMBOL(tegra_core_get_format_by_fourcc);
+diff --git a/include/media/tegra_camera_core.h b/include/media/tegra_camera_core.h
+index 43d5316b..d9e459b8 100644
+--- a/include/media/tegra_camera_core.h
++++ b/include/media/tegra_camera_core.h
+@@ -49,16 +49,17 @@ enum tegra_image_dt {
+-
+-	TEGRA_IMAGE_DT_RAW6 = 40,
+-	TEGRA_IMAGE_DT_RAW7,
+-	TEGRA_IMAGE_DT_RAW8,
+-	TEGRA_IMAGE_DT_RAW10,
+-	TEGRA_IMAGE_DT_RAW12,
+-	TEGRA_IMAGE_DT_RAW14,
+-
+-	TEGRA_IMAGE_DT_USER_1 = 48,
+-	TEGRA_IMAGE_DT_USER_2,
+-	TEGRA_IMAGE_DT_USER_3,
+-	TEGRA_IMAGE_DT_USER_4,
+-
+-};
+-
++
++	TEGRA_IMAGE_DT_RAW6 = 40,
++	TEGRA_IMAGE_DT_RAW7,
++	TEGRA_IMAGE_DT_RAW8,
++	TEGRA_IMAGE_DT_RAW10,
++	TEGRA_IMAGE_DT_RAW12,
++	TEGRA_IMAGE_DT_RAW14,
++	TEGRA_IMAGE_DT_RAW16,
++
++	TEGRA_IMAGE_DT_USER_1 = 48,
++	TEGRA_IMAGE_DT_USER_2,
++	TEGRA_IMAGE_DT_USER_3,
++	TEGRA_IMAGE_DT_USER_4,
++
++};
++
+ /* Supported CSI to VI Data Formats */
 diff --git a/drivers/media/platform/tegra/camera/vi/vi5_formats.h b/drivers/media/platform/tegra/camera/vi/vi5_formats.h
 index fb07cfd2..1cb54ba8 100644
 --- a/drivers/media/platform/tegra/camera/vi/vi5_formats.h
 +++ b/drivers/media/platform/tegra/camera/vi/vi5_formats.h
-@@ -76,6 +76,14 @@ enum tegra_image_format {
+@@ -76,6 +76,18 @@ enum tegra_image_format {
  	TEGRA_IMAGE_FORMAT_T_DPCM_RAW20,
  };
  
++#ifndef MEDIA_BUS_FMT_RS_SGRBG10_1X16
++#define MEDIA_BUS_FMT_RS_SGRBG10_1X16 0x5003
++#endif
++
 +#ifndef MEDIA_BUS_FMT_RS_SGRBG10P_1X10
 +#define MEDIA_BUS_FMT_RS_SGRBG10P_1X10 0x5002
 +#endif
@@ -86,10 +193,17 @@ index fb07cfd2..1cb54ba8 100644
  static const struct tegra_video_format vi5_video_formats[] = {
  	/* RAW 6: TODO */
  
-@@ -170,6 +178,13 @@ static const struct tegra_video_format vi5_video_formats[] = {
+@@ -170,6 +182,20 @@ static const struct tegra_video_format vi5_video_formats[] = {
  	TEGRA_VIDEO_FORMAT(RAW8, 8, UYYVYY8_0_5X24, 1, 1, T_R8,
  				RAW8, NV12, "YUV 4:2:0 NV12"),
  
++	/*
++	 * D5x unpacked GRBG10: CSI RAW16 carries one complete 16-bit
++	 * container per sample. Expose the standard V4L2 BA10 surface.
++	 */
++	TEGRA_VIDEO_FORMAT(RAW10, 10, RS_SGRBG10_1X16, 2, 1, T_R16,
++				RAW16, SGRBG10, "GRBG10 in 16-bit containers"),
++
 +	/*
 +	 * D5x FMT_SGRBG10P: 50 little-endian 10-bit pixels per 64-byte
 +	 * cache line. Receive CSI UD30 and preserve every byte in T_R8.
@@ -100,3 +214,65 @@ index fb07cfd2..1cb54ba8 100644
  };
  
  #endif
+diff --git a/include/media/camera_common.h b/include/media/camera_common.h
+--- a/include/media/camera_common.h
++++ b/include/media/camera_common.h
+@@ -164,6 +164,11 @@ struct camera_common_framesync {
+ struct tegracam_device ;
+ struct camera_common_data;
+ 
++struct tegra_frame_postprocess_ops {
++	void (*process)(struct camera_common_data *s_data, void *data,
++			size_t bytesused, u32 mbus_code);
++};
++
+ struct camera_common_sensor_ops {
+ 	u32 numfrmfmts;
+ 	const struct camera_common_frmfmt *frmfmt_table;
+@@ -258,6 +263,7 @@ struct camera_common_data {
+ 	bool	use_sensor_mode_id;
+ 	bool	override_enable;
+ 	const struct tegra_embedded_metadata_ops *embedded_metadata_ops;
++	const struct tegra_frame_postprocess_ops *frame_postprocess_ops;
+ 	u32	version;
+ };
+ 
+diff --git a/drivers/media/platform/tegra/camera/vi/channel.c b/drivers/media/platform/tegra/camera/vi/channel.c
+--- a/drivers/media/platform/tegra/camera/vi/channel.c
++++ b/drivers/media/platform/tegra/camera/vi/channel.c
+@@ -1068,10 +1068,35 @@ static void tegra_channel_stop_streaming(struct vb2_queue *vq)
+ 	queue_init_ts = 0;
+ }
+ 
++static void tegra_channel_buffer_finish(struct vb2_buffer *vb)
++{
++	struct tegra_channel *chan = vb2_get_drv_priv(vb->vb2_queue);
++	struct camera_common_data *s_data;
++	void *data;
++	size_t bytesused;
++
++	if (!chan->subdev_on_csi)
++		return;
++
++	s_data = to_camera_common_data(chan->subdev_on_csi->dev);
++	if (!s_data || !s_data->frame_postprocess_ops ||
++	    !s_data->frame_postprocess_ops->process)
++		return;
++
++	data = vb2_plane_vaddr(vb, 0);
++	bytesused = vb2_get_plane_payload(vb, 0);
++	if (!data || !bytesused)
++		return;
++
++	s_data->frame_postprocess_ops->process(s_data, data, bytesused,
++					      chan->fmtinfo->code);
++}
++
+ static const struct vb2_ops tegra_channel_queue_qops = {
+ 	.queue_setup = tegra_channel_queue_setup,
+ 	.buf_prepare = tegra_channel_buffer_prepare,
+ 	.buf_queue = tegra_channel_buffer_queue,
++	.buf_finish = tegra_channel_buffer_finish,
+ 	.wait_prepare = vb2_ops_wait_prepare,
+ 	.wait_finish = vb2_ops_wait_finish,
+ 	.start_streaming = tegra_channel_start_streaming,

--- a/nvidia-oot/6.2/0015-Add-D5x-GRBG10P-byte-surface.patch
+++ b/nvidia-oot/6.2/0015-Add-D5x-GRBG10P-byte-surface.patch
@@ -1,0 +1,102 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: zhou <shengyong.zhou@realsenseai.com>
+Date: Fri, 24 Jul 2026 19:30:00 +0800
+Subject: [PATCH] media: tegra: receive D5x GRBG10P over UD30
+
+D5x RGB ISYS stores FMT_SGRBG10P as 50 little-endian 10-bit pixels
+in each 64-byte cache line. HIF MIPI preserves the complete aligned
+row in a CSI User Defined 1 packet so the receiver treats the payload
+as an opaque byte stream.
+
+Add a private mbus/fourcc tuple for this product surface. VI matches
+wire DT 0x30, maps the User Defined byte stream to RAW8/T_R8, and writes
+the payload unchanged. The visible V4L2 geometry remains 1600x1300 while
+bytesperline and capture frame_x use the 2048-byte HKR stride.
+
+Signed-off-by: zhou <shengyong.zhou@realsenseai.com>
+---
+diff --git a/drivers/media/platform/tegra/camera/vi/vi5_fops.c b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
+index 079b5865..fa0acd21 100644
+--- a/drivers/media/platform/tegra/camera/vi/vi5_fops.c
++++ b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
+@@ -394,6 +394,8 @@ static void vi5_setup_surface(struct tegra_channel *chan,
+ 	u32 bpl = chan->format.bytesperline;
+ 	u32 data_type = chan->fmtinfo->img_dt;
+ 	bool flat_nv12 = chan->fmtinfo->fourcc == V4L2_PIX_FMT_NV12;
++	bool d5x_sgrbg10p =
++		chan->fmtinfo->fourcc == V4L2_PIX_FMT_RS_SGRBG10P;
+ 	u32 nvcsi_stream = chan->port[vi_port];
+ 	struct capture_descriptor_memoryinfo *desc_memoryinfo =
+ 		&chan->tegra_vi_channel[vi_port]->
+@@ -409,6 +411,9 @@ static void vi5_setup_surface(struct tegra_channel *chan,
+ 	/* D5xx carries flat NV12 bytes as W x (H * 3 / 2) RAW8 rows. */
+ 	if (flat_nv12)
+ 		height = height * 3 / 2;
++	else if (d5x_sgrbg10p)
++		/* RAW8 parser width is the byte-identical HKR DDR stride. */
++		width = bpl;
+ 
+ 	memcpy(desc, &capture_template, sizeof(capture_template));
+ 	memset(desc_memoryinfo, 0, sizeof(*desc_memoryinfo));
+@@ -421,6 +426,14 @@ static void vi5_setup_surface(struct tegra_channel *chan,
+ 	desc->ch_cfg.frame.frame_y = height;
+ 	desc->ch_cfg.match.datatype = data_type;
+ 	desc->ch_cfg.match.datatype_mask = 0x3f;
++	if (d5x_sgrbg10p) {
++		/*
++		 * UD30 is an opaque byte stream. Map it to RAW8 only inside VI
++		 * so each packet payload byte reaches the V4L2 surface unchanged.
++		 */
++		desc->ch_cfg.dt_enable = 1;
++		desc->ch_cfg.dt_override = TEGRA_IMAGE_DT_RAW8;
++	}
+ 	desc->ch_cfg.pixfmt_enable = 1;
+ 	desc->ch_cfg.pixfmt.format = format;
+ 
+diff --git a/drivers/media/platform/tegra/camera/vi/channel.c b/drivers/media/platform/tegra/camera/vi/channel.c
+index 6dc16c9f..58f80bd4 100644
+--- a/drivers/media/platform/tegra/camera/vi/channel.c
++++ b/drivers/media/platform/tegra/camera/vi/channel.c
+@@ -1156,6 +1156,9 @@ tegra_channel_enum_format(struct file *file, void *fh, struct v4l2_fmtdesc *f)
+ 	index -= 1;
+ 	f->pixelformat = tegra_core_get_fourcc_by_idx(chan, index);
+ 
++	if (f->pixelformat == v4l2_fourcc('G', 'R', '0', 'P'))
++		strscpy(f->description, "RealSense GRBG10P CL64", sizeof(f->description));
++
+ 	return 0;
+ }
+ 
+diff --git a/drivers/media/platform/tegra/camera/vi/vi5_formats.h b/drivers/media/platform/tegra/camera/vi/vi5_formats.h
+index fb07cfd2..1cb54ba8 100644
+--- a/drivers/media/platform/tegra/camera/vi/vi5_formats.h
++++ b/drivers/media/platform/tegra/camera/vi/vi5_formats.h
+@@ -76,6 +76,14 @@ enum tegra_image_format {
+ 	TEGRA_IMAGE_FORMAT_T_DPCM_RAW20,
+ };
+ 
++#ifndef MEDIA_BUS_FMT_RS_SGRBG10P_1X10
++#define MEDIA_BUS_FMT_RS_SGRBG10P_1X10 0x5002
++#endif
++
++#ifndef V4L2_PIX_FMT_RS_SGRBG10P
++#define V4L2_PIX_FMT_RS_SGRBG10P v4l2_fourcc('G', 'R', '0', 'P')
++#endif
++
+ static const struct tegra_video_format vi5_video_formats[] = {
+ 	/* RAW 6: TODO */
+ 
+@@ -170,6 +178,13 @@ static const struct tegra_video_format vi5_video_formats[] = {
+ 	TEGRA_VIDEO_FORMAT(RAW8, 8, UYYVYY8_0_5X24, 1, 1, T_R8,
+ 				RAW8, NV12, "YUV 4:2:0 NV12"),
+ 
++	/*
++	 * D5x FMT_SGRBG10P: 50 little-endian 10-bit pixels per 64-byte
++	 * cache line. Receive CSI UD30 and preserve every byte in T_R8.
++	 */
++	TEGRA_VIDEO_FORMAT(RAW10, 10, RS_SGRBG10P_1X10, 32, 25, T_R8,
++				USER_1, RS_SGRBG10P, "RealSense GRBG10P CL64"),
++
+ };
+ 
+ #endif

--- a/nvidia-oot/6.2/0015-Add-D5x-GRBG10P-byte-surface.patch
+++ b/nvidia-oot/6.2/0015-Add-D5x-GRBG10P-byte-surface.patch
@@ -13,8 +13,10 @@ container and sends those containers unchanged using CSI RAW16.
 
 Add separate internal mbus tuples for both transports. The packed path
 keeps its private GR0P ABI. The unpacked RAW16 path uses T_R16 and exposes
-the standard V4L2 SGRBG10/BA10 surface. Prefer formats advertised by the
-active subdevice when two transport tuples share a standard FourCC.
+the standard V4L2 SGRBG10/BA10 surface or, through a D5x frame-finish
+callback, the associated standard packed SGRBG10P/pgAA surface. Prefer
+formats advertised by the active subdevice when transport tuples share
+a standard FourCC.
 
 Signed-off-by: zhou <shengyong.zhou@realsenseai.com>
 ---
@@ -174,12 +176,16 @@ diff --git a/drivers/media/platform/tegra/camera/vi/vi5_formats.h b/drivers/medi
 index fb07cfd2..1cb54ba8 100644
 --- a/drivers/media/platform/tegra/camera/vi/vi5_formats.h
 +++ b/drivers/media/platform/tegra/camera/vi/vi5_formats.h
-@@ -76,6 +76,18 @@ enum tegra_image_format {
+@@ -76,6 +76,26 @@ enum tegra_image_format {
  	TEGRA_IMAGE_FORMAT_T_DPCM_RAW20,
  };
  
 +#ifndef MEDIA_BUS_FMT_RS_SGRBG10_1X16
 +#define MEDIA_BUS_FMT_RS_SGRBG10_1X16 0x5003
++#endif
++
++#ifndef MEDIA_BUS_FMT_RS_SGRBG10P_RAW16_1X16
++#define MEDIA_BUS_FMT_RS_SGRBG10P_RAW16_1X16 0x5004
 +#endif
 +
 +#ifndef MEDIA_BUS_FMT_RS_SGRBG10P_1X10
@@ -190,10 +196,14 @@ index fb07cfd2..1cb54ba8 100644
 +#define V4L2_PIX_FMT_RS_SGRBG10P v4l2_fourcc('G', 'R', '0', 'P')
 +#endif
 +
++#ifndef V4L2_PIX_FMT_SGRBG10P
++#define V4L2_PIX_FMT_SGRBG10P v4l2_fourcc('p', 'g', 'A', 'A')
++#endif
++
  static const struct tegra_video_format vi5_video_formats[] = {
  	/* RAW 6: TODO */
  
-@@ -170,6 +182,20 @@ static const struct tegra_video_format vi5_video_formats[] = {
+@@ -170,6 +190,27 @@ static const struct tegra_video_format vi5_video_formats[] = {
  	TEGRA_VIDEO_FORMAT(RAW8, 8, UYYVYY8_0_5X24, 1, 1, T_R8,
  				RAW8, NV12, "YUV 4:2:0 NV12"),
  
@@ -203,6 +213,13 @@ index fb07cfd2..1cb54ba8 100644
 +	 */
 +	TEGRA_VIDEO_FORMAT(RAW10, 10, RS_SGRBG10_1X16, 2, 1, T_R16,
 +				RAW16, SGRBG10, "GRBG10 in 16-bit containers"),
++
++	/*
++	 * Associated Host-output option for the same D5x RAW16/T_R16
++	 * transport. The D5x frame-finish callback packs each row to pgAA.
++	 */
++	TEGRA_VIDEO_FORMAT(RAW10, 10, RS_SGRBG10P_RAW16_1X16, 2, 1, T_R16,
++				RAW16, SGRBG10P, "Packed GRBG10 from RAW16"),
 +
 +	/*
 +	 * D5x FMT_SGRBG10P: 50 little-endian 10-bit pixels per 64-byte

--- a/nvidia-oot/6.2/0015-Add-D5x-GRBG10P-byte-surface.patch
+++ b/nvidia-oot/6.2/0015-Add-D5x-GRBG10P-byte-surface.patch
@@ -239,8 +239,8 @@ diff --git a/include/media/camera_common.h b/include/media/camera_common.h
  struct camera_common_data;
  
 +struct tegra_frame_postprocess_ops {
-+	void (*process)(struct camera_common_data *s_data, void *data,
-+			size_t bytesused, u32 mbus_code);
++	int (*process)(struct camera_common_data *s_data, void *data,
++		       size_t bytesused, u32 mbus_code);
 +};
 +
  struct camera_common_sensor_ops {
@@ -257,7 +257,7 @@ diff --git a/include/media/camera_common.h b/include/media/camera_common.h
 diff --git a/drivers/media/platform/tegra/camera/vi/channel.c b/drivers/media/platform/tegra/camera/vi/channel.c
 --- a/drivers/media/platform/tegra/camera/vi/channel.c
 +++ b/drivers/media/platform/tegra/camera/vi/channel.c
-@@ -1068,10 +1068,35 @@ static void tegra_channel_stop_streaming(struct vb2_queue *vq)
+@@ -1068,10 +1068,33 @@ static void tegra_channel_stop_streaming(struct vb2_queue *vq)
  	queue_init_ts = 0;
  }
  
@@ -276,13 +276,11 @@ diff --git a/drivers/media/platform/tegra/camera/vi/channel.c b/drivers/media/pl
 +	    !s_data->frame_postprocess_ops->process)
 +		return;
 +
-+	data = vb2_plane_vaddr(vb, 0);
 +	bytesused = vb2_get_plane_payload(vb, 0);
-+	if (!data || !bytesused)
-+		return;
-+
-+	s_data->frame_postprocess_ops->process(s_data, data, bytesused,
-+					      chan->fmtinfo->code);
++	data = vb2_plane_vaddr(vb, 0);
++	if (s_data->frame_postprocess_ops->process(s_data, data, bytesused,
++						  chan->fmtinfo->code))
++		to_vb2_v4l2_buffer(vb)->flags |= V4L2_BUF_FLAG_ERROR;
 +}
 +
  static const struct vb2_ops tegra_channel_queue_qops = {

--- a/nvidia-oot/7.0/0015-Add-D5x-GRBG10P-byte-surface.patch
+++ b/nvidia-oot/7.0/0015-Add-D5x-GRBG10P-byte-surface.patch
@@ -1,0 +1,102 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: zhou <shengyong.zhou@realsenseai.com>
+Date: Fri, 24 Jul 2026 19:30:00 +0800
+Subject: [PATCH] media: tegra: receive D5x GRBG10P over UD30
+
+D5x RGB ISYS stores FMT_SGRBG10P as 50 little-endian 10-bit pixels
+in each 64-byte cache line. HIF MIPI preserves the complete aligned
+row in a CSI User Defined 1 packet so the receiver treats the payload
+as an opaque byte stream.
+
+Add a private mbus/fourcc tuple for this product surface. VI matches
+wire DT 0x30, maps the User Defined byte stream to RAW8/T_R8, and writes
+the payload unchanged. The visible V4L2 geometry remains 1600x1300 while
+bytesperline and capture frame_x use the 2048-byte HKR stride.
+
+Signed-off-by: zhou <shengyong.zhou@realsenseai.com>
+---
+diff --git a/drivers/media/platform/tegra/camera/vi/vi5_fops.c b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
+index 079b5865..fa0acd21 100644
+--- a/drivers/media/platform/tegra/camera/vi/vi5_fops.c
++++ b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
+@@ -394,6 +394,8 @@ static void vi5_setup_surface(struct tegra_channel *chan,
+ 	u32 bpl = chan->format.bytesperline;
+ 	u32 data_type = chan->fmtinfo->img_dt;
+ 	bool flat_nv12 = chan->fmtinfo->fourcc == V4L2_PIX_FMT_NV12;
++	bool d5x_sgrbg10p =
++		chan->fmtinfo->fourcc == V4L2_PIX_FMT_RS_SGRBG10P;
+ 	u32 nvcsi_stream = chan->port[vi_port];
+ 	struct capture_descriptor_memoryinfo *desc_memoryinfo =
+ 		&chan->tegra_vi_channel[vi_port]->
+@@ -409,6 +411,9 @@ static void vi5_setup_surface(struct tegra_channel *chan,
+ 	/* D5xx carries flat NV12 bytes as W x (H * 3 / 2) RAW8 rows. */
+ 	if (flat_nv12)
+ 		height = height * 3 / 2;
++	else if (d5x_sgrbg10p)
++		/* RAW8 parser width is the byte-identical HKR DDR stride. */
++		width = bpl;
+ 
+ 	memcpy(desc, &capture_template, sizeof(capture_template));
+ 	memset(desc_memoryinfo, 0, sizeof(*desc_memoryinfo));
+@@ -421,6 +426,14 @@ static void vi5_setup_surface(struct tegra_channel *chan,
+ 	desc->ch_cfg.frame.frame_y = height;
+ 	desc->ch_cfg.match.datatype = data_type;
+ 	desc->ch_cfg.match.datatype_mask = 0x3f;
++	if (d5x_sgrbg10p) {
++		/*
++		 * UD30 is an opaque byte stream. Map it to RAW8 only inside VI
++		 * so each packet payload byte reaches the V4L2 surface unchanged.
++		 */
++		desc->ch_cfg.dt_enable = 1;
++		desc->ch_cfg.dt_override = TEGRA_IMAGE_DT_RAW8;
++	}
+ 	desc->ch_cfg.pixfmt_enable = 1;
+ 	desc->ch_cfg.pixfmt.format = format;
+ 
+diff --git a/drivers/media/platform/tegra/camera/vi/channel.c b/drivers/media/platform/tegra/camera/vi/channel.c
+index 6dc16c9f..58f80bd4 100644
+--- a/drivers/media/platform/tegra/camera/vi/channel.c
++++ b/drivers/media/platform/tegra/camera/vi/channel.c
+@@ -1156,6 +1156,9 @@ tegra_channel_enum_format(struct file *file, void *fh, struct v4l2_fmtdesc *f)
+ 	index -= 1;
+ 	f->pixelformat = tegra_core_get_fourcc_by_idx(chan, index);
+ 
++	if (f->pixelformat == v4l2_fourcc('G', 'R', '0', 'P'))
++		strscpy(f->description, "RealSense GRBG10P CL64", sizeof(f->description));
++
+ 	return 0;
+ }
+ 
+diff --git a/drivers/media/platform/tegra/camera/vi/vi5_formats.h b/drivers/media/platform/tegra/camera/vi/vi5_formats.h
+index fb07cfd2..1cb54ba8 100644
+--- a/drivers/media/platform/tegra/camera/vi/vi5_formats.h
++++ b/drivers/media/platform/tegra/camera/vi/vi5_formats.h
+@@ -76,6 +76,14 @@ enum tegra_image_format {
+ 	TEGRA_IMAGE_FORMAT_T_DPCM_RAW20,
+ };
+ 
++#ifndef MEDIA_BUS_FMT_RS_SGRBG10P_1X10
++#define MEDIA_BUS_FMT_RS_SGRBG10P_1X10 0x5002
++#endif
++
++#ifndef V4L2_PIX_FMT_RS_SGRBG10P
++#define V4L2_PIX_FMT_RS_SGRBG10P v4l2_fourcc('G', 'R', '0', 'P')
++#endif
++
+ static const struct tegra_video_format vi5_video_formats[] = {
+ 	/* RAW 6: TODO */
+ 
+@@ -170,6 +178,13 @@ static const struct tegra_video_format vi5_video_formats[] = {
+ 	TEGRA_VIDEO_FORMAT(RAW8, 8, UYYVYY8_0_5X24, 1, 1, T_R8,
+ 				RAW8, NV12, "YUV 4:2:0 NV12"),
+ 
++	/*
++	 * D5x FMT_SGRBG10P: 50 little-endian 10-bit pixels per 64-byte
++	 * cache line. Receive CSI UD30 and preserve every byte in T_R8.
++	 */
++	TEGRA_VIDEO_FORMAT(RAW10, 10, RS_SGRBG10P_1X10, 32, 25, T_R8,
++				USER_1, RS_SGRBG10P, "RealSense GRBG10P CL64"),
++
+ };
+ 
+ #endif

--- a/nvidia-oot/7.0/0015-Add-D5x-GRBG10P-byte-surface.patch
+++ b/nvidia-oot/7.0/0015-Add-D5x-GRBG10P-byte-surface.patch
@@ -13,8 +13,10 @@ container and sends those containers unchanged using CSI RAW16.
 
 Add separate internal mbus tuples for both transports. The packed path
 keeps its private GR0P ABI. The unpacked RAW16 path uses T_R16 and exposes
-the standard V4L2 SGRBG10/BA10 surface. Prefer formats advertised by the
-active subdevice when two transport tuples share a standard FourCC.
+the standard V4L2 SGRBG10/BA10 surface or, through a D5x frame-finish
+callback, the associated standard packed SGRBG10P/pgAA surface. Prefer
+formats advertised by the active subdevice when transport tuples share
+a standard FourCC.
 
 Signed-off-by: zhou <shengyong.zhou@realsenseai.com>
 ---
@@ -174,12 +176,16 @@ diff --git a/drivers/media/platform/tegra/camera/vi/vi5_formats.h b/drivers/medi
 index fb07cfd2..1cb54ba8 100644
 --- a/drivers/media/platform/tegra/camera/vi/vi5_formats.h
 +++ b/drivers/media/platform/tegra/camera/vi/vi5_formats.h
-@@ -76,6 +76,18 @@ enum tegra_image_format {
+@@ -76,6 +76,26 @@ enum tegra_image_format {
  	TEGRA_IMAGE_FORMAT_T_DPCM_RAW20,
  };
  
 +#ifndef MEDIA_BUS_FMT_RS_SGRBG10_1X16
 +#define MEDIA_BUS_FMT_RS_SGRBG10_1X16 0x5003
++#endif
++
++#ifndef MEDIA_BUS_FMT_RS_SGRBG10P_RAW16_1X16
++#define MEDIA_BUS_FMT_RS_SGRBG10P_RAW16_1X16 0x5004
 +#endif
 +
 +#ifndef MEDIA_BUS_FMT_RS_SGRBG10P_1X10
@@ -190,10 +196,14 @@ index fb07cfd2..1cb54ba8 100644
 +#define V4L2_PIX_FMT_RS_SGRBG10P v4l2_fourcc('G', 'R', '0', 'P')
 +#endif
 +
++#ifndef V4L2_PIX_FMT_SGRBG10P
++#define V4L2_PIX_FMT_SGRBG10P v4l2_fourcc('p', 'g', 'A', 'A')
++#endif
++
  static const struct tegra_video_format vi5_video_formats[] = {
  	/* RAW 6: TODO */
  
-@@ -170,6 +182,20 @@ static const struct tegra_video_format vi5_video_formats[] = {
+@@ -170,6 +190,27 @@ static const struct tegra_video_format vi5_video_formats[] = {
  	TEGRA_VIDEO_FORMAT(RAW8, 8, UYYVYY8_0_5X24, 1, 1, T_R8,
  				RAW8, NV12, "YUV 4:2:0 NV12"),
  
@@ -203,6 +213,13 @@ index fb07cfd2..1cb54ba8 100644
 +	 */
 +	TEGRA_VIDEO_FORMAT(RAW10, 10, RS_SGRBG10_1X16, 2, 1, T_R16,
 +				RAW16, SGRBG10, "GRBG10 in 16-bit containers"),
++
++	/*
++	 * Associated Host-output option for the same D5x RAW16/T_R16
++	 * transport. The D5x frame-finish callback packs each row to pgAA.
++	 */
++	TEGRA_VIDEO_FORMAT(RAW10, 10, RS_SGRBG10P_RAW16_1X16, 2, 1, T_R16,
++				RAW16, SGRBG10P, "Packed GRBG10 from RAW16"),
 +
 +	/*
 +	 * D5x FMT_SGRBG10P: 50 little-endian 10-bit pixels per 64-byte

--- a/nvidia-oot/7.0/0015-Add-D5x-GRBG10P-byte-surface.patch
+++ b/nvidia-oot/7.0/0015-Add-D5x-GRBG10P-byte-surface.patch
@@ -239,8 +239,8 @@ diff --git a/include/media/camera_common.h b/include/media/camera_common.h
  struct camera_common_data;
  
 +struct tegra_frame_postprocess_ops {
-+	void (*process)(struct camera_common_data *s_data, void *data,
-+			size_t bytesused, u32 mbus_code);
++	int (*process)(struct camera_common_data *s_data, void *data,
++		       size_t bytesused, u32 mbus_code);
 +};
 +
  struct camera_common_sensor_ops {
@@ -257,7 +257,7 @@ diff --git a/include/media/camera_common.h b/include/media/camera_common.h
 diff --git a/drivers/media/platform/tegra/camera/vi/channel.c b/drivers/media/platform/tegra/camera/vi/channel.c
 --- a/drivers/media/platform/tegra/camera/vi/channel.c
 +++ b/drivers/media/platform/tegra/camera/vi/channel.c
-@@ -1068,10 +1068,35 @@ static void tegra_channel_stop_streaming(struct vb2_queue *vq)
+@@ -1068,10 +1068,33 @@ static void tegra_channel_stop_streaming(struct vb2_queue *vq)
  	queue_init_ts = 0;
  }
  
@@ -276,13 +276,11 @@ diff --git a/drivers/media/platform/tegra/camera/vi/channel.c b/drivers/media/pl
 +	    !s_data->frame_postprocess_ops->process)
 +		return;
 +
-+	data = vb2_plane_vaddr(vb, 0);
 +	bytesused = vb2_get_plane_payload(vb, 0);
-+	if (!data || !bytesused)
-+		return;
-+
-+	s_data->frame_postprocess_ops->process(s_data, data, bytesused,
-+					      chan->fmtinfo->code);
++	data = vb2_plane_vaddr(vb, 0);
++	if (s_data->frame_postprocess_ops->process(s_data, data, bytesused,
++						  chan->fmtinfo->code))
++		to_vb2_v4l2_buffer(vb)->flags |= V4L2_BUF_FLAG_ERROR;
 +}
 +
  static const struct vb2_ops tegra_channel_queue_qops = {

--- a/nvidia-oot/7.0/0015-Add-D5x-GRBG10P-byte-surface.patch
+++ b/nvidia-oot/7.0/0015-Add-D5x-GRBG10P-byte-surface.patch
@@ -1,17 +1,20 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: zhou <shengyong.zhou@realsenseai.com>
 Date: Fri, 24 Jul 2026 19:30:00 +0800
-Subject: [PATCH] media: tegra: receive D5x GRBG10P over UD30
+Subject: [PATCH] media: tegra: receive D5x RGB Bayer surfaces
 
 D5x RGB ISYS stores FMT_SGRBG10P as 50 little-endian 10-bit pixels
 in each 64-byte cache line. HIF MIPI preserves the complete aligned
 row in a CSI User Defined 1 packet so the receiver treats the payload
 as an opaque byte stream.
 
-Add a private mbus/fourcc tuple for this product surface. VI matches
-wire DT 0x30, maps the User Defined byte stream to RAW8/T_R8, and writes
-the payload unchanged. The visible V4L2 geometry remains 1600x1300 while
-bytesperline and capture frame_x use the 2048-byte HKR stride.
+The optional unpacked path stores one 10-bit sample in each 16-bit
+container and sends those containers unchanged using CSI RAW16.
+
+Add separate internal mbus tuples for both transports. The packed path
+keeps its private GR0P ABI. The unpacked RAW16 path uses T_R16 and exposes
+the standard V4L2 SGRBG10/BA10 surface. Prefer formats advertised by the
+active subdevice when two transport tuples share a standard FourCC.
 
 Signed-off-by: zhou <shengyong.zhou@realsenseai.com>
 ---
@@ -19,16 +22,16 @@ diff --git a/drivers/media/platform/tegra/camera/vi/vi5_fops.c b/drivers/media/p
 index 079b5865..fa0acd21 100644
 --- a/drivers/media/platform/tegra/camera/vi/vi5_fops.c
 +++ b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
-@@ -394,6 +394,8 @@ static void vi5_setup_surface(struct tegra_channel *chan,
+@@ -392,6 +392,8 @@ static void vi5_setup_surface(struct tegra_channel *chan,
  	u32 bpl = chan->format.bytesperline;
  	u32 data_type = chan->fmtinfo->img_dt;
  	bool flat_nv12 = chan->fmtinfo->fourcc == V4L2_PIX_FMT_NV12;
 +	bool d5x_sgrbg10p =
 +		chan->fmtinfo->fourcc == V4L2_PIX_FMT_RS_SGRBG10P;
  	u32 nvcsi_stream = chan->port[vi_port];
+ 	unsigned int range = 0;
  	struct capture_descriptor_memoryinfo *desc_memoryinfo =
- 		&chan->tegra_vi_channel[vi_port]->
-@@ -409,6 +411,9 @@ static void vi5_setup_surface(struct tegra_channel *chan,
+@@ -423,6 +425,9 @@ static void vi5_setup_surface(struct tegra_channel *chan,
  	/* D5xx carries flat NV12 bytes as W x (H * 3 / 2) RAW8 rows. */
  	if (flat_nv12)
  		height = height * 3 / 2;
@@ -38,7 +41,7 @@ index 079b5865..fa0acd21 100644
  
  	memcpy(desc, &capture_template, sizeof(capture_template));
  	memset(desc_memoryinfo, 0, sizeof(*desc_memoryinfo));
-@@ -421,6 +426,14 @@ static void vi5_setup_surface(struct tegra_channel *chan,
+@@ -434,6 +439,14 @@ static void vi5_setup_surface(struct tegra_channel *chan,
  	desc->ch_cfg.frame.frame_y = height;
  	desc->ch_cfg.match.datatype = data_type;
  	desc->ch_cfg.match.datatype_mask = 0x3f;
@@ -57,8 +60,8 @@ diff --git a/drivers/media/platform/tegra/camera/vi/channel.c b/drivers/media/pl
 index 6dc16c9f..58f80bd4 100644
 --- a/drivers/media/platform/tegra/camera/vi/channel.c
 +++ b/drivers/media/platform/tegra/camera/vi/channel.c
-@@ -1156,6 +1156,9 @@ tegra_channel_enum_format(struct file *file, void *fh, struct v4l2_fmtdesc *f)
- 	index -= 1;
+@@ -1226,6 +1226,9 @@ tegra_channel_enum_format(struct file *file, void *fh, struct v4l2_fmtdesc *f)
+ 	}
  	f->pixelformat = tegra_core_get_fourcc_by_idx(chan, index);
  
 +	if (f->pixelformat == v4l2_fourcc('G', 'R', '0', 'P'))
@@ -67,14 +70,118 @@ index 6dc16c9f..58f80bd4 100644
  	return 0;
  }
  
+diff --git a/drivers/media/platform/tegra/camera/vi/core.c b/drivers/media/platform/tegra/camera/vi/core.c
+index 4923d9b6..6ec75573 100644
+--- a/drivers/media/platform/tegra/camera/vi/core.c
++++ b/drivers/media/platform/tegra/camera/vi/core.c
+@@ -94,13 +94,19 @@ int tegra_core_get_code_by_fourcc(struct tegra_channel *chan,
+-		unsigned int fourcc, unsigned offset)
++		unsigned int fourcc, unsigned offset)
+ {
+-	unsigned int i;
+-
+-	for (i = offset; i < chan->num_video_formats; ++i) {
+-		if (chan->video_formats[i]->fourcc == fourcc)
+-			return chan->video_formats[i]->code;
+-	}
+-	spec_bar();
+-
+-	return -1;
++	unsigned int i;
++	int fallback = -1;
++
++	for (i = offset; i < chan->num_video_formats; ++i) {
++		if (chan->video_formats[i]->fourcc != fourcc)
++			continue;
++
++		if (fallback < 0)
++			fallback = chan->video_formats[i]->code;
++		if (test_bit(i, chan->fmts_bitmap))
++			return chan->video_formats[i]->code;
++	}
++	spec_bar();
++
++	return fallback;
+ }
+ EXPORT_SYMBOL(tegra_core_get_code_by_fourcc);
+@@ -154,13 +160,19 @@ const struct tegra_video_format *
+ tegra_core_get_format_by_fourcc(struct tegra_channel *chan, u32 fourcc)
+ {
+-	unsigned int i;
+-
+-	for (i = 0; i < chan->num_video_formats; ++i) {
+-		if (chan->video_formats[i]->fourcc == fourcc)
+-			return chan->video_formats[i];
+-	}
+-	spec_bar();
+-
+-	return NULL;
++	unsigned int i;
++	const struct tegra_video_format *fallback = NULL;
++
++	for (i = 0; i < chan->num_video_formats; ++i) {
++		if (chan->video_formats[i]->fourcc != fourcc)
++			continue;
++
++		if (!fallback)
++			fallback = chan->video_formats[i];
++		if (test_bit(i, chan->fmts_bitmap))
++			return chan->video_formats[i];
++	}
++	spec_bar();
++
++	return fallback;
+ }
+ EXPORT_SYMBOL(tegra_core_get_format_by_fourcc);
+diff --git a/include/media/tegra_camera_core.h b/include/media/tegra_camera_core.h
+index 43d5316b..d9e459b8 100644
+--- a/include/media/tegra_camera_core.h
++++ b/include/media/tegra_camera_core.h
+@@ -49,16 +49,17 @@ enum tegra_image_dt {
+-
+-	TEGRA_IMAGE_DT_RAW6 = 40,
+-	TEGRA_IMAGE_DT_RAW7,
+-	TEGRA_IMAGE_DT_RAW8,
+-	TEGRA_IMAGE_DT_RAW10,
+-	TEGRA_IMAGE_DT_RAW12,
+-	TEGRA_IMAGE_DT_RAW14,
+-
+-	TEGRA_IMAGE_DT_USER_1 = 48,
+-	TEGRA_IMAGE_DT_USER_2,
+-	TEGRA_IMAGE_DT_USER_3,
+-	TEGRA_IMAGE_DT_USER_4,
+-
+-};
+-
++
++	TEGRA_IMAGE_DT_RAW6 = 40,
++	TEGRA_IMAGE_DT_RAW7,
++	TEGRA_IMAGE_DT_RAW8,
++	TEGRA_IMAGE_DT_RAW10,
++	TEGRA_IMAGE_DT_RAW12,
++	TEGRA_IMAGE_DT_RAW14,
++	TEGRA_IMAGE_DT_RAW16,
++
++	TEGRA_IMAGE_DT_USER_1 = 48,
++	TEGRA_IMAGE_DT_USER_2,
++	TEGRA_IMAGE_DT_USER_3,
++	TEGRA_IMAGE_DT_USER_4,
++
++};
++
+ /* Supported CSI to VI Data Formats */
 diff --git a/drivers/media/platform/tegra/camera/vi/vi5_formats.h b/drivers/media/platform/tegra/camera/vi/vi5_formats.h
 index fb07cfd2..1cb54ba8 100644
 --- a/drivers/media/platform/tegra/camera/vi/vi5_formats.h
 +++ b/drivers/media/platform/tegra/camera/vi/vi5_formats.h
-@@ -76,6 +76,14 @@ enum tegra_image_format {
+@@ -76,6 +76,18 @@ enum tegra_image_format {
  	TEGRA_IMAGE_FORMAT_T_DPCM_RAW20,
  };
  
++#ifndef MEDIA_BUS_FMT_RS_SGRBG10_1X16
++#define MEDIA_BUS_FMT_RS_SGRBG10_1X16 0x5003
++#endif
++
 +#ifndef MEDIA_BUS_FMT_RS_SGRBG10P_1X10
 +#define MEDIA_BUS_FMT_RS_SGRBG10P_1X10 0x5002
 +#endif
@@ -86,10 +193,17 @@ index fb07cfd2..1cb54ba8 100644
  static const struct tegra_video_format vi5_video_formats[] = {
  	/* RAW 6: TODO */
  
-@@ -170,6 +178,13 @@ static const struct tegra_video_format vi5_video_formats[] = {
+@@ -170,6 +182,20 @@ static const struct tegra_video_format vi5_video_formats[] = {
  	TEGRA_VIDEO_FORMAT(RAW8, 8, UYYVYY8_0_5X24, 1, 1, T_R8,
  				RAW8, NV12, "YUV 4:2:0 NV12"),
  
++	/*
++	 * D5x unpacked GRBG10: CSI RAW16 carries one complete 16-bit
++	 * container per sample. Expose the standard V4L2 BA10 surface.
++	 */
++	TEGRA_VIDEO_FORMAT(RAW10, 10, RS_SGRBG10_1X16, 2, 1, T_R16,
++				RAW16, SGRBG10, "GRBG10 in 16-bit containers"),
++
 +	/*
 +	 * D5x FMT_SGRBG10P: 50 little-endian 10-bit pixels per 64-byte
 +	 * cache line. Receive CSI UD30 and preserve every byte in T_R8.
@@ -100,3 +214,65 @@ index fb07cfd2..1cb54ba8 100644
  };
  
  #endif
+diff --git a/include/media/camera_common.h b/include/media/camera_common.h
+--- a/include/media/camera_common.h
++++ b/include/media/camera_common.h
+@@ -164,6 +164,11 @@ struct camera_common_framesync {
+ struct tegracam_device ;
+ struct camera_common_data;
+ 
++struct tegra_frame_postprocess_ops {
++	void (*process)(struct camera_common_data *s_data, void *data,
++			size_t bytesused, u32 mbus_code);
++};
++
+ struct camera_common_sensor_ops {
+ 	u32 numfrmfmts;
+ 	const struct camera_common_frmfmt *frmfmt_table;
+@@ -258,6 +263,7 @@ struct camera_common_data {
+ 	bool	use_sensor_mode_id;
+ 	bool	override_enable;
+ 	const struct tegra_embedded_metadata_ops *embedded_metadata_ops;
++	const struct tegra_frame_postprocess_ops *frame_postprocess_ops;
+ 	u32	version;
+ };
+ 
+diff --git a/drivers/media/platform/tegra/camera/vi/channel.c b/drivers/media/platform/tegra/camera/vi/channel.c
+--- a/drivers/media/platform/tegra/camera/vi/channel.c
++++ b/drivers/media/platform/tegra/camera/vi/channel.c
+@@ -1068,10 +1068,35 @@ static void tegra_channel_stop_streaming(struct vb2_queue *vq)
+ 	queue_init_ts = 0;
+ }
+ 
++static void tegra_channel_buffer_finish(struct vb2_buffer *vb)
++{
++	struct tegra_channel *chan = vb2_get_drv_priv(vb->vb2_queue);
++	struct camera_common_data *s_data;
++	void *data;
++	size_t bytesused;
++
++	if (!chan->subdev_on_csi)
++		return;
++
++	s_data = to_camera_common_data(chan->subdev_on_csi->dev);
++	if (!s_data || !s_data->frame_postprocess_ops ||
++	    !s_data->frame_postprocess_ops->process)
++		return;
++
++	data = vb2_plane_vaddr(vb, 0);
++	bytesused = vb2_get_plane_payload(vb, 0);
++	if (!data || !bytesused)
++		return;
++
++	s_data->frame_postprocess_ops->process(s_data, data, bytesused,
++					      chan->fmtinfo->code);
++}
++
+ static const struct vb2_ops tegra_channel_queue_qops = {
+ 	.queue_setup = tegra_channel_queue_setup,
+ 	.buf_prepare = tegra_channel_buffer_prepare,
+ 	.buf_queue = tegra_channel_buffer_queue,
++	.buf_finish = tegra_channel_buffer_finish,
+ 	.wait_prepare = vb2_ops_wait_prepare,
+ 	.wait_finish = vb2_ops_wait_finish,
+ 	.start_streaming = tegra_channel_start_streaming,

--- a/nvidia-oot/7.1/0015-Add-D5x-GRBG10P-byte-surface.patch
+++ b/nvidia-oot/7.1/0015-Add-D5x-GRBG10P-byte-surface.patch
@@ -1,34 +1,37 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: zhou <shengyong.zhou@realsenseai.com>
 Date: Fri, 24 Jul 2026 19:30:00 +0800
-Subject: [PATCH] media: tegra: receive D5x GRBG10P over UD30
+Subject: [PATCH] media: tegra: receive D5x RGB Bayer surfaces
 
 D5x RGB ISYS stores FMT_SGRBG10P as 50 little-endian 10-bit pixels
 in each 64-byte cache line. HIF MIPI preserves the complete aligned
 row in a CSI User Defined 1 packet so the receiver treats the payload
 as an opaque byte stream.
 
-Add a private mbus/fourcc tuple for this product surface. VI matches
-wire DT 0x30, maps the User Defined byte stream to RAW8/T_R8, and writes
-the payload unchanged. The visible V4L2 geometry remains 1600x1300 while
-bytesperline and capture frame_x use the 2048-byte HKR stride.
+The optional unpacked path stores one 10-bit sample in each 16-bit
+container and sends those containers unchanged using CSI RAW16.
+
+Add separate internal mbus tuples for both transports. The packed path
+keeps its private GR0P ABI. The unpacked RAW16 path uses T_R16 and exposes
+the standard V4L2 SGRBG10/BA10 surface. Prefer formats advertised by the
+active subdevice when two transport tuples share a standard FourCC.
 
 Signed-off-by: zhou <shengyong.zhou@realsenseai.com>
 ---
 diff --git a/drivers/media/platform/tegra/camera/vi/vi5_fops.c b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
-index 079b5865..fa0acd21 100644
+index 117a3040..067185b3 100644
 --- a/drivers/media/platform/tegra/camera/vi/vi5_fops.c
 +++ b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
-@@ -394,6 +394,8 @@ static void vi5_setup_surface(struct tegra_channel *chan,
+@@ -392,6 +392,8 @@ static void vi5_setup_surface(struct tegra_channel *chan,
  	u32 bpl = chan->format.bytesperline;
  	u32 data_type = chan->fmtinfo->img_dt;
  	bool flat_nv12 = chan->fmtinfo->fourcc == V4L2_PIX_FMT_NV12;
 +	bool d5x_sgrbg10p =
 +		chan->fmtinfo->fourcc == V4L2_PIX_FMT_RS_SGRBG10P;
  	u32 nvcsi_stream = chan->port[vi_port];
+ 	unsigned int range = 0;
  	struct capture_descriptor_memoryinfo *desc_memoryinfo =
- 		&chan->tegra_vi_channel[vi_port]->
-@@ -409,6 +411,9 @@ static void vi5_setup_surface(struct tegra_channel *chan,
+@@ -423,6 +425,9 @@ static void vi5_setup_surface(struct tegra_channel *chan,
  	/* D5xx carries flat NV12 bytes as W x (H * 3 / 2) RAW8 rows. */
  	if (flat_nv12)
  		height = height * 3 / 2;
@@ -38,7 +41,7 @@ index 079b5865..fa0acd21 100644
  
  	memcpy(desc, &capture_template, sizeof(capture_template));
  	memset(desc_memoryinfo, 0, sizeof(*desc_memoryinfo));
-@@ -421,6 +426,14 @@ static void vi5_setup_surface(struct tegra_channel *chan,
+@@ -434,6 +439,14 @@ static void vi5_setup_surface(struct tegra_channel *chan,
  	desc->ch_cfg.frame.frame_y = height;
  	desc->ch_cfg.match.datatype = data_type;
  	desc->ch_cfg.match.datatype_mask = 0x3f;
@@ -54,11 +57,11 @@ index 079b5865..fa0acd21 100644
  	desc->ch_cfg.pixfmt.format = format;
  
 diff --git a/drivers/media/platform/tegra/camera/vi/channel.c b/drivers/media/platform/tegra/camera/vi/channel.c
-index 6dc16c9f..58f80bd4 100644
+index c0330920..4d428730 100644
 --- a/drivers/media/platform/tegra/camera/vi/channel.c
 +++ b/drivers/media/platform/tegra/camera/vi/channel.c
-@@ -1156,6 +1156,9 @@ tegra_channel_enum_format(struct file *file, void *fh, struct v4l2_fmtdesc *f)
- 	index -= 1;
+@@ -1235,6 +1235,9 @@ tegra_channel_enum_format(struct file *file, void *fh, struct v4l2_fmtdesc *f)
+ 	}
  	f->pixelformat = tegra_core_get_fourcc_by_idx(chan, index);
  
 +	if (f->pixelformat == v4l2_fourcc('G', 'R', '0', 'P'))
@@ -67,14 +70,81 @@ index 6dc16c9f..58f80bd4 100644
  	return 0;
  }
  
+diff --git a/drivers/media/platform/tegra/camera/vi/core.c b/drivers/media/platform/tegra/camera/vi/core.c
+index 4923d9b6..6ec75573 100644
+--- a/drivers/media/platform/tegra/camera/vi/core.c
++++ b/drivers/media/platform/tegra/camera/vi/core.c
+@@ -94,13 +94,19 @@ int tegra_core_get_code_by_fourcc(struct tegra_channel *chan,
+-		unsigned int fourcc, unsigned offset)
++		unsigned int fourcc, unsigned offset)
+ {
+-	unsigned int i;
+-
+-	for (i = offset; i < chan->num_video_formats; ++i) {
+-		if (chan->video_formats[i]->fourcc == fourcc)
+-			return chan->video_formats[i]->code;
+-	}
+-	spec_bar();
+-
+-	return -1;
++	unsigned int i;
++	int fallback = -1;
++
++	for (i = offset; i < chan->num_video_formats; ++i) {
++		if (chan->video_formats[i]->fourcc != fourcc)
++			continue;
++
++		if (fallback < 0)
++			fallback = chan->video_formats[i]->code;
++		if (test_bit(i, chan->fmts_bitmap))
++			return chan->video_formats[i]->code;
++	}
++	spec_bar();
++
++	return fallback;
+ }
+ EXPORT_SYMBOL(tegra_core_get_code_by_fourcc);
+@@ -154,13 +160,19 @@ const struct tegra_video_format *
+ tegra_core_get_format_by_fourcc(struct tegra_channel *chan, u32 fourcc)
+ {
+-	unsigned int i;
+-
+-	for (i = 0; i < chan->num_video_formats; ++i) {
+-		if (chan->video_formats[i]->fourcc == fourcc)
+-			return chan->video_formats[i];
+-	}
+-	spec_bar();
+-
+-	return NULL;
++	unsigned int i;
++	const struct tegra_video_format *fallback = NULL;
++
++	for (i = 0; i < chan->num_video_formats; ++i) {
++		if (chan->video_formats[i]->fourcc != fourcc)
++			continue;
++
++		if (!fallback)
++			fallback = chan->video_formats[i];
++		if (test_bit(i, chan->fmts_bitmap))
++			return chan->video_formats[i];
++	}
++	spec_bar();
++
++	return fallback;
+ }
+ EXPORT_SYMBOL(tegra_core_get_format_by_fourcc);
 diff --git a/drivers/media/platform/tegra/camera/vi/vi5_formats.h b/drivers/media/platform/tegra/camera/vi/vi5_formats.h
 index fb07cfd2..1cb54ba8 100644
 --- a/drivers/media/platform/tegra/camera/vi/vi5_formats.h
 +++ b/drivers/media/platform/tegra/camera/vi/vi5_formats.h
-@@ -76,6 +76,14 @@ enum tegra_image_format {
+@@ -76,6 +76,18 @@ enum tegra_image_format {
  	TEGRA_IMAGE_FORMAT_T_DPCM_RAW20,
  };
  
++#ifndef MEDIA_BUS_FMT_RS_SGRBG10_1X16
++#define MEDIA_BUS_FMT_RS_SGRBG10_1X16 0x5003
++#endif
++
 +#ifndef MEDIA_BUS_FMT_RS_SGRBG10P_1X10
 +#define MEDIA_BUS_FMT_RS_SGRBG10P_1X10 0x5002
 +#endif
@@ -86,10 +156,17 @@ index fb07cfd2..1cb54ba8 100644
  static const struct tegra_video_format vi5_video_formats[] = {
  	/* RAW 6: TODO */
  
-@@ -170,6 +178,13 @@ static const struct tegra_video_format vi5_video_formats[] = {
+@@ -170,6 +182,20 @@ static const struct tegra_video_format vi5_video_formats[] = {
  	TEGRA_VIDEO_FORMAT(RAW8, 8, UYYVYY8_0_5X24, 1, 1, T_R8,
  				RAW8, NV12, "YUV 4:2:0 NV12"),
  
++	/*
++	 * D5x unpacked GRBG10: CSI RAW16 carries one complete 16-bit
++	 * container per sample. Expose the standard V4L2 BA10 surface.
++	 */
++	TEGRA_VIDEO_FORMAT(RAW10, 10, RS_SGRBG10_1X16, 2, 1, T_R16,
++				RAW16, SGRBG10, "GRBG10 in 16-bit containers"),
++
 +	/*
 +	 * D5x FMT_SGRBG10P: 50 little-endian 10-bit pixels per 64-byte
 +	 * cache line. Receive CSI UD30 and preserve every byte in T_R8.
@@ -100,3 +177,65 @@ index fb07cfd2..1cb54ba8 100644
  };
  
  #endif
+diff --git a/include/media/camera_common.h b/include/media/camera_common.h
+--- a/include/media/camera_common.h
++++ b/include/media/camera_common.h
+@@ -164,6 +164,11 @@ struct camera_common_framesync {
+ struct tegracam_device ;
+ struct camera_common_data;
+ 
++struct tegra_frame_postprocess_ops {
++	void (*process)(struct camera_common_data *s_data, void *data,
++			size_t bytesused, u32 mbus_code);
++};
++
+ struct camera_common_sensor_ops {
+ 	u32 numfrmfmts;
+ 	const struct camera_common_frmfmt *frmfmt_table;
+@@ -258,6 +263,7 @@ struct camera_common_data {
+ 	bool	use_sensor_mode_id;
+ 	bool	override_enable;
+ 	const struct tegra_embedded_metadata_ops *embedded_metadata_ops;
++	const struct tegra_frame_postprocess_ops *frame_postprocess_ops;
+ 	u32	version;
+ };
+ 
+diff --git a/drivers/media/platform/tegra/camera/vi/channel.c b/drivers/media/platform/tegra/camera/vi/channel.c
+--- a/drivers/media/platform/tegra/camera/vi/channel.c
++++ b/drivers/media/platform/tegra/camera/vi/channel.c
+@@ -1068,10 +1068,35 @@ static void tegra_channel_stop_streaming(struct vb2_queue *vq)
+ 	queue_init_ts = 0;
+ }
+ 
++static void tegra_channel_buffer_finish(struct vb2_buffer *vb)
++{
++	struct tegra_channel *chan = vb2_get_drv_priv(vb->vb2_queue);
++	struct camera_common_data *s_data;
++	void *data;
++	size_t bytesused;
++
++	if (!chan->subdev_on_csi)
++		return;
++
++	s_data = to_camera_common_data(chan->subdev_on_csi->dev);
++	if (!s_data || !s_data->frame_postprocess_ops ||
++	    !s_data->frame_postprocess_ops->process)
++		return;
++
++	data = vb2_plane_vaddr(vb, 0);
++	bytesused = vb2_get_plane_payload(vb, 0);
++	if (!data || !bytesused)
++		return;
++
++	s_data->frame_postprocess_ops->process(s_data, data, bytesused,
++					      chan->fmtinfo->code);
++}
++
+ static const struct vb2_ops tegra_channel_queue_qops = {
+ 	.queue_setup = tegra_channel_queue_setup,
+ 	.buf_prepare = tegra_channel_buffer_prepare,
+ 	.buf_queue = tegra_channel_buffer_queue,
++	.buf_finish = tegra_channel_buffer_finish,
+ 	.wait_prepare = vb2_ops_wait_prepare,
+ 	.wait_finish = vb2_ops_wait_finish,
+ 	.start_streaming = tegra_channel_start_streaming,

--- a/nvidia-oot/7.1/0015-Add-D5x-GRBG10P-byte-surface.patch
+++ b/nvidia-oot/7.1/0015-Add-D5x-GRBG10P-byte-surface.patch
@@ -13,8 +13,10 @@ container and sends those containers unchanged using CSI RAW16.
 
 Add separate internal mbus tuples for both transports. The packed path
 keeps its private GR0P ABI. The unpacked RAW16 path uses T_R16 and exposes
-the standard V4L2 SGRBG10/BA10 surface. Prefer formats advertised by the
-active subdevice when two transport tuples share a standard FourCC.
+the standard V4L2 SGRBG10/BA10 surface or, through a D5x frame-finish
+callback, the associated standard packed SGRBG10P/pgAA surface. Prefer
+formats advertised by the active subdevice when transport tuples share
+a standard FourCC.
 
 Signed-off-by: zhou <shengyong.zhou@realsenseai.com>
 ---
@@ -137,12 +139,16 @@ diff --git a/drivers/media/platform/tegra/camera/vi/vi5_formats.h b/drivers/medi
 index fb07cfd2..1cb54ba8 100644
 --- a/drivers/media/platform/tegra/camera/vi/vi5_formats.h
 +++ b/drivers/media/platform/tegra/camera/vi/vi5_formats.h
-@@ -76,6 +76,18 @@ enum tegra_image_format {
+@@ -76,6 +76,26 @@ enum tegra_image_format {
  	TEGRA_IMAGE_FORMAT_T_DPCM_RAW20,
  };
  
 +#ifndef MEDIA_BUS_FMT_RS_SGRBG10_1X16
 +#define MEDIA_BUS_FMT_RS_SGRBG10_1X16 0x5003
++#endif
++
++#ifndef MEDIA_BUS_FMT_RS_SGRBG10P_RAW16_1X16
++#define MEDIA_BUS_FMT_RS_SGRBG10P_RAW16_1X16 0x5004
 +#endif
 +
 +#ifndef MEDIA_BUS_FMT_RS_SGRBG10P_1X10
@@ -153,10 +159,14 @@ index fb07cfd2..1cb54ba8 100644
 +#define V4L2_PIX_FMT_RS_SGRBG10P v4l2_fourcc('G', 'R', '0', 'P')
 +#endif
 +
++#ifndef V4L2_PIX_FMT_SGRBG10P
++#define V4L2_PIX_FMT_SGRBG10P v4l2_fourcc('p', 'g', 'A', 'A')
++#endif
++
  static const struct tegra_video_format vi5_video_formats[] = {
  	/* RAW 6: TODO */
  
-@@ -170,6 +182,20 @@ static const struct tegra_video_format vi5_video_formats[] = {
+@@ -170,6 +190,27 @@ static const struct tegra_video_format vi5_video_formats[] = {
  	TEGRA_VIDEO_FORMAT(RAW8, 8, UYYVYY8_0_5X24, 1, 1, T_R8,
  				RAW8, NV12, "YUV 4:2:0 NV12"),
  
@@ -166,6 +176,13 @@ index fb07cfd2..1cb54ba8 100644
 +	 */
 +	TEGRA_VIDEO_FORMAT(RAW10, 10, RS_SGRBG10_1X16, 2, 1, T_R16,
 +				RAW16, SGRBG10, "GRBG10 in 16-bit containers"),
++
++	/*
++	 * Associated Host-output option for the same D5x RAW16/T_R16
++	 * transport. The D5x frame-finish callback packs each row to pgAA.
++	 */
++	TEGRA_VIDEO_FORMAT(RAW10, 10, RS_SGRBG10P_RAW16_1X16, 2, 1, T_R16,
++				RAW16, SGRBG10P, "Packed GRBG10 from RAW16"),
 +
 +	/*
 +	 * D5x FMT_SGRBG10P: 50 little-endian 10-bit pixels per 64-byte

--- a/nvidia-oot/7.1/0015-Add-D5x-GRBG10P-byte-surface.patch
+++ b/nvidia-oot/7.1/0015-Add-D5x-GRBG10P-byte-surface.patch
@@ -202,8 +202,8 @@ diff --git a/include/media/camera_common.h b/include/media/camera_common.h
  struct camera_common_data;
  
 +struct tegra_frame_postprocess_ops {
-+	void (*process)(struct camera_common_data *s_data, void *data,
-+			size_t bytesused, u32 mbus_code);
++	int (*process)(struct camera_common_data *s_data, void *data,
++		       size_t bytesused, u32 mbus_code);
 +};
 +
  struct camera_common_sensor_ops {
@@ -220,7 +220,7 @@ diff --git a/include/media/camera_common.h b/include/media/camera_common.h
 diff --git a/drivers/media/platform/tegra/camera/vi/channel.c b/drivers/media/platform/tegra/camera/vi/channel.c
 --- a/drivers/media/platform/tegra/camera/vi/channel.c
 +++ b/drivers/media/platform/tegra/camera/vi/channel.c
-@@ -1068,10 +1068,35 @@ static void tegra_channel_stop_streaming(struct vb2_queue *vq)
+@@ -1068,10 +1068,33 @@ static void tegra_channel_stop_streaming(struct vb2_queue *vq)
  	queue_init_ts = 0;
  }
  
@@ -239,13 +239,11 @@ diff --git a/drivers/media/platform/tegra/camera/vi/channel.c b/drivers/media/pl
 +	    !s_data->frame_postprocess_ops->process)
 +		return;
 +
-+	data = vb2_plane_vaddr(vb, 0);
 +	bytesused = vb2_get_plane_payload(vb, 0);
-+	if (!data || !bytesused)
-+		return;
-+
-+	s_data->frame_postprocess_ops->process(s_data, data, bytesused,
-+					      chan->fmtinfo->code);
++	data = vb2_plane_vaddr(vb, 0);
++	if (s_data->frame_postprocess_ops->process(s_data, data, bytesused,
++						  chan->fmtinfo->code))
++		to_vb2_v4l2_buffer(vb)->flags |= V4L2_BUF_FLAG_ERROR;
 +}
 +
  static const struct vb2_ops tegra_channel_queue_qops = {

--- a/nvidia-oot/7.1/0015-Add-D5x-GRBG10P-byte-surface.patch
+++ b/nvidia-oot/7.1/0015-Add-D5x-GRBG10P-byte-surface.patch
@@ -1,0 +1,102 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: zhou <shengyong.zhou@realsenseai.com>
+Date: Fri, 24 Jul 2026 19:30:00 +0800
+Subject: [PATCH] media: tegra: receive D5x GRBG10P over UD30
+
+D5x RGB ISYS stores FMT_SGRBG10P as 50 little-endian 10-bit pixels
+in each 64-byte cache line. HIF MIPI preserves the complete aligned
+row in a CSI User Defined 1 packet so the receiver treats the payload
+as an opaque byte stream.
+
+Add a private mbus/fourcc tuple for this product surface. VI matches
+wire DT 0x30, maps the User Defined byte stream to RAW8/T_R8, and writes
+the payload unchanged. The visible V4L2 geometry remains 1600x1300 while
+bytesperline and capture frame_x use the 2048-byte HKR stride.
+
+Signed-off-by: zhou <shengyong.zhou@realsenseai.com>
+---
+diff --git a/drivers/media/platform/tegra/camera/vi/vi5_fops.c b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
+index 079b5865..fa0acd21 100644
+--- a/drivers/media/platform/tegra/camera/vi/vi5_fops.c
++++ b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
+@@ -394,6 +394,8 @@ static void vi5_setup_surface(struct tegra_channel *chan,
+ 	u32 bpl = chan->format.bytesperline;
+ 	u32 data_type = chan->fmtinfo->img_dt;
+ 	bool flat_nv12 = chan->fmtinfo->fourcc == V4L2_PIX_FMT_NV12;
++	bool d5x_sgrbg10p =
++		chan->fmtinfo->fourcc == V4L2_PIX_FMT_RS_SGRBG10P;
+ 	u32 nvcsi_stream = chan->port[vi_port];
+ 	struct capture_descriptor_memoryinfo *desc_memoryinfo =
+ 		&chan->tegra_vi_channel[vi_port]->
+@@ -409,6 +411,9 @@ static void vi5_setup_surface(struct tegra_channel *chan,
+ 	/* D5xx carries flat NV12 bytes as W x (H * 3 / 2) RAW8 rows. */
+ 	if (flat_nv12)
+ 		height = height * 3 / 2;
++	else if (d5x_sgrbg10p)
++		/* RAW8 parser width is the byte-identical HKR DDR stride. */
++		width = bpl;
+ 
+ 	memcpy(desc, &capture_template, sizeof(capture_template));
+ 	memset(desc_memoryinfo, 0, sizeof(*desc_memoryinfo));
+@@ -421,6 +426,14 @@ static void vi5_setup_surface(struct tegra_channel *chan,
+ 	desc->ch_cfg.frame.frame_y = height;
+ 	desc->ch_cfg.match.datatype = data_type;
+ 	desc->ch_cfg.match.datatype_mask = 0x3f;
++	if (d5x_sgrbg10p) {
++		/*
++		 * UD30 is an opaque byte stream. Map it to RAW8 only inside VI
++		 * so each packet payload byte reaches the V4L2 surface unchanged.
++		 */
++		desc->ch_cfg.dt_enable = 1;
++		desc->ch_cfg.dt_override = TEGRA_IMAGE_DT_RAW8;
++	}
+ 	desc->ch_cfg.pixfmt_enable = 1;
+ 	desc->ch_cfg.pixfmt.format = format;
+ 
+diff --git a/drivers/media/platform/tegra/camera/vi/channel.c b/drivers/media/platform/tegra/camera/vi/channel.c
+index 6dc16c9f..58f80bd4 100644
+--- a/drivers/media/platform/tegra/camera/vi/channel.c
++++ b/drivers/media/platform/tegra/camera/vi/channel.c
+@@ -1156,6 +1156,9 @@ tegra_channel_enum_format(struct file *file, void *fh, struct v4l2_fmtdesc *f)
+ 	index -= 1;
+ 	f->pixelformat = tegra_core_get_fourcc_by_idx(chan, index);
+ 
++	if (f->pixelformat == v4l2_fourcc('G', 'R', '0', 'P'))
++		strscpy(f->description, "RealSense GRBG10P CL64", sizeof(f->description));
++
+ 	return 0;
+ }
+ 
+diff --git a/drivers/media/platform/tegra/camera/vi/vi5_formats.h b/drivers/media/platform/tegra/camera/vi/vi5_formats.h
+index fb07cfd2..1cb54ba8 100644
+--- a/drivers/media/platform/tegra/camera/vi/vi5_formats.h
++++ b/drivers/media/platform/tegra/camera/vi/vi5_formats.h
+@@ -76,6 +76,14 @@ enum tegra_image_format {
+ 	TEGRA_IMAGE_FORMAT_T_DPCM_RAW20,
+ };
+ 
++#ifndef MEDIA_BUS_FMT_RS_SGRBG10P_1X10
++#define MEDIA_BUS_FMT_RS_SGRBG10P_1X10 0x5002
++#endif
++
++#ifndef V4L2_PIX_FMT_RS_SGRBG10P
++#define V4L2_PIX_FMT_RS_SGRBG10P v4l2_fourcc('G', 'R', '0', 'P')
++#endif
++
+ static const struct tegra_video_format vi5_video_formats[] = {
+ 	/* RAW 6: TODO */
+ 
+@@ -170,6 +178,13 @@ static const struct tegra_video_format vi5_video_formats[] = {
+ 	TEGRA_VIDEO_FORMAT(RAW8, 8, UYYVYY8_0_5X24, 1, 1, T_R8,
+ 				RAW8, NV12, "YUV 4:2:0 NV12"),
+ 
++	/*
++	 * D5x FMT_SGRBG10P: 50 little-endian 10-bit pixels per 64-byte
++	 * cache line. Receive CSI UD30 and preserve every byte in T_R8.
++	 */
++	TEGRA_VIDEO_FORMAT(RAW10, 10, RS_SGRBG10P_1X10, 32, 25, T_R8,
++				USER_1, RS_SGRBG10P, "RealSense GRBG10P CL64"),
++
+ };
+ 
+ #endif


### PR DESCRIPTION
## Summary

- Keep private `GR0P` for byte-identical HKR `FMT_SGRBG10P` over UD30.
- Expose HKR `FMT_SGRBG10` over RAW16 as standard unpacked `BA10`.
- Optionally expose the same RAW16 receive path as standard packed `pgAA`.
- Stage each matching D5xx RAW16 frame in a cached scratch buffer, then perform a fused byte-order restore or row pack.
- Return postprocess failures to the generic VI adapter, which marks the V4L2 buffer erroneous instead of exposing mislabeled data.
- Keep existing NV12 and D4xx paths outside the D5xx-only callback.

## Format layers

- GR0P: HKR `FMT_SGRBG10P` -> VC1 / DT `0x30` / WC 2048 -> VI `T_R8` -> private `GR0P`, 2048 BPL
- BA10: HKR `FMT_SGRBG10` -> VC1 / DT `0x2E` / WC 3200 -> VI `T_R16` -> D5xx byte-order restore -> standard `BA10`, 3200 BPL
- pgAA: HKR `FMT_SGRBG10` -> VC1 / DT `0x2E` / WC 3200 -> VI `T_R16` -> D5xx row pack -> standard `pgAA`, 3200 BPL with 2000 active packed bytes per row

The optional VI frame-finish adapter remains generic. Only D5xx registers the callback, and the D5xx implementation returns immediately unless the complete private RAW16/Bayer media-bus tuple matches.

## Frame conversion

Direct repeated reads from write-combined VI memory reduced BA10 capture to approximately 3.5-6 fps. The cached scratch stage converts from normal cached memory and restores capture to 25 fps. The scratch allocation is lazy, reused by subsequent frames, and owned by the D5xx sensor instance.

## E2E dependencies

- https://github.com/RealSenseAI-Internal/soc-rs-hkr-apps/pull/229
- https://github.com/RealSenseAI-Internal/soc-rs-soc-device-mgr/pull/406
- https://github.com/RealSenseAI-Internal/soc-rs-soc-io-drivers/pull/470
- https://github.com/RealSenseAI-Internal/soc-rs-hkr-test/pull/332

## Validation

- JP6.0, JP6.1, JP6.2, JP7.0, and JP7.1 patch chains: clean application PASS
- JP6.2.2 driver build, package, deployment, loaded-module hash, and GMSL link verification: PASS
- Three retained-SerDes module reload cycles: PASS
- GR0P/UD30, BA10/RAW16, and pgAA/RAW16: 1600x1300@25 strict-counter E2E PASS
- BA10 capture-only: 25.1 fps, no sequence drops
- BA10 frame 20: 4,160,000 bytes; 2,080,000 little-endian samples; range 64-1023; zero samples above 10 bits
- pgAA: 25.1 fps, 3200 BPL with 2000 active packed bytes per row

The unfiltered suite still stops on a separate strict metadata gate: Depth metadata reports stream-ID mismatches and one RGB metadata frame-counter gap was observed. No tolerance was relaxed for this PR.

## References

- https://rsconf.realsenseai.com/display/RealSense/GMSL_MIPI_CSI/
- https://rsconf.realsenseai.com/display/RealSense/D5x+GMSL+RGB+RAW10+Host+Receiver+Wiki
