### PR TITLE
Bump driver version to 1.0.6.0

### DIFF
--- a/kernel/realsense/d4xx.c
+++ b/kernel/realsense/d4xx.c
@@ -7607,4 +7607,4 @@ MODULE_AUTHOR("Guennadi Liakhovetski <guennadi.liakhovetski@intel.com>,\n\
 				Shikun Ding <shikun.ding@intel.com>,\n\
 				Dmitry Perchanov <dmitry.perchanov@intel.com>");
 MODULE_LICENSE("GPL v2");
-MODULE_VERSION("1.0.5.20");
+MODULE_VERSION("1.0.6.0");


### PR DESCRIPTION
## Summary

Manual driver minor-version rollover: `1.0.5.20` → `1.0.6.0`.

`MODULE_VERSION()` in `kernel/realsense/d4xx.c` is the single source of truth for the driver version. CI's `.github/workflows/jenkins/driver_version.sh` only auto-increments the **last** field (`sed -E "/MODULE_VERSION/ s/([0-9]+\.[0-9]+\.[0-9]+\.)([0-9]+)/\1$NEW_REV/"`), so a minor-field bump has to be made by hand. After this merges, CI auto-increments continue from `1.0.6.1`.

## Changes

- `kernel/realsense/d4xx.c` — `MODULE_VERSION("1.0.5.20")` → `MODULE_VERSION("1.0.6.0")`

One line, no functional change.

## Test plan

- CI build across all JetPack versions (no code path touched; `MODULE_VERSION` is a module-info string).
- On-device sanity: `modinfo d4xx | grep version` reports `1.0.6.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)