### PR TITLE
[D58x] DFU: wait for dfuMANIFEST_WAIT_RESET terminal state

### DIFF
--- a/kernel/realsense/d4xx.c
+++ b/kernel/realsense/d4xx.c
@@ -139,6 +139,10 @@ struct ser_interface {
 #define DS5_DEVICE_TYPE_D45X		6
 #define DS5_DEVICE_TYPE_D43X		5
 #define DS5_DEVICE_TYPE_UNKNOWN		0
+/* FW version major byte identifies the family in recovery, where DEVICE_TYPE
+ * (0x0310) is not served: D58x reports 7 or 8, D4xx reports 5.
+ */
+#define DS5_D58X_FW_MAJOR_MIN		7
 
 /* GVD response payload size per product line */
 #define DS5_GVD_LEN_D4XX		276
@@ -285,6 +289,11 @@ enum ds5_mux_pad {
 #define PIPE_NOT_CONFIGURED	-1
 
 #define DFU_WAIT_RET_LEN 6
+
+/* Deadline for the D58x manifest wait; the manifest can legitimately take
+ * up to ~90 s, so the bound is generous and only guards against a device
+ * stuck in an intermediate manifest state. */
+#define DFU_MANIFEST_TIMEOUT_MS 180000
 
 #define DS5_START_POLL_TIME	10
 #define DS5_START_MAX_TIME	2000
@@ -6634,6 +6643,8 @@ static int ds5_dfu_wait_for_get_dfu_status(struct ds5 *state,
 	u16 status, dfu_state_len = 0x0000;
 	unsigned char dfu_asw_buf[DFU_WAIT_RET_LEN];
 	unsigned int dfu_wr_wait_msec = 0;
+	unsigned long manifest_deadline = jiffies +
+			msecs_to_jiffies(DFU_MANIFEST_TIMEOUT_MS);
 
 	do {
 		ds5_write_with_check(state, 0x5008, 0x0003); // Get Write state
@@ -6665,7 +6676,16 @@ static int ds5_dfu_wait_for_get_dfu_status(struct ds5 *state,
 		dfu_wr_wait_msec = (((unsigned int)dfu_asw_buf[3]) << 16)
 						| (((unsigned int)dfu_asw_buf[2]) << 8)
 						| dfu_asw_buf[1];
-	} while (dfu_asw_buf[4] == dfuDNBUSY && exp_state == dfuDNLOAD_IDLE);
+	/* D58x manifestation runs dfuMANIFEST_SYNC -> dfuMANIFEST ->
+	 * dfuMANIFEST_WAIT_RESET; keep polling through the intermediate
+	 * states until the terminal wait-reset state is reached, bounded by
+	 * manifest_deadline so a stuck device errors out instead of hanging. */
+	} while ((dfu_asw_buf[4] == dfuDNBUSY &&
+		  exp_state == dfuDNLOAD_IDLE) ||
+		 ((dfu_asw_buf[4] == dfuMANIFEST_SYNC ||
+		   dfu_asw_buf[4] == dfuMANIFEST) &&
+		  exp_state == dfuMANIFEST_WAIT_RESET &&
+		  time_before(jiffies, manifest_deadline)));
 
 	if (dfu_asw_buf[4] != exp_state) {
 		dev_notice(&state->client->dev,
@@ -6713,6 +6733,16 @@ static int ds5_dfu_detach(struct ds5 *state)
 			__func__, buf.FW_lastVersion);
 	dev_notice(&state->client->dev, "%s():FW status (%s)\n",
 			__func__, buf.DFU_isLocked ? "locked" : "unlocked");
+	/* Recovery never ran ds5_wait_device_type(), so cached_device_type is
+	 * UNKNOWN; recover the family from the FW major byte so the DFU
+	 * manifest wait picks the D58x terminal state (dfuMANIFEST_WAIT_RESET).
+	 */
+	if (!ret && state->ds5_dev &&
+	    !ds5_is_valid_device_type(
+		    READ_ONCE(state->ds5_dev->cached_device_type)) &&
+	    ((buf.FW_lastVersion >> 24) & 0xff) >= DS5_D58X_FW_MAJOR_MIN)
+		WRITE_ONCE(state->ds5_dev->cached_device_type,
+			   DS5_DEVICE_TYPE_D58X);
 	return ret;
 };
 
@@ -6823,8 +6853,15 @@ static ssize_t ds5_dfu_device_write(struct file *flip,
 				ret = ds5_dfu_wait_for_get_dfu_status(state, dfuDNLOAD_IDLE);
 			if (!ret)
 				ret = ds5_write(state, 0x4a04, 0x00); /*Download complete */
-			if (!ret)
-				ret = ds5_dfu_wait_for_get_dfu_status(state, dfuMANIFEST);
+			if (!ret) {
+				/* D58x finalizes DFU at dfuMANIFEST_WAIT_RESET;
+				 * D4xx completes at dfuMANIFEST. */
+				enum dfu_fw_state manifest_state =
+					ds5_is_d58x(state) ?
+					dfuMANIFEST_WAIT_RESET : dfuMANIFEST;
+				ret = ds5_dfu_wait_for_get_dfu_status(state,
+								      manifest_state);
+			}
 			if (ret < 0)
 				goto dfu_write_error;
 			state->dfu_dev.dfu_state_flag = DS5_DFU_DONE;


### PR DESCRIPTION
D58x firmware finalizes DFU at dfuMANIFEST_WAIT_RESET (0x08) after transitioning dfuMANIFEST_SYNC -> dfuMANIFEST -> dfuMANIFEST_WAIT_RESET, whereas D4xx completes at dfuMANIFEST (0x07). All changes are gated on ds5_is_d58x() so the D4xx DFU path is byte-for-byte unchanged:

- ds5_dfu_device_write(): pick terminal state per device type.
- ds5_dfu_wait_for_get_dfu_status(): poll through the D58x manifest intermediate states, only when the caller expects WAIT_RESET. The manifest poll is bounded by a generous deadline (DFU_MANIFEST_TIMEOUT_MS, 180 s) so a device stuck in an intermediate manifest state errors out via the existing 'Wrong dfu_state' -EINVAL path instead of spinning forever. The proven D4xx dfuDNBUSY path is untouched.
- ds5_dfu_detach(): in recovery (DEVICE_TYPE 0x0310 not served, cached_device_type UNKNOWN), recover the D58x family from the FW major version byte (D58x=7/8, D4xx=5) so the correct terminal state is chosen. Only upgrades an UNKNOWN type, so D4xx is never affected.

HW-validated on D585 (JP6.2.1): GMSL DFU from recovery with rvp-flash-dfu.img, FW 8.58.243.51 -> 7.58.243.85, camera re-enumerated.