### PR TITLE
Add FG12 4-channel D5xx overlay

### DIFF
--- a/README_JP6.0.md
+++ b/README_JP6.0.md
@@ -175,6 +175,7 @@ sudo ln -s /boot/initrd.img-5.15.136-tegra /boot/initrd
     | `tegra234-camera-d4xx-overlay-dual.dtbo` | max9296 deserializer board w/ two connected cameras |
     | `tegra234-camera-d4xx-overlay-max96712-EVB.dtbo` | max96712 evaluation board |
     | `tegra234-camera-d4xx-overlay-max96712-EVB-cams-0-1.dtbo` | max96712 evaluation board w/ two connected cameras |
+    | `tegra234-camera-d4xx-overlay-fg12-4ch-d5xx.dtbo` | Fangzhu fg12-4ch board with a single D5xx camera (max96717 serializer, 4-lane) connected to link A |
     | `tegra234-camera-d4xx-overlay-fg12-16ch.dtbo` | Fangzhu fg12-16ch board with a single camera connected to cam0 |
     | `tegra234-camera-d4xx-overlay-fg12-16ch-d5xx.dtbo` | Fangzhu fg12-16ch board with a single D5xx camera (max96717 serializer, 4-lane) connected to cam0 |
     | `tegra234-camera-d4xx-overlay-fg12-16ch-cams-0-1.dtbo` | Fangzhu fg12-16ch board with two cameras connected to cam0 & cam1 |

--- a/README_JP6.2.md
+++ b/README_JP6.2.md
@@ -175,6 +175,7 @@ sudo ln -s /boot/initrd.img-5.15.148-tegra /boot/initrd
     | `tegra234-camera-d4xx-overlay-dual.dtbo` | max9296 deserializer board w/ two connected cameras |
     | `tegra234-camera-d4xx-overlay-max96712-EVB.dtbo` | max96712 evaluation board |
     | `tegra234-camera-d4xx-overlay-max96712-EVB-cams-0-1.dtbo` | max96712 evaluation board w/ two connected cameras |
+    | `tegra234-camera-d4xx-overlay-fg12-4ch-d5xx.dtbo` | Fangzhu fg12-4ch board with a single D5xx camera (max96717 serializer, 4-lane) connected to link A |
     | `tegra234-camera-d4xx-overlay-fg12-16ch.dtbo` | Fangzhu fg12-16ch board with a single camera connected to cam0 |
     | `tegra234-camera-d4xx-overlay-fg12-16ch-d5xx.dtbo` | Fangzhu fg12-16ch board with a single D5xx camera (max96717 serializer, 4-lane) connected to cam0 |
     | `tegra234-camera-d4xx-overlay-fg12-16ch-cams-0-1.dtbo` | Fangzhu fg12-16ch board with two cameras connected to cam0 & cam1 |

--- a/hardware/nvidia/t23x/nv-public/6.x/0001-overlay-enable-d4xx-camera-for-Orin-jp6.patch
+++ b/hardware/nvidia/t23x/nv-public/6.x/0001-overlay-enable-d4xx-camera-for-Orin-jp6.patch
@@ -5,14 +5,14 @@ Subject: [PATCH] overlay: enable d4xx camera for Orin jp6
 
 Signed-off-by: ejgoldik <ehud.joseph.goldik@realsenseai.com>
 ---
- overlay/Makefile | 23 +++++++++++++++++++++++
- 1 file changed, 23 insertions(+)
+ overlay/Makefile | 24 ++++++++++++++++++++++++
+ 1 file changed, 24 insertions(+)
 
 diff --git a/overlay/Makefile b/overlay/Makefile
 index c88bbe2..cdd125f 100644
 --- a/overlay/Makefile
 +++ b/overlay/Makefile
-@@ -60,6 +60,29 @@ dtbo-y += tegra234-p3767-camera-p3768-imx219-A.dtbo
+@@ -60,6 +60,30 @@ dtbo-y += tegra234-p3767-camera-p3768-imx219-A.dtbo
  dtbo-y += tegra234-p3767-camera-p3768-imx219-imx477.dtbo
  dtbo-y += tegra234-p3767-camera-p3768-imx477-C.dtbo
  dtbo-y += tegra234-p3767-camera-p3768-imx477-A.dtbo
