### PR TITLE
draft--[D585][gmsl] feat: receive Perception_1..3 on VC5-VC7

### DIFF
--- a/apply_patches.sh
+++ b/apply_patches.sh
@@ -218,6 +218,9 @@ if [[ "$ACTION" = "apply" ]]; then
             if [[ -f "$JP6_OVERLAY_MAKEFILE" ]] && ! grep -q '^dtbo-y += tegra234-camera-d5xx-overlay-fg24-5ch-dual-rgb.dtbo$' "$JP6_OVERLAY_MAKEFILE"; then
                 sed -i '/^dtbo-y += tegra234-camera-d5xx-overlay-fg24-4ch.dtbo$/a dtbo-y += tegra234-camera-d5xx-overlay-fg24-5ch-dual-rgb.dtbo' "$JP6_OVERLAY_MAKEFILE"
             fi
+            if [[ -f "$JP6_OVERLAY_MAKEFILE" ]] && ! grep -q '^dtbo-y += tegra234-camera-d5xx-overlay-fg24-8ch.dtbo$' "$JP6_OVERLAY_MAKEFILE"; then
+                sed -i '/^dtbo-y += tegra234-camera-d5xx-overlay-fg24-5ch-dual-rgb.dtbo$/a dtbo-y += tegra234-camera-d5xx-overlay-fg24-8ch.dtbo' "$JP6_OVERLAY_MAKEFILE"
+            fi
             ln -f ${BUILD_SRCS}/hardware/nvidia/t23x/nv-public/include/platforms/dt-bindings/tegra234-p3737-0000+p3701-0000.h \
                     ${BUILD_SRCS}/$KERNEL_DIR/include/dt-bindings/
             ln -f ${BUILD_SRCS}/hardware/nvidia/t23x/nv-public/include/platforms/dt-bindings/tegra234-p3767-0000-common.h \

--- a/apply_patches_ext.sh
+++ b/apply_patches_ext.sh
@@ -90,6 +90,9 @@ if [[ "$JETPACK_VERSION" == "6.x" ]]; then
     if [[ -f "$JP6_OVERLAY_MAKEFILE" ]] && ! grep -q '^dtbo-y += tegra234-camera-d5xx-overlay-fg24-5ch-dual-rgb.dtbo$' "$JP6_OVERLAY_MAKEFILE"; then
         sed -i '/^dtbo-y += tegra234-camera-d5xx-overlay-fg24-4ch.dtbo$/a dtbo-y += tegra234-camera-d5xx-overlay-fg24-5ch-dual-rgb.dtbo' "$JP6_OVERLAY_MAKEFILE"
     fi
+    if [[ -f "$JP6_OVERLAY_MAKEFILE" ]] && ! grep -q '^dtbo-y += tegra234-camera-d5xx-overlay-fg24-8ch.dtbo$' "$JP6_OVERLAY_MAKEFILE"; then
+        sed -i '/^dtbo-y += tegra234-camera-d5xx-overlay-fg24-5ch-dual-rgb.dtbo$/a dtbo-y += tegra234-camera-d5xx-overlay-fg24-8ch.dtbo' "$JP6_OVERLAY_MAKEFILE"
+    fi
     # max96712 header
     cp nvidia-oot/max96712.h "$TARGET/nvidia-oot/include/media/"
 elif [[ "$JETPACK_VERSION" == "4.x" || "$JETPACK_VERSION" == "5.x" ]]; then

--- a/build_all.sh
+++ b/build_all.sh
@@ -167,12 +167,17 @@ else
                   "$BUILD_SRCS/hardware/nvidia/t23x/nv-public/overlay/" 2>/dev/null || true
             cp -f "$DEVDIR/hardware/realsense/tegra234-camera-d5xx-overlay-fg24-5ch-dual-rgb.dts" \
                   "$BUILD_SRCS/hardware/nvidia/t23x/nv-public/overlay/" 2>/dev/null || true
+            cp -f "$DEVDIR/hardware/realsense/tegra234-camera-d5xx-overlay-fg24-8ch.dts" \
+                  "$BUILD_SRCS/hardware/nvidia/t23x/nv-public/overlay/" 2>/dev/null || true
             JP6_OVERLAY_MAKEFILE="$BUILD_SRCS/hardware/nvidia/t23x/nv-public/overlay/Makefile"
             if ! grep -q '^dtbo-y += tegra234-camera-d5xx-overlay-fg24-4ch.dtbo$' "$JP6_OVERLAY_MAKEFILE"; then
                 sed -i '/^dtbo-y += tegra234-camera-d5xx-overlay.dtbo$/a dtbo-y += tegra234-camera-d5xx-overlay-fg24-4ch.dtbo' "$JP6_OVERLAY_MAKEFILE"
             fi
             if ! grep -q '^dtbo-y += tegra234-camera-d5xx-overlay-fg24-5ch-dual-rgb.dtbo$' "$JP6_OVERLAY_MAKEFILE"; then
                 sed -i '/^dtbo-y += tegra234-camera-d5xx-overlay-fg24-4ch.dtbo$/a dtbo-y += tegra234-camera-d5xx-overlay-fg24-5ch-dual-rgb.dtbo' "$JP6_OVERLAY_MAKEFILE"
+            fi
+            if ! grep -q '^dtbo-y += tegra234-camera-d5xx-overlay-fg24-8ch.dtbo$' "$JP6_OVERLAY_MAKEFILE"; then
+                sed -i '/^dtbo-y += tegra234-camera-d5xx-overlay-fg24-5ch-dual-rgb.dtbo$/a dtbo-y += tegra234-camera-d5xx-overlay-fg24-8ch.dtbo' "$JP6_OVERLAY_MAKEFILE"
             fi
         fi
         make RS_USE_D5XX=$RS_USE_D5XX RS_CSI_LANES=$RS_CSI_LANES dtbs
