### PR TITLE
[RSDEV-13422][Jetson][GMSL] Fix VI5 recovery teardown failures

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -164,6 +164,9 @@ Each MIPI segment's lane count comes from a **different** DT property, so the ca
 
 ## Concurrency notes
 
+- A stored kthread pointer whose worker may return before teardown must own an
+  extra task reference. Acquire it before waking the new task, release it after
+  `kthread_stop()`, and clear the stored pointer on creation failure and after stop.
 - In SERDES builds, hold `serdes_lock__` while scanning or assigning global topology slots (`ds5_inited[]`, `dser_inited[]`).
 - Protect per-camera mutable slot state (`ds5_primary`, `depth/rgb/ir/imu_streaming`) with `struct ds5_dev::lock`.
 - Protect per-deserializer slot assignment (`dser_dev`) with `struct dser_control::lock`.

--- a/kernel/nvidia/5.0.2/0023-Fix-vi5-kthread-task-lifetime.patch
+++ b/kernel/nvidia/5.0.2/0023-Fix-vi5-kthread-task-lifetime.patch
@@ -1,0 +1,86 @@
+From 5bf0ae88273e963dac1fa2fc9f08deea64d0d1cf Mon Sep 17 00:00:00 2001
+From: zhou <shengyong.zhou@realsenseai.com>
+Date: Wed, 5 Aug 2026 20:35:31 +0800
+Subject: [PATCH] media: tegra: keep VI5 kthread task references alive
+
+The VI5 dequeue worker can return after fatal capture recovery failure.
+Keep an owned task reference until stream-off so kthread_stop() never
+receives a stale task pointer.
+
+Signed-off-by: zhou <shengyong.zhou@realsenseai.com>
+---
+ .../media/platform/tegra/camera/vi/vi5_fops.c   | 17 +++++++++++++++--
+ 1 file changed, 15 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/media/platform/tegra/camera/vi/vi5_fops.c b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
+index cd7083c26..ecbab54fa 100644
+--- a/drivers/media/platform/tegra/camera/vi/vi5_fops.c
++++ b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
+@@ -12,6 +12,7 @@
+ 
+ #include <linux/freezer.h>
+ #include <linux/kthread.h>
++#include <linux/sched/task.h>
+ #include <linux/nvhost.h>
+ #include <linux/semaphore.h>
+ #include <linux/version.h>
+@@ -868,14 +869,18 @@ static int vi5_channel_start_kthreads(struct tegra_channel *chan)
+ 		err = -1;
+ 		goto done;
+ 	}
+-	chan->kthread_capture_start = kthread_run(
++	chan->kthread_capture_start = kthread_create(
+ 		tegra_channel_kthread_capture_enqueue, chan, chan->video->name);
+ 	if (IS_ERR(chan->kthread_capture_start)) {
+ 		dev_err(&chan->video->dev,
+ 			"failed to run kthread for capture enqueue\n");
+ 		err = PTR_ERR(chan->kthread_capture_start);
++		chan->kthread_capture_start = NULL;
+ 		goto done;
+ 	}
++	/* Keep the task valid if the worker exits before stream-off. */
++	get_task_struct(chan->kthread_capture_start);
++	wake_up_process(chan->kthread_capture_start);
+ 
+ 	/* Start the kthread for capture dequeue */
+ 	if (chan->kthread_capture_dequeue) {
+@@ -883,14 +888,20 @@ static int vi5_channel_start_kthreads(struct tegra_channel *chan)
+ 		err = -1;
+ 		goto done;
+ 	}
+-	chan->kthread_capture_dequeue = kthread_run(
++	chan->kthread_capture_dequeue = kthread_create(
+ 		tegra_channel_kthread_capture_dequeue, chan, chan->video->name);
+ 	if (IS_ERR(chan->kthread_capture_dequeue)) {
+ 		dev_err(&chan->video->dev,
+ 			"failed to run kthread for capture dequeue\n");
+ 		err = PTR_ERR(chan->kthread_capture_dequeue);
++		chan->kthread_capture_dequeue = NULL;
++		kthread_stop(chan->kthread_capture_start);
++		put_task_struct(chan->kthread_capture_start);
++		chan->kthread_capture_start = NULL;
+ 		goto done;
+ 	}
++	get_task_struct(chan->kthread_capture_dequeue);
++	wake_up_process(chan->kthread_capture_dequeue);
+ 
+ done:
+ 	return err;
+@@ -903,12 +914,14 @@ static void vi5_channel_stop_kthreads(struct tegra_channel *chan)
+ 	/* Stop the kthread for capture enqueue */
+ 	if (chan->kthread_capture_start) {
+ 		kthread_stop(chan->kthread_capture_start);
++		put_task_struct(chan->kthread_capture_start);
+ 		chan->kthread_capture_start = NULL;
+ 	}
+ 
+ 	/* Stop the kthread for capture dequeue */
+ 	if (chan->kthread_capture_dequeue) {
+ 		kthread_stop(chan->kthread_capture_dequeue);
++		put_task_struct(chan->kthread_capture_dequeue);
+ 		chan->kthread_capture_dequeue = NULL;
+ 	}
+ 
+-- 
+2.34.1
+

--- a/kernel/nvidia/5.0.2/0024-Fix-vi5-failed-request-buffer-cleanup.patch
+++ b/kernel/nvidia/5.0.2/0024-Fix-vi5-failed-request-buffer-cleanup.patch
@@ -1,0 +1,27 @@
+From d84391a874aa24b0f2ec778a16d057ac3fb6c71d Mon Sep 17 00:00:00 2001
+From: zhou <shengyong.zhou@realsenseai.com>
+Date: Wed, 5 Aug 2026 21:24:08 +0800
+Subject: [PATCH] media: tegra: fix failed VI5 request-buffer cleanup
+
+tegra_channel_capture_setup() passed the request-pointer array itself to
+dma_free_coherent() after vi_capture_setup() failed. Free the per-port
+allocation and clear its slot so stream-off cannot unmap the same IOVA.
+
+Signed-off-by: zhou <shengyong.zhou@realsenseai.com>
+---
+ drivers/media/platform/tegra/camera/vi/vi5_fops.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/media/platform/tegra/camera/vi/vi5_fops.c b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
+index ecbab54fa..a2f95cb4d 100644
+--- a/drivers/media/platform/tegra/camera/vi/vi5_fops.c
++++ b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
+@@ -312,3 +312,4 @@ static int tegra_channel_capture_setup(struct tegra_channel *chan, unsigned int
+ 				setup.queue_depth * setup.request_size,
+-				chan->request, setup.iova);
++				chan->request[vi_port], setup.iova);
++		chan->request[vi_port] = NULL;
+ 		return err;
+-- 
+2.34.1
+

--- a/kernel/nvidia/5.1.2/0012-Fix-vi5-kthread-task-lifetime.patch
+++ b/kernel/nvidia/5.1.2/0012-Fix-vi5-kthread-task-lifetime.patch
@@ -1,0 +1,82 @@
+From e4366cc2d9335e989233515f4c8f46a7262fced8 Mon Sep 17 00:00:00 2001
+From: zhou <shengyong.zhou@realsenseai.com>
+Date: Wed, 5 Aug 2026 20:38:01 +0800
+Subject: [PATCH] media: tegra: keep VI5 kthread task references alive
+
+The VI5 dequeue worker can return after fatal capture recovery failure.
+Keep an owned task reference until stream-off so kthread_stop() never
+receives a stale task pointer.
+
+Signed-off-by: zhou <shengyong.zhou@realsenseai.com>
+---
+ .../media/platform/tegra/camera/vi/vi5_fops.c   | 17 +++++++++++++++--
+ 1 file changed, 15 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/media/platform/tegra/camera/vi/vi5_fops.c b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
+index 0efce2347..8200a0d76 100644
+--- a/drivers/media/platform/tegra/camera/vi/vi5_fops.c
++++ b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
+@@ -14,6 +14,7 @@
+ #include <linux/fs.h>
+ #include <linux/freezer.h>
+ #include <linux/kthread.h>
++#include <linux/sched/task.h>
+ #include <linux/nvhost.h>
+ #include <linux/errno.h>
+ #include <linux/semaphore.h>
+@@ -917,14 +918,18 @@ static int vi5_channel_start_kthreads(struct tegra_channel *chan)
+ 		err = -1;
+ 		goto done;
+ 	}
+-	chan->kthread_capture_start = kthread_run(
++	chan->kthread_capture_start = kthread_create(
+ 		tegra_channel_kthread_capture_enqueue, chan, chan->video->name);
+ 	if (IS_ERR(chan->kthread_capture_start)) {
+ 		dev_err(&chan->video->dev,
+ 			"failed to run kthread for capture enqueue\n");
+ 		err = PTR_ERR(chan->kthread_capture_start);
++		chan->kthread_capture_start = NULL;
+ 		goto done;
+ 	}
++	/* Keep the task valid if the worker exits before stream-off. */
++	get_task_struct(chan->kthread_capture_start);
++	wake_up_process(chan->kthread_capture_start);
+ 
+ 	/* Start the kthread for capture dequeue */
+ 	if (chan->kthread_capture_dequeue) {
+@@ -932,14 +937,20 @@ static int vi5_channel_start_kthreads(struct tegra_channel *chan)
+ 		err = -1;
+ 		goto done;
+ 	}
+-	chan->kthread_capture_dequeue = kthread_run(
++	chan->kthread_capture_dequeue = kthread_create(
+ 		tegra_channel_kthread_capture_dequeue, chan, chan->video->name);
+ 	if (IS_ERR(chan->kthread_capture_dequeue)) {
+ 		dev_err(&chan->video->dev,
+ 			"failed to run kthread for capture dequeue\n");
+ 		err = PTR_ERR(chan->kthread_capture_dequeue);
++		chan->kthread_capture_dequeue = NULL;
++		kthread_stop(chan->kthread_capture_start);
++		put_task_struct(chan->kthread_capture_start);
++		chan->kthread_capture_start = NULL;
+ 		goto done;
+ 	}
++	get_task_struct(chan->kthread_capture_dequeue);
++	wake_up_process(chan->kthread_capture_dequeue);
+ 
+ done:
+ 	return err;
+@@ -952,6 +963,7 @@ static void vi5_channel_stop_kthreads(struct tegra_channel *chan)
+ 	/* Stop the kthread for capture enqueue */
+ 	if (chan->kthread_capture_start) {
+ 		kthread_stop(chan->kthread_capture_start);
++		put_task_struct(chan->kthread_capture_start);
+ 		chan->kthread_capture_start = NULL;
+ 	}
+ 
+@@ -960,2 +972,3 @@ static void vi5_channel_stop_kthreads(struct tegra_channel *chan)
+ 		kthread_stop(chan->kthread_capture_dequeue);
++		put_task_struct(chan->kthread_capture_dequeue);
+ 		chan->kthread_capture_dequeue = NULL;
+-- 
+2.34.1

--- a/kernel/nvidia/5.1.2/0013-Fix-vi5-failed-request-buffer-cleanup.patch
+++ b/kernel/nvidia/5.1.2/0013-Fix-vi5-failed-request-buffer-cleanup.patch
@@ -1,0 +1,27 @@
+From b230e621733f481d85895c34f5797c684c11aa83 Mon Sep 17 00:00:00 2001
+From: zhou <shengyong.zhou@realsenseai.com>
+Date: Wed, 5 Aug 2026 21:24:08 +0800
+Subject: [PATCH] media: tegra: fix failed VI5 request-buffer cleanup
+
+tegra_channel_capture_setup() passed the request-pointer array itself to
+dma_free_coherent() after vi_capture_setup() failed. Free the per-port
+allocation and clear its slot so stream-off cannot unmap the same IOVA.
+
+Signed-off-by: zhou <shengyong.zhou@realsenseai.com>
+---
+ drivers/media/platform/tegra/camera/vi/vi5_fops.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/media/platform/tegra/camera/vi/vi5_fops.c b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
+index 8200a0d76..f941b076a 100644
+--- a/drivers/media/platform/tegra/camera/vi/vi5_fops.c
++++ b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
+@@ -363,3 +363,4 @@ static int tegra_channel_capture_setup(struct tegra_channel *chan, unsigned int
+ 				setup.queue_depth * setup.request_size,
+-				chan->request, setup.iova);
++				chan->request[vi_port], setup.iova);
++		chan->request[vi_port] = NULL;
+ 		return err;
+-- 
+2.34.1
+

--- a/kernel/nvidia/5.1.6/0014-Fix-vi5-kthread-task-lifetime.patch
+++ b/kernel/nvidia/5.1.6/0014-Fix-vi5-kthread-task-lifetime.patch
@@ -1,0 +1,1 @@
+../5.1.2/0012-Fix-vi5-kthread-task-lifetime.patch

--- a/kernel/nvidia/5.1.6/0015-Fix-vi5-failed-request-buffer-cleanup.patch
+++ b/kernel/nvidia/5.1.6/0015-Fix-vi5-failed-request-buffer-cleanup.patch
@@ -1,0 +1,1 @@
+../5.1.2/0013-Fix-vi5-failed-request-buffer-cleanup.patch

--- a/nvidia-oot/6.0/0011-Fix-vi5-kthread-task-lifetime.patch
+++ b/nvidia-oot/6.0/0011-Fix-vi5-kthread-task-lifetime.patch
@@ -1,0 +1,1 @@
+../6.2/0011-Fix-vi5-kthread-task-lifetime.patch

--- a/nvidia-oot/6.0/0012-Fix-vi5-failed-request-buffer-cleanup.patch
+++ b/nvidia-oot/6.0/0012-Fix-vi5-failed-request-buffer-cleanup.patch
@@ -1,0 +1,1 @@
+../6.2/0012-Fix-vi5-failed-request-buffer-cleanup.patch

--- a/nvidia-oot/6.1/0011-Fix-vi5-kthread-task-lifetime.patch
+++ b/nvidia-oot/6.1/0011-Fix-vi5-kthread-task-lifetime.patch
@@ -1,0 +1,1 @@
+../6.2/0011-Fix-vi5-kthread-task-lifetime.patch

--- a/nvidia-oot/6.1/0012-Fix-vi5-failed-request-buffer-cleanup.patch
+++ b/nvidia-oot/6.1/0012-Fix-vi5-failed-request-buffer-cleanup.patch
@@ -1,0 +1,1 @@
+../6.2/0012-Fix-vi5-failed-request-buffer-cleanup.patch

--- a/nvidia-oot/6.2/0011-Fix-vi5-kthread-task-lifetime.patch
+++ b/nvidia-oot/6.2/0011-Fix-vi5-kthread-task-lifetime.patch
@@ -1,0 +1,63 @@
+From 3b369cde363a27c124caab52cf5442201b99290a Mon Sep 17 00:00:00 2001
+From: zhou <shengyong.zhou@realsenseai.com>
+Date: Wed, 5 Aug 2026 20:57:12 +0800
+Subject: [PATCH] media: tegra: keep VI5 kthread task references alive
+
+The VI5 dequeue worker can return after fatal capture recovery failure.
+Keep an owned task reference until stream-off so kthread_stop() never
+receives a stale task pointer.
+
+Signed-off-by: zhou <shengyong.zhou@realsenseai.com>
+---
+ .../media/platform/tegra/camera/vi/vi5_fops.c   | 17 +++++++++++++++--
+ 1 file changed, 15 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/media/platform/tegra/camera/vi/vi5_fops.c b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
+index 68b78cc9..5f22c888 100644
+--- a/drivers/media/platform/tegra/camera/vi/vi5_fops.c
++++ b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
+@@ -19,2 +19,3 @@
+ #include <linux/pm_runtime.h>
++#include <linux/sched/task.h>
+ #include <linux/semaphore.h>
+@@ -872,3 +873,3 @@ static int vi5_channel_start_kthreads(struct tegra_channel *chan)
+ 	}
+-	chan->kthread_capture_start = kthread_run(
++	chan->kthread_capture_start = kthread_create(
+ 		tegra_channel_kthread_capture_enqueue, chan, chan->video->name);
+@@ -878,4 +879,8 @@ static int vi5_channel_start_kthreads(struct tegra_channel *chan)
+ 		err = PTR_ERR(chan->kthread_capture_start);
++		chan->kthread_capture_start = NULL;
+ 		goto done;
+ 	}
++	/* Keep the task valid if the worker exits before stream-off. */
++	get_task_struct(chan->kthread_capture_start);
++	wake_up_process(chan->kthread_capture_start);
+ 
+@@ -887,3 +892,3 @@ static int vi5_channel_start_kthreads(struct tegra_channel *chan)
+ 	}
+-	chan->kthread_capture_dequeue = kthread_run(
++	chan->kthread_capture_dequeue = kthread_create(
+ 		tegra_channel_kthread_capture_dequeue, chan, chan->video->name);
+@@ -893,4 +898,10 @@ static int vi5_channel_start_kthreads(struct tegra_channel *chan)
+ 		err = PTR_ERR(chan->kthread_capture_dequeue);
++		chan->kthread_capture_dequeue = NULL;
++		kthread_stop(chan->kthread_capture_start);
++		put_task_struct(chan->kthread_capture_start);
++		chan->kthread_capture_start = NULL;
+ 		goto done;
+ 	}
++	get_task_struct(chan->kthread_capture_dequeue);
++	wake_up_process(chan->kthread_capture_dequeue);
+ 
+@@ -907,2 +918,3 @@ static void vi5_channel_stop_kthreads(struct tegra_channel *chan)
+ 		kthread_stop(chan->kthread_capture_start);
++		put_task_struct(chan->kthread_capture_start);
+ 		chan->kthread_capture_start = NULL;
+@@ -914,2 +926,3 @@ static void vi5_channel_stop_kthreads(struct tegra_channel *chan)
+ 		kthread_stop(chan->kthread_capture_dequeue);
++		put_task_struct(chan->kthread_capture_dequeue);
+ 		chan->kthread_capture_dequeue = NULL;
+-- 
+2.34.1
+

