### PR TITLE
[RSDEV-12730][D58X][GMSL] Harden exposure control

### DIFF
--- a/kernel/realsense/d4xx.c
+++ b/kernel/realsense/d4xx.c
@@ -296,6 +296,7 @@ enum ds5_mux_pad {
 /* I2C retry configuration */
 #define DS5_I2C_RETRY_COUNT	5
 #define DS5_I2C_RETRY_DELAY_US	5000
+#define DS5_EXPOSURE_READ_RETRY_COUNT	3
 
 /* DFU definition section */
 #define DFU_MAGIC_NUMBER "/0x01/0x02/0x03/0x04"
@@ -3502,6 +3503,7 @@ static int ds5_g_volatile_ctrl(struct v4l2_ctrl *ctrl)
 			
 	u32 data;
 	int ret = 0;
+	int retry;
 	struct ds5_sensor *sensor = (struct ds5_sensor *)ctrl->priv;
 	u16 base;
 	u16 reg;
@@ -3559,11 +3561,28 @@ static int ds5_g_volatile_ctrl(struct v4l2_ctrl *ctrl)
 		if (state->is_imu)
 			return -EINVAL;
 		/* see ds5_hw_set_exposure */
-		ds5_read(state, base | DS5_MANUAL_EXPOSURE_MSB, &reg);
-		data = ((u32)reg << 16) & 0xffff0000;
-		ds5_read(state, base | DS5_MANUAL_EXPOSURE_LSB, &reg);
-		data |= reg;
-		*ctrl->p_new.p_u32 = data;
+		for (retry = 0; retry < DS5_EXPOSURE_READ_RETRY_COUNT; retry++) {
+			ret = ds5_read(state,
+				       base | DS5_MANUAL_EXPOSURE_MSB, &reg);
+			if (!ret) {
+				data = ((u32)reg << 16) & 0xffff0000;
+				ret = ds5_read(state,
+					       base | DS5_MANUAL_EXPOSURE_LSB,
+					       &reg);
+			}
+			if (!ret) {
+				data |= reg;
+				if (data >= ctrl->minimum &&
+				    data <= ctrl->maximum) {
+					*ctrl->p_new.p_u32 = data;
+					break;
+				}
+				ret = -ERANGE;
+			}
+			if (retry < DS5_EXPOSURE_READ_RETRY_COUNT - 1)
+				usleep_range(DS5_I2C_RETRY_DELAY_US,
+					     DS5_I2C_RETRY_DELAY_US + 500);
+		}
 		break;
 
 	case V4L2_CID_BRIGHTNESS:

--- a/kernel/realsense/d4xx.c
+++ b/kernel/realsense/d4xx.c
@@ -3033,7 +3033,11 @@ static int ds5_s_ctrl(struct v4l2_ctrl *ctrl)
 		break;
 
 	case V4L2_CID_EXPOSURE_ABSOLUTE:
-		ret = ds5_hw_set_exposure(state, base, ctrl->val);
+		if (!ctrl->p_new.p_u32)
+			ret = -EINVAL;
+		else
+			ret = ds5_hw_set_exposure(state, base,
+						  *ctrl->p_new.p_u32);
 		break;
 	case V4L2_CID_BRIGHTNESS:
 		if (state->is_rgb)
@@ -3861,6 +3865,36 @@ static int ds5_g_volatile_ctrl(struct v4l2_ctrl *ctrl)
 static const struct v4l2_ctrl_ops ds5_ctrl_ops = {
 	.s_ctrl	= ds5_s_ctrl,
 	.g_volatile_ctrl = ds5_g_volatile_ctrl,
+};
+
+static const struct v4l2_ctrl_config ds5_ctrl_depth_exposure = {
+	.ops = &ds5_ctrl_ops,
+	.id = V4L2_CID_EXPOSURE_ABSOLUTE,
+	.name = "Exposure Time, Absolute",
+	.type = V4L2_CTRL_TYPE_U32,
+	.min = 1,
+	.max = MAX_DEPTH_EXP,
+	.step = 1,
+	.def = DEF_DEPTH_EXP,
+	.dims = {1},
+	.elem_size = sizeof(u32),
+	.flags = V4L2_CTRL_FLAG_VOLATILE |
+		 V4L2_CTRL_FLAG_EXECUTE_ON_WRITE,
+};
+
+static const struct v4l2_ctrl_config ds5_ctrl_rgb_exposure = {
+	.ops = &ds5_ctrl_ops,
+	.id = V4L2_CID_EXPOSURE_ABSOLUTE,
+	.name = "Exposure Time, Absolute",
+	.type = V4L2_CTRL_TYPE_U32,
+	.min = 1,
+	.max = MAX_RGB_EXP,
+	.step = 1,
+	.def = DEF_RGB_EXP,
+	.dims = {1},
+	.elem_size = sizeof(u32),
+	.flags = V4L2_CTRL_FLAG_VOLATILE |
+		 V4L2_CTRL_FLAG_EXECUTE_ON_WRITE,
 };
 
 static const struct v4l2_ctrl_config ds5_ctrl_log = {
@@ -4978,23 +5012,11 @@ static int ds5_ctrl_init(struct ds5 *state, int sid)
 		}
 	}
 