@@ -182,8 +187,10 @@ else
         fi
         if [[ "$FG24" == "1" ]]; then
             test -f "$BUILD_SRCS/nvidia-oot/device-tree/platform/generic-dts/dtbs/tegra234-camera-d5xx-overlay-fg24-5ch-dual-rgb.dtbo"
+            test -f "$BUILD_SRCS/nvidia-oot/device-tree/platform/generic-dts/dtbs/tegra234-camera-d5xx-overlay-fg24-8ch.dtbo"
             cp $BUILD_SRCS/nvidia-oot/device-tree/platform/generic-dts/dtbs/tegra234-camera-d5xx-overlay-fg24-4ch.dtbo $TEGRA_KERNEL_OUT/rootfs/boot/ 2>/dev/null || true
             cp $BUILD_SRCS/nvidia-oot/device-tree/platform/generic-dts/dtbs/tegra234-camera-d5xx-overlay-fg24-5ch-dual-rgb.dtbo $TEGRA_KERNEL_OUT/rootfs/boot/ 2>/dev/null || true
+            cp $BUILD_SRCS/nvidia-oot/device-tree/platform/generic-dts/dtbs/tegra234-camera-d5xx-overlay-fg24-8ch.dtbo $TEGRA_KERNEL_OUT/rootfs/boot/ 2>/dev/null || true
         fi
         if [[ "$FG24" == "1" ]]; then
             cp $BUILD_SRCS/nvidia-oot/device-tree/platform/generic-dts/dtbs/tegra234-p3768-0000+p3767-0000-nv.dtb $TEGRA_KERNEL_OUT/rootfs/boot/dtb/kernel_tegra234-p3768-0000+p3767-0000-nv.dtb
@@ -200,6 +207,7 @@ else
         if [[ "$FG24" == "1" ]]; then
             cp $BUILD_SRCS/$KERNEL_DIR/arch/arm64/boot/dts/nvidia/tegra234-camera-d5xx-overlay-fg24-4ch.dtbo $TEGRA_KERNEL_OUT/rootfs/boot/ 2>/dev/null || true
             cp $BUILD_SRCS/$KERNEL_DIR/arch/arm64/boot/dts/nvidia/tegra234-camera-d5xx-overlay-fg24-5ch-dual-rgb.dtbo $TEGRA_KERNEL_OUT/rootfs/boot/ 2>/dev/null || true
+            cp $BUILD_SRCS/$KERNEL_DIR/arch/arm64/boot/dts/nvidia/tegra234-camera-d5xx-overlay-fg24-8ch.dtbo $TEGRA_KERNEL_OUT/rootfs/boot/ 2>/dev/null || true
         fi
     fi
     export INSTALL_MOD_PATH=$TEGRA_KERNEL_OUT/rootfs/

--- a/hardware/realsense/tegra234-camera-d5xx-overlay-fg24-4ch.dts
+++ b/hardware/realsense/tegra234-camera-d5xx-overlay-fg24-4ch.dts
@@ -22,13 +22,12 @@
  *              __overlay__). It patches nodes into the base tree; it does not
  *              replace it. Selected by the OVERLAYS line in
  *              /boot/extlinux/extlinux.conf, so changing it needs a reboot.
- *   superset - declare the MAXIMUM hardware topology once and let the driver
- *              decide at runtime which streams the attached device actually
- *              provides. Streams the device does not report stay registered but
- *              enumerate no formats, so userspace skips them. This keeps the
- *              boot configuration constant while the product stream set
- *              (3C vs 2C) varies. The same mechanism is what a later VC5-VC7
- *              perception overlay plugs into; only VC0-VC4 ship today.
+ *   superset - declare the MAXIMUM hardware topology (all 8 VCs) once, and let
+ *              the driver decide at runtime which streams the attached device
+ *              actually provides. Streams the device does not report stay
+ *              registered but enumerate no formats, so userspace skips them.
+ *              This keeps the boot configuration constant while the product
+ *              stream set (3C vs 2C, VC5-VC7 perception) varies.
  *
  * VC assignment (SAS D5X5 3.4.5):
  *   VC0 = Depth        Z16                    1280x720  @60
@@ -36,6 +35,9 @@
  *   VC2 = IR           Y8 / Y8I / Y12I        1280x720  @60
  *   VC3 = IMU          RAW8
  *   VC4 = DUALRGB_RIGHT        same profiles as RGB   (D5XX_CHANNEL_COUNT >= 5)
+ *   VC5 = Perception_1 RAW8 over UD33         (D5XX_CHANNEL_COUNT >= 8)
+ *   VC6 = Perception_2 RAW8 over UD34         (D5XX_CHANNEL_COUNT >= 8)
+ *   VC7 = Perception_3 RAW8 over UD35         (D5XX_CHANNEL_COUNT >= 8)
  *
  * LAYER MAPPING for one VC (VC=N)
  *   HKR FlowGmsl        stream slot -> CameraId -> VC N, source DT, output DT
@@ -100,16 +102,21 @@
  * Stream-count selector. Wrappers define one of these and include this file:
  *   (none)          -> 4 channels, VC0-VC3
  *   D5XX_DUAL_RGB   -> 5 channels, adds DUALRGB_RIGHT on VC4
+ *   D5XX_ALL_VC     -> 8 channels, adds Perception_1..3 on VC5-VC7
  * Everything below keys off D5XX_CHANNEL_COUNT, never off the wrapper macro.
  */