--- a/nvidia-oot/6.2/0012-Fix-vi5-failed-request-buffer-cleanup.patch
+++ b/nvidia-oot/6.2/0012-Fix-vi5-failed-request-buffer-cleanup.patch
@@ -1,0 +1,27 @@
+From 3c6a3e1a2d31b41b47451797c87f17531099410a Mon Sep 17 00:00:00 2001
+From: zhou <shengyong.zhou@realsenseai.com>
+Date: Wed, 5 Aug 2026 21:24:08 +0800
+Subject: [PATCH] media: tegra: fix failed VI5 request-buffer cleanup
+
+tegra_channel_capture_setup() passed the request-pointer array itself to
+dma_free_coherent() after vi_capture_setup() failed. Free the per-port
+allocation and clear its slot so stream-off cannot unmap the same IOVA.
+
+Signed-off-by: zhou <shengyong.zhou@realsenseai.com>
+---
+ drivers/media/platform/tegra/camera/vi/vi5_fops.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/media/platform/tegra/camera/vi/vi5_fops.c b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
+index 5f22c888..5d23df93 100644
+--- a/drivers/media/platform/tegra/camera/vi/vi5_fops.c
++++ b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
+@@ -380,3 +380,4 @@ static int tegra_channel_capture_setup(struct tegra_channel *chan, unsigned int
+ 				setup.queue_depth * setup.request_size,
+-				chan->request, setup.iova);
++				chan->request[vi_port], setup.iova);
++		chan->request[vi_port] = NULL;
+ 		return err;
+-- 
+2.34.1
+

