### PR TITLE
docs: fix deploy instructions and record rig deploy pitfalls

### DIFF
--- a/.claude/skills/deploy/SKILL.md
+++ b/.claude/skills/deploy/SKILL.md
@@ -18,10 +18,18 @@ Always ask the user which JetPack version to target if not specified.
 To deploy use this bash command:
 
 ```bash
-./scripts/deploy_kernel.sh $VERSION <TARGET_IP> [USERNAME] [REMOTE_PATH]
+./scripts/deploy_kernel.sh $VERSION <TARGET_IP> [USERNAME] [REMOTE_PATH] [REMOTE_BOOT_FOLDER]
 ```
 
-Defaults: USERNAME=`administrator`, REMOTE_PATH='git.USER.NAME'
+Defaults: USERNAME=`administrator`, REMOTE_PATH='git.USER.NAME', REMOTE_BOOT_FOLDER=`dev`
+
+`REMOTE_BOOT_FOLDER` selects which `/boot/<folder>` receives the kernel `Image`; rigs whose `extlinux.conf` boots a non-default folder need it set explicitly. Known-good example:
+
+```bash
+./scripts/deploy_kernel.sh 6.2 fw-orin-3 nvidia drgb_poc dev
+```
+
+This script is the **only** supported way to deploy a driver build — it replaces the whole `/lib/modules/$(uname -r)` tree, so every module stays ABI-consistent. Never hand-copy individual `.ko` files: `tegra-camera.ko` exports `camera_common_*` to `d4xx.ko` and `tegra_csi_*`/`csi5_fops` to `nvhost-nvcsi*`, so a partial copy strands the other consumers ("disagrees about version of symbol"), NVCSI fails to load, and no `/dev/video*` are created at all.
 
 The command must have all 3 arguments to perform the full deploy.
 Ask the user to provide username and remote path if not provided.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,10 +38,14 @@ The `--one-cam`/`--dual-cam` options only apply to JetPack 5.0.2. The target ver
 
 ### Deploy to Jetson
 
+`scripts/deploy_kernel.sh` is the deploy path for **all** JetPack versions (there is no `deploy_kernel_6.2.sh`). It packages the modules, copies them to the target, updates `/boot/<REMOTE_BOOT_FOLDER>` and reboots:
+
 ```bash
-./scripts/deploy_kernel.sh        # For JP 4.x/5.x
-./scripts/deploy_kernel_6.2.sh    # For JP 6.2+
+./scripts/deploy_kernel.sh <JP_VERSION> [TARGET] [USERNAME] [REMOTE_PATH] [REMOTE_BOOT_FOLDER]
+./scripts/deploy_kernel.sh 6.2 fw-orin-3 nvidia drgb_poc dev   # → /home/nvidia/drgb_poc, /boot/dev
 ```
+
+Deploy the **whole** module set this script produces — never hand-copy individual `.ko` files. `tegra-camera.ko` exports `camera_common_*` to `d4xx.ko` **and** `tegra_csi_*`/`csi5_fops` to `nvhost-nvcsi*`, so replacing it alone strands the other consumers ("disagrees about version of symbol") and NVCSI fails to load, leaving no `/dev/video*` at all. Two further traps on a live rig: `rmmod` of the SerDes/camera modules can wedge in **D-state** (unkillable, needs a power cycle), and a `modprobe` issued *after* boot binds the I2C devices but creates no `/dev/video*` — the VI nodes are only built during boot-time setup, so reboot instead of reloading by hand. `d4xx` has no `modules-load.d`/initramfs entry; it autoloads from the DT modalias, and that enumeration is intermittent — a boot with 0 nodes is usually the known GMSL cold-boot flakiness, so reboot (or power-cycle) rather than assuming the build is bad.
 
 On JetPack 5.x, `install_to_kernel.sh` refuses to install a kernel `Image` whose embedded `Linux version` differs from the running `uname -r` (JP5 installs only a few `.ko`, so a mismatched-JetPack Image boots with no modules and can latch the bootloader into recovery); `SKIP_KERNEL_CHECK=1` overrides. Keep this guard when editing the deploy scripts.
 


### PR DESCRIPTION
## Why

`CLAUDE.md` told readers to use `scripts/deploy_kernel_6.2.sh` for "JP 6.2+" — **that script does not exist**. `deploy_kernel.sh` handles every JetPack version. The deploy skill also documented only 4 of its 5 arguments, omitting `REMOTE_BOOT_FOLDER`.

Both were hit in practice this week: the missing script sent me looking for a JP6.2-specific deploy path, and the undocumented 5th argument matters on rigs whose `extlinux.conf` boots a non-default `/boot/<folder>`.

## What changed

- **`CLAUDE.md`** — corrected the deploy section: one script for all versions, full 5-arg signature, plus a known-good invocation.
- **`.claude/skills/deploy/SKILL.md`** — added `REMOTE_BOOT_FOLDER` with an explanation and example.

Both files also record three pitfalls learned while deploying to fw-orin-3:

1. **Deploy the whole module set** the script produces; never hand-copy single `.ko` files. `tegra-camera.ko` exports `camera_common_*` to `d4xx.ko` **and** `tegra_csi_*`/`csi5_fops` to `nvhost-nvcsi*` — replacing it alone strands the other consumers (`disagrees about version of symbol`), NVCSI fails to load, and **no `/dev/video*` are created at all**.
2. **`rmmod` of the SerDes/camera modules can wedge in D-state** — unkillable, needs a power cycle.
3. **A post-boot `modprobe` binds the I2C devices but creates no VI nodes**, and `d4xx` autoloads from the DT modalias (no `modules-load.d`/initramfs entry) with intermittent enumeration — a 0-node boot is usually the known GMSL cold-boot flakiness, not a bad build.

## Scope

Documentation only — no code, no build or driver behavior change. Split out of #459 deliberately so that PR stays limited to the D401 dual-RGB passthrough change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)