### PR TITLE
[D585][GMSL] Configure pixel mode CSI lane rates to 1300M Serializer / 1400M Deserializer

### DIFF
--- a/hardware/realsense/tegra234-camera-d4xx-overlay-fg12-4ch-d5xx.dts
+++ b/hardware/realsense/tegra234-camera-d4xx-overlay-fg12-4ch-d5xx.dts
@@ -281,6 +281,8 @@
 							compatible = "maxim,max96712";
 							csi-mode = "2x4";
 							lane_cnt = <4>;
+							csi-lane-rate-mbps = <1400>;
+							force-csi-out-clock;
 							link-mask = <0x1>;
 							channel = "a";
 							fangzhu,fg12-reverse-lane-polarity;
@@ -302,6 +304,7 @@
 							compatible = "intel,d4xx";
 							use_sensor_mode_id = "true";
 							cam-type = "IMU";
+							mipi-lane-rate-mbps = <1300>;
 							nvidia,gmsl-ser-device = <&ser_a>;
 							nvidia,gmsl-dser-device = <&dser>;
 							ports {
@@ -325,9 +328,12 @@
 								active_w = "640";
 								active_h = "480";
 								tegra_sinterface = "serial_c";
+								discontinuous_clk = "no";
+								deskew_initial_enable = "false";
+								deskew_periodic_enable = "false";
 								mclk_khz = "24000";
 								pix_clk_hz = "74250000";
-								serdes_pix_clk_hz = "325000000";
+								serdes_pix_clk_hz = "350000000";
 								line_length = "1280"; /* 2200 */
 								embedded_metadata_height = "0";
 							};
@@ -350,6 +356,7 @@
 							compatible = "intel,d4xx";
 							use_sensor_mode_id = "true";
 							cam-type = "Y8";
+							mipi-lane-rate-mbps = <1300>;
 							nvidia,gmsl-ser-device = <&ser_a>;
 							nvidia,gmsl-dser-device = <&dser>;
 							ports {
@@ -374,9 +381,12 @@
 								active_w = "1280";
 								active_h = "720";
 								tegra_sinterface = "serial_c";
+								discontinuous_clk = "no";
+								deskew_initial_enable = "false";
+								deskew_periodic_enable = "false";
 								mclk_khz = "24000";
 								pix_clk_hz = "74250000";
-								serdes_pix_clk_hz = "325000000";
+								serdes_pix_clk_hz = "350000000";
 								line_length = "1280"; /* 2200 */
 								embedded_metadata_height = "1";
 							};
@@ -399,6 +409,7 @@
 							compatible = "intel,d4xx";
 							use_sensor_mode_id = "true";
 							cam-type = "RGB";
+							mipi-lane-rate-mbps = <1300>;
 							nvidia,gmsl-ser-device = <&ser_a>;
 							nvidia,gmsl-dser-device = <&dser>;
 							ports {
@@ -422,9 +433,12 @@
 								active_w = "1920";
 								active_h = "1080";
 								tegra_sinterface = "serial_c";
+								discontinuous_clk = "no";
+								deskew_initial_enable = "false";
+								deskew_periodic_enable = "false";
 								mclk_khz = "24000";
 								pix_clk_hz = "74250000";
-								serdes_pix_clk_hz = "325000000";
+								serdes_pix_clk_hz = "350000000";
 								line_length = "1280"; /* 2200 */
 								embedded_metadata_height = "1";
 							};
@@ -446,6 +460,7 @@
 							compatible = "intel,d4xx";
 							use_sensor_mode_id = "true";
 							cam-type = "Depth";
+							mipi-lane-rate-mbps = <1300>;
 							nvidia,gmsl-ser-device = <&ser_a>;
 							nvidia,gmsl-dser-device = <&dser>;
 							ports {
@@ -469,9 +484,12 @@
 								active_w = "1280";
 								active_h = "720";
 								tegra_sinterface = "serial_c";
+								discontinuous_clk = "no";
+								deskew_initial_enable = "false";
+								deskew_periodic_enable = "false";
 								mclk_khz = "24000";
 								pix_clk_hz = "74250000";
-								serdes_pix_clk_hz = "325000000";
+								serdes_pix_clk_hz = "350000000";
 								line_length = "1280"; /* 2200 */
 								embedded_metadata_height = "1";
 							};

