### PR TITLE
Fix D5xx video node enumeration order

### DIFF
--- a/hardware/realsense/tegra234-camera-d4xx-overlay-d5xx.dts
+++ b/hardware/realsense/tegra234-camera-d4xx-overlay-d5xx.dts
@@ -285,6 +285,202 @@
 							};
 
 							/*
+							 * D585 IMU stream — VC3
+							 * IMU follows the D5xx stream model as stream 3 / VC3.
+							 *
+							 * def-addr: 0x10 = HKR SoC I2C base
+							 * reg: 0x1d = aliased address
+							 * override_reg: 0x1a = redirect to primary node
+							 */
+							d5xx_imu: d5xx@1d {
+								status = "okay";
+								def-addr = <0x10>;
+								reg = <0x1d>;
+								override_reg = <0x1a>;
+								compatible = "realsense,d5xx";
+								use_sensor_mode_id = "true";
+								vcc-supply = <&vdd_1v8_ls>;
+								cam-type = "IMU";
+								nvidia,gmsl-ser-device = <&ser_a>;
+								nvidia,gmsl-dser-device = <&dser>;
+
+								ports {
+									#address-cells = <1>;
+									#size-cells = <0>;
+
+									port@0 {
+										reg = <0>;
+										d5xx_imu_out: endpoint {
+											vc-id = <3>;
+											port-index = <0>;
+										bus-width = <2>;
+											remote-endpoint = <&d5xx_csi_in3>;
+										};
+									};
+								};
+
+								/*
+								 * IMU mode: RAW8 logical stream on VC3.
+								 * embedded_metadata_height: 0 — IMU has no metadata row.
+								 */
+								mode0 {
+									pixel_t = "grey_y8";
+									num_lanes = "2";
+									csi_pixel_bit_depth = "8";
+									active_w = "640";
+									active_h = "480";
+									tegra_sinterface = "serial_a";
+									phy_mode = "DPHY";
+									discontinuous_clk = "no";
+									mclk_khz = "24000";
+									pix_clk_hz = "175000000";
+									line_length = "1280";
+									embedded_metadata_height = "0";
+								};
+
+								gmsl-link {
+									src-csi-port = "a";
+									dst-csi-port = "a";
+									serdes-csi-link = "a";
+									csi-mode = "1x4";
+									st-vc = <3>;
+									vc-id = <3>;
+									num-lanes = <2>;
+								};
+							};
+
+							/*
+							 * D585 IR stream — VC2
+							 * Y8, Y8I, and Y12I are mutually exclusive formats on
+							 * one logical IR stream, not separate left/right nodes.
+							 *
+							 * def-addr: 0x10 = HKR SoC I2C base
+							 * reg: 0x1c = aliased address
+							 * override_reg: 0x1a = redirect to primary node
+							 */
+							d5xx_ir: d5xx@1c {
+								status = "okay";
+								def-addr = <0x10>;
+								reg = <0x1c>;
+								override_reg = <0x1a>;
+								compatible = "realsense,d5xx";
+								use_sensor_mode_id = "true";
+								vcc-supply = <&vdd_1v8_ls>;
+								cam-type = "Y8";
+								nvidia,gmsl-ser-device = <&ser_a>;
+								nvidia,gmsl-dser-device = <&dser>;
+
+								ports {
+									#address-cells = <1>;
+									#size-cells = <0>;
+
+									port@0 {
+										reg = <0>;
+										d5xx_ir_out: endpoint {
+											vc-id = <2>;
+											port-index = <0>;
+										bus-width = <2>;
+											remote-endpoint = <&d5xx_csi_in2>;
+										};
+									};
+								};
+
+								/*
+								 * IR mode: Y8/Y8I/Y12I, 1280x720
+								 * embedded_metadata_height: 1 — IR metadata row
+								 */
+								mode0 {
+									pixel_t = "grey_y8";
+									num_lanes = "2";
+									csi_pixel_bit_depth = "8";
+									active_w = "1280";
+									active_h = "720";
+									tegra_sinterface = "serial_a";
+									phy_mode = "DPHY";
+									discontinuous_clk = "no";
+									mclk_khz = "24000";
+									pix_clk_hz = "175000000";
+									line_length = "1280";
+									embedded_metadata_height = "1";
+								};
+
+								gmsl-link {
+									src-csi-port = "a";
+									dst-csi-port = "a";
+									serdes-csi-link = "a";
+									csi-mode = "1x4";
+									st-vc = <2>;
+									vc-id = <2>;
+									num-lanes = <2>;
+								};
+							};
+
+							/*
+							 * D585 RGB stream — VC1
+							 * RGB follows the D5xx stream model as stream 1 / VC1.
+							 *
+							 * def-addr: 0x10 = HKR SoC I2C base
+							 * reg: 0x1b = aliased address
+							 * override_reg: 0x1a = redirect to primary node
+							 */
+							d5xx_rgb: d5xx@1b {
+								status = "okay";
+								def-addr = <0x10>;
+								reg = <0x1b>;
+								override_reg = <0x1a>;
+								compatible = "realsense,d5xx";
+								use_sensor_mode_id = "true";
+								vcc-supply = <&vdd_1v8_ls>;
+								cam-type = "RGB";
+								nvidia,gmsl-ser-device = <&ser_a>;
+								nvidia,gmsl-dser-device = <&dser>;
+
+								ports {
+									#address-cells = <1>;
+									#size-cells = <0>;
+
+									port@0 {
+										reg = <0>;
+										d5xx_rgb_out: endpoint {
+											vc-id = <1>;
+											port-index = <0>;
+										bus-width = <2>;
+											remote-endpoint = <&d5xx_csi_in1>;
+										};
+									};
+								};
+
+								/*
+								 * RGB mode: YUY2 (16bpp), 1920x1080
+								 * embedded_metadata_height: 1 — RGB metadata row
+								 */
+								mode0 {
+									pixel_t = "yuv_yuyv16";
+									num_lanes = "2";
+									csi_pixel_bit_depth = "16";
+									active_w = "1920";
+									active_h = "1080";
+									tegra_sinterface = "serial_a";
+									phy_mode = "DPHY";
+									discontinuous_clk = "no";
+									mclk_khz = "24000";
+									pix_clk_hz = "175000000";
+									line_length = "1920";
+									embedded_metadata_height = "1";
+								};
+
+								gmsl-link {
+									src-csi-port = "a";
+									dst-csi-port = "a";
+									serdes-csi-link = "a";
+									csi-mode = "1x4";
+									st-vc = <1>;
+									vc-id = <1>;
+									num-lanes = <2>;
+								};
+							};
+
+							/*
 							 * D585 Depth stream — VC0
 							 * [HAS] Table 3-5: Depth, Z16, 1280x720, 60fps, VC0
 							 * [HAS] Section 4.1: "HKR assigns output streams to
@@ -359,202 +555,6 @@
 									csi-mode = "1x4";
 									st-vc = <0>;
 									vc-id = <0>;
-									num-lanes = <2>;
-								};
-							};
-
-							/*
-							 * D585 RGB stream — VC1
-							 * RGB follows the D5xx stream model as stream 1 / VC1.
-							 *
-							 * def-addr: 0x10 = HKR SoC I2C base
-							 * reg: 0x1b = aliased address
-							 * override_reg: 0x1a = redirect to primary node
-							 */
-							d5xx_rgb: d5xx@1b {
-								status = "okay";
-								def-addr = <0x10>;
-								reg = <0x1b>;
-								override_reg = <0x1a>;
-								compatible = "realsense,d5xx";
-								use_sensor_mode_id = "true";
-								vcc-supply = <&vdd_1v8_ls>;
-								cam-type = "RGB";
-								nvidia,gmsl-ser-device = <&ser_a>;
-								nvidia,gmsl-dser-device = <&dser>;
-
-								ports {
-									#address-cells = <1>;
-									#size-cells = <0>;
-
-									port@0 {
-										reg = <0>;
-										d5xx_rgb_out: endpoint {
-											vc-id = <1>;
-											port-index = <0>;
-										bus-width = <2>;
-											remote-endpoint = <&d5xx_csi_in1>;
-										};
-									};
-								};
-
-								/*
-								 * RGB mode: YUY2 (16bpp), 1920x1080
-								 * embedded_metadata_height: 1 — RGB metadata row
-								 */
-								mode0 {
-									pixel_t = "yuv_yuyv16";
-									num_lanes = "2";
-									csi_pixel_bit_depth = "16";
-									active_w = "1920";
-									active_h = "1080";
-									tegra_sinterface = "serial_a";
-									phy_mode = "DPHY";
-									discontinuous_clk = "no";
-									mclk_khz = "24000";
-									pix_clk_hz = "175000000";
-									line_length = "1920";
-									embedded_metadata_height = "1";
-								};
-
-								gmsl-link {
-									src-csi-port = "a";
-									dst-csi-port = "a";
-									serdes-csi-link = "a";
-									csi-mode = "1x4";
-									st-vc = <1>;
-									vc-id = <1>;
-									num-lanes = <2>;
-								};
-							};
-
-							/*
-							 * D585 IR stream — VC2
-							 * Y8, Y8I, and Y12I are mutually exclusive formats on
-							 * one logical IR stream, not separate left/right nodes.
-							 *
-							 * def-addr: 0x10 = HKR SoC I2C base
-							 * reg: 0x1c = aliased address
-							 * override_reg: 0x1a = redirect to primary node
-							 */
-							d5xx_ir: d5xx@1c {
-								status = "okay";
-								def-addr = <0x10>;
-								reg = <0x1c>;
-								override_reg = <0x1a>;
-								compatible = "realsense,d5xx";
-								use_sensor_mode_id = "true";
-								vcc-supply = <&vdd_1v8_ls>;
-								cam-type = "Y8";
-								nvidia,gmsl-ser-device = <&ser_a>;
-								nvidia,gmsl-dser-device = <&dser>;
-
-								ports {
-									#address-cells = <1>;
-									#size-cells = <0>;
-
-									port@0 {
-										reg = <0>;
-										d5xx_ir_out: endpoint {
-											vc-id = <2>;
-											port-index = <0>;
-										bus-width = <2>;
-											remote-endpoint = <&d5xx_csi_in2>;
-										};
-									};
-								};
-
-								/*
-								 * IR mode: Y8/Y8I/Y12I, 1280x720
-								 * embedded_metadata_height: 1 — IR metadata row
-								 */
-								mode0 {
-									pixel_t = "grey_y8";
-									num_lanes = "2";
-									csi_pixel_bit_depth = "8";
-									active_w = "1280";
-									active_h = "720";
-									tegra_sinterface = "serial_a";
-									phy_mode = "DPHY";
-									discontinuous_clk = "no";
-									mclk_khz = "24000";
-									pix_clk_hz = "175000000";
-									line_length = "1280";
-									embedded_metadata_height = "1";
-								};
-
-								gmsl-link {
-									src-csi-port = "a";
-									dst-csi-port = "a";
-									serdes-csi-link = "a";
-									csi-mode = "1x4";
-									st-vc = <2>;
-									vc-id = <2>;
-									num-lanes = <2>;
-								};
-							};
-
-							/*
-							 * D585 IMU stream — VC3
-							 * IMU follows the D5xx stream model as stream 3 / VC3.
-							 *
-							 * def-addr: 0x10 = HKR SoC I2C base
-							 * reg: 0x1d = aliased address
-							 * override_reg: 0x1a = redirect to primary node
-							 */
-							d5xx_imu: d5xx@1d {
-								status = "okay";
-								def-addr = <0x10>;
-								reg = <0x1d>;
-								override_reg = <0x1a>;
-								compatible = "realsense,d5xx";
-								use_sensor_mode_id = "true";
-								vcc-supply = <&vdd_1v8_ls>;
-								cam-type = "IMU";
-								nvidia,gmsl-ser-device = <&ser_a>;
-								nvidia,gmsl-dser-device = <&dser>;
-
-								ports {
-									#address-cells = <1>;
-									#size-cells = <0>;
-
-									port@0 {
-										reg = <0>;
-										d5xx_imu_out: endpoint {
-											vc-id = <3>;
-											port-index = <0>;
-										bus-width = <2>;
-											remote-endpoint = <&d5xx_csi_in3>;
-										};
-									};
-								};
-
-								/*
-								 * IMU mode: RAW8 logical stream on VC3.
-								 * embedded_metadata_height: 0 — IMU has no metadata row.
-								 */
-								mode0 {
-									pixel_t = "grey_y8";
-									num_lanes = "2";
-									csi_pixel_bit_depth = "8";
-									active_w = "640";
-									active_h = "480";
-									tegra_sinterface = "serial_a";
-									phy_mode = "DPHY";
-									discontinuous_clk = "no";
-									mclk_khz = "24000";
-									pix_clk_hz = "175000000";
-									line_length = "1280";
-									embedded_metadata_height = "0";
-								};
-
-								gmsl-link {
-									src-csi-port = "a";
-									dst-csi-port = "a";
-									serdes-csi-link = "a";
-									csi-mode = "1x4";
-									st-vc = <3>;
-									vc-id = <3>;
 									num-lanes = <2>;
 								};
 							};

