### PR TITLE
ci: bridge merge queue to D4xx_Kernel_Module_Jetson_JP6 Jenkins job

### DIFF
--- a/.github/workflows/merge-queue-gate.yml
+++ b/.github/workflows/merge-queue-gate.yml
@@ -1,0 +1,150 @@
+name: Merge Queue Gate (Jenkins bridge)
+
+# The D4xx_Kernel_Module_Jetson_JP6 required check is produced by the Jenkins GHPRB
+# job, which only understands pull_request events. The merge queue builds an
+# ephemeral gh-readonly-queue/** commit and waits for that same status context on
+# it. Nothing reports it there, so the queue hangs. This workflow bridges the gap:
+# on merge_group it triggers the existing Jenkins job against the merge-group
+# head SHA, waits for the real result, and reports D4xx_Kernel_Module_Jetson_JP6
+# back. Mirrors perc_hw_fw-rs400's .github/workflows/merge-queue-gate.yml.
+
+on:
+  merge_group:
+
+concurrency:
+  # one bridge run per queue entry; never cancel in-flight (would orphan a Jenkins build)
+  group: mq-gate-${{ github.event.merge_group.head_sha }}
+  cancel-in-progress: false
+
+permissions:
+  statuses: write
+  contents: read
+  pull-requests: read
+
+jobs:
+  gated:
+    # runs on the self-hosted runner on rslnx-kernel, which can reach internal Jenkins
+    runs-on: [self-hosted, rsjenkins-bridge]
+    timeout-minutes: 240
+    env:
+      JENKINS_BASE: https://rsjenkins.realsenseai.com
+      JOB: D4xx_Kernel_Module_Jetson_JP6
+      CONTEXT: D4xx_Kernel_Module_Jetson_JP6
+      SHA: ${{ github.event.merge_group.head_sha }}
+      HEAD_REF: ${{ github.event.merge_group.head_ref }}
+      REPO: ${{ github.repository }}
+      JENKINS_USER: ${{ secrets.JENKINS_USER }}
+      JENKINS_TOKEN: ${{ secrets.JENKINS_TOKEN }}
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Report pending
+        run: |
+          curl -sfS -X POST \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/$REPO/statuses/$SHA" \
+            -d "{\"state\":\"pending\",\"context\":\"$CONTEXT\",\"description\":\"Jenkins gated build queued\"}" \
+            >/dev/null
+
+      - name: Trigger Jenkins gated build and wait
+        run: |
+          set -euo pipefail
+          AUTH="$JENKINS_USER:$JENKINS_TOKEN"
+
+          # CSRF crumb: harmless if the instance does not require one with token auth
+          CRUMB_HDR=()
+          CRUMB=$(curl -s --max-time 20 -u "$AUTH" "$JENKINS_BASE/crumbIssuer/api/json" 2>/dev/null | jq -r '.crumb // empty' || true)
+          if [ -n "$CRUMB" ]; then CRUMB_HDR=(-H "Jenkins-Crumb: $CRUMB"); fi
+
+          # Enqueue the build against the merge-group commit; grab the queue item URL.
+          # JETPACK_VER has no configured default (a Jenkins ChoiceParameterDefinition) -
+          # pin it explicitly to 6.2 (R36.4.3), the JP6 job's mainstream target, rather
+          # than rely on Jenkins' implicit first-choice-wins behavior.
+          QUEUE_URL=$(curl -sS --max-time 30 -u "$AUTH" "${CRUMB_HDR[@]}" -D - -o /dev/null \
+            -X POST "$JENKINS_BASE/job/$JOB/buildWithParameters" \
+            --data-urlencode "sha1=$SHA" \
+            --data-urlencode "JETPACK_VER=6.2" \
+            | tr -d '\r' | awk 'tolower($1)=="location:"{print $2}')
+          echo "Queue item: ${QUEUE_URL:-<none>}"
+          [ -n "$QUEUE_URL" ] || { echo "::error::Jenkins did not enqueue the build"; exit 1; }
+          echo "QUEUE_URL=$QUEUE_URL" >> "$GITHUB_ENV"
+
+          # Resolve queue item -> concrete build URL (wait out quiet period / executor wait)
+          BUILD_URL=""
+          for _ in $(seq 1 120); do
+            Q=$(curl -s --max-time 20 -u "$AUTH" "${QUEUE_URL%/}/api/json" || true)
+            if [ "$(printf '%s' "$Q" | jq -r '.cancelled // false' 2>/dev/null || echo false)" = "true" ]; then
+              echo "::error::Jenkins queue item was cancelled"; exit 1
+            fi
+            BUILD_URL=$(printf '%s' "$Q" | jq -r '.executable.url // empty' 2>/dev/null || true)
+            [ -n "$BUILD_URL" ] && break
+            sleep 5
+          done
+          [ -n "$BUILD_URL" ] || { echo "::error::Build did not start within timeout"; exit 1; }
+          echo "Build: $BUILD_URL"
+          echo "BUILD_URL=$BUILD_URL" >> "$GITHUB_ENV"
+
+          # Label the Jenkins build with the PR it belongs to (like GHPRB), so the job page shows it.
+          # PR number comes from the merge_group head_ref, e.g. gh-readonly-queue/master/pr-173-<sha>.
+          # Best-effort: needs Jenkins Run/Update permission, which not every credential has.
+          PR_NUM=$(printf '%s' "$HEAD_REF" | grep -oiE 'pr-[0-9]+' | grep -oE '[0-9]+' | head -1 || true)
+          if [ -n "$PR_NUM" ]; then
+            PR_TITLE=$(curl -s --max-time 20 -H "Authorization: Bearer $GH_TOKEN" -H "Accept: application/vnd.github+json" \
+              "https://api.github.com/repos/$REPO/pulls/$PR_NUM" | jq -r '.title // empty' 2>/dev/null || true)
+            curl -s --max-time 20 -u "$AUTH" -X POST "${BUILD_URL%/}/submitDescription" \
+              --data-urlencode "description=PR #${PR_NUM}: ${PR_TITLE} (merge queue)" -o /dev/null || true
+            echo "Set Jenkins build description for PR #$PR_NUM"
+          fi
+
+          # Poll to completion (up to ~3h at 15s cadence)
+          RESULT=""
+          for _ in $(seq 1 720); do
+            J=$(curl -s --max-time 20 -u "$AUTH" "${BUILD_URL%/}/api/json" || true)
+            # NOTE: read .building directly. Do NOT use `.building // true` — jq's // treats the
+            # boolean false as fall-through, so `.building // true` returns "true" when a build has
+            # FINISHED (building:false), and the loop would never break. Empty/parse-error -> "" -> keep polling.
+            BUILDING=$(printf '%s' "$J" | jq -r '.building' 2>/dev/null || echo "")
+            if [ "$BUILDING" = "false" ]; then
+              RESULT=$(printf '%s' "$J" | jq -r '.result // empty' 2>/dev/null || true)
+              [ -n "$RESULT" ] && break
+            fi
+            sleep 15
+          done
+          echo "Jenkins result: ${RESULT:-<none>}"
+          echo "JENKINS_RESULT=${RESULT:-UNKNOWN}" >> "$GITHUB_ENV"
+
+      - name: Report final status to merge-group commit
+        if: always()
+        run: |
+          case "${JENKINS_RESULT:-UNKNOWN}" in
+            SUCCESS)  STATE=success; DESC="Jenkins gated build passed" ;;
+            UNSTABLE) STATE=success; DESC="Jenkins gated build unstable (treated as pass)" ;;
+            *)        STATE=failure; DESC="Jenkins gated build result: ${JENKINS_RESULT:-error}" ;;
+          esac
+          curl -sfS -X POST \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/$REPO/statuses/$SHA" \
+            -d "{\"state\":\"$STATE\",\"context\":\"$CONTEXT\",\"description\":\"$DESC\",\"target_url\":\"${BUILD_URL:-$JENKINS_BASE/job/$JOB/}\"}" \
+            >/dev/null
+          echo "Reported $STATE for $CONTEXT on $SHA"
+
+      - name: Abort orphaned Jenkins build on cancel/early-exit
+        if: always()
+        run: |
+          # If we reached a terminal Jenkins result, the build already finished — nothing to abort.
+          case "${JENKINS_RESULT:-UNKNOWN}" in
+            SUCCESS|FAILURE|UNSTABLE|ABORTED) echo "Jenkins build terminal (${JENKINS_RESULT}); no cleanup needed"; exit 0 ;;
+          esac
+          # Otherwise the run was cancelled or bailed while a build may still be running — stop it.
+          AUTH="$JENKINS_USER:$JENKINS_TOKEN"
+          if [ -n "${BUILD_URL:-}" ]; then
+            curl -s --max-time 20 -u "$AUTH" -X POST "${BUILD_URL%/}/stop" -o /dev/null || true
+            echo "Aborted orphaned build ${BUILD_URL}"
+          elif [ -n "${QUEUE_URL:-}" ]; then
+            QID=$(printf '%s' "$QUEUE_URL" | grep -oE '[0-9]+/?$' | tr -d '/')
+            curl -s --max-time 20 -u "$AUTH" -X POST "$JENKINS_BASE/queue/cancelItem?id=$QID" -o /dev/null || true
+            echo "Cancelled queue item ${QID}"
+          else
+            echo "No Jenkins build/queue item to clean up"
+          fi