--- a/nvidia-oot/6.2/0013-max96712-configurable-csi-lane-rate.patch
+++ b/nvidia-oot/6.2/0013-max96712-configurable-csi-lane-rate.patch
@@ -1,0 +1,101 @@
+diff --git a/drivers/media/i2c/max96712.c b/drivers/media/i2c/max96712.c
+index 88de8179..74848273 100644
+--- a/drivers/media/i2c/max96712.c
++++ b/drivers/media/i2c/max96712.c
+@@ -45,8 +45,12 @@
+ 
+ #define MAX96712_BACKTOP25_ADDR 0x418
+ #define MAX96712_BACKTOP25_PHY1_SW_OVRR_OFFS 0x5
+-#define MAX96712_BACKTOP25_2500Mbps 0x19
+-#define MAX96712_BACKTOP25_1300Mbps 0xd
++#define MAX96712_CSI_LANE_COUNT_DEFAULT 2
++#define MAX96712_CSI_LANE_RATE_2_LANE_DEFAULT_MBPS 2500
++#define MAX96712_CSI_LANE_RATE_4_LANE_DEFAULT_MBPS 1300
++#define MAX96712_CSI_LANE_RATE_MIN_MBPS 100
++#define MAX96712_CSI_LANE_RATE_MAX_MBPS 2500
++#define MAX96712_CSI_LANE_RATE_STEP_MBPS 100
+ 
+ #define MAX96712_MIPI_TX_EXT0_ADDR 0x800
+ #define MAX96712_MIPI_TX_EXT1_ADDR 0x801
+@@ -154,7 +158,9 @@ struct max96712 {
+ 	int link_multi_vc_pipe[MAX96712_MAX_LINKS];
+ 	bool multi_vc_configured[MAX96712_MAX_PIPES];
+ 	bool force_clk0;
++	bool force_csi_out_clock;
+ 	int lane_cnt;
++	u32 csi_lane_rate_mbps;
+ 	bool fangzhu_fg12_reverse_lane_polarity;
+ 	bool fangzhu_fg12_poc_enable;
+ };
+@@ -424,6 +430,10 @@ static int max96712_probe(struct i2c_client *client,
+ 		return -ENODEV;
+ 	}
+ 	mutex_init(&priv->lock);
++	/* Preserve legacy defaults when the device has no OF node. */
++	priv->lane_cnt = MAX96712_CSI_LANE_COUNT_DEFAULT;
++	priv->csi_lane_rate_mbps =
++		MAX96712_CSI_LANE_RATE_2_LANE_DEFAULT_MBPS;
+ 
+ 	np = client->dev.of_node;
+ 	if (np) {
+@@ -451,6 +461,8 @@ static int max96712_probe(struct i2c_client *client,
+ 		} else {
+ 			priv->force_clk0 = false;
+ 		}
++		priv->force_csi_out_clock =
++			of_property_read_bool(np, "force-csi-out-clock");
+ 
+ 		err = of_property_read_u32(np, "lane_cnt", &value);
+ 		if (err < 0) {
+@@ -465,6 +477,22 @@ static int max96712_probe(struct i2c_client *client,
+ 			priv->lane_cnt = value;
+ 		}
+ 
++		priv->csi_lane_rate_mbps = priv->lane_cnt == 4 ?
++			MAX96712_CSI_LANE_RATE_4_LANE_DEFAULT_MBPS :
++			MAX96712_CSI_LANE_RATE_2_LANE_DEFAULT_MBPS;
++		err = of_property_read_u32(np, "csi-lane-rate-mbps", &value);
++		if (!err) {
++			if (value < MAX96712_CSI_LANE_RATE_MIN_MBPS ||
++			    value > MAX96712_CSI_LANE_RATE_MAX_MBPS ||
++			    value % MAX96712_CSI_LANE_RATE_STEP_MBPS) {
++				dev_warn(&client->dev,
++					 "%s: invalid csi-lane-rate-mbps %u, using %u\n",
++					 __func__, value, priv->csi_lane_rate_mbps);
++			} else {
++				priv->csi_lane_rate_mbps = value;
++			}
++		}
++
+ 		priv->fangzhu_fg12_reverse_lane_polarity =
+ 			of_property_read_bool(np, "fangzhu,fg12-reverse-lane-polarity");
+ 		priv->fangzhu_fg12_poc_enable =
+@@ -913,13 +941,16 @@ int max96712_init_settings(struct device *dev)
+ 		{MAX96712_VIDEO_PIPE_EN_ADDR, 0x00}, //0xF4, Disable all pipes for now
+ 	};
+ 
+-	/* 1300Mbps per lane for 4 lanes, 2500Mbps per lane for 2 lanes */
+-	uint8_t lane_rate = (priv->lane_cnt == 4) ? MAX96712_BACKTOP25_1300Mbps : MAX96712_BACKTOP25_2500Mbps;
++	/* BACKTOP25 encodes the per-lane rate in 100 Mbps units. */
++	u8 lane_rate = priv->csi_lane_rate_mbps /
++		MAX96712_CSI_LANE_RATE_STEP_MBPS;
+ 
+ 	struct reg_pair map_phy_opt[] =
+ 	{
+ 		/* MIPI D-PHY Config */
+-		{MAX96712_MIPI_PHY0_ADDR, (priv->force_clk0 ? 0x20 : 0x0) | 0x04}, //0x8A0
++		{MAX96712_MIPI_PHY0_ADDR,
++			(priv->force_csi_out_clock ? 0x80 : 0x0) |
++			(priv->force_clk0 ? 0x20 : 0x0) | 0x04}, //0x8A0
+ 
+ 		/* 0x94a - 2/4 MIPI lanes (Master controller for PHYA), and enable extended VC */
+ 		{MAX96712_MIPI_TX10_ADDR,
+@@ -945,6 +976,8 @@ int max96712_init_settings(struct device *dev)
+ 	};
+ 
+ 	mutex_lock(&priv->lock);
++	dev_info(dev, "CSI TX configured: %d lanes at %u Mbps/lane\n",
++		 priv->lane_cnt, priv->csi_lane_rate_mbps);
+ 
+ 	err |= max96712_set_registers(priv, map_pipe_opt, ARRAY_SIZE(map_pipe_opt));
+ 	err |= max96712_set_registers(priv, map_phy_opt, ARRAY_SIZE(map_phy_opt));

--- a/nvidia-oot/max96717.c
+++ b/nvidia-oot/max96717.c
@@ -20,6 +20,8 @@
 #define MAX96717_ENMINUS_FORCE_ON (BIT(4) | BIT(3))
 #define MAX96717_EXT11_ADDR 0x383
 #define MAX96717_FRONTTOP_10_ADDR 0x312
+#define MAX96717_FRONTTOP_22_ADDR 0x31E
+#define MAX96717_FRONTTOP_22_BPP16_OVERRIDE 0x30
 #define MAX96717_VIDEO_TX0_ADDR 0x110
 #define MAX96717_VIDEO_TX1_ADDR 0x111
 #define MAX96717_VIDEO_TX0_TUN 0xED
@@ -29,10 +31,13 @@
 #define MAX96717_MIPI_RX3_ADDR 0x333
 #define MAX96717_MIPI_RX8_ADDR 0x338
 
-/* MIPI_RX0 (0x330): bit3 = mipi_rx_reset (not self-clearing), bit6 = non-cont-clk.
- * Pulsing reset re-arms the serializer MIPI RX PHY; both values keep bit6 as-is. */
-#define MAX96717_MIPI_RX0_RESET 0x48
-#define MAX96717_MIPI_RX0_NORMAL 0x40
+/*
+ * MIPI_RX0 (0x330): bit3 = mipi_rx_reset (not self-clearing), bit6 =
+ * non-cont-clk. Keep bit6 clear because the D5x CSI transmitter supplies a
+ * continuous clock.
+ */
+#define MAX96717_MIPI_RX0_RESET 0x08
+#define MAX96717_MIPI_RX0_NORMAL 0x00
 
 #define MAX96717_SRC_CTRL_ADDR 0x2BF
 #define MAX96717_SRC_PWDN_ADDR 0x02BE
@@ -322,16 +327,13 @@ static int max96717_set_registers(struct device *dev, struct reg_pair *map,
 
 static int max96717_mipi_rx_reset_pulse(struct device *dev)
 {
-	struct max96717 *priv = dev_get_drvdata(dev);
-	u8 reset = priv->pixel_mode ? MAX96717_MIPI_RX0_RESET : 0x08;
-	u8 normal = priv->pixel_mode ? MAX96717_MIPI_RX0_NORMAL : 0x00;
 	int err;
 
 	err  = max96717_write_reg(dev, MAX96717_MIPI_RX0_ADDR,
-				  reset);
+				  MAX96717_MIPI_RX0_RESET);
 	usleep_range(2000, 2100);
 	err |= max96717_write_reg(dev, MAX96717_MIPI_RX0_ADDR,
-				  normal);
+				  MAX96717_MIPI_RX0_NORMAL);
 
 	return err;
 }
@@ -353,12 +355,15 @@ int max96717_init_settings(struct device *dev)
 		{MAX96717_REG2_ADDR, 0x03}, /* 0x2 - REG2: VID_TX_EN=0, INIT=1 */
 		{MAX96717_CTRL0_ADDR, 0x21}, /* 0x10 - CTRL0: RESET_ONESHOT, GMSL2 link A */
 	};