@@ -21,6 +21,7 @@ index c88bbe2..cdd125f 100644
 +dtbo-y += tegra234-camera-d4xx-overlay-max96712-EVB.dtbo
 +dtbo-y += tegra234-camera-d4xx-overlay-max96712-EVB-cams-0-1.dtbo
 +dtbo-y += tegra234-camera-d4xx-overlay-fg12-4ch.dtbo
++dtbo-y += tegra234-camera-d4xx-overlay-fg12-4ch-d5xx.dtbo
 +dtbo-y += tegra234-camera-d4xx-overlay-fg12-4ch-cams-0-1-2-3.dtbo
 +dtbo-y += tegra234-camera-d4xx-overlay-fg12-16ch.dtbo
 +dtbo-y += tegra234-camera-d4xx-overlay-fg12-16ch-d5xx.dtbo

--- a/hardware/realsense/tegra234-camera-d4xx-overlay-fg12-4ch-d5xx.dts
+++ b/hardware/realsense/tegra234-camera-d4xx-overlay-fg12-4ch-d5xx.dts
@@ -1,0 +1,493 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// SPDX-FileCopyrightText: Copyright (c) 2018-2023, INTEL CORPORATION.  All rights reserved.
+
+/*
+ * RealSense D5xx overlay for the FangZhu FG12-4CH carrier board on
+ * NVIDIA Jetson Orin Nano (p3768-0000 + p3767-xxxx).
+ *
+ * Board topology (single D5xx on deserializer link A):
+ *   D5xx --CSI-2 4-lane--> MAX96717 serializer (0x40)
+ *        --GMSL2--> MAX96712 deserializer (0x29)
+ *        --CSI-2 4-lane--> Orin Nano CSI port C/D
+ *                         (port-index = 2 / serial_c).
+ *
+ * The board-specific I2C GPIO mux, PoC control and reversed CSI lane polarity
+ * are inherited from the verified FG12-4CH D457 configuration.  The MAX96717
+ * and 4-lane camera settings are derived from the FG12-16CH D5xx overlay.
+ */
+
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/clock/tegra234-clock.h>
+#include <dt-bindings/gpio/tegra234-gpio.h>
+#include <dt-bindings/tegra234-p3767-0000-common.h>
+
+/* Camera control GPIO definitions from the official FG12-4CH device tree. */
+#define CAM0_SYNC	TEGRA234_MAIN_GPIO(H, 6)
+#define CAM1_SYNC	TEGRA234_MAIN_GPIO(AC, 0)
+#define CAM_I2C_MUX	TEGRA234_AON_GPIO(CC, 3)
+
+/ {
+	overlay-name = "Jetson RealSense Camera D5xx with max96712 for FangZhu FG12-4CH on Orin Nano (link A)";
+	jetson-header-name = "Jetson 22pin CSI Connector";
+	compatible = JETSON_COMPATIBLE_P3768;
+
+	fragment@0 {
+		target-path = "/";
+		__overlay__ {
+			tegra-capture-vi {
+				num-channels = <4>;
+				ports {
+					status = "okay";
+					port@0 {
+						status = "okay";
+						reg = <0>;
+						d4xx_vi_in0: endpoint {
+							status = "okay";
+							vc-id = <0>;
+							port-index = <2>;
+							bus-width = <4>;
+							remote-endpoint = <&d4xx_csi_out0>;
+						};
+					};
+					port@1 {
+						status = "okay";
+						reg = <1>;
+						d4xx_vi_in1: endpoint {
+							status = "okay";
+							vc-id = <1>;
+							port-index = <2>;
+							bus-width = <4>;
+							remote-endpoint = <&d4xx_csi_out1>;
+						};
+					};
+					port@2 {
+						status = "okay";
+						reg = <2>;
+						d4xx_vi_in2: endpoint {
+							status = "okay";
+							vc-id = <2>;
+							port-index = <2>;
+							bus-width = <4>;
+							remote-endpoint = <&d4xx_csi_out2>;
+						};
+					};
+					port@3 {
+						status = "okay";
+						reg = <3>;
+						d4xx_vi_in3: endpoint {
+							status = "okay";
+							vc-id = <3>;
+							port-index = <2>;
+							bus-width = <4>;
+							remote-endpoint = <&d4xx_csi_out3>;
+						};
+					};
+				};
+			};
+
+			tegra-camera-platform {
+				compatible = "nvidia, tegra-camera-platform";
+				status = "okay";
+				num_csi_lanes = <4>;
+				max_lane_speed = <1500000>;
+				min_bits_per_pixel = <8>;
+				vi_peak_byte_per_pixel = <2>;
+				vi_bw_margin_pct = <25>;
+				max_pixel_rate = <160000>;
+				isp_peak_byte_per_pixel = <5>;
+				isp_bw_margin_pct = <25>;
+				modules {
+					status = "okay";
+					module0 {
+						status = "okay";
+						badge = "d5xx_depth";
+						position = "left";
+						orientation = "1";
+						drivernode0 {
+							status = "okay";
+							pcl_id = "v4l2_sensor";
+							devname = "DS5 mux 2-001a";
+							sysfs-device-tree = "/sys/firmware/devicetree/base/bus@0/cam_i2cmux/i2c@1/ds5@1a";
+						};
+					};
+					module1 {
+						status = "okay";
+						badge = "d5xx_rgb";
+						position = "left";
+						orientation = "1";
+						drivernode0 {
+							status = "okay";
+							pcl_id = "v4l2_sensor";
+							devname = "DS5 mux 2-001b";
+							sysfs-device-tree = "/sys/firmware/devicetree/base/bus@0/cam_i2cmux/i2c@1/ds5@1b";
+						};
+					};
+					module2 {
+						status = "okay";
+						badge = "d5xx_Y8";
+						position = "left";
+						orientation = "1";
+						drivernode0 {
+							status = "okay";
+							pcl_id = "v4l2_sensor";
+							devname = "DS5 mux 2-001c";
+							sysfs-device-tree = "/sys/firmware/devicetree/base/bus@0/cam_i2cmux/i2c@1/ds5@1c";
+						};
+					};
+					module3 {
+						status = "okay";
+						badge = "d5xx_imu";
+						position = "left";
+						orientation = "1";
+						drivernode0 {
+							status = "okay";
+							pcl_id = "v4l2_sensor";
+							devname = "DS5 mux 2-001d";
+							sysfs-device-tree = "/sys/firmware/devicetree/base/bus@0/cam_i2cmux/i2c@1/ds5@1d";
+						};
+					};
+				};
+			};
+
+			bus@0 {
+				host1x@13e00000 {
+					nvcsi@15a00000 {
+						num-channels = <4>;
+						channel@0 {
+							status = "okay";
+							reg = <0>;
+							ports {
+								status = "okay";
+								port@0 {
+									status = "okay";
+									reg = <0>;
+									d4xx_csi_in0: endpoint@0 {
+										status = "okay";
+										port-index = <2>;
+										bus-width = <4>;
+										remote-endpoint = <&ds5_0_out>;
+									};
+								};
+								port@1 {
+									status = "okay";
+									reg = <1>;
+									d4xx_csi_out0: endpoint@1 {
+										status = "okay";
+										remote-endpoint = <&d4xx_vi_in0>;
+									};
+								};
+							};
+						};
+						channel@1 {
+							status = "okay";
+							reg = <1>;
+							ports {
+								status = "okay";
+								port@0 {
+									status = "okay";
+									reg = <0>;
+									d4xx_csi_in1: endpoint@2 {
+										status = "okay";
+										port-index = <2>;
+										bus-width = <4>;
+										remote-endpoint = <&ds5_1_out>;
+									};
+								};
+								port@1 {
+									status = "okay";
+									reg = <1>;
+									d4xx_csi_out1: endpoint@3 {
+										status = "okay";
+										remote-endpoint = <&d4xx_vi_in1>;
+									};
+								};
+							};
+						};
+						channel@2 {
+							status = "okay";
+							reg = <2>;
+							ports {
+								status = "okay";
+								port@0 {
+									status = "okay";
+									reg = <0>;
+									d4xx_csi_in2: endpoint@4 {
+										status = "okay";
+										port-index = <2>;
+										bus-width = <4>;
+										remote-endpoint = <&ds5_2_out>;
+									};
+								};
+								port@1 {
+									status = "okay";
+									reg = <1>;
+									d4xx_csi_out2: endpoint@5 {
+										status = "okay";
+										remote-endpoint = <&d4xx_vi_in2>;
+									};
+								};
+							};
+						};
+						channel@3 {
+							status = "okay";
+							reg = <3>;
+							ports {
+								status = "okay";
+								port@0 {
+									status = "okay";
+									reg = <0>;
+									d4xx_csi_in3: endpoint@6 {
+										status = "okay";
+										port-index = <2>;
+										bus-width = <4>;
+										remote-endpoint = <&ds5_3_out>;
+									};
+								};
+								port@1 {
+									status = "okay";
+									reg = <1>;
+									d4xx_csi_out3: endpoint@7 {
+										status = "okay";
+										remote-endpoint = <&d4xx_vi_in3>;
+									};
+								};
+							};
+						};
+					};
+				};
+
+				/*
+				 * FG12-4CH routes camera I2C through a GPIO-selected mux.
+				 * The deserializer is on i2c@1 (GPIO high); video is routed
+				 * independently to CSI C/D (port-index 2 / serial_c).
+				 */
+				cam_i2cmux {
+					compatible = "i2c-mux-gpio";
+					#address-cells = <1>;
+					#size-cells = <0>;
+					i2c-parent = <&cam_i2c>;
+					mux-gpios = <&gpio_aon CAM_I2C_MUX GPIO_ACTIVE_HIGH>;
+
+					i2c@1 {
+						reg = <1>;
+						#address-cells = <1>;
+						#size-cells = <0>;
+
+						dser: max96712@29 {
+							status = "okay";
+							reg = <0x29>;
+							compatible = "maxim,max96712";
+							csi-mode = "2x4";
+							lane_cnt = <4>;
+							link-mask = <0x1>;
+							channel = "a";
+							fangzhu,fg12-reverse-lane-polarity;
+							fangzhu,fg12-poc-enable;
+						};
+
+						ser_a: max96717@40 {
+							status = "okay";
+							compatible = "maxim,max96717";
+							reg = <0x40>;
+							maxim,gmsl-dser-device = <&dser>;
+						};
+
+						ds5_3: ds5@1d {
+							status = "okay";
+							def-addr = <0x10>;
+							reg = <0x1d>;
+							override_reg = <0x1a>;
+							compatible = "intel,d4xx";
+							use_sensor_mode_id = "true";
+							cam-type = "IMU";
+							nvidia,gmsl-ser-device = <&ser_a>;
+							nvidia,gmsl-dser-device = <&dser>;
+							ports {
+								#address-cells = <1>;
+								#size-cells = <0>;
+
+								port@0 {
+									reg = <0>;
+									ds5_3_out: endpoint {
+										vc-id = <3>;
+										port-index = <2>;
+										bus-width = <4>;
+										remote-endpoint = <&d4xx_csi_in3>;
+									};
+								};
+							};
+							mode0 {
+								pixel_t = "grey_y16";
+								num_lanes = "4";
+								csi_pixel_bit_depth = "16";
+								active_w = "640";
+								active_h = "480";
+								tegra_sinterface = "serial_c";
+								mclk_khz = "24000";
+								pix_clk_hz = "74250000";
+								serdes_pix_clk_hz = "275000000";
+								line_length = "1280"; /* 2200 */
+								embedded_metadata_height = "0";
+							};
+							gmsl-link {
+								src-csi-port = "b";
+								dst-csi-port = "a";
+								serdes-csi-link = "a";
+								csi-mode = "1x4";
+								st-vc = <0>;
+								vc-id = <3>;
+								num-lanes = <4>;
+							};
+						};
+
+						ds5_2: ds5@1c {
+							status = "okay";
+							def-addr = <0x10>;
+							reg = <0x1c>;
+							override_reg = <0x1a>;
+							compatible = "intel,d4xx";
+							use_sensor_mode_id = "true";
+							cam-type = "Y8";
+							nvidia,gmsl-ser-device = <&ser_a>;
+							nvidia,gmsl-dser-device = <&dser>;
+							ports {
+								#address-cells = <1>;
+								#size-cells = <0>;
+
+								port@0 {
+									reg = <0>;
+									ds5_2_out: endpoint {
+										vc-id = <2>;
+										port-index = <2>;
+										bus-width = <4>;
+										remote-endpoint = <&d4xx_csi_in2>;
+									};
+								};
+							};
+							/* mode0: Y8, mode1: depth D16 */
+							mode0 {
+								pixel_t = "grey_y16";
+								num_lanes = "4";
+								csi_pixel_bit_depth = "16";
+								active_w = "1280";
+								active_h = "720";
+								tegra_sinterface = "serial_c";
+								mclk_khz = "24000";
+								pix_clk_hz = "74250000";
+								serdes_pix_clk_hz = "275000000";
+								line_length = "1280"; /* 2200 */
+								embedded_metadata_height = "1";
+							};
+							gmsl-link {
+								src-csi-port = "b";
+								dst-csi-port = "a";
+								serdes-csi-link = "a";
+								csi-mode = "1x4";
+								st-vc = <0>;
+								vc-id = <2>;
+								num-lanes = <4>;
+							};
+						};
+
+						ds5_1: ds5@1b {
+							status = "okay";
+							def-addr = <0x10>;
+							reg = <0x1b>;
+							override_reg = <0x1a>;
+							compatible = "intel,d4xx";
+							use_sensor_mode_id = "true";
+							cam-type = "RGB";
+							nvidia,gmsl-ser-device = <&ser_a>;
+							nvidia,gmsl-dser-device = <&dser>;
+							ports {
+								#address-cells = <1>;
+								#size-cells = <0>;
+
+								port@0 {
+									reg = <0>;
+									ds5_1_out: endpoint {
+										vc-id = <1>;
+										port-index = <2>;
+										bus-width = <4>;
+										remote-endpoint = <&d4xx_csi_in1>;
+									};
+								};
+							};
+							mode0 {
+								pixel_t = "grey_y16";
+								num_lanes = "4";
+								csi_pixel_bit_depth = "16";
+								active_w = "1920";
+								active_h = "1080";
+								tegra_sinterface = "serial_c";
+								mclk_khz = "24000";
+								pix_clk_hz = "74250000";
+								serdes_pix_clk_hz = "275000000";
+								line_length = "1280"; /* 2200 */
+								embedded_metadata_height = "1";
+							};
+							gmsl-link {
+								src-csi-port = "b";
+								dst-csi-port = "a";
+								serdes-csi-link = "a";
+								csi-mode = "1x4";
+								st-vc = <0>;
+								vc-id = <1>;
+								num-lanes = <4>;
+							};
+						};
+
+						ds5_0: ds5@1a {
+							status = "okay";
+							def-addr = <0x10>;
+							reg = <0x1a>;
+							compatible = "intel,d4xx";
+							use_sensor_mode_id = "true";
+							cam-type = "Depth";
+							nvidia,gmsl-ser-device = <&ser_a>;
+							nvidia,gmsl-dser-device = <&dser>;
+							ports {
+								#address-cells = <1>;
+								#size-cells = <0>;
+
+								port@0 {
+									reg = <0>;
+									ds5_0_out: endpoint {
+										vc-id = <0>;
+										port-index = <2>;
+										bus-width = <4>;
+										remote-endpoint = <&d4xx_csi_in0>;
+									};
+								};
+							};
+							mode0 {
+								pixel_t = "grey_y16";
+								num_lanes = "4";
+								csi_pixel_bit_depth = "16";
+								active_w = "1280";
+								active_h = "720";
+								tegra_sinterface = "serial_c";
+								mclk_khz = "24000";
+								pix_clk_hz = "74250000";
+								serdes_pix_clk_hz = "275000000";
+								line_length = "1280"; /* 2200 */
+								embedded_metadata_height = "1";
+							};
+							gmsl-link {
+								src-csi-port = "b";
+								dst-csi-port = "a";
+								serdes-csi-link = "a";
+								csi-mode = "1x4";
+								st-vc = <0>;
+								vc-id = <0>;
+								num-lanes = <4>;
+							};
+						};
+					};
+				};
+			};
+		};
+	};
+};


### PR DESCRIPTION
## Summary

- Add the FG12-4CH D5xx overlay for Jetson Orin Nano with MAX96717 and MAX96712.
- Preserve the FG12 board-specific I2C mux, PoC, reversed lane polarity, four-lane CSI routing, and D5xx stream topology.
- Register the overlay in the JP6 overlay Makefile so the DTBO is built.

## Why

The dev branch contains the FG12-4CH D4xx overlay and other D5xx overlays, but it does not contain a buildable FG12-4CH D5xx overlay.

## Validation

- Preprocessed with the JetPack 6.2 device-tree headers.
- Compiled successfully with `dtc -@` into a DTBO.
- Verified the generated overlay contains the MAX96712, MAX96717, and four D5xx stream nodes.
- `git diff --check origin/dev..HEAD` passed.

Hardware validation was not rerun as part of this publishing step.