--- a/hardware/realsense/tegra234-camera-d4xx-overlay-fg24-4ch-d5xx.dts
+++ b/hardware/realsense/tegra234-camera-d4xx-overlay-fg24-4ch-d5xx.dts
@@ -353,96 +353,17 @@
 						};
 
 						/*
-						 * D585 Depth stream — VC0
-						 * Z16, 1280x720, 60fps
+						 * D585 IMU stream — VC3
+						 * RAW8 logical stream
 						 */
-						d5xx_depth: d5xx@1a {
+						d5xx_imu: d5xx@1d {
 							status = "okay";
 							def-addr = <0x10>;
-							reg = <0x1a>;
-							compatible = "realsense,d5xx";
-							use_sensor_mode_id = "true";
-							cam-type = "Depth";
-							nvidia,gmsl-ser-device = <&ser_a>;
-							nvidia,gmsl-dser-device = <&dser>;
-
-							ports {
-								#address-cells = <1>;
-								#size-cells = <0>;
-
-								port@0 {
-									reg = <0>;
-									d5xx_depth_out: endpoint {
-										vc-id = <0>;
-										port-index = <2>;
-										bus-width = <4>;
-										remote-endpoint = <&d5xx_csi_in0>;
-									};
-								};
-							};
-
-							/*
-							 * Pixel clock reference for mixed-VC tunnel mode:
-							 *   pix_clk_hz = lane_rate_bps * lane_count / bits_per_pixel
-							 *
-							 * The MAX96724->Orin D-PHY output is configured to
-							 * 2.0Gbps/lane over 4 lanes, so the payload budget is
-							 * 2,000,000,000 * 4 = 8,000,000,000 bits/s.
-							 *
-							 * Tunnel mode carries each source packet as-is. There is
-							 * no single rewritten DES-side BPP when VC0-3 run
-							 * concurrently, so each Orin mode uses its own
-							 * csi_pixel_bit_depth:
-							 *   16-bit modes: 8,000,000,000 / 16 = 500,000,000 Hz
-							 *   8-bit modes:  8,000,000,000 /  8 = 1,000,000,000 Hz
-							 *
-							 * Aggregate bandwidth closure is still checked against
-							 * the shared 4-lane physical link and the 6Gbps GMSL2
-							 * forward link; pix_clk_hz here is the per-mode parser
-							 * clock NVIDIA uses for VI/NVCSI bandwidth setup.
-							 */
-							mode0 {
-								pixel_t = "yuv_uyvy16";
-								num_lanes = "4";
-								csi_pixel_bit_depth = "16";
-								active_w = "1280";
-								active_h = "720";
-								tegra_sinterface = "serial_c";
-								phy_mode = "DPHY";
-								discontinuous_clk = "no";
-								cil_settletime = "0";
-								deskew_initial_enable = "true";
-								deskew_periodic_enable = "true";
-								mclk_khz = "24000";
-								pix_clk_hz = "500000000";
-								serdes_pix_clk_hz = "500000000";
-								line_length = "1280";
-								embedded_metadata_height = "1";
-							};
-
-							gmsl-link {
-								src-csi-port = "a";
-								dst-csi-port = "a";
-								serdes-csi-link = "a";
-								csi-mode = "1x4";
-								st-vc = <0>;
-								vc-id = <0>;
-								num-lanes = <4>;
-							};
-						};
-
-						/*
-						 * D585 RGB stream — VC1
-						 * YUY2, 1920x1080, 30fps
-						 */
-						d5xx_rgb: d5xx@1b {
-							status = "okay";
-							def-addr = <0x10>;
-							reg = <0x1b>;
+							reg = <0x1d>;
 							override_reg = <0x1a>;
 							compatible = "realsense,d5xx";
 							use_sensor_mode_id = "true";
-							cam-type = "RGB";
+							cam-type = "IMU";
 							nvidia,gmsl-ser-device = <&ser_a>;
 							nvidia,gmsl-dser-device = <&dser>;
 
@@ -452,32 +373,30 @@
 
 								port@0 {
 									reg = <0>;
-									d5xx_rgb_out: endpoint {
-										vc-id = <1>;
+									d5xx_imu_out: endpoint {
+										vc-id = <3>;
 										port-index = <2>;
 										bus-width = <4>;
-										remote-endpoint = <&d5xx_csi_in1>;
+										remote-endpoint = <&d5xx_csi_in3>;
 									};
 								};
 							};
 
 							mode0 {
-								pixel_t = "yuv_yuyv16";
+								pixel_t = "grey_y8";
 								num_lanes = "4";
-								csi_pixel_bit_depth = "16";
-								active_w = "1920";
-								active_h = "1080";
+								csi_pixel_bit_depth = "8";
+								active_w = "640";
+								active_h = "480";
 								tegra_sinterface = "serial_c";
 								phy_mode = "DPHY";
 								discontinuous_clk = "no";
 								cil_settletime = "0";
-								deskew_initial_enable = "true";
-								deskew_periodic_enable = "true";
 								mclk_khz = "24000";
-								pix_clk_hz = "500000000";
-								serdes_pix_clk_hz = "500000000";
-								line_length = "1920";
-								embedded_metadata_height = "1";
+								pix_clk_hz = "1000000000";
+								serdes_pix_clk_hz = "1000000000";
+								line_length = "640";
+								embedded_metadata_height = "0";
 							};
 
 							gmsl-link {
@@ -485,8 +404,8 @@
 								dst-csi-port = "a";
 								serdes-csi-link = "a";
 								csi-mode = "1x4";
-								st-vc = <1>;
-								vc-id = <1>;
+								st-vc = <3>;
+								vc-id = <3>;
 								num-lanes = <4>;
 							};
 						};
@@ -571,17 +490,17 @@
 						};
 
 						/*
-						 * D585 IMU stream — VC3
-						 * RAW8 logical stream
+						 * D585 RGB stream — VC1
+						 * YUY2, 1920x1080, 30fps
 						 */
