### PR TITLE
[D585][GMSL] Set tunnel mode CSI lane rates to 1300M Serializer / 1500M Deserializer

### DIFF
--- a/hardware/realsense/tegra234-camera-d4xx-overlay-fg24-4ch-d5xx.dts
+++ b/hardware/realsense/tegra234-camera-d4xx-overlay-fg24-4ch-d5xx.dts
@@ -127,7 +127,7 @@
 				status = "okay";
 				compatible = "nvidia, tegra-camera-platform";
 				num_csi_lanes = <4>;
-				max_lane_speed = <2000000>;
+				max_lane_speed = <1500000>;
 				min_bits_per_pixel = <10>;
 				vi_peak_byte_per_pixel = <2>;
 				vi_bw_margin_pct = <25>;
@@ -334,7 +334,9 @@
 							reg = <0x27>;
 							compatible = "adi,max96724";
 							csi-mode = "2x4";
+							csi-lane-count = <4>;
 							max-src = <1>;
+							csi-lane-rate-mbps = <1500>;
 							link-mask = <0x1>;
 							gmsl-link-speed = <6>;
 						};
@@ -364,6 +366,7 @@
 							compatible = "realsense,d5xx";
 							use_sensor_mode_id = "true";
 							cam-type = "IMU";
+							mipi-lane-rate-mbps = <1300>;
 							nvidia,gmsl-ser-device = <&ser_a>;
 							nvidia,gmsl-dser-device = <&dser>;
 
@@ -392,9 +395,11 @@
 								phy_mode = "DPHY";
 								discontinuous_clk = "no";
 								cil_settletime = "0";
+								deskew_initial_enable = "false";
+								deskew_periodic_enable = "false";
 								mclk_khz = "24000";
-								pix_clk_hz = "1000000000";
-								serdes_pix_clk_hz = "1000000000";
+								pix_clk_hz = "700000000";
+								serdes_pix_clk_hz = "750000000";
 								line_length = "640";
 								embedded_metadata_height = "0";
 							};
@@ -422,6 +427,7 @@
 							compatible = "realsense,d5xx";
 							use_sensor_mode_id = "true";
 							cam-type = "Y8";
+							mipi-lane-rate-mbps = <1300>;
 							nvidia,gmsl-ser-device = <&ser_a>;
 							nvidia,gmsl-dser-device = <&dser>;
 
@@ -451,9 +457,11 @@
 								phy_mode = "DPHY";
 								discontinuous_clk = "no";
 								cil_settletime = "0";
+								deskew_initial_enable = "false";
+								deskew_periodic_enable = "false";
 								mclk_khz = "24000";
-								pix_clk_hz = "1000000000";
-								serdes_pix_clk_hz = "1000000000";
+								pix_clk_hz = "700000000";
+								serdes_pix_clk_hz = "750000000";
 								line_length = "1280";
 								embedded_metadata_height = "1";
 							};
@@ -469,11 +477,11 @@
 								phy_mode = "DPHY";
 								discontinuous_clk = "no";
 								cil_settletime = "0";
-								deskew_initial_enable = "true";
-								deskew_periodic_enable = "true";
+								deskew_initial_enable = "false";
+								deskew_periodic_enable = "false";
 								mclk_khz = "24000";
-								pix_clk_hz = "500000000";
-								serdes_pix_clk_hz = "500000000";
+								pix_clk_hz = "350000000";
+								serdes_pix_clk_hz = "375000000";
 								line_length = "1280";
 								embedded_metadata_height = "1";
 							};
@@ -501,6 +509,7 @@
 							compatible = "realsense,d5xx";
 							use_sensor_mode_id = "true";
 							cam-type = "RGB";
+							mipi-lane-rate-mbps = <1300>;
 							nvidia,gmsl-ser-device = <&ser_a>;
 							nvidia,gmsl-dser-device = <&dser>;
 
@@ -529,11 +538,11 @@
 								phy_mode = "DPHY";
 								discontinuous_clk = "no";
 								cil_settletime = "0";
-								deskew_initial_enable = "true";
-								deskew_periodic_enable = "true";
+								deskew_initial_enable = "false";
+								deskew_periodic_enable = "false";
 								mclk_khz = "24000";
-								pix_clk_hz = "500000000";
-								serdes_pix_clk_hz = "500000000";
+								pix_clk_hz = "350000000";
+								serdes_pix_clk_hz = "375000000";
 								line_length = "1920";
 								embedded_metadata_height = "1";
 							};
@@ -560,6 +569,7 @@
 							compatible = "realsense,d5xx";
 							use_sensor_mode_id = "true";
 							cam-type = "Depth";
