### PR TITLE
Fix D585 GMSL laser power range (RSDEV-13457)

### DIFF
--- a/kernel/realsense/d4xx.c
+++ b/kernel/realsense/d4xx.c
@@ -3873,6 +3873,18 @@ static const struct v4l2_ctrl_config ds5_ctrl_manual_laser_power = {
 	.flags = V4L2_CTRL_FLAG_VOLATILE | V4L2_CTRL_FLAG_EXECUTE_ON_WRITE,
 };
 
+static const struct v4l2_ctrl_config ds5_ctrl_manual_laser_power_d58x = {
+	.ops = &ds5_ctrl_ops,
+	.id = DS5_CAMERA_CID_MANUAL_LASER_POWER,
+	.name = "Manual laser power",
+	.type = V4L2_CTRL_TYPE_INTEGER,
+	.min = 0,
+	.max = 540,
+	.step = 45,
+	.def = 225,
+	.flags = V4L2_CTRL_FLAG_VOLATILE | V4L2_CTRL_FLAG_EXECUTE_ON_WRITE,
+};
+
 static const struct v4l2_ctrl_config ds5_ctrl_fw_version = {
 	.ops = &ds5_ctrl_ops,
 	.id = DS5_CAMERA_CID_FW_VERSION,
@@ -4913,21 +4925,16 @@ static int ds5_ctrl_init(struct ds5 *state, int sid)
 	}
 
 	if (sid == DEPTH_SID || sid == IR_SID) {
-		struct v4l2_ctrl_config manual_laser_power_config =
-			ds5_ctrl_manual_laser_power;
-
-		if (is_d58x) {
-			manual_laser_power_config.max = 540;
-			manual_laser_power_config.step = 45;
-			manual_laser_power_config.def = 225;
-		}
-
 		ctrls->laser_power = v4l2_ctrl_new_custom(hdl,
-						&ds5_ctrl_laser_power,
-						sensor);
-		ctrls->manual_laser_power = v4l2_ctrl_new_custom(hdl,
-						&manual_laser_power_config,
-						sensor);
+							&ds5_ctrl_laser_power,
+							sensor);
+		if (is_d58x) {
+			ctrls->manual_laser_power = v4l2_ctrl_new_custom(hdl,
+					&ds5_ctrl_manual_laser_power_d58x, sensor);
+		} else {
+			ctrls->manual_laser_power = v4l2_ctrl_new_custom(hdl,
+					&ds5_ctrl_manual_laser_power, sensor);
+		}
 	}
 
 	/* Total gain */

--- a/kernel/realsense/d4xx.c
+++ b/kernel/realsense/d4xx.c
@@ -4913,11 +4913,20 @@ static int ds5_ctrl_init(struct ds5 *state, int sid)
 	}
 
 	if (sid == DEPTH_SID || sid == IR_SID) {
+		struct v4l2_ctrl_config manual_laser_power_config =
+			ds5_ctrl_manual_laser_power;
+
+		if (is_d58x) {
+			manual_laser_power_config.max = 540;
+			manual_laser_power_config.step = 45;
+			manual_laser_power_config.def = 225;
+		}
+
 		ctrls->laser_power = v4l2_ctrl_new_custom(hdl,
 						&ds5_ctrl_laser_power,
 						sensor);
 		ctrls->manual_laser_power = v4l2_ctrl_new_custom(hdl,
-						&ds5_ctrl_manual_laser_power,
+						&manual_laser_power_config,
 						sensor);
 	}
 


### PR DESCRIPTION
## Summary

Fixes the Host/Viewer side of the D585 GMSL Laser Power range mismatch reported in [RSDEV-13457](https://rsjira.realsenseai.com/browse/RSDEV-13457).

## Root cause

The V4L2 Manual Laser Power control hard-coded maximum 360, step 30, and default 150. Librealsense and Viewer obtain option metadata from this Host control, so firmware support for 540/45 alone cannot expose the correct D585 range.

## Fix

- Use maximum 540, step 45, and default 225 when the detected device is D58x.
- Preserve the existing 360/30/150 metadata for all other devices.
- Keep live GET/SET behavior unchanged; values continue to use the existing GMSL register path.

## Verification

- JP6.2.2 cross-build: PASS.
- Module version: 1.0.5.17; matching 5.15.185-tegra vermagic.
- V4L2 range on D585: maximum 540, step 45, default 225 — PASS.
- Librealsense range: 0..540, step 45, default 225 — PASS.
- Set 540/read back 540/restore 225 — PASS.
- Viewer detected the D585 with MIPI Driver 1.0.5.17 and firmware 7.58.40908.13264.

The validation module was loaded temporarily; no persistent Jetson module was overwritten.

## Related PRs

- Common: https://github.com/RealSenseAI-Internal/soc-rs-hkr-common/pull/150
- IO: https://github.com/RealSenseAI-Internal/soc-rs-soc-io-drivers/pull/502
- Tests: https://github.com/RealSenseAI-Internal/soc-rs-hkr-test/pull/347