-						d5xx_imu: d5xx@1d {
+						d5xx_rgb: d5xx@1b {
 							status = "okay";
 							def-addr = <0x10>;
-							reg = <0x1d>;
+							reg = <0x1b>;
 							override_reg = <0x1a>;
 							compatible = "realsense,d5xx";
 							use_sensor_mode_id = "true";
-							cam-type = "IMU";
+							cam-type = "RGB";
 							nvidia,gmsl-ser-device = <&ser_a>;
 							nvidia,gmsl-dser-device = <&dser>;
 
@@ -591,30 +510,32 @@
 
 								port@0 {
 									reg = <0>;
-									d5xx_imu_out: endpoint {
-										vc-id = <3>;
+									d5xx_rgb_out: endpoint {
+										vc-id = <1>;
 										port-index = <2>;
 										bus-width = <4>;
-										remote-endpoint = <&d5xx_csi_in3>;
+										remote-endpoint = <&d5xx_csi_in1>;
 									};
 								};
 							};
 
 							mode0 {
-								pixel_t = "grey_y8";
+								pixel_t = "yuv_yuyv16";
 								num_lanes = "4";
-								csi_pixel_bit_depth = "8";
-								active_w = "640";
-								active_h = "480";
+								csi_pixel_bit_depth = "16";
+								active_w = "1920";
+								active_h = "1080";
 								tegra_sinterface = "serial_c";
 								phy_mode = "DPHY";
 								discontinuous_clk = "no";
 								cil_settletime = "0";
+								deskew_initial_enable = "true";
+								deskew_periodic_enable = "true";
 								mclk_khz = "24000";
-								pix_clk_hz = "1000000000";
-								serdes_pix_clk_hz = "1000000000";
-								line_length = "640";
-								embedded_metadata_height = "0";
+								pix_clk_hz = "500000000";
+								serdes_pix_clk_hz = "500000000";
+								line_length = "1920";
+								embedded_metadata_height = "1";
 							};
 
 							gmsl-link {
@@ -622,8 +543,87 @@
 								dst-csi-port = "a";
 								serdes-csi-link = "a";
 								csi-mode = "1x4";
-								st-vc = <3>;
-								vc-id = <3>;
+								st-vc = <1>;
+								vc-id = <1>;
+								num-lanes = <4>;
+							};
+						};
+
+						/*
+						 * D585 Depth stream — VC0
+						 * Z16, 1280x720, 60fps
+						 */
+						d5xx_depth: d5xx@1a {
+							status = "okay";
+							def-addr = <0x10>;
+							reg = <0x1a>;
+							compatible = "realsense,d5xx";
+							use_sensor_mode_id = "true";
+							cam-type = "Depth";
+							nvidia,gmsl-ser-device = <&ser_a>;
+							nvidia,gmsl-dser-device = <&dser>;
+
+							ports {
+								#address-cells = <1>;
+								#size-cells = <0>;
+
+								port@0 {
+									reg = <0>;
+									d5xx_depth_out: endpoint {
+										vc-id = <0>;
+										port-index = <2>;
+										bus-width = <4>;
+										remote-endpoint = <&d5xx_csi_in0>;
+									};
+								};
+							};
+
+							/*
+							 * Pixel clock reference for mixed-VC tunnel mode:
+							 *   pix_clk_hz = lane_rate_bps * lane_count / bits_per_pixel
+							 *
+							 * The MAX96724->Orin D-PHY output is configured to
+							 * 2.0Gbps/lane over 4 lanes, so the payload budget is
+							 * 2,000,000,000 * 4 = 8,000,000,000 bits/s.
+							 *
+							 * Tunnel mode carries each source packet as-is. There is
+							 * no single rewritten DES-side BPP when VC0-3 run
+							 * concurrently, so each Orin mode uses its own
+							 * csi_pixel_bit_depth:
+							 *   16-bit modes: 8,000,000,000 / 16 = 500,000,000 Hz
+							 *   8-bit modes:  8,000,000,000 /  8 = 1,000,000,000 Hz
+							 *
+							 * Aggregate bandwidth closure is still checked against
+							 * the shared 4-lane physical link and the 6Gbps GMSL2
+							 * forward link; pix_clk_hz here is the per-mode parser
+							 * clock NVIDIA uses for VI/NVCSI bandwidth setup.
+							 */
+							mode0 {
+								pixel_t = "yuv_uyvy16";
+								num_lanes = "4";
+								csi_pixel_bit_depth = "16";
+								active_w = "1280";
+								active_h = "720";
+								tegra_sinterface = "serial_c";
+								phy_mode = "DPHY";
+								discontinuous_clk = "no";
+								cil_settletime = "0";
+								deskew_initial_enable = "true";
+								deskew_periodic_enable = "true";
+								mclk_khz = "24000";
+								pix_clk_hz = "500000000";
+								serdes_pix_clk_hz = "500000000";
+								line_length = "1280";
+								embedded_metadata_height = "1";
+							};
+
+							gmsl-link {
+								src-csi-port = "a";
+								dst-csi-port = "a";
+								serdes-csi-link = "a";
+								csi-mode = "1x4";
+								st-vc = <0>;
+								vc-id = <0>;
 								num-lanes = <4>;
 							};
 						};


### PR DESCRIPTION
## Summary

- reorder the D5xx I2C child nodes as IMU, IR, RGB, Depth in the generic and FG24 overlays
- preserve every sensor node property, endpoint, VC assignment, clock, and format setting
- make Tegra register the resulting video nodes in the Depth, Color, IR, IMU order expected by the packaged MIPI enumeration script

## Root cause

The affected overlays declared their D5xx children as Depth, RGB, IR, IMU. After the overlay is applied, the Tegra driver probes these children in reverse order and registers the streaming nodes as IMU, IR, RGB, Depth. The packaged enumeration script assigns sensor names in Depth, Color, IR, IMU order, which can link the Depth device to the IMU node. GVD queries against that node then fail with `EINVAL`.

## Validation

- confirmed each moved Depth, RGB, IR, and IMU node is byte-identical to its version on `dev`
- built the JetPack 6.2 DTBO set successfully; existing graph warnings remain unchanged
- decompiled both generated DTBOs and confirmed the intended IMU, IR, RGB, Depth child order
- deployed the FG24 DTBO on two Orin systems and rebooted with the package-original `rs-enum.sh`
- verified runtime nodes enumerate as Depth `video0`, Color `video2`, IR `video4`, IMU `video6`
- completed repeated `rs-enumerate-devices` runs without failure on both FG24 systems

The generic overlay is compile-validated; runtime hardware validation was performed on the FG24 overlay.