### PR DESCRIPTION
## Summary
- Same problem as `perc_hw_fw-rs400`'s merge-queue bridge: `D4xx_Kernel_Module_Jetson_JP6` is a Jenkins GHPRB job that only understands `pull_request` webhooks, not `merge_group`. Once a `merge_queue` ruleset rule is enabled here, queued PRs will hang waiting for that status check on the ephemeral `gh-readonly-queue/**` commit, since nothing ever reports it there.
- Adds `.github/workflows/merge-queue-gate.yml`, ported from `perc_hw_fw-rs400`: on `merge_group`, triggers the Jenkins job against the merge-group head SHA (`sha1` + pinned `JETPACK_VER=6.2`), polls for the real result, and reports `D4xx_Kernel_Module_Jetson_JP6` back to GitHub.
- Runs on a new self-hosted runner `rslnx-kernel-mqbridge-mipi` (labels `[self-hosted, rsjenkins-bridge]`) on `rslnx-kernel`, alongside (but independent of) the existing FW-repo bridge runner, so both merge queues can run their bridge jobs in parallel.
- `JENKINS_USER`/`JENKINS_TOKEN` repo secrets added.

## Not yet done (separate step, needs a live decision on ruleset knobs)
- The repo's `Master/Dev` ruleset (id 6736523) does not yet have a `merge_queue` rule — this PR only adds the bridge; enabling the actual merge queue is a follow-up once this workflow is validated.

## Test plan
- [ ] Merge (or admin-merge) this PR, then open a throwaway PR against `master`/`dev` to confirm the workflow file is valid (won't fire until `merge_group` events exist, i.e. after a `merge_queue` rule is added).
- [ ] Once merge_queue is enabled: queue a PR, confirm the bridge job picks it up on `rslnx-kernel-mqbridge-mipi`, triggers the Jenkins build, and reports the status back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)