--- a/nvidia-oot/7.0/0011-Fix-vi5-kthread-task-lifetime.patch
+++ b/nvidia-oot/7.0/0011-Fix-vi5-kthread-task-lifetime.patch
@@ -1,0 +1,1 @@
+../6.2/0011-Fix-vi5-kthread-task-lifetime.patch

--- a/nvidia-oot/7.0/0012-Fix-vi5-failed-request-buffer-cleanup.patch
+++ b/nvidia-oot/7.0/0012-Fix-vi5-failed-request-buffer-cleanup.patch
@@ -1,0 +1,1 @@
+../7.2/0012-Fix-vi5-failed-request-buffer-cleanup.patch

--- a/nvidia-oot/7.1/0011-Fix-vi5-kthread-task-lifetime.patch
+++ b/nvidia-oot/7.1/0011-Fix-vi5-kthread-task-lifetime.patch
@@ -1,0 +1,1 @@
+../6.2/0011-Fix-vi5-kthread-task-lifetime.patch

--- a/nvidia-oot/7.1/0012-Fix-vi5-failed-request-buffer-cleanup.patch
+++ b/nvidia-oot/7.1/0012-Fix-vi5-failed-request-buffer-cleanup.patch
@@ -1,0 +1,1 @@
+../7.2/0012-Fix-vi5-failed-request-buffer-cleanup.patch