+							mipi-lane-rate-mbps = <1300>;
 							nvidia,gmsl-ser-device = <&ser_a>;
 							nvidia,gmsl-dser-device = <&dser>;
 
@@ -578,26 +588,8 @@
 								};
 							};
 
-							/*
-							 * Pixel clock reference for mixed-VC tunnel mode:
-							 *   pix_clk_hz = lane_rate_bps * lane_count / bits_per_pixel
-							 *
-							 * The MAX96724->Orin D-PHY output is configured to
-							 * 2.0Gbps/lane over 4 lanes, so the payload budget is
-							 * 2,000,000,000 * 4 = 8,000,000,000 bits/s.
-							 *
-							 * Tunnel mode carries each source packet as-is. There is
-							 * no single rewritten DES-side BPP when VC0-3 run
-							 * concurrently, so each Orin mode uses its own
-							 * csi_pixel_bit_depth:
-							 *   16-bit modes: 8,000,000,000 / 16 = 500,000,000 Hz
-							 *   8-bit modes:  8,000,000,000 /  8 = 1,000,000,000 Hz
-							 *
-							 * Aggregate bandwidth closure is still checked against
-							 * the shared 4-lane physical link and the 6Gbps GMSL2
-							 * forward link; pix_clk_hz here is the per-mode parser
-							 * clock NVIDIA uses for VI/NVCSI bandwidth setup.
-							 */
+							/* 1.5Gbps/lane x4 gives a 375MHz SerDes pixel clock at
+							 * 16bpp and 750MHz at 8bpp in mixed-VC tunnel mode. */
 							mode0 {
 								pixel_t = "yuv_uyvy16";
 								num_lanes = "4";
@@ -608,11 +600,11 @@
 								phy_mode = "DPHY";
 								discontinuous_clk = "no";
 								cil_settletime = "0";
-								deskew_initial_enable = "true";
-								deskew_periodic_enable = "true";
+								deskew_initial_enable = "false";
+								deskew_periodic_enable = "false";
 								mclk_khz = "24000";
-								pix_clk_hz = "500000000";
-								serdes_pix_clk_hz = "500000000";
+								pix_clk_hz = "350000000";
+								serdes_pix_clk_hz = "375000000";
 								line_length = "1280";
 								embedded_metadata_height = "1";
 							};