-	struct reg_pair ser_cfg_mid[] = {
+	struct reg_pair pixel_cfg_mid[] = {
 		{MAX96717_TX1_ADDR, 0x00}, /* 0x29 - FEC OFF */
 		{MAX96717_EXT11_ADDR, 0x00}, /* 0x383 - Pixel mode */
 		{MAX96717_VIDEO_TX0_ADDR, 0x60}, /* 0x110 - VIDEO_TX0 AUTO_BPP=0 ENC_MODE=10 */
 		{MAX96717_VIDEO_TX1_ADDR, 0x10}, /* 0x111 - VIDEO_TX1 BPP=16 forced (matches DT) */
 		{MAX96717_FRONTTOP_10_ADDR, 0x4}, /* 0x312 - Fronttop_10 double 8bit */
+		/* 0x31E - force 16bpp after metadata 8-to-16 double-load */
+		{MAX96717_FRONTTOP_22_ADDR,
+		 MAX96717_FRONTTOP_22_BPP16_OVERRIDE},
 		{MAX96717_MIPI_RX1_ADDR, 0x30}, /* 0x331 - MIPI_RX1: 4-lane */
 	};
 	struct reg_pair ser_cfg_post[] = {
@@ -405,8 +410,8 @@ int max96717_init_settings(struct device *dev)
 		err |= max96717_set_registers(dev, ser_cfg_pre,
 					     ARRAY_SIZE(ser_cfg_pre));
 		msleep(100);
-		err |= max96717_set_registers(dev, ser_cfg_mid,
-					     ARRAY_SIZE(ser_cfg_mid));
+		err |= max96717_set_registers(dev, pixel_cfg_mid,
+					     ARRAY_SIZE(pixel_cfg_mid));
 		err |= max96717_mipi_rx_reset_pulse(dev);
 		err |= max96717_set_registers(dev, ser_cfg_post,
 					     ARRAY_SIZE(ser_cfg_post));


### PR DESCRIPTION
## Summary

- Configure D585 pixel/MAX96712 mode for 1300 Mbps/lane from D585 to SER and 1400 Mbps/lane from DES to Host.
- Add opt-in MAX96712 CSI output-rate and continuous-clock properties.
- Keep the MAX96717 CSI input in continuous-clock mode and apply the 16-bpp override required after metadata 8-to-16 double-loading.

## D4xx isolation

- Only the D5x FG12 overlay opts into the new lane-rate and clock properties.
- D4xx MAX96712 overlays do not opt into the PR 570 properties and retain the PR 568 base defaults: 1300 Mbps/lane for four lanes and 2500 Mbps/lane for two lanes.
- D4xx uses MAX9295 rather than MAX96717. The MAX96717 16-bpp override remains inside the pixel-only branch; tunnel-mode reset values are unchanged.
- This PR has no `d4xx.c`, D4xx overlay, MAX9295, or MAX9296 diff relative to PR #567.

## Dependencies

Depends-On: https://github.com/realsenseai/realsense_mipi_platform_driver/pull/567

PR #567 is stacked on [PR #568](https://github.com/realsenseai/realsense_mipi_platform_driver/pull/568). This PR is based directly on the current PR #567 head.

## Validation

- MAX96712 JP 6.2.2 incremental patch dry-run: passed.
- JP 6.2.2 DTB/DTBO build, including the D5x FG12 overlay: passed.
- JP 6.2.2 MAX96717 module build with `-Werror`: passed.
- 300-cycle direct-V4L2 3VC test at 1300/1400: 101/300 clean cycles, 3038 `EMBED_RUNAWAY` events, and zero VI timeouts.

The lane-rate change removes the severe VI-timeout path but does not fully resolve the remaining metadata/frame-boundary issue.