### PR TITLE
Validate D585 GMSL exposure and ROI readback

### DIFF
--- a/kernel/realsense/d4xx.c
+++ b/kernel/realsense/d4xx.c
@@ -968,6 +968,34 @@ static int ds5_read_poll(struct ds5 *state, u16 reg, u16 *val)
 	return regmap_raw_read(state->regmap, reg, val, 2);
 }
 
+static int ds5_read_exposure(struct ds5 *state, u16 base, u32 max,
+			     u32 *value)
+{
+	u16 msw;
+	u16 lsw;
+	u32 exposure;
+	int ret;
+
+	ret = ds5_read(state, base | DS5_MANUAL_EXPOSURE_MSB, &msw);
+	if (ret)
+		return ret;
+
+	ret = ds5_read(state, base | DS5_MANUAL_EXPOSURE_LSB, &lsw);
+	if (ret)
+		return ret;
+
+	exposure = ((u32)msw << 16) | lsw;
+	if (exposure < 1 || exposure > max) {
+		dev_err(&state->client->dev,
+			"%s(): invalid exposure pair 0x%04x:0x%04x\n",
+			__func__, msw, lsw);
+		return -ERANGE;
+	}
+
+	*value = exposure;
+	return 0;
+}
+
 static int ds5_raw_read(struct ds5 *state, u16 reg, void *val, size_t val_len)
 {
 	int ret;
@@ -3629,11 +3657,11 @@ static int ds5_g_volatile_ctrl(struct v4l2_ctrl *ctrl)
 		if (state->is_imu)
 			return -EINVAL;
 		/* see ds5_hw_set_exposure */
-		ds5_read(state, base | DS5_MANUAL_EXPOSURE_MSB, &reg);
-		data = ((u32)reg << 16) & 0xffff0000;
-		ds5_read(state, base | DS5_MANUAL_EXPOSURE_LSB, &reg);
-		data |= reg;
-		*ctrl->p_new.p_u32 = data;
+		ret = ds5_read_exposure(state, base,
+					state->is_rgb ? MAX_RGB_EXP : MAX_DEPTH_EXP,
+					&data);
+		if (!ret)
+			*ctrl->p_new.p_u32 = data;
 		break;
 
 	case V4L2_CID_BRIGHTNESS:
@@ -3763,27 +3791,21 @@ static int ds5_g_volatile_ctrl(struct v4l2_ctrl *ctrl)
 		break;
 	case DS5_CAMERA_CID_AE_ROI_GET:
 		if (ctrl->p_new.p_u16) {
-			u16 len = sizeof(struct hwm_cmd) + 12;
-			u16 dataLen = 0;
-			struct hwm_cmd *ae_roi_cmd;
-			ae_roi_cmd = devm_kzalloc(&state->client->dev, len, GFP_KERNEL);
-			if (!ae_roi_cmd) {
-				dev_err(&state->client->dev,
-					"%s(): Can't allocate memory for 0x%x\n",
-					__func__, ctrl->id);
-				ret = -ENOMEM;
-				break;
-			}
-			memcpy(ae_roi_cmd, &get_ae_roi, sizeof(struct hwm_cmd));
-			ret = ds5_hwmc_send(state, sizeof(struct hwm_cmd), ae_roi_cmd);
-			if (ret) {
-				devm_kfree(&state->client->dev, ae_roi_cmd);
+			u16 data_len = 0;
+			u8 response[sizeof(u32) + (4 * sizeof(u16))];
+			struct hwm_cmd ae_roi_cmd;
+
+			memcpy(&ae_roi_cmd, &get_ae_roi, sizeof(ae_roi_cmd));
+			ret = ds5_hwmc_send(state, sizeof(ae_roi_cmd), &ae_roi_cmd);
+			if (ret)
 				return ret;
-			}
-			ret = ds5_get_hwmc(state, ae_roi_cmd->Data, len, &dataLen);
-			if (!ret && dataLen <= ctrl->dims[0])
-				memcpy(ctrl->p_new.p_u16, ae_roi_cmd->Data + 4, 8);
-			devm_kfree(&state->client->dev, ae_roi_cmd);
+
+			ret = ds5_get_hwmc(state, response, sizeof(response), &data_len);
+			if (!ret && data_len == sizeof(response))
+				memcpy(ctrl->p_new.p_u16, response + sizeof(u32),
+				       sizeof(response) - sizeof(u32));
+			else if (!ret)
+				ret = -EBADMSG;
 		}
 		break;
 	case DS5_CAMERA_CID_AE_SETPOINT_GET:


### PR DESCRIPTION
## What changed

- propagate failures from both 16-bit Exposure reads
- validate the assembled Exposure range without adding a second retry layer
- parse AE ROI GET in an exact 12-byte HWMC response buffer (4-byte opcode plus 8-byte ROI payload)
- reject malformed ROI response lengths instead of copying an invalid payload
- keep AE ROI on legacy HWMC opcodes `0x44`/`0x45`, aligned with the previous generation

## Retry policy

This change does not add complete-pair retries. The existing `ds5_read()` transport policy remains unchanged. Pair integrity must be guaranteed by the firmware snapshot/cache path rather than hidden by nested Host retries.

## Validation

- rebased onto `dev` (`2ba3952`)
- JP 6.2.1 full module build passed
- checkpatch: 0 errors, 0 warnings, 0 checks
- no-pair-retry module: 400 Depth plus 400 RGB startup Exposure reads passed
- no-pair-retry control run: 1,752 operations, 0 retries, 0 terminal errors, 0 mismatches, maximum ioctl 1.96 ms (`--skip-roi`)
- a full post-reboot run found one ROI SET/GET mismatch; the dependent HWMC lifecycle path remains under investigation

## Dependencies and blockers

- firmware command lifecycle draft: RealSenseAI-Internal/soc-rs-soc-io-drivers#531
- validation coverage: RealSenseAI-Internal/soc-rs-hkr-test#362
- merge remains blocked until ROI lifecycle and streaming acceptance gates pass

## Separate streaming blocker

`realsense-viewer` STREAMON produced a confirmed Jetson kernel panic. Persistent ramoops shows a NULL dereference in `nvcsi_deskew_setup+0x298`, following `stream already ... treating as no-op` and `max96724 ... no active pipes`. This is in the CSI/deskew stream path, not this control-readback diff, but it blocks overall D585 validation.