-	/* Exposure time: V4L2_CID_EXPOSURE_ABSOLUTE default unit: 100 us. */
+	/* Exposure time is a one-element U32 payload in microseconds. */
 	if (sid == DEPTH_SID || sid == IR_SID) {
-		ctrls->exposure = v4l2_ctrl_new_std(hdl, ops,
-					V4L2_CID_EXPOSURE_ABSOLUTE,
-					1, MAX_DEPTH_EXP, 1, DEF_DEPTH_EXP);
+		ctrls->exposure = v4l2_ctrl_new_custom(hdl, &ds5_ctrl_depth_exposure, sensor);
 	} else if (sid == RGB_SID) {
-		ctrls->exposure = v4l2_ctrl_new_std(hdl, ops,
-					V4L2_CID_EXPOSURE_ABSOLUTE,
-					1, MAX_RGB_EXP, 1, DEF_RGB_EXP);
-	}
-
-	if ((ctrls->exposure) && (sid >= DEPTH_SID && sid < IMU_SID)) {
-		ctrls->exposure->priv = sensor;
-		ctrls->exposure->flags |=
-				V4L2_CTRL_FLAG_VOLATILE | V4L2_CTRL_FLAG_EXECUTE_ON_WRITE;
-		/* override default int type to u32 to match SKU & UVC */
-		ctrls->exposure->type = V4L2_CTRL_TYPE_U32;
+		ctrls->exposure = v4l2_ctrl_new_custom(hdl, &ds5_ctrl_rgb_exposure, sensor);
 	}
 
 	/* RGB-only ISP controls wired into the FW via DS5_RGB_CONTROL_BASE

--- a/kernel/realsense/d4xx.c
+++ b/kernel/realsense/d4xx.c
@@ -3092,11 +3092,7 @@ static int ds5_s_ctrl(struct v4l2_ctrl *ctrl)
 		break;
 
 	case V4L2_CID_EXPOSURE_ABSOLUTE:
-		if (!ctrl->p_new.p_u32)
-			ret = -EINVAL;
-		else
-			ret = ds5_hw_set_exposure(state, base,
-						  *ctrl->p_new.p_u32);
+		ret = ds5_hw_set_exposure(state, base, ctrl->val);
 		break;
 	case V4L2_CID_BRIGHTNESS:
 		if (state->is_rgb)
@@ -3628,7 +3624,7 @@ static int ds5_g_volatile_ctrl(struct v4l2_ctrl *ctrl)
 					(u32)ctrl->maximum, &data);
 		mutex_unlock(&state->lock);
 		if (!ret)
-			*ctrl->p_new.p_u32 = data;
+			*ctrl->p_new.p_s32 = data;
 		break;
 
 	case V4L2_CID_BRIGHTNESS:
@@ -3907,36 +3903,6 @@ static int ds5_g_volatile_ctrl(struct v4l2_ctrl *ctrl)
 static const struct v4l2_ctrl_ops ds5_ctrl_ops = {
 	.s_ctrl	= ds5_s_ctrl,
 	.g_volatile_ctrl = ds5_g_volatile_ctrl,
-};
-
-static const struct v4l2_ctrl_config ds5_ctrl_depth_exposure = {
-	.ops = &ds5_ctrl_ops,
-	.id = V4L2_CID_EXPOSURE_ABSOLUTE,
-	.name = "Exposure Time, Absolute",
-	.type = V4L2_CTRL_TYPE_U32,
-	.min = 1,
-	.max = MAX_DEPTH_EXP,
-	.step = 1,
-	.def = DEF_DEPTH_EXP,
-	.dims = {1},
-	.elem_size = sizeof(u32),
-	.flags = V4L2_CTRL_FLAG_VOLATILE |
-		 V4L2_CTRL_FLAG_EXECUTE_ON_WRITE,
-};
-
-static const struct v4l2_ctrl_config ds5_ctrl_rgb_exposure = {
-	.ops = &ds5_ctrl_ops,
-	.id = V4L2_CID_EXPOSURE_ABSOLUTE,
-	.name = "Exposure Time, Absolute",
-	.type = V4L2_CTRL_TYPE_U32,
-	.min = 1,
-	.max = MAX_RGB_EXP,
-	.step = 1,
-	.def = DEF_RGB_EXP,
-	.dims = {1},
-	.elem_size = sizeof(u32),
-	.flags = V4L2_CTRL_FLAG_VOLATILE |
-		 V4L2_CTRL_FLAG_EXECUTE_ON_WRITE,
 };
 
 static const struct v4l2_ctrl_config ds5_ctrl_log = {
@@ -5054,11 +5020,21 @@ static int ds5_ctrl_init(struct ds5 *state, int sid)
 		}
 	}
 
-	/* Exposure time is a one-element U32 payload in microseconds. */
+	/* Exposure time in microseconds. Keep the standard scalar V4L2 ABI. */
 	if (sid == DEPTH_SID || sid == IR_SID) {
-		ctrls->exposure = v4l2_ctrl_new_custom(hdl, &ds5_ctrl_depth_exposure, sensor);
+		ctrls->exposure = v4l2_ctrl_new_std(hdl, ops,
+					V4L2_CID_EXPOSURE_ABSOLUTE,
+					1, MAX_DEPTH_EXP, 1, DEF_DEPTH_EXP);
 	} else if (sid == RGB_SID) {
-		ctrls->exposure = v4l2_ctrl_new_custom(hdl, &ds5_ctrl_rgb_exposure, sensor);
+		ctrls->exposure = v4l2_ctrl_new_std(hdl, ops,
+					V4L2_CID_EXPOSURE_ABSOLUTE,
+					1, MAX_RGB_EXP, 1, DEF_RGB_EXP);
+	}
+
+	if (ctrls->exposure) {
+		ctrls->exposure->priv = sensor;
+		ctrls->exposure->flags |= V4L2_CTRL_FLAG_VOLATILE |
+					  V4L2_CTRL_FLAG_EXECUTE_ON_WRITE;
 	}
 
 	/* RGB-only ISP controls wired into the FW via DS5_RGB_CONTROL_BASE

--- a/kernel/realsense/d4xx.c
+++ b/kernel/realsense/d4xx.c
@@ -296,7 +296,7 @@ enum ds5_mux_pad {
 /* I2C retry configuration */
 #define DS5_I2C_RETRY_COUNT	5
 #define DS5_I2C_RETRY_DELAY_US	5000