--- a/kernel/realsense/d4xx.c
+++ b/kernel/realsense/d4xx.c
@@ -6203,6 +6203,9 @@ static int ds5_hw_init(struct i2c_client *c, struct ds5 *state)
 {
 	struct v4l2_subdev *sd = &state->mux.sd.subdev;
 	u16 mipi_status, n_lanes, phy, drate_min, drate_max;
+	u16 lane_rate, default_lane_rate;
+	u32 dt_lane_rate;
+	bool mipi_caps_valid;
 	bool is_d58x = ds5_is_d58x(state);
 	int ret = ds5_read(state, DS5_MIPI_SUPPORT_LINES, &n_lanes);
 	if (!ret)
@@ -6214,9 +6217,37 @@ static int ds5_hw_init(struct i2c_client *c, struct ds5 *state)
 	if (!ret)
 		ret = ds5_read(state, DS5_MIPI_DATARATE_MAX, &drate_max);
 
+	mipi_caps_valid = !ret;
 	if (!ret)
 		dev_dbg(sd->dev, "%s(): %d: %u lanes, phy %x, data rate %u-%u\n",
 			 __func__, __LINE__, n_lanes, phy, drate_min, drate_max);
+
+	/* D58x board/link overlays may override the product default.
+	 * D4xx keeps its existing 1000 Mbps rate. */
+	default_lane_rate = is_d58x ? MIPI_LANE_RATE_HKR : MIPI_LANE_RATE_DS5;
+	lane_rate = default_lane_rate;
+	if (is_d58x && sd->dev->of_node &&
+	    !of_property_read_u32(sd->dev->of_node,
+				  "mipi-lane-rate-mbps", &dt_lane_rate)) {
+		if (!mipi_caps_valid) {
+			dev_warn(sd->dev,
+				 "FW MIPI caps unavailable, ignoring DT rate %u; using %u Mbps\n",
+				 dt_lane_rate, default_lane_rate);
+		} else if (!dt_lane_rate || dt_lane_rate > U16_MAX) {
+			dev_warn(sd->dev,
+				 "invalid DT MIPI lane rate %u, using %u Mbps\n",
+				 dt_lane_rate, default_lane_rate);
+		} else {
+			lane_rate = dt_lane_rate;
+		}
+	}
+	if (mipi_caps_valid &&
+	    (lane_rate < drate_min || lane_rate > drate_max)) {
+		dev_warn(sd->dev,
+			 "MIPI lane rate %u outside FW range %u-%u, using %u Mbps\n",
+			 lane_rate, drate_min, drate_max, default_lane_rate);
+		lane_rate = default_lane_rate;
+	}
 
 #ifdef CONFIG_TEGRA_CAMERA_PLATFORM
 	n_lanes = state->mux.sd.numlanes;
@@ -6225,13 +6256,11 @@ static int ds5_hw_init(struct i2c_client *c, struct ds5 *state)
 #endif
 
 	ret = ds5_write(state, DS5_MIPI_LANE_NUMS, n_lanes - 1);
-	if (!ret) {
-		if (is_d58x) {
-			ret = ds5_write(state, DS5_MIPI_LANE_DATARATE, MIPI_LANE_RATE_HKR);
-		} else {
-			ret = ds5_write(state, DS5_MIPI_LANE_DATARATE, MIPI_LANE_RATE_DS5);
-		}
-	}
+	if (!ret)
+		ret = ds5_write(state, DS5_MIPI_LANE_DATARATE, lane_rate);
+	if (!ret)
+		dev_info(sd->dev, "MIPI TX configured: %u lanes at %u Mbps/lane\n",
+			 n_lanes, lane_rate);
 
 	if (!ret && state->d58x_pixel_mode) {
 		/* Tell HKR FW the deserializer runs in PIXEL mode so it

--- a/nvidia-oot/max96724.c
+++ b/nvidia-oot/max96724.c
@@ -87,8 +87,13 @@
 #define MAX96724_CSI_OUT_EN_VAL		0x84
 #define MAX96724_CSI_PHY_EN_ALL		0xF0
 #define MAX96724_CSI_LANE_MAP_DEFAULT	0xE4
-#define MAX96724_LANE_CTRL_4LANE	0xC0
-#define MAX96724_DPLL_2000MBPS		0x34
+#define MAX96724_LANE_CTRL_NUM_LANES(n)	(((n) - 1) << 6)
+#define MAX96724_DPLL_FREQ_OVERRIDE	BIT(5)
+#define MAX96724_CSI_LANE_RATE_MIN_MBPS	100
+#define MAX96724_CSI_LANE_RATE_MAX_MBPS	2500
+#define MAX96724_CSI_LANE_RATE_STEP_MBPS	100
+#define MAX96724_CSI_LANE_RATE_DEFAULT_MBPS	1500
+#define MAX96724_CSI_LANE_COUNT_DEFAULT	4
 #define MAX96724_ONESHOT_ALL		0x0F
 #define MAX96724_PIPE_SEL0		0x62
 #define MAX96724_PIPE_SEL1		0xEA
@@ -143,6 +148,8 @@ struct max96724 {
 	struct pipe_ctx pipe[MAX96724_MAX_PIPES];
 	u8 csi_mode;
 	u8 lane_mp1;
+	u32 csi_lane_rate_mbps;
+	u32 csi_lane_count;
 	struct gpio_desc *reset_gpio;
 	int pw_ref;
 	struct regulator *vdd_cam_1v2;
@@ -364,7 +371,7 @@ static int max96724_configure_csi_port(struct device *dev,
 		u16 addr = MAX96724_LANE_CTRL0_ADDR + 0x40 * i;
 
 		err = max96724_write_reg(dev, addr,
-					 MAX96724_LANE_CTRL_4LANE);
+			MAX96724_LANE_CTRL_NUM_LANES(priv->csi_lane_count));
 	}
 
 	return err;
@@ -398,7 +405,11 @@ static int max96724_configure_datapath(struct device *dev, bool oneshot,
 {
 	struct max96724 *priv = dev_get_drvdata(dev);
 	unsigned int i;
+	u8 dpll_freq;
 	int err;
+
+	dpll_freq = MAX96724_DPLL_FREQ_OVERRIDE |
+		priv->csi_lane_rate_mbps / MAX96724_CSI_LANE_RATE_STEP_MBPS;
 
 	err = max96724_write_reg(dev, MAX96724_PIPE_EN_ADDR, 0x00);
 	err |= max96724_write_reg(dev, MAX96724_PIPE_SEL0_ADDR,
@@ -410,9 +421,11 @@ static int max96724_configure_datapath(struct device *dev, bool oneshot,
 	for (i = 0; !err && i < MAX96724_MAX_PIPES; i++) {
 		u16 addr = MAX96724_DPLL_FREQ0_ADDR + 3 * i;
 
-		err = max96724_write_reg(dev, addr,
-					 MAX96724_DPLL_2000MBPS);
+		err = max96724_write_reg(dev, addr, dpll_freq);
 	}
+	if (!err)
+		dev_info(dev, "CSI TX configured at %u Mbps/lane, %u lanes\n",
+			 priv->csi_lane_rate_mbps, priv->csi_lane_count);
 
 	err |= max96724_write_reg(dev, MAX96724_MIPI_CTRL_SEL_ADDR,
 				  MAX96724_MIPI_CTRL_SEL);
@@ -1370,6 +1383,30 @@ static int max96724_parse_dt(struct max96724 *priv,
 		return -EINVAL;
 	}
 	priv->link_mask = value;
+	priv->csi_lane_count = MAX96724_CSI_LANE_COUNT_DEFAULT;
+	err = of_property_read_u32(node, "csi-lane-count", &value);
+	if (!err) {
+		if (value != MAX96724_CSI_LANE_COUNT_DEFAULT) {
+			dev_warn(&client->dev,
+				 "unsupported csi-lane-count %u, using %u lanes\n",
+				 value, priv->csi_lane_count);
+		} else {
+			priv->csi_lane_count = value;
+		}
+	}
+	priv->csi_lane_rate_mbps = MAX96724_CSI_LANE_RATE_DEFAULT_MBPS;
+	err = of_property_read_u32(node, "csi-lane-rate-mbps", &value);
+	if (!err) {
+		if (value < MAX96724_CSI_LANE_RATE_MIN_MBPS ||
+		    value > MAX96724_CSI_LANE_RATE_MAX_MBPS ||
+		    value % MAX96724_CSI_LANE_RATE_STEP_MBPS) {
+			dev_warn(&client->dev,
+				 "invalid csi-lane-rate-mbps %u, using %u Mbps\n",
+				 value, priv->csi_lane_rate_mbps);
+		} else {
+			priv->csi_lane_rate_mbps = value;
+		}
+	}
 
 	priv->reset_gpio = devm_gpiod_get_optional(&client->dev, "reset",
 						   GPIOD_OUT_LOW);


### PR DESCRIPTION
## Depends on

https://github.com/realsenseai/realsense_mipi_platform_driver/pull/568

## Summary

- Configure the D5x FG24/MAX96724 tunnel path for 1300 Mbps/lane from D585 to MAX96717 and 1500 Mbps/lane from MAX96724 to Host, using four lanes on both CSI segments.
- Make 1500 Mbps/lane the MAX96724 fallback and keep the device-tree lane rate, NVIDIA bandwidth value, and per-format SerDes pixel clocks consistent.
- Apply the camera-side override only to D58x and validate it against firmware-reported MIPI capabilities. D4xx always keeps its existing 1000 Mbps/lane rate and its existing lane count.
- Keep continuous clock enabled and deskew calibration disabled at 1500 Mbps/lane.

## Validation

- Jetson67, JP 6.2.2 / L4T 36.5 / kernel 5.15.185-tegra, D5x tunnel mode with MAX96717/MAX96724.
- Full clean build and deployment passed. The live device tree reported 4 lanes, 1300 Mbps/lane input, 1500 Mbps/lane output, continuous clock, and deskew disabled.
- Direct V4L2, wire metadata enabled: Depth Z16 + IR Y8I + RGB YUYV, all 1280x960@60, 5 seconds per cycle, 300 consecutive start/stop cycles.

| Path | Host good frames | Host FPS mean (min-max) | V4L2 error / sequence drop | Metadata V4L2 / payload error | HKR HIF request / done | HKR done-cadence FPS |
|---|---:|---:|---:|---:|---:|---:|
| Depth | 76,435 | 60.00 (59.90-60.60) | 0 / 0 | 0 / 0 | 86,045 / 86,045 | 60.46 |
| IR | 76,627 | 60.00 (59.70-60.10) | 0 / 0 | 0 / 0 | 78,219 / 78,219 | 60.00 |
| RGB | 80,269 | 60.00 (59.80-60.20) | 0 / 0 | 0 / 0 | 78,347 / 78,347 | 60.00 |

| Result | Count |
|---|---:|
| App pass / Host-clean cycles | 300/300 / 300/300 |
| VI corr_err / EMBED_RUNAWAY / PIXEL_RUNAWAY | 0 / 0 / 0 |
| VI timeout / recovery | 0 / 0 |
| Panic / Oops / Host reboot | 0 / 0 / 0 |

The six SerDes latch/status bits observed in the post-stop boundary snapshot all returned to zero on idle reread. No new persistent SerDes error remained, and the SER/DES link-integrity, ECC/CRC, decode/idle, pixel-CRC, and memory-ECC counters stayed at zero.

The previous 1300/1400 Mbps tunnel smoke test was also clean. The 1500 Mbps result adds output bandwidth margin (41.0% versus 36.8% for the 3.538944 Gbps image payload) and passes the longer 300-cycle regression without introducing a Host-side or persistent SerDes error.