-#if defined(D5XX_DUAL_RGB)
+#if defined(D5XX_ALL_VC)
+#define D5XX_CHANNEL_COUNT 8
+#elif defined(D5XX_DUAL_RGB)
 #define D5XX_CHANNEL_COUNT 5
 #else
 #define D5XX_CHANNEL_COUNT 4
 #endif
 
 / {
-#if D5XX_CHANNEL_COUNT >= 5
+#if D5XX_CHANNEL_COUNT >= 8
+	overlay-name = "Jetson RealSense Camera D5xx all VC with max96724 on FG24-4CH";
+#elif D5XX_CHANNEL_COUNT >= 5
 	overlay-name = "Jetson RealSense Camera D5xx dual RGB with max96724 on FG24-4CH";
 #else
 	overlay-name = "Jetson RealSense Camera D5xx with max96724 on FG24-4CH";
@@ -192,6 +199,42 @@
 						};
 					};
 #endif
+#if D5XX_CHANNEL_COUNT >= 8
+					/* VC5-VC7: Perception_1..3 byte streams over UD33/UD34/UD35. */
+					port@5 {
+						status = "okay";
+						reg = <5>;
+						d5xx_vi_in5: endpoint {
+							status = "okay";
+							vc-id = <5>;
+							port-index = <2>;
+							bus-width = <4>;
+							remote-endpoint = <&d5xx_csi_out5>;
+						};
+					};
+					port@6 {
+						status = "okay";
+						reg = <6>;
+						d5xx_vi_in6: endpoint {
+							status = "okay";
+							vc-id = <6>;
+							port-index = <2>;
+							bus-width = <4>;
+							remote-endpoint = <&d5xx_csi_out6>;
+						};
+					};
+					port@7 {
+						status = "okay";
+						reg = <7>;
+						d5xx_vi_in7: endpoint {
+							status = "okay";
+							vc-id = <7>;
+							port-index = <2>;
+							bus-width = <4>;
+							remote-endpoint = <&d5xx_csi_out7>;
+						};
+					};
+#endif
 				};
 			};
 
@@ -261,6 +304,35 @@
 						cam_module4_drivernode0: drivernode0 {
 							pcl_id = "v4l2_sensor";
 							sysfs-device-tree = "/sys/firmware/devicetree/base/bus@0/cam_i2cmux/i2c@1/d5xx@1e";
+						};
+					};
+#endif
+#if D5XX_CHANNEL_COUNT >= 8
+					cam_module5: module5 {
+						badge = "d5xx_per1";
+						position = "topleft";
+						orientation = "1";
+						cam_module5_drivernode0: drivernode0 {
+							pcl_id = "v4l2_sensor";
+							sysfs-device-tree = "/sys/firmware/devicetree/base/bus@0/cam_i2cmux/i2c@1/d5xx@1f";
+						};
+					};
+					cam_module6: module6 {
+						badge = "d5xx_per2";
+						position = "topright";
+						orientation = "1";
+						cam_module6_drivernode0: drivernode0 {
+							pcl_id = "v4l2_sensor";
+							sysfs-device-tree = "/sys/firmware/devicetree/base/bus@0/cam_i2cmux/i2c@1/d5xx@20";
+						};
+					};
+					cam_module7: module7 {
+						badge = "d5xx_per3";
+						position = "bottomright";
+						orientation = "1";
+						cam_module7_drivernode0: drivernode0 {
+							pcl_id = "v4l2_sensor";
+							sysfs-device-tree = "/sys/firmware/devicetree/base/bus@0/cam_i2cmux/i2c@1/d5xx@21";
 						};
 					};
 #endif
@@ -420,6 +492,97 @@
 									d5xx_csi_out4: endpoint@9 {
 										status = "okay";
 										remote-endpoint = <&d5xx_vi_in4>;
+									};
+								};
+							};
+						};
+#endif
+#if D5XX_CHANNEL_COUNT >= 8
+						/* NVCSI channel 5: Perception_1 (VC5) */
+						channel@5 {
+							status = "okay";
+							reg = <5>;
+							ports {
+								status = "okay";
+								#address-cells = <1>;
+								#size-cells = <0>;
+								port@0 {
+									status = "okay";
+									reg = <0>;
+									d5xx_csi_in5: endpoint@10 {
+										status = "okay";
+										port-index = <2>;
+										bus-width = <4>;
+										vc-id = <5>;
+										remote-endpoint = <&d5xx_per1_out>;
+									};
+								};
+								port@1 {
+									status = "okay";
+									reg = <1>;
+									d5xx_csi_out5: endpoint@11 {
+										status = "okay";
+										remote-endpoint = <&d5xx_vi_in5>;
+									};
+								};
+							};
+						};
+
+						/* NVCSI channel 6: Perception_2 (VC6) */
+						channel@6 {
+							status = "okay";
+							reg = <6>;
+							ports {
+								status = "okay";
+								#address-cells = <1>;
+								#size-cells = <0>;
+								port@0 {
+									status = "okay";
+									reg = <0>;
+									d5xx_csi_in6: endpoint@12 {
+										status = "okay";
+										port-index = <2>;
+										bus-width = <4>;
+										vc-id = <6>;
+										remote-endpoint = <&d5xx_per2_out>;
+									};
+								};
+								port@1 {
+									status = "okay";
+									reg = <1>;
+									d5xx_csi_out6: endpoint@13 {
+										status = "okay";
+										remote-endpoint = <&d5xx_vi_in6>;
+									};
+								};
+							};
+						};
+
+						/* NVCSI channel 7: Perception_3 (VC7) */
+						channel@7 {
+							status = "okay";
+							reg = <7>;
+							ports {
+								status = "okay";
+								#address-cells = <1>;
+								#size-cells = <0>;
+								port@0 {
+									status = "okay";
+									reg = <0>;
+									d5xx_csi_in7: endpoint@14 {
+										status = "okay";
+										port-index = <2>;
+										bus-width = <4>;
+										vc-id = <7>;
+										remote-endpoint = <&d5xx_per3_out>;
+									};
+								};
+								port@1 {
+									status = "okay";
+									reg = <1>;
+									d5xx_csi_out7: endpoint@15 {
+										status = "okay";
+										remote-endpoint = <&d5xx_vi_in7>;
 									};
 								};
 							};
@@ -682,6 +845,181 @@
 								csi-mode = "1x4";
 								st-vc = <4>;
 								vc-id = <4>;
+								num-lanes = <4>;
+							};
+						};
+#endif
+#if D5XX_CHANNEL_COUNT >= 8
+						/*
+						 * Perception_1..3 — VC5/VC6/VC7.
+						 * SAS carries these as UD33/UD34/UD35; the host exposes them
+						 * through the RAW8 GREY fallback until the product payload
+						 * contract is fixed, so the FourCC here is provisional.
+						 *
+						 * The 0x1f/0x20/0x21 sensor aliases were validated on the
+						 * FG24 board: all eight d5xx instances probe (9-001a..9-0021)
+						 * with no address collision on the muxed cam_i2c bus.
+						 * Firmware that does not publish VC5-VC7 simply fails
+						 * STREAMON with -EAGAIN; the other streams are unaffected.
+						 */
+						d5xx_per1: d5xx@1f {
+							status = "okay";
+							def-addr = <0x10>;
+							reg = <0x1f>;
+							override_reg = <0x1a>;
+							compatible = "realsense,d5xx";
+							use_sensor_mode_id = "true";
+							cam-type = "PER1";
+							nvidia,gmsl-ser-device = <&ser_a>;
+							nvidia,gmsl-dser-device = <&dser>;
+
+							ports {
+								#address-cells = <1>;
+								#size-cells = <0>;
+
+								port@0 {
+									reg = <0>;
+									d5xx_per1_out: endpoint {
+										vc-id = <5>;
+										port-index = <2>;
+										bus-width = <4>;
+										remote-endpoint = <&d5xx_csi_in5>;
+									};
+								};
+							};
+
+							mode0 {
+								pixel_t = "grey_y8";
+								num_lanes = "4";
+								csi_pixel_bit_depth = "8";
+								active_w = "1024";
+								active_h = "1024";
+								tegra_sinterface = "serial_c";
+								phy_mode = "DPHY";
+								discontinuous_clk = "no";
+								cil_settletime = "0";
+								mclk_khz = "24000";
+								pix_clk_hz = "1000000000";
+								serdes_pix_clk_hz = "1000000000";
+								line_length = "1024";
+								embedded_metadata_height = "0";
+							};
+
+							gmsl-link {
+								src-csi-port = "a";
+								dst-csi-port = "a";
+								serdes-csi-link = "a";
+								csi-mode = "1x4";
+								st-vc = <5>;
+								vc-id = <5>;
+								num-lanes = <4>;
+							};
+						};
+
+						d5xx_per2: d5xx@20 {
+							status = "okay";
+							def-addr = <0x10>;
+							reg = <0x20>;
+							override_reg = <0x1a>;
+							compatible = "realsense,d5xx";
+							use_sensor_mode_id = "true";
+							cam-type = "PER2";
+							nvidia,gmsl-ser-device = <&ser_a>;
+							nvidia,gmsl-dser-device = <&dser>;
+
+							ports {
+								#address-cells = <1>;
+								#size-cells = <0>;
+
+								port@0 {
+									reg = <0>;
+									d5xx_per2_out: endpoint {
+										vc-id = <6>;
+										port-index = <2>;
+										bus-width = <4>;
+										remote-endpoint = <&d5xx_csi_in6>;
+									};
+								};
+							};
+
+							mode0 {
+								pixel_t = "grey_y8";
+								num_lanes = "4";
+								csi_pixel_bit_depth = "8";
+								active_w = "1024";
+								active_h = "1024";
+								tegra_sinterface = "serial_c";
+								phy_mode = "DPHY";
+								discontinuous_clk = "no";
+								cil_settletime = "0";
+								mclk_khz = "24000";
+								pix_clk_hz = "1000000000";
+								serdes_pix_clk_hz = "1000000000";
+								line_length = "1024";
+								embedded_metadata_height = "0";
+							};
+
+							gmsl-link {
+								src-csi-port = "a";
+								dst-csi-port = "a";
+								serdes-csi-link = "a";
+								csi-mode = "1x4";
+								st-vc = <6>;
+								vc-id = <6>;
+								num-lanes = <4>;
+							};
+						};
+
+						d5xx_per3: d5xx@21 {
+							status = "okay";
+							def-addr = <0x10>;
+							reg = <0x21>;
+							override_reg = <0x1a>;
+							compatible = "realsense,d5xx";
+							use_sensor_mode_id = "true";
+							cam-type = "PER3";
+							nvidia,gmsl-ser-device = <&ser_a>;
+							nvidia,gmsl-dser-device = <&dser>;
+
+							ports {
+								#address-cells = <1>;
+								#size-cells = <0>;
+
+								port@0 {
+									reg = <0>;
+									d5xx_per3_out: endpoint {
+										vc-id = <7>;
+										port-index = <2>;
+										bus-width = <4>;
+										remote-endpoint = <&d5xx_csi_in7>;
+									};
+								};
+							};
+
+							mode0 {
+								pixel_t = "grey_y8";
+								num_lanes = "4";
+								csi_pixel_bit_depth = "8";
+								active_w = "1024";
+								active_h = "1024";
+								tegra_sinterface = "serial_c";
+								phy_mode = "DPHY";
+								discontinuous_clk = "no";
+								cil_settletime = "0";
+								mclk_khz = "24000";
+								pix_clk_hz = "1000000000";
+								serdes_pix_clk_hz = "1000000000";
+								line_length = "1024";
+								embedded_metadata_height = "0";
+							};
+
+							gmsl-link {
+								src-csi-port = "a";
+								dst-csi-port = "a";
+								serdes-csi-link = "a";
+								csi-mode = "1x4";
+								st-vc = <7>;
+								vc-id = <7>;
 								num-lanes = <4>;
 							};
 						};

