### PR TITLE
[RSDSO-21786] d4xx: flush the GMSL link line buffer on cold bring-up

### DIFF
--- a/kernel/realsense/d4xx.c
+++ b/kernel/realsense/d4xx.c
@@ -56,8 +56,9 @@ struct dser_interface {
 	int (*set_pipe)(struct device *dev, int pipe_id, u8 data_type1, u8 data_type2, u32 vc_id);
 	int (*release_pipe)(struct device *dev, int pipe_id);
 	void (*reset_oneshot)(struct device *dev);
-	/* RSDEV-12608: flush one link's line buffer after a camera HW reset;
-	 * NULL if the deser leaves no stale buffer (max9296). */
+	/* Flush one link's pixel line buffer, after a camera HW reset and on
+	 * link cold bring-up; NULL if the deser leaves no stale buffer
+	 * (max9296). Must not be called while the link has live streams. */
 	void (*reset_oneshot_link)(struct device *dev, u32 vc_id);
 
 	/* Setup and control */
@@ -620,6 +621,11 @@ struct ds5_dev {
 #ifdef CONFIG_VIDEO_D4XX_SERDES
  	/* Pointer to the deserializer dev */
 	struct dser_control *dser_control;
+
+	/* Cold-bring-up flush request for this camera's GMSL link: the first
+	 * stream on a link the deser already served for another camera wedges
+	 * (VI discards every frame) until a one-shot. Guarded by lock. */
+	bool link_flush_pending;
 #endif
 
 	/* Pointer to the primary DS5 struct */
@@ -5352,6 +5358,28 @@ static int ds5_mux_s_frame_interval(struct v4l2_subdev *sd,
 	return 0;
 }
 
+#ifdef CONFIG_VIDEO_D4XX_SERDES
+/* RSDSO-21786: fire the link flush at most once per cold bring-up. The flag is
+ * consumed under ds5_dev->lock, but the op itself (CTRL1 write plus a 100 ms
+ * settle) must run unlocked so it cannot stall a sibling's start. */
+static void ds5_flush_idle_link(struct ds5 *state)
+{
+	bool flush;
+
+	if (!state->dser_ops->reset_oneshot_link)
+		return;
+
+	mutex_lock(&state->ds5_dev->lock);
+	flush = state->ds5_dev->link_flush_pending;
+	state->ds5_dev->link_flush_pending = false;
+	mutex_unlock(&state->ds5_dev->lock);
+
+	if (flush)
+		state->dser_ops->reset_oneshot_link(state->dser_dev,
+						    state->g_ctx.dst_vc);
+}
+#endif
+
 static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on)
 {
 	struct ds5 *state = container_of(sd, struct ds5, mux.sd.subdev);
@@ -5476,6 +5504,12 @@ static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on)
 				"stream %d in %d state already (status: 0x%04x) %dms, treating as no-op\n",
 				stream_id, on, status, jiffies_to_msecs(jiffies - ts));
 			mutex_lock(&state->ds5_dev->lock);
+#ifdef CONFIG_VIDEO_D4XX_SERDES
+			/* FW reports this stream live without passing the consume
+			 * point; drop the arm so it cannot flush a live link. */
+			if (on)
+				state->ds5_dev->link_flush_pending = false;
+#endif
 			*streaming_flag = on;
 			mutex_unlock(&state->ds5_dev->lock);
 			sensor->streaming = on;
@@ -5485,6 +5519,15 @@ static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on)
 
 	restore_val = sensor->streaming;
 	mutex_lock(&state->ds5_dev->lock);
+#ifdef CONFIG_VIDEO_D4XX_SERDES
+	/* Test before setting our own flag: all four down means the link is idle,
+	 * so the flush cannot truncate a sibling's in-flight frames. */
+	if (on && !(state->ds5_dev->depth_streaming ||
+		    state->ds5_dev->rgb_streaming ||
+		    state->ds5_dev->ir_streaming ||
+		    state->ds5_dev->imu_streaming))
+		state->ds5_dev->link_flush_pending = true;
+#endif
 	*streaming_flag = on;
 	mutex_unlock(&state->ds5_dev->lock);
 	sensor->streaming = on;
@@ -5510,6 +5553,9 @@ static int ds5_mux_s_stream(struct v4l2_subdev *sd, int on)
 				continue;
 			}
 			ds5_config_done = true;