--- a/nvidia-oot/7.2/0011-Fix-vi5-kthread-task-lifetime.patch
+++ b/nvidia-oot/7.2/0011-Fix-vi5-kthread-task-lifetime.patch
@@ -1,0 +1,1 @@
+../6.2/0011-Fix-vi5-kthread-task-lifetime.patch

--- a/nvidia-oot/7.2/0012-Fix-vi5-failed-request-buffer-cleanup.patch
+++ b/nvidia-oot/7.2/0012-Fix-vi5-failed-request-buffer-cleanup.patch
@@ -1,0 +1,27 @@
+From 291a67028bfad2b64caf0e61b3560f67ec34be4a Mon Sep 17 00:00:00 2001
+From: zhou <shengyong.zhou@realsenseai.com>
+Date: Wed, 5 Aug 2026 21:31:19 +0800
+Subject: [PATCH] media: tegra: fix failed VI5 request-buffer cleanup
+
+tegra_channel_capture_setup() passed the request-pointer array itself to
+dma_free_coherent() after vi_capture_setup() failed. Free the per-port
+allocation and clear its slot so stream-off cannot unmap the same IOVA.
+
+Signed-off-by: zhou <shengyong.zhou@realsenseai.com>
+---
+ drivers/media/platform/tegra/camera/vi/vi5_fops.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/media/platform/tegra/camera/vi/vi5_fops.c b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
+index 8f84de7c..7175d185 100644
+--- a/drivers/media/platform/tegra/camera/vi/vi5_fops.c
++++ b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
+@@ -376,3 +376,4 @@ static int tegra_channel_capture_setup(struct tegra_channel *chan, unsigned int
+ 				setup.queue_depth * setup.request_size,
+-				chan->request, setup.iova);
++				chan->request[vi_port], setup.iova);
++		chan->request[vi_port] = NULL;
+ 		chan->tegra_vi_channel[vi_port]->capture_data->requests.va = NULL;
+-- 
+2.34.1
+