--- a/hardware/realsense/tegra234-camera-d5xx-overlay-fg24-8ch.dts
+++ b/hardware/realsense/tegra234-camera-d5xx-overlay-fg24-8ch.dts
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// SPDX-FileCopyrightText: Copyright (c) 2026, RealSense CORPORATION.  All rights reserved.
+
+/*
+ * Superset overlay: declares the maximum D5xx topology, VC0-VC7.
+ * Streams the attached device does not report stay registered but enumerate no
+ * formats, so the boot configuration no longer has to change when the product
+ * stream set does. See tegra234-camera-d5xx-overlay-fg24-4ch.dts for the layer
+ * mapping and for the sensor alias addresses that still need hardware
+ * validation.
+ */
+
+#define D5XX_ALL_VC 1
+#include "tegra234-camera-d5xx-overlay-fg24-4ch.dts"

--- a/kernel/realsense/d5xx.c
+++ b/kernel/realsense/d5xx.c
@@ -188,12 +188,20 @@ MODULE_PARM_DESC(y12i_raw16_carrier,
 #define D5X_IMU_STREAM_STATUS		0x100C
 #define D5X_DUALRGB_RIGHT_STREAM_STATUS		0x1010
 #define D5X_IR_STREAM_STATUS		0x1014
+/* Perception_1..3 (VC5-VC7) extend the stream-control window to 0x102F. */
+#define D5X_PER1_STREAM_STATUS		0x1018
+#define D5X_PER2_STREAM_STATUS		0x101C
+#define D5X_PER3_STREAM_STATUS		0x1020
 
 #define D5X_STREAM_DEPTH			0x0
 #define D5X_STREAM_RGB				0x1
 #define D5X_STREAM_IMU				0x2
 #define D5X_STREAM_DUALRGB_RIGHT				0x3
 #define D5X_STREAM_IR				0x4
+#define D5X_STREAM_PER1				0x5
+#define D5X_STREAM_PER2				0x6
+#define D5X_STREAM_PER3				0x7
+#define D5X_PER_STREAM_COUNT			3
 #define D5X_STREAM_STOP				0x100
 #define D5X_STREAM_START			0x200
 #define D5X_STREAM_IDLE				0x1
@@ -238,6 +246,31 @@ MODULE_PARM_DESC(y12i_raw16_carrier,
 #define D5X_IR_OVERRIDE				0x409C
 #define D5X_IR_CONTROL_STATUS 		0x409E
 
+/* Perception_1..3 config blocks are appended after IR; existing bases never move. */
+#define D5X_PER1_STREAM_DT			0x40A0
+#define D5X_PER1_STREAM_MD			0x40A2
+#define D5X_PER1_RES_WIDTH			0x40A4
+#define D5X_PER1_RES_HEIGHT			0x40A8
+#define D5X_PER1_FPS				0x40AC
+#define D5X_PER1_OVERRIDE			0x40BC
+#define D5X_PER1_CONTROL_STATUS		0x40BE
+
+#define D5X_PER2_STREAM_DT			0x40C0
+#define D5X_PER2_STREAM_MD			0x40C2
+#define D5X_PER2_RES_WIDTH			0x40C4
+#define D5X_PER2_RES_HEIGHT			0x40C8
+#define D5X_PER2_FPS				0x40CC
+#define D5X_PER2_OVERRIDE			0x40DC
+#define D5X_PER2_CONTROL_STATUS		0x40DE
+
+#define D5X_PER3_STREAM_DT			0x40E0
+#define D5X_PER3_STREAM_MD			0x40E2
+#define D5X_PER3_RES_WIDTH			0x40E4
+#define D5X_PER3_RES_HEIGHT			0x40E8
+#define D5X_PER3_FPS				0x40EC
+#define D5X_PER3_OVERRIDE			0x40FC
+#define D5X_PER3_CONTROL_STATUS		0x40FE
+
 #define D5X_DEPTH_CONTROL_BASE		0x4100
 #define D5X_RGB_CONTROL_BASE		0x4200
 #define D5X_MANUAL_EXPOSURE_LSB		0x0000
@@ -276,6 +309,9 @@ MODULE_PARM_DESC(y12i_raw16_carrier,
 #define D5X_IMU_CONFIG_STATUS		0x4804
 #define D5X_DUALRGB_RIGHT_CONFIG_STATUS		0x4806
 #define D5X_IR_CONFIG_STATUS		0x4808
+#define D5X_PER1_CONFIG_STATUS		0x480A
+#define D5X_PER2_CONFIG_STATUS		0x480C
+#define D5X_PER3_CONFIG_STATUS		0x480E
 
 #define D5X_STATUS_STREAMING		0x1
 #define D5X_STATUS_INVALID_DT		0x2
@@ -631,6 +667,9 @@ struct d5x {
 	struct regulator *vcc;
 	const struct d5x_variant *variant;
 	int is_depth, is_y8, is_rgb, is_dualrgb_right, is_imu;
+	/* Perception_1..3 (VC5-VC7). is_per selects the family, per_index picks 0..2. */
+	int is_per;
+	int per_index;
 	bool metadata_enabled;
 	int aggregated;
 	int reset_ref_d5x;
@@ -845,6 +884,7 @@ struct d5x_dev {
 	bool ir_streaming;
 	bool rgb_streaming;
 	bool dualrgb_right_streaming;
+	bool per_streaming[D5X_PER_STREAM_COUNT];
 	bool imu_streaming;
 };
 
@@ -1608,6 +1648,27 @@ static const struct d5x_format d5x_y_formats_d58x[] = {
 	},
 };
 
+static const struct d5x_resolution d58x_per_sizes[] = {
+	D5X_RES(1024, 1024, d5x_framerate_to_60)	/* default */
+};
+
+/*
+ * Perception_1..3 payloads are opaque bytes produced by the camera's on-board
+ * processing; there is no imager-level pixel semantic. RAW8 in / RAW8 out with
+ * a GREY-compatible mbus code is a provisional container so the data reaches
+ * userspace unmodified. Both the FourCC and the geometry are expected to change
+ * once the perception payload format is finalised.
+ */
+static const struct d5x_format d5x_per_formats_d58x[] = {
+	{
+		.source_dt = GMSL_CSI_DT_RAW_8,
+		.csi_out_dt = GMSL_CSI_DT_RAW_8,
+		.mbus_code = MEDIA_BUS_FMT_Y8_1X8,
+		.n_resolutions = ARRAY_SIZE(d58x_per_sizes),
+		.resolutions = d58x_per_sizes,
+	},
+};
+
 static const struct d5x_format d5x_y_formats_d58x_raw16[] = {
 	{
 		/* First format: default */
@@ -1734,9 +1795,12 @@ static inline bool d5x_is_dualrgb_left(const struct d5x *state)
 static const char *d5x_get_sensor_name(struct d5x *state)
 {
 	static const char *sensor_name[] = {"unknown", "RGB", "DEPTH", "Y8", "IMU"};
+	static const char *per_name[D5X_PER_STREAM_COUNT] = {"PER1", "PER2", "PER3"};
 	int sensor_id = state->is_rgb * 1 + state->is_depth * 2 + \
 			state->is_y8 * 3 + state->is_imu * 4;
 
+	if (state->is_per)
+		return per_name[state->per_index];
 	if (state->is_dualrgb_right)
 		return "DUALRGB_RIGHT";
 	if (sensor_id >= (sizeof(sensor_name)/sizeof(*sensor_name)))
@@ -1752,6 +1816,8 @@ static void d5x_set_state_last_set(struct d5x *state)
 
 	if (state->is_depth)
 		state->mux.last_set = &state->depth.sensor;
+	else if (state->is_per)
+		state->mux.last_set = &state->ir.sensor;
 	else if (state->is_rgb)
 		state->mux.last_set = &state->rgb.sensor;
 	else if (state->is_y8)
@@ -2340,6 +2406,33 @@ static int d5x_configure(struct d5x *state)
 		width_addr = D5X_DUALRGB_RIGHT_RES_WIDTH;
 		height_addr = D5X_DUALRGB_RIGHT_RES_HEIGHT;
 #endif
+	} else if (state->is_per) {
+		static const u16 per_dt[D5X_PER_STREAM_COUNT] = {
+			D5X_PER1_STREAM_DT, D5X_PER2_STREAM_DT, D5X_PER3_STREAM_DT };
+		static const u16 per_md[D5X_PER_STREAM_COUNT] = {
+			D5X_PER1_STREAM_MD, D5X_PER2_STREAM_MD, D5X_PER3_STREAM_MD };
+		static const u16 per_override[D5X_PER_STREAM_COUNT] = {
+			D5X_PER1_OVERRIDE, D5X_PER2_OVERRIDE, D5X_PER3_OVERRIDE };
+		static const u16 per_fps[D5X_PER_STREAM_COUNT] = {
+			D5X_PER1_FPS, D5X_PER2_FPS, D5X_PER3_FPS };
+		static const u16 per_width[D5X_PER_STREAM_COUNT] = {
+			D5X_PER1_RES_WIDTH, D5X_PER2_RES_WIDTH, D5X_PER3_RES_WIDTH };
+		static const u16 per_height[D5X_PER_STREAM_COUNT] = {
+			D5X_PER1_RES_HEIGHT, D5X_PER2_RES_HEIGHT, D5X_PER3_RES_HEIGHT };
+
+		/*
+		 * Perception payloads are opaque byte streams, so they reuse the
+		 * IR (grey) sensor plumbing rather than a dedicated struct.
+		 */
+		sensor = &state->ir.sensor;
+#if !D5X_BYPASS_CAMERA_I2C
+		dt_addr = per_dt[state->per_index];
+		md_addr = per_md[state->per_index];
+		override_addr = per_override[state->per_index];
+		fps_addr = per_fps[state->per_index];
+		width_addr = per_width[state->per_index];
+		height_addr = per_height[state->per_index];
+#endif
 	} else if (d5x_is_dualrgb_left(state)) {
 		sensor = &state->rgb.sensor;
 #if !D5X_BYPASS_CAMERA_I2C
@@ -2473,6 +2566,7 @@ static int d5x_configure(struct d5x *state)
 	}
 #else /* Non-SERDES configuration */
 	vc_id = (state->is_depth) ? 0 : (state->is_dualrgb_right) ? 4 :
+		(state->is_per) ? (5 + state->per_index) :
 		d5x_is_dualrgb_left(state) ? 1 : (state->is_y8) ? 2 : 3;
 #endif
 
@@ -5696,7 +5790,7 @@ static int d5x_mux_enum_mbus_code(struct v4l2_subdev *sd,
 			remote_sd = &state->depth.sensor.sd;
 			break;
 		}
-		if (state->is_y8) {
+		if (state->is_y8 || state->is_per) {
 			remote_sd = &state->ir.sensor.sd;
 			break;
 		}
@@ -5731,7 +5825,7 @@ static int d5x_mux_enum_mbus_code(struct v4l2_subdev *sd,
 		remote_sd = &state->rgb.sensor.sd;
 	if (state->is_depth)
 		remote_sd = &state->depth.sensor.sd;
-	if (state->is_y8)
+	if (state->is_y8 || state->is_per)
 		remote_sd = &state->ir.sensor.sd;
 	if (state->is_imu)
 		remote_sd = &state->imu.sensor.sd;
@@ -5750,7 +5844,7 @@ static int d5x_state_to_pad(struct d5x *state) {
 	int pad = -1;
 	if (state->is_depth)
 		pad = D5X_MUX_PAD_DEPTH;
-	if (state->is_y8)
+	if (state->is_y8 || state->is_per)
 		pad = D5X_MUX_PAD_IR;
 	if (state->is_rgb)
 		pad = D5X_MUX_PAD_RGB;
@@ -6089,6 +6183,8 @@ static int d5x_mux_s_stream(struct v4l2_subdev *sd, int on)
 		streaming_flag = &state->d5x_dev->depth_streaming;
 	else if (state->is_dualrgb_right)
 		streaming_flag = &state->d5x_dev->dualrgb_right_streaming;
+	else if (state->is_per)
+		streaming_flag = &state->d5x_dev->per_streaming[state->per_index];
 	else if (d5x_is_dualrgb_left(state))
 		streaming_flag = &state->d5x_dev->rgb_streaming;
 	else if (state->is_y8)
@@ -6192,6 +6288,21 @@ static int d5x_mux_s_stream(struct v4l2_subdev *sd, int on)
 		stream_id = D5X_STREAM_DUALRGB_RIGHT;
 		vc_id = 4;
 		streaming_flag = &state->d5x_dev->dualrgb_right_streaming;
+	} else if (state->is_per) {
+		static const u16 per_config_status[D5X_PER_STREAM_COUNT] = {
+			D5X_PER1_CONFIG_STATUS, D5X_PER2_CONFIG_STATUS,
+			D5X_PER3_CONFIG_STATUS };
+		static const u16 per_stream_status[D5X_PER_STREAM_COUNT] = {
+			D5X_PER1_STREAM_STATUS, D5X_PER2_STREAM_STATUS,
+			D5X_PER3_STREAM_STATUS };
+		static const u16 per_stream_id[D5X_PER_STREAM_COUNT] = {
+			D5X_STREAM_PER1, D5X_STREAM_PER2, D5X_STREAM_PER3 };
+
+		config_status_base = per_config_status[state->per_index];
+		stream_status_base = per_stream_status[state->per_index];
+		stream_id = per_stream_id[state->per_index];
+		vc_id = 5 + state->per_index;
+		streaming_flag = &state->d5x_dev->per_streaming[state->per_index];
 	} else if (d5x_is_dualrgb_left(state)) {
 		config_status_base = D5X_RGB_CONFIG_STATUS;
 		stream_status_base = D5X_RGB_STREAM_STATUS;
@@ -6768,6 +6879,15 @@ static int d5x_mux_init(struct i2c_client *c, struct d5x *state)
 	}
 	else if (state->is_dualrgb_right)
 		state->mux.last_set = &state->rgb.sensor;
+	else if (state->is_per)
+		/*
+		 * Perception streams carry an opaque, already-processed byte
+		 * payload, so imager controls (exposure, gain, laser power)
+		 * have no meaning here and no handler is attached. If firmware
+		 * later exposes per-stream tunables, add a dedicated
+		 * handler_per here rather than reusing handler_y8.
+		 */
+		state->mux.last_set = &state->ir.sensor;
 	else if (state->is_y8) {
 #if LINUX_VERSION_CODE < KERNEL_VERSION(4, 20, 0)
 		v4l2_ctrl_add_handler(&state->ctrls.handler,
@@ -6870,20 +6990,27 @@ static int d5x_fixed_configuration(struct i2c_client *client, struct d5x *state)
 	sensor->mux_pad = D5X_MUX_PAD_DEPTH;
 
 	sensor = &state->ir.sensor;
-	switch (dev_type) {
-	case D5X_DEVICE_TYPE_D58X:
-		if (y12i_raw16_carrier) {
-			sensor->formats = d5x_y_formats_d58x_raw16;
-			sensor->n_formats =
-				ARRAY_SIZE(d5x_y_formats_d58x_raw16);
-		} else {
-			sensor->formats = d5x_y_formats_d58x;
-			sensor->n_formats = ARRAY_SIZE(d5x_y_formats_d58x);
+	if (state->is_per) {
+		/* Perception instances reuse the IR pad with their own table. */
+		sensor->formats = d5x_per_formats_d58x;
+		sensor->n_formats = ARRAY_SIZE(d5x_per_formats_d58x);
+	} else {
+		switch (dev_type) {
+		case D5X_DEVICE_TYPE_D58X:
+			if (y12i_raw16_carrier) {
+				sensor->formats = d5x_y_formats_d58x_raw16;
+				sensor->n_formats =
+					ARRAY_SIZE(d5x_y_formats_d58x_raw16);
+			} else {
+				sensor->formats = d5x_y_formats_d58x;
+				sensor->n_formats =
+					ARRAY_SIZE(d5x_y_formats_d58x);
+			}
+			break;
+		default:
+			sensor->formats = state->variant->formats;
+			sensor->n_formats = state->variant->n_formats;
 		}
-		break;
-	default:
-		sensor->formats = state->variant->formats;
-		sensor->n_formats = state->variant->n_formats;
 	}
 	sensor->mux_pad = D5X_MUX_PAD_IR;
 
@@ -7764,6 +7891,8 @@ static int d5x_probe(struct i2c_client *c
 	state->is_rgb = 0;
 	state->is_dualrgb_right = 0;
 	state->is_imu = 0;
+	state->is_per = 0;
+	state->per_index = 0;
 #ifdef CONFIG_OF
 	ret = of_property_read_string(c->dev.of_node, "cam-type", &str);
 	if (!ret && !strncmp(str, "Depth", strlen("Depth"))) {
@@ -7793,6 +7922,23 @@ static int d5x_probe(struct i2c_client *c
 		state->is_imu = 1;
 		state->control_base = D5X_DEPTH_CONTROL_BASE;
 		state->control_status_reg = D5X_DEPTH_CONTROL_STATUS;
+	}
+	if (!ret && !strncmp(str, "PER", strlen("PER"))) {
+		/* "PER1"."PER3" -> per_index 0..2; anything else stays unclaimed. */
+		int idx = str[strlen("PER")] - '1';
+
+		if (idx >= 0 && idx < D5X_PER_STREAM_COUNT) {
+			static const u16 per_ctrl_status[D5X_PER_STREAM_COUNT] = {
+				D5X_PER1_CONTROL_STATUS,
+				D5X_PER2_CONTROL_STATUS,
+				D5X_PER3_CONTROL_STATUS,
+			};
+
+			state->is_per = 1;
+			state->per_index = idx;
+			state->control_base = D5X_DEPTH_CONTROL_BASE;
+			state->control_status_reg = per_ctrl_status[idx];
+		}
 	}
 
 	mode0_node = of_get_child_by_name(state->client->dev.of_node, "mode0");


### PR DESCRIPTION
## Summary

Adds the three perception streams (Perception_1..3) on **VC5 / VC6 / VC7**, stacked on top of #576.

**This PR is intentionally kept separate from #576.** #576 delivers the Dual-RGB / VC4 feature that the
2C product needs now; VC5–VC7 is forward-looking scaffolding whose payload contract is not yet fixed.
Merging them together would have blocked the Dual-RGB feature behind an unfinished stream definition.

## Base

Stacked on `zhous/gmsl_rgb2_vcx` (#576). Review and merge #576 first.

## What it does

Extends the FG24 superset overlay from 5 to 8 channels and teaches `d5xx.c` the `PER1` / `PER2` /
`PER3` cam-types.

| Item | Value |
| --- | --- |
| `cam-type` | `"PER1"` / `"PER2"` / `"PER3"` → `is_per` + `per_index` 0..2 |
| Config register blocks | `0x40A0` / `0x40C0` / `0x40E0`, appended after IR `0x409E`; no existing base moves |
| `CONFIG_STATUS` | `0x480A` / `0x480C` / `0x480E` |
| `STREAM_STATUS` | `0x1018` / `0x101C` / `0x1020` |
| `stream_id` | `0x5` / `0x6` / `0x7` |
| Virtual channel | `5 + per_index` |
| Pad | reuses `D5X_MUX_PAD_IR` |
| Format | RAW8 in/out, `MEDIA_BUS_FMT_Y8_1X8`, 1024x1024 — **provisional** |
| Control handler | none, deliberately |

Perception payloads are opaque bytes produced by the camera's own processing, so imager controls
(exposure, gain, laser power) have no meaning for them. The code documents that a dedicated
`handler_per` should be added if firmware later exposes per-stream tunables, rather than reusing
`handler_y8`.

## Compatibility

Register blocks are appended after IR, so no existing base address moves. Firmware that does not
publish VC5–VC7 fails `VIDIOC_STREAMON` with `-EAGAIN` and leaves VC0–VC4 untouched. The 4-channel
and 5-channel overlays are unchanged; the 8-channel overlay is opt-in via `D5XX_ALL_VC`.

## Validation (jetson67, JP6.2.2, tunnel mode / MAX96724)

| Gate | Result |
| --- | --- |
| Full build with the 8ch overlay | PASS, zero `d5xx.c` warnings |
| All 8 d5xx instances probe | PASS, `9-001a` … `9-0021`, no I2C address collision |
| `PER1/PER2/PER3` identification | PASS |
| `/dev/video-rs-*` alias count | 12, `video-rs-depth-md-0` preserved |
| PER node format | `GREY 1024x1024`, `bytesperline=1024`, `sizeimage=1048576` |
| STREAMON with firmware that does not publish VC5–7 | clean `-EAGAIN`, no panic |
| Per-node STREAMON across all 10 nodes | no panic |
| 4ch / 5ch overlay regression | PASS (`num-channels` 4/5/8) |

## Known gaps before this can ship

1. The perception payload contract is not defined. The `GREY 1024x1024` container is a transport
   placeholder; both the FourCC and the geometry are expected to change.
2. The HKR firmware side (register blocks, `defaultVcForStream()`, CSI format routes) is not
   implemented yet, so VC5–VC7 currently never carry data.
3. `realsense-rs-enum.sh` only recognises the depth/rgb/ir/imu families, so perception nodes surface
   as `video-rs-ir-1/2/3`. Proper `video-rs-per-N` naming needs a librealsense-side change.
4. Full-rate 8-VC concurrency has not been measured; only per-node STREAMON and VC0/VC1 concurrency
   were exercised.