+#ifdef CONFIG_VIDEO_D4XX_SERDES
+			ds5_flush_idle_link(state);
+#endif
 		}
 
 		if (streaming != expected_streaming_state) {


### PR DESCRIPTION
## Problem

On a MAX96712 with more than one camera, once one camera has streamed, the **others cannot stream at all**. FW starts fine (`stream 0 toggle ok to 1`), frames reach the VI and are all discarded (`err_data 512`, then endless `uncorr_err: request timed out after 2500 ms`), zero frames. Order-dependent and symmetric. On the reporter's 4-camera rig: camera 0 works, cameras 1/2/3 all deliver **0 frames**.

A wedge coexisting with a live stream on another link is **kernel-fatal** (NULL deref in `vi_capture_release` via `tegra_channel_error_recover`) — three panics while reproducing.

## Root cause

Regression from `9a93638` (RSDEV-12608), which moved the one-shot flush out of `__max96712_set_pipe` into the HW-reset recovery path only. v1.0.4.9 fired `reset_oneshot_link_mask(1 << link)` on every `set_pipe`; with it gone, nothing flushes in the pipe-config window, so a link the deserializer already served for another camera comes up with a line buffer the VI can't drain.

Proven in-band before any code: with a camera wedged at 0 frames, one forced `CTRL1` (`0x0018`) write delivered **300 frames instantly** — with mask `0x0F` *and* per-link `0x02`, so per-link scoping suffices.

Not the coarse `reset_oneshot(0x0F)` (byte-identical in 1.0.4.9, and only reachable on the Y12I/`is_calib` path), and not fixed by the probe-time `0x0F` in `setup_link`.

## Fix

Arm `ds5_dev.link_flush_pending` in `ds5_mux_s_stream()` while the starting stream's own flag is still clear — all four of the camera's flags down means the link is idle — and consume it once, after `ds5_configure()` succeeds and before the FW stream start, via the **existing** `dser_interface.reset_oneshot_link` op.

- **48 insertions, one file.** `d4xx.c` is symlinked into every JetPack tree and the op already ships in every generation's SerDes header → **no patch regeneration** (note `7.0/0006` and `7.1` symlink to `6.0/0003`, so a SerDes edit would auto-ship to Thor untested).
- Flag consumed under `ds5_dev->lock`; the `CTRL1` write + `msleep(100)` runs under **no** lock.
- `max9296` wires no op — the NULL guard makes it a no-op for free.
- The "treating as no-op" branch disarms, since it goes FW-live without passing the consume point.

Rejected: reinstating the serdes-side `arm_link_reset` machinery (invariant falsified on the stop path, bypassed by a failed `release_pipe`, 6 patch carriers); a max96712-internal pipe refcount (blind to multi-VC/D585 cold restarts, count drift silently returns the P1).

## Invariants — please preserve

1. **Fire only on an idle link.** Flushing a live link truncates in-flight frames (PIXEL_INCOMPLETE) — RSDEV-12608's bug.
2. **Don't move it back into** `__max96712_set_pipe` / `__max96712_set_multi_vc_pipe` — those fire on every pipe (re)alloc regardless of sibling state.
3. **Don't re-check the flags at the consume site.** On a normal multi-stream start depth arms and sets `depth_streaming`, so rgb doesn't arm — re-checking makes depth skip the flush on a genuinely cold link. An adversarial review proposed exactly this; HW then showed the race it targeted never fires (20/20 concurrent double-starts, `corr_err=0`).

## Validation

**fw-orin-nano-1** (D457 + D401, one MAX96712, JP6.2)

| Leg | Result |
|---|---|
| Cold-start other camera, 10×, both orders | **10/10** — 45/45 frames, 1 flush on the correct link (was `rc=124`, 0 frames) |
| Cold start after a *failed* attempt, 5× | **5/5** |
| RSDEV-12608 non-regression: 15 sibling toggles | **0** flushes, **0** PIXEL_INCOMPLETE, held stream 111→879 frames |
| Same camera, 3× restart | 3 flushes — one per restart, each a genuine cold bring-up |
| Concurrent same-camera double-start, 20× | **20/20** — 1 flush each, `corr_err=0` every time |
| Alternating cold-start soak | **4000/4000 cycles over 5.5 h, 0 failures** — every cycle delivered 2×30 frames at `uncorr_err=0`, 2 flushes/cycle (one per link) |

**fw-orin-nano-2** — the reporter's 4-camera quad, one MAX96712. Before: cam0 = 30 frames, **cam1/2/3 = 0 frames each**, 12 `uncorr_err`, zero flushes. After:

| Leg | Result |
|---|---|
| Sequential sweep of all 4 cameras | **4/4 × 30 frames**, one flush each on **links 0, 1, 2, 3**, `uncorr_err=0` |
| Cold-start pairs 0→1, 0→2, 0→3, 3→0, 1→2, 2→3 | **6/6** — 1 flush per second-start, landing on the correct link every time |
| Sibling toggles (RSDEV-12608 guard) | **0** flushes, **0** PIXEL_INCOMPLETE |

This closes the per-link mask on **links 2 and 3**, previously generalized but unproven.

Zero panics across every validation leg and the 4000-cycle soak. Build: JP6.2 incremental clean; `nvidia-oot/Makefile` sets `-Werror` globally, so exit-0 proves no unused-variable/function warnings from the new `#ifdef`-guarded code.

## Known, out of scope

- **Cost:** one 100 ms one-shot per *cold* stream start. Strictly cheaper than v1.0.4.9, which fired on warm starts too.
- **Pre-existing depth starvation on the quad**, not caused by this change: depth-0 runs 28.7 fps alone but ~1.2 fps while its IR sibling toggles. A/B against the unpatched module is identical (**1.3 fps**, same `uncorr_err=15`, PIXEL_INCOMPLETE=0, and no flush fires during the toggles). This is the RSDSO-21245 / RSDEV-13047 class.
- Companion docs update in #533. Regression tests for both directions of the invariant are specified for the DS5 test repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