### PR DESCRIPTION
## Summary

Fix two VI5 teardown bugs exposed when a capture recovery overlaps STREAMOFF:

- Hold an explicit `task_struct` reference for each capture kthread until `kthread_stop()` has finished.
- On capture setup failure, free the per-port coherent request buffer, clear the stored pointer, and avoid a later invalid/double free.
- Carry both fixes across the supported JetPack 5, 6, and 7 kernel source families.

The branch is rebased on the latest `dev` and contains one signed-off commit. The unrelated `.gitignore` change was removed from this PR.

Jira: [RSDEV-13422](https://rsjira.realsenseai.com/browse/RSDEV-13422)

## Scope

This PR fixes the host kernel panic/Oops/reboot cascade after VI recovery. It does not change normal streaming, the recovery trigger, SerDes configuration, or HIF scheduling.

The remaining 1280x960@60 RGB/IR FPS drop and VI data-path failures are a separate, existing problem—not a kernel crash. These require continued deep-dive under [RSDSO-21757](https://rsjira.realsenseai.com/browse/RSDSO-21757), with particular attention to the pixel-mode multi-VC scheduling introduced by [soc-rs-soc-io-drivers PR 452](https://github.com/RealSenseAI-Internal/soc-rs-soc-io-drivers/pull/452).

PR 557 contains only the recovery teardown stability fix. It does not claim to restore 60 FPS or eliminate the underlying VI data-path errors.

## Long-run validation

Environment:

- Jetson AGX Orin, JetPack 6.2.1 / L4T 36.4.4 / Linux 5.15.148-tegra
- MAX96717 + MAX96712, pixel mode
- D585 firmware 7.58.40933.13319

Native validation command:

```bash
python3 StreamingTestRunner.py \
  --profiles DEPTH_1280_960_Z16_60_IR1_1280_960_Y8_60_IR2_1280_960_Y8_60_COLOR_1280_960_RGB8_60 \
  -c 1500 -t 5 -m 1 --no-metadata-tracking --stability
```

The run reached and completed **Cycle 1500/1500**.

- Host reboot / fatal panic / Oops: **0 / 0 / 0**
- HKR HIF timeout / assert / exception / panic: **0 / 0 / 0 / 0**
- Validation result: **FAILED** because of the existing RGB/IR FPS drop and VI data-path problem tracked by [RSDSO-21757](https://rsjira.realsenseai.com/browse/RSDSO-21757) and [PR 452](https://github.com/RealSenseAI-Internal/soc-rs-soc-io-drivers/pull/452); the PR 557 host-stability target passed with no kernel crash
- 1500-run VI totals: **14,294 `EMBED_RUNAWAY`**, 5,362 2.5-second timeouts/recovery attempts

### End-to-end counters

The HIF rate below is derived from TaskDone cadence, not the old HIF FPS field. Host FPS is calculated over the complete sensor-open interval.

| Stream / VC | HIF TaskDone median | Median completed-task samples / cycle | Host delivered median | Host frames / cycle | Focused same-profile VI error DQBUF |
|---|---:|---:|---:|---:|---:|
| Depth / VC0 | 51.26 task/s | 324 | 42.59 FPS | 319 | 0 |
| Color / VC1 | 51.27 task/s | 310 | 1.69 FPS | 12 | 17 |
| IR-Y8I / VC2 | 59.88 task/s | 365 | 4.14 FPS | 31 | 13 |

The retained 1500-run kernel printk does not encode the VC on each `EMBED_RUNAWAY`, so the 14,294 count is aggregate. A focused V4L2 trace with the same profile mapped all 30 errored image DQBUFs to Color (17) and IR-Y8I (13), with Depth at 0. This confirms that HIF tasks continue completing while effective Host delivery collapses downstream.

## D401 hardware validation

PR 557 was built and deployed on jetson67 with a physical D401 connected through MAX96712. The relevant D401 gated/PIT streaming scenario was exercised on the real device and completed successfully with PR 557 applied. No Host kernel panic, Oops, or reboot was observed, confirming that this recovery-teardown fix does not introduce a D401 hardware regression.## Root cause and fix

The data-path error first causes VI to discard frames and enter recovery after 2.5 seconds without a valid completion. Recovery and STREAMOFF can then overlap:

1. A capture worker exits and releases its own final task reference while teardown still stores the raw pointer. A later `kthread_stop()` dereferences freed task state.
2. A capture-setup failure frees the request-array base instead of the per-port DMA buffer. Later teardown can release the same resource again.

The fix adds only the missing task reference lifetime and corrects the failed-setup buffer cleanup. It does not add locking or timing changes to the normal capture path.
