### PR TITLE
[RSDEV-13999][D58x][GMSL] Align IR mode and camera controls

### DIFF
--- a/kernel/realsense/d4xx.c
+++ b/kernel/realsense/d4xx.c
@@ -814,6 +814,13 @@ static inline u16 ds5_dev_type(struct ds5 *state, u16 dev_type)
 	return dev_type;
 }
 
+static bool ds5_is_d58x(const struct ds5 *state)
+{
+	return state->ds5_dev &&
+		READ_ONCE(state->ds5_dev->cached_device_type) ==
+			DS5_DEVICE_TYPE_D58X;
+}
+
 static bool ds5_is_valid_device_type(u16 dev_type)
 {
 	switch (dev_type) {
@@ -1988,9 +1995,23 @@ static int __ds5_sensor_set_fmt(struct ds5 *state, struct ds5_sensor *sensor,
 #endif
 #endif
 
-	else
+	else {
 // FIXME: use this format in .s_stream()
 		sensor->format = *mf;
+#ifdef CONFIG_TEGRA_CAMERA_PLATFORM
+		/*
+		 * D58x IR uses mode0 for Y8 and mode1 for interleaved formats.
+		 * Keep every D4xx product on its existing mode-selection path.
+		 */
+		if (state->is_y8 && ds5_is_d58x(state)) {
+			if (sensor->config.format->mbus_code ==
+			    MEDIA_BUS_FMT_Y8_1X8)
+				state->mux.sd.mode_prop_idx = 0;
+			else
+				state->mux.sd.mode_prop_idx = 1;
+		}
+#endif
+	}
 
 	state->mux.last_set = sensor;
 


### PR DESCRIPTION
Tracked-On: https://rsjira.realsenseai.com/browse/RSDEV-13399

## Problem

The unified `d4xx.c` driver had three D58x gaps that must be integrated and reviewed together:

- D58x interleaved IR Y8I at 1280x720@60 could inherit the mode0 1 GHz Tegra clock properties, enter NVCSI deskew, and panic in `nvcsi_deskew_setup`.

## Changes

### IR mode selection

- Detect D58x through the cached runtime product type.
- Select mode0 for D58x Y8 and mode1 for D58x interleaved IR formats after `set_fmt`.
- Keep D4xx mode selection unchanged.

## Commit stack

1. `e46acbc` — D58x IR Tegra mode selection.

## Validation

IR mode selection was hardware validated by the original PR leg:

- Built JetPack 6.2.2 kernel/modules from `dev` without legacy `--d5xx --fg` flags.
- Deployed with the D5x MAX96724 tunnel overlay and verified the installed 5.15.185-tegra artifacts.
- Captured D58x Y8I 1280x720@60 with metadata; strict video/metadata counter checks passed and the NVCSI deskew panic did not recur.
- Ran the baseline E2E suite for Depth, IR, RGB, IMU, combined CIT profiles, SerDes, module reload, node inventory, and controls.

The combined three-commit PR additionally passed:

- JP6.2.1 ARM64 `d4xx.o` single-object compile.
- Strict checkpatch: 0 errors, 0 warnings, 0 checks.
- `git diff --check`.

D585 Sync Mode hardware validation remains pending; this PR does not claim runtime validation for the new `0/2/3` and stream/reset lifecycle paths.

## Follow-up scope

Remaining D5x features can continue as separate commits on this PR, with the accumulated E2E regression run before each additional feature is accepted.