-#define DS5_EXPOSURE_READ_MAX_TIME_MS	1000
+#define DS5_EXPOSURE_READ_RETRY_COUNT	15
 
 /* DFU definition section */
 #define DFU_MAGIC_NUMBER "/0x01/0x02/0x03/0x04"
@@ -967,58 +967,53 @@ static int ds5_read_poll(struct ds5 *state, u16 reg, u16 *val)
 static int ds5_read_exposure(struct ds5 *state, u16 base,
 			     u32 minimum, u32 maximum, u32 *value)
 {
-	unsigned long start = jiffies;
-	unsigned long timeout =
-		start + msecs_to_jiffies(DS5_EXPOSURE_READ_MAX_TIME_MS);
 	u16 msw;
 	u16 lsw;
 	u32 data;
-	unsigned int attempts = 0;
+	unsigned int attempt;
 	int ret;
 
 	if (!value)
 		return -EINVAL;
 
-	do {
-		attempts++;
-
+	for (attempt = 0; attempt < DS5_EXPOSURE_READ_RETRY_COUNT; attempt++) {
 		/*
-		 * Read MSW first so every retry starts a fresh FW snapshot. Use
-		 * one-shot reads here because this function owns the total retry
-		 * deadline; ds5_read() has an independent five-attempt budget.
+		 * Reading MSW starts the FW snapshot. On a transport failure or
+		 * invalid pair, always restart the complete pair from MSW.
 		 */
 		ret = ds5_read_poll(state,
 				    base | DS5_MANUAL_EXPOSURE_MSB, &msw);
-		if (!ret) {
-			if (!time_before(jiffies, timeout)) {
-				ret = -ETIMEDOUT;
-				break;
-			}
-
+		if (!ret)
 			ret = ds5_read_poll(state,
 					    base | DS5_MANUAL_EXPOSURE_LSB, &lsw);
-		}
 
 		if (!ret) {
 			data = ((u32)msw << 16) | lsw;
-			if (data >= minimum && data <= maximum) {
+			if (data < minimum || data > maximum) {
+				ret = -ERANGE;
+				if (attempt < DS5_EXPOSURE_READ_RETRY_COUNT - 1)
+					dev_dbg(&state->client->dev,
+						"%s(): complete-pair retry %u, value %u outside range %u..%u\n",
+						__func__, attempt + 1, data,
+						minimum, maximum);
+			} else {
 				*value = data;
 				return 0;
 			}
-			ret = -ERANGE;
+		} else if (attempt < DS5_EXPOSURE_READ_RETRY_COUNT - 1) {
+			dev_dbg(&state->client->dev,
+				"%s(): complete-pair retry %u, err %d\n",
+				__func__, attempt + 1, ret);
 		}
 
-		if (!time_before(jiffies, timeout))
-			break;
-
-		usleep_range(DS5_I2C_RETRY_DELAY_US,
-			     DS5_I2C_RETRY_DELAY_US + 500);
-	} while (time_before(jiffies, timeout));
+		if (attempt < DS5_EXPOSURE_READ_RETRY_COUNT - 1)
+			usleep_range(DS5_I2C_RETRY_DELAY_US,
+				     DS5_I2C_RETRY_DELAY_US + 500);
+	}
 
 	dev_err(&state->client->dev,
-		"%s(): failed after %u attempts in %u ms, err %d\n",
-		__func__, attempts,
-		jiffies_to_msecs(jiffies - start), ret);
+		"%s(): failed after %u attempts, err %d\n",
+		__func__, DS5_EXPOSURE_READ_RETRY_COUNT, ret);
 
 	return ret;
 }

