### PR TITLE
Bypass MAX96717 clock detection in tunnel mode

### DIFF
--- a/nvidia-oot/files/6.2/drivers/media/i2c/max96717.c
+++ b/nvidia-oot/files/6.2/drivers/media/i2c/max96717.c
@@ -86,7 +86,9 @@
 
 /*
  *   VIDEO_TX0/TX1: Video TX path config
- *   0x0110=0xE9, 0x0111=0x10 for tunnel mode data path
+ *   VIDEO_TX0[2] bypasses PCLK detection.  Tunnel mode carries CSI-2
+ *   packets directly and must not gate sparse 5/15 FPS traffic on the
+ *   recovered pixel-clock detector.
  */
 #define MAX96717_VIDEO_TX0_ADDR		0x110
 #define MAX96717_VIDEO_TX1_ADDR		0x111
@@ -145,8 +147,9 @@
 #define MAX96717_TUN_MODE_EN		0x80
 #define MAX96717_TUN_MODE_DIS		0x00
 
-/* VIDEO_TX0 tunnel mode data path enable */
-#define MAX96717_VIDEO_TX0_TUN		0xE9
+/* VIDEO_TX0 tunnel mode data path enable + CLKDET_BYP (bit 2). */
+#define MAX96717_VIDEO_TX0_CLKDET_BYP	BIT(2)
+#define MAX96717_VIDEO_TX0_TUN		(0xE9 | MAX96717_VIDEO_TX0_CLKDET_BYP)
 /* VIDEO_TX1 tunnel mode config */
 #define MAX96717_VIDEO_TX1_TUN		0x10
 #define MAX96717_VIDEO_TX0_BPP_MANUAL	0x60


### PR DESCRIPTION
## Summary

- bypass MAX96717 pixel-clock detection for the tunnel-mode video path
- document why sparse 5/15 FPS CSI-2 traffic must not be gated by the recovered pixel clock

## Root cause

Tunnel mode forwards CSI-2 packets directly, but the existing `VIDEO_TX0` configuration left `CLKDET_BYP` disabled. Sparse low-frame-rate traffic can therefore be gated by the recovered pixel-clock detector.

## Impact

Tunnel-mode `VIDEO_TX0` now uses `0xED` instead of `0xE9`, enabling `CLKDET_BYP` while preserving the existing data-path settings.

## Validation

- `git diff --check`
- Hardware validation not run in this checkout