--- a/kernel/realsense/d4xx.c
+++ b/kernel/realsense/d4xx.c
@@ -296,7 +296,7 @@ enum ds5_mux_pad {
 /* I2C retry configuration */
 #define DS5_I2C_RETRY_COUNT	5
 #define DS5_I2C_RETRY_DELAY_US	5000
-#define DS5_EXPOSURE_READ_RETRY_COUNT	3
+#define DS5_EXPOSURE_READ_MAX_TIME_MS	1000
 
 /* DFU definition section */
 #define DFU_MAGIC_NUMBER "/0x01/0x02/0x03/0x04"
@@ -962,6 +962,65 @@ static int ds5_read(struct ds5 *state, u16 reg, u16 *val)
 static int ds5_read_poll(struct ds5 *state, u16 reg, u16 *val)
 {
 	return regmap_raw_read(state->regmap, reg, val, 2);
+}
+
+static int ds5_read_exposure(struct ds5 *state, u16 base,
+			     u32 minimum, u32 maximum, u32 *value)
+{
+	unsigned long start = jiffies;
+	unsigned long timeout =
+		start + msecs_to_jiffies(DS5_EXPOSURE_READ_MAX_TIME_MS);
+	u16 msw;
+	u16 lsw;
+	u32 data;
+	unsigned int attempts = 0;
+	int ret;
+
+	if (!value)
+		return -EINVAL;
+
+	do {
+		attempts++;
+
+		/*
+		 * Read MSW first so every retry starts a fresh FW snapshot. Use
+		 * one-shot reads here because this function owns the total retry
+		 * deadline; ds5_read() has an independent five-attempt budget.
+		 */
+		ret = ds5_read_poll(state,
+				    base | DS5_MANUAL_EXPOSURE_MSB, &msw);
+		if (!ret) {
+			if (!time_before(jiffies, timeout)) {
+				ret = -ETIMEDOUT;
+				break;
+			}
+
+			ret = ds5_read_poll(state,
+					    base | DS5_MANUAL_EXPOSURE_LSB, &lsw);
+		}
+
+		if (!ret) {
+			data = ((u32)msw << 16) | lsw;
+			if (data >= minimum && data <= maximum) {
+				*value = data;
+				return 0;
+			}
+			ret = -ERANGE;
+		}
+
+		if (!time_before(jiffies, timeout))
+			break;
+
+		usleep_range(DS5_I2C_RETRY_DELAY_US,
+			     DS5_I2C_RETRY_DELAY_US + 500);
+	} while (time_before(jiffies, timeout));
+
+	dev_err(&state->client->dev,
+		"%s(): failed after %u attempts in %u ms, err %d\n",
+		__func__, attempts,
+		jiffies_to_msecs(jiffies - start), ret);
+
+	return ret;
 }
 
 static int ds5_raw_read(struct ds5 *state, u16 reg, void *val, size_t val_len)
@@ -3507,7 +3566,6 @@ static int ds5_g_volatile_ctrl(struct v4l2_ctrl *ctrl)
 			
 	u32 data;
 	int ret = 0;
-	int retry;
 	struct ds5_sensor *sensor = (struct ds5_sensor *)ctrl->priv;
 	u16 base;
 	u16 reg;
@@ -3564,29 +3622,13 @@ static int ds5_g_volatile_ctrl(struct v4l2_ctrl *ctrl)
 	case V4L2_CID_EXPOSURE_ABSOLUTE:
 		if (state->is_imu)
 			return -EINVAL;
-		/* see ds5_hw_set_exposure */
-		for (retry = 0; retry < DS5_EXPOSURE_READ_RETRY_COUNT; retry++) {
-			ret = ds5_read(state,
-				       base | DS5_MANUAL_EXPOSURE_MSB, &reg);
-			if (!ret) {
-				data = ((u32)reg << 16) & 0xffff0000;
-				ret = ds5_read(state,
-					       base | DS5_MANUAL_EXPOSURE_LSB,
-					       &reg);
-			}
-			if (!ret) {
-				data |= reg;
-				if (data >= ctrl->minimum &&
-				    data <= ctrl->maximum) {
-					*ctrl->p_new.p_u32 = data;
-					break;
-				}
-				ret = -ERANGE;
-			}
-			if (retry < DS5_EXPOSURE_READ_RETRY_COUNT - 1)
-				usleep_range(DS5_I2C_RETRY_DELAY_US,
-					     DS5_I2C_RETRY_DELAY_US + 500);
-		}
+		mutex_lock(&state->lock);
+		ret = ds5_read_exposure(state, base,
+					(u32)ctrl->minimum,
+					(u32)ctrl->maximum, &data);
+		mutex_unlock(&state->lock);
+		if (!ret)
+			*ctrl->p_new.p_u32 = data;
 		break;
 
 	case V4L2_CID_BRIGHTNESS:


### PR DESCRIPTION
## What

Harden D4xx/D58x Exposure readback while preserving the existing userspace ABI:

- keep `V4L2_CID_EXPOSURE_ABSOLUTE` as a standard scalar INTEGER control
- serialize Exposure GET with device-level SET and stream operations
- read a complete MSW-first / LSW-second FW snapshot
- restart the complete pair after a transport error or an invalid combined value
- use a fixed 15-attempt transport budget; remove the 1,000 ms wall-clock retry
- publish only complete values inside the advertised Exposure range

## Why

The old Host path ignored both register-read return values and assembled whatever
was left in the two half-word variables. That allowed corrupt values such as
2147483648 to reach userspace.

Reading Exposure MSW starts the FW snapshot and LSW completes that same snapshot,
so a failed or invalid pair must restart from MSW. Normal cached reads with the
FW change below complete in about 4–6 ms. D585 testing still found transient GMSL
transport contention during SET/stream overlap: one successful test needed 12
non-publishable attempts (`-EREMOTEIO` plus an out-of-range `0xFF` pair) before
the next complete pair succeeded. A bounded Host transport retry is therefore
still needed even with the new FW, but it is not used for cache freshness or
old-FW compatibility.

A true one-element `V4L2_CTRL_TYPE_U32` control is pointer-backed in V4L2 and
rejects the repository's existing streamApp and librealsense `size=0` scalar
requests before the driver callback. The supported Depth 1..200000 and RGB
1..10000 ranges fit in signed 32 bits, so the standard INTEGER control preserves
the contract for D4xx and D58x without an ABI split.

## Firmware dependency

Companion FW PR:
[RealSenseAI-Internal/soc-rs-soc-device-mgr#430](https://github.com/RealSenseAI-Internal/soc-rs-soc-device-mgr/pull/430)

That PR moves synchronous Application GET out of the I2C response path and
serves mapped reads from a per-camera cache/shadow, with asynchronous refresh
and SET write-through. It removes the previous 600–940 ms normal startup GET
tail. The Host retry in this PR handles only the remaining transport/snapshot
integrity failures; it cannot and does not provide cache freshness.

The attached Jetson has a D585, so no separate D4xx hardware smoke test was run.
D4xx remains on the standard scalar V4L2 control ABI it used before this PR.

## Validation

- strict full-PR checkpatch: 0 errors, 0 warnings, 0 checks
- full clean JP6.2.1 NVIDIA OOT build: PASS
- final targeted NVIDIA OOT rebuild: PASS
- final module:
  - `srcversion=7019F13C69197CA259799F5`
  - `vermagic=5.15.148-tegra`
  - SHA-256 `15f276b2e7d5feefef6350e150172247818f97641057caa91d7ee52795915a8b`
- Depth startup: 5 streams, 400/400 valid Exposure reads, zero read/stream
  failures, maximum GET 5.824 ms
- RGB:
  - idle 200/200 valid reads, maximum GET 5.952 ms
  - 5 stream starts, 400/400 valid reads, zero read/stream failures, maximum
    GET 5.844 ms
- Depth Exposure boundary SET/GET: 1, 10000, 200000 — 3/3 exact
- live Depth stream: 100 Exposure+Gain SET/GET iterations, zero SET/GET/stream
  failures; longest transport-contended GET 480.204 ms and maximum convergence
  485.011 ms
- Depth+IR mixed stress at 1280x960@30:
  - 600 Depth + 600 IR frames
  - zero sequence gaps and zero intervals over one second
  - 240 mixed AE/Exposure/Gain operations with readback, zero failures
- no terminal 15-attempt Exposure error, kernel warning, timeout, or call trace
  with the final module
- controls restored to Exposure 10000 on Depth and RGB

The reported frame-stop symptom was not reproduced with the current FW/Host
pair.
