### PR TITLE
[D585][GMSL] Enable pixel-mode NV12 over UD31

### DIFF
--- a/kernel/kernel-5.10/5.0.2/0005-Add-Realsense-NV12-UD31-media-bus-format.patch
+++ b/kernel/kernel-5.10/5.0.2/0005-Add-Realsense-NV12-UD31-media-bus-format.patch
@@ -1,0 +1,12 @@
+diff --git a/include/uapi/linux/media-bus-format.h b/include/uapi/linux/media-bus-format.h
+index b2362999fd3d..2327f0a740aa 100644
+--- a/include/uapi/linux/media-bus-format.h
++++ b/include/uapi/linux/media-bus-format.h
+@@ -159,4 +159,6 @@
+ #define MEDIA_BUS_FMT_S5C_UYVY_JPEG_1X8		0x5001
+-
++/* RealSense flat NV12 bytes carried over CSI-2 DT 0x31 (UD31) */
++#define MEDIA_BUS_FMT_RS_NV12_UD31_1X8		0x5008
++
+ /* HSV - next is	0x6002 */
+ #define MEDIA_BUS_FMT_AHSV8888_1X32		0x6001

--- a/kernel/kernel-5.10/5.1.2/0003-Add-Realsense-NV12-UD31-media-bus-format.patch
+++ b/kernel/kernel-5.10/5.1.2/0003-Add-Realsense-NV12-UD31-media-bus-format.patch
@@ -1,0 +1,12 @@
+diff --git a/include/uapi/linux/media-bus-format.h b/include/uapi/linux/media-bus-format.h
+index b2362999fd3d..2327f0a740aa 100644
+--- a/include/uapi/linux/media-bus-format.h
++++ b/include/uapi/linux/media-bus-format.h
+@@ -159,4 +159,6 @@
+ #define MEDIA_BUS_FMT_S5C_UYVY_JPEG_1X8		0x5001
+-
++/* RealSense flat NV12 bytes carried over CSI-2 DT 0x31 (UD31) */
++#define MEDIA_BUS_FMT_RS_NV12_UD31_1X8		0x5008
++
+ /* HSV - next is	0x6002 */
+ #define MEDIA_BUS_FMT_AHSV8888_1X32		0x6001

--- a/kernel/kernel-jammy-src/6.0/0002-realsense-camera-formats-jammy-master.patch
+++ b/kernel/kernel-jammy-src/6.0/0002-realsense-camera-formats-jammy-master.patch
@@ -10,8 +10,9 @@ Signed-off-by: Dmitry Perchanov <dmitry.perchanov@intel.com>
  drivers/media/usb/uvc/uvc_driver.c   | 57 ++++++++++++++++++++++++++++
  drivers/media/usb/uvc/uvcvideo.h     | 34 +++++++++++++++++
  drivers/media/v4l2-core/v4l2-ioctl.c |  9 +++++
+ include/uapi/linux/media-bus-format.h |  3 +++
  include/uapi/linux/videodev2.h       |  9 +++++
- 4 files changed, 109 insertions(+)
+ 5 files changed, 112 insertions(+)
 
 diff --git a/drivers/media/usb/uvc/uvc_driver.c b/drivers/media/usb/uvc/uvc_driver.c
 index 9a791d8ef200..205d524128da 100644
@@ -193,6 +194,13 @@ index 9260791b8438..fd50e9c34a0e 100644
  
  /* 10bit raw bayer packed, 32 bytes for every 25 pixels, last LSB 6 bits unused */
  #define V4L2_PIX_FMT_IPU3_SBGGR10	v4l2_fourcc('i', 'p', '3', 'b') /* IPU3 packed 10-bit BGGR bayer */
+diff --git a/include/uapi/linux/media-bus-format.h b/include/uapi/linux/media-bus-format.h
+--- a/include/uapi/linux/media-bus-format.h
++++ b/include/uapi/linux/media-bus-format.h
+@@ -162,1 +162,4 @@
++/* RealSense flat NV12 bytes carried over CSI-2 DT 0x31 (UD31) */
++#define MEDIA_BUS_FMT_RS_NV12_UD31_1X8		0x5008
++
+ /* HSV - next is	0x6002 */
 -- 
 2.37.1
-

--- a/kernel/kernel-jammy-src/6.2.1/0002-realsense-camera-formats-jammy-master.patch
+++ b/kernel/kernel-jammy-src/6.2.1/0002-realsense-camera-formats-jammy-master.patch
@@ -10,8 +10,9 @@ Signed-off-by: Dmitry Perchanov <dmitry.perchanov@intel.com>
  drivers/media/usb/uvc/uvc_driver.c   | 57 ++++++++++++++++++++++++++++
  drivers/media/usb/uvc/uvcvideo.h     | 34 +++++++++++++++++
  drivers/media/v4l2-core/v4l2-ioctl.c |  9 +++++
+ include/uapi/linux/media-bus-format.h |  3 +++
  include/uapi/linux/videodev2.h       |  9 +++++
- 4 files changed, 109 insertions(+)
+ 5 files changed, 112 insertions(+)
 
 diff --git a/drivers/media/usb/uvc/uvc_driver.c b/drivers/media/usb/uvc/uvc_driver.c
 index 9a791d8ef200..205d524128da 100644
@@ -193,6 +194,13 @@ index 9260791b8438..fd50e9c34a0e 100644
  
  /* 10bit raw bayer packed, 32 bytes for every 25 pixels, last LSB 6 bits unused */
  #define V4L2_PIX_FMT_IPU3_SBGGR10	v4l2_fourcc('i', 'p', '3', 'b') /* IPU3 packed 10-bit BGGR bayer */
+diff --git a/include/uapi/linux/media-bus-format.h b/include/uapi/linux/media-bus-format.h
+--- a/include/uapi/linux/media-bus-format.h
++++ b/include/uapi/linux/media-bus-format.h
+@@ -162,1 +162,4 @@
++/* RealSense flat NV12 bytes carried over CSI-2 DT 0x31 (UD31) */
++#define MEDIA_BUS_FMT_RS_NV12_UD31_1X8		0x5008
++
+ /* HSV - next is	0x6002 */
 -- 
 2.37.1
-

--- a/kernel/kernel-jammy-src/6.2/0002-realsense-camera-formats-jammy-master.patch
+++ b/kernel/kernel-jammy-src/6.2/0002-realsense-camera-formats-jammy-master.patch
@@ -10,8 +10,9 @@ Signed-off-by: Dmitry Perchanov <dmitry.perchanov@intel.com>
  drivers/media/usb/uvc/uvc_driver.c   | 57 ++++++++++++++++++++++++++++
  drivers/media/usb/uvc/uvcvideo.h     | 34 +++++++++++++++++
  drivers/media/v4l2-core/v4l2-ioctl.c |  9 +++++
+ include/uapi/linux/media-bus-format.h |  3 +++
  include/uapi/linux/videodev2.h       |  9 +++++
- 4 files changed, 109 insertions(+)
+ 5 files changed, 112 insertions(+)
 
 diff --git a/drivers/media/usb/uvc/uvc_driver.c b/drivers/media/usb/uvc/uvc_driver.c
 index 9a791d8ef200..205d524128da 100644
@@ -193,6 +194,13 @@ index 9260791b8438..fd50e9c34a0e 100644
  
  /* 10bit raw bayer packed, 32 bytes for every 25 pixels, last LSB 6 bits unused */
  #define V4L2_PIX_FMT_IPU3_SBGGR10	v4l2_fourcc('i', 'p', '3', 'b') /* IPU3 packed 10-bit BGGR bayer */
+diff --git a/include/uapi/linux/media-bus-format.h b/include/uapi/linux/media-bus-format.h
+--- a/include/uapi/linux/media-bus-format.h
++++ b/include/uapi/linux/media-bus-format.h
+@@ -162,1 +162,4 @@
++/* RealSense flat NV12 bytes carried over CSI-2 DT 0x31 (UD31) */
++#define MEDIA_BUS_FMT_RS_NV12_UD31_1X8		0x5008
++
+ /* HSV - next is	0x6002 */
 -- 
 2.37.1
-

--- a/kernel/kernel-noble-src/7.0/0002-realsense-camera-formats-jammy-master.patch
+++ b/kernel/kernel-noble-src/7.0/0002-realsense-camera-formats-jammy-master.patch
@@ -10,8 +10,9 @@ Signed-off-by: Dmitry Perchanov <dmitry.perchanov@intel.com>
  drivers/media/common/uvc.c   | 57 ++++++++++++++++++++++++++++
  drivers/include/linux/usb/uvc.h     | 34 +++++++++++++++++
  drivers/media/v4l2-core/v4l2-ioctl.c |  9 +++++
+ include/uapi/linux/media-bus-format.h |  3 +++
  include/uapi/linux/videodev2.h       |  9 +++++
- 4 files changed, 109 insertions(+)
+ 5 files changed, 112 insertions(+)
 
 diff --git a/drivers/media/common/uvc.c b/drivers/media/common/uvc.c
 index 9a791d8ef200..205d524128da 100644
@@ -189,6 +190,13 @@ index 9260791b8438..fd50e9c34a0e 100644
  
  /* 10bit raw packed, 32 bytes for every 25 pixels, last LSB 6 bits unused */
  #define V4L2_PIX_FMT_IPU3_SBGGR10	v4l2_fourcc('i', 'p', '3', 'b') /* IPU3 packed 10-bit BGGR bayer */
+diff --git a/include/uapi/linux/media-bus-format.h b/include/uapi/linux/media-bus-format.h
+--- a/include/uapi/linux/media-bus-format.h
++++ b/include/uapi/linux/media-bus-format.h
+@@ -162,1 +162,4 @@
++/* RealSense flat NV12 bytes carried over CSI-2 DT 0x31 (UD31) */
++#define MEDIA_BUS_FMT_RS_NV12_UD31_1X8		0x5008
++
+ /* HSV - next is	0x6002 */
 --
 2.37.1
-

--- a/kernel/kernel-noble-src/7.1/0002-realsense-camera-formats-jammy-master.patch
+++ b/kernel/kernel-noble-src/7.1/0002-realsense-camera-formats-jammy-master.patch
@@ -10,8 +10,9 @@ Signed-off-by: Dmitry Perchanov <dmitry.perchanov@intel.com>
  drivers/media/common/uvc.c   | 57 ++++++++++++++++++++++++++++
  drivers/include/linux/usb/uvc.h     | 34 +++++++++++++++++
  drivers/media/v4l2-core/v4l2-ioctl.c |  9 +++++
+ include/uapi/linux/media-bus-format.h |  3 +++
  include/uapi/linux/videodev2.h       |  9 +++++
- 4 files changed, 109 insertions(+)
+ 5 files changed, 112 insertions(+)
 
 diff --git a/drivers/media/common/uvc.c b/drivers/media/common/uvc.c
 index 9a791d8ef200..205d524128da 100644
@@ -189,6 +190,13 @@ index 9260791b8438..fd50e9c34a0e 100644
  
  /* 10bit raw packed, 32 bytes for every 25 pixels, last LSB 6 bits unused */
  #define V4L2_PIX_FMT_IPU3_SBGGR10	v4l2_fourcc('i', 'p', '3', 'b') /* IPU3 packed 10-bit BGGR bayer */
+diff --git a/include/uapi/linux/media-bus-format.h b/include/uapi/linux/media-bus-format.h
+--- a/include/uapi/linux/media-bus-format.h
++++ b/include/uapi/linux/media-bus-format.h
+@@ -162,1 +162,4 @@
++/* RealSense flat NV12 bytes carried over CSI-2 DT 0x31 (UD31) */
++#define MEDIA_BUS_FMT_RS_NV12_UD31_1X8		0x5008
++
+ /* HSV - next is	0x6002 */
 --
 2.37.1
-

--- a/kernel/nvidia/5.0.2/0025-Receive-flat-NV12-over-UD31.patch
+++ b/kernel/nvidia/5.0.2/0025-Receive-flat-NV12-over-UD31.patch
@@ -1,0 +1,1 @@
+../../../nvidia-oot/6.0/0013-Receive-flat-NV12-over-UD31.patch

--- a/kernel/nvidia/5.1.2/0014-Receive-flat-NV12-over-UD31.patch
+++ b/kernel/nvidia/5.1.2/0014-Receive-flat-NV12-over-UD31.patch
@@ -1,0 +1,1 @@
+../../../nvidia-oot/6.0/0013-Receive-flat-NV12-over-UD31.patch

--- a/kernel/nvidia/5.1.6/0016-Receive-flat-NV12-over-UD31.patch
+++ b/kernel/nvidia/5.1.6/0016-Receive-flat-NV12-over-UD31.patch
@@ -1,0 +1,1 @@
+../../../nvidia-oot/6.0/0013-Receive-flat-NV12-over-UD31.patch

--- a/kernel/realsense/d4xx.c
+++ b/kernel/realsense/d4xx.c
@@ -520,7 +520,8 @@ struct ds5_format {
 	unsigned int n_resolutions;
 	const struct ds5_resolution *resolutions;
 	u32 mbus_code;
-	u8 data_type;
+	u8 data_type;		/* Source format DT programmed into HKR. */
+	u8 override_data_type;	/* Non-zero CSI packet DT override on the wire. */
 };
 
 struct ds5_sensor {
@@ -1691,7 +1692,35 @@ static const struct ds5_format ds5_rgb_formats_d58x[] = {
 		.resolutions = d58x_calibration_sizes,
 	},
 };
-#define DS5_D58X_RGB_N_FORMATS 2
+
+#define DS5_D58X_NV12_SOURCE_DT		0x18
+#define DS5_D58X_NV12_CARRIER_DT	0x31
+
+/* Keep shared YUYV and calibration entries aligned with the base table. */
+static const struct ds5_format ds5_rgb_formats_d58x_tunnel[] = {
+	{
+		/* First format: default */
+		.data_type = GMSL_CSI_DT_YUV422_8,	/* UYVY */
+		.mbus_code = MEDIA_BUS_FMT_YUYV8_1X16,
+		.n_resolutions = ARRAY_SIZE(d58x_rgb_sizes),
+		.resolutions = d58x_rgb_sizes,
+	}, {
+		/* Flat NV12 bytes use UD31 as an opaque 8-bit CSI carrier. */
+		.data_type = DS5_D58X_NV12_SOURCE_DT,
+		.override_data_type = DS5_D58X_NV12_CARRIER_DT,
+		.mbus_code = MEDIA_BUS_FMT_RS_NV12_UD31_1X8,
+		.n_resolutions = ARRAY_SIZE(d58x_rgb_sizes),
+		.resolutions = d58x_rgb_sizes,
+	}, {
+		/* RGB calibration: unpacked GRBG10, one little-endian
+		 * 10-bit sample per 16-bit container, 2 bytes/pixel.
+		 */
+		.data_type = GMSL_CSI_DT_RAW_16,
+		.mbus_code = MEDIA_BUS_FMT_SGRBG16_1X16,
+		.n_resolutions = ARRAY_SIZE(d58x_calibration_sizes),
+		.resolutions = d58x_calibration_sizes,
+	},
+};
 
 static const struct ds5_variant ds5_variants[] = {
 	[DS5_DS5U] = {
@@ -2162,6 +2191,14 @@ static void ds5_invalidate_sensor(struct ds5 *state, struct ds5_sensor *sensor)
 	sensor->pipe_vc_id = 0xFFFF;
 }
 
+#ifdef CONFIG_VIDEO_D4XX_SERDES
+static u8 ds5_wire_data_type(const struct ds5_format *format)
+{
+	return format->override_data_type ? format->override_data_type :
+		format->data_type;
+}
+#endif
+
 static int ds5_configure(struct ds5 *state)
 {
 	struct ds5_sensor *sensor;
@@ -2190,10 +2227,12 @@ static int ds5_configure(struct ds5 *state)
 		sensor = &state->rgb.sensor;
 		dt_addr = DS5_RGB_STREAM_DT;
 		md_addr = DS5_RGB_STREAM_MD;
-		/* Only CSI-PT needs the FW DT override; leave the YUYV path on the
-		 * FW default so non-passthrough RGB behaviour is unchanged. */
-		override_addr = sensor->config.format->mbus_code ==
-				MEDIA_BUS_FMT_SBGGR8_1X8 ? DS5_RGB_OVERRIDE : 0;
+		/* D58x tunnel formats always program the stream override contract:
+		 * non-zero selects a carrier DT and zero clears any prior carrier.
+		 * The format cache avoids redundant I2C writes. D4xx is unchanged. */
+		override_addr = (ds5_is_d58x(state) && !state->d58x_pixel_mode) ||
+			sensor->config.format->mbus_code == MEDIA_BUS_FMT_SBGGR8_1X8 ?
+			DS5_RGB_OVERRIDE : 0;
 		fps_addr = DS5_RGB_FPS;
 		width_addr = DS5_RGB_RES_WIDTH;
 		height_addr = DS5_RGB_RES_HEIGHT;
@@ -2220,7 +2259,7 @@ static int ds5_configure(struct ds5 *state)
 	md_fmt = (state->metadata_enabled) ? GMSL_CSI_DT_EMBED : 0x00;
 
 #ifdef CONFIG_VIDEO_D4XX_SERDES
-	data_type1 = sensor->config.format->data_type;
+	data_type1 = ds5_wire_data_type(sensor->config.format);
 	data_type2 = md_fmt;
 	is_calib = (state->is_y8 && (data_type1 == GMSL_CSI_DT_RGB_888));
 
@@ -2325,7 +2364,14 @@ static int ds5_configure(struct ds5 *state)
 	}
 
 	if (override_addr != 0) {
-		dt_value = sensor->config.format->data_type;
+		/* D58x tunnel uses an explicit per-format carrier contract, including
+		 * zero to clear a previous override. Preserve the existing D4xx
+		 * depth/IR override values. */
+		if (state->is_rgb && ds5_is_d58x(state) &&
+		    !state->d58x_pixel_mode)
+			dt_value = sensor->config.format->override_data_type;
+		else
+			dt_value = sensor->config.format->data_type;
 		/* RAW8 CSI passthrough: FW runs in CSI-PT mode (0x2E → dt_addr) and
 		 * remaps all wire DTs to RAW8 via override_addr=0x2A.
 		 */
@@ -6409,6 +6455,12 @@ static int ds5_fixed_configuration(struct i2c_client *client, struct ds5 *state)
 
 	sensor = &state->depth.sensor;
 	dev_type = ds5_dev_type(state, dev_type);
+	state->d58x_pixel_mode = false;
+#ifdef CONFIG_VIDEO_D4XX_SERDES
+	state->d58x_pixel_mode = (dev_type == DS5_DEVICE_TYPE_D58X) &&
+				 (state->dser_ops == &max96712_interface);
+#endif
+
 	switch (dev_type) {
 	case DS5_DEVICE_TYPE_D41X:
 		sensor->formats = ds5_depth_formats_d41x;
@@ -6477,8 +6529,13 @@ static int ds5_fixed_configuration(struct i2c_client *client, struct ds5 *state)
 		sensor->n_formats = DS5_RLT_RGB_N_FORMATS;
 		break;
 	case DS5_DEVICE_TYPE_D58X:
-		sensor->formats = ds5_rgb_formats_d58x;
-		sensor->n_formats = DS5_D58X_RGB_N_FORMATS;
+		if (!state->d58x_pixel_mode) {
+			sensor->formats = ds5_rgb_formats_d58x_tunnel;
+			sensor->n_formats = ARRAY_SIZE(ds5_rgb_formats_d58x_tunnel);
+		} else {
+			sensor->formats = ds5_rgb_formats_d58x;
+			sensor->n_formats = ARRAY_SIZE(ds5_rgb_formats_d58x);
+		}
 		break;
 	default:
 		sensor->formats = &ds5_onsemi_rgb_format;
@@ -6487,13 +6544,6 @@ static int ds5_fixed_configuration(struct i2c_client *client, struct ds5 *state)
 	sensor->mux_pad = DS5_MUX_PAD_RGB;
 
 	sensor = &state->imu.sensor;
-
-	state->d58x_pixel_mode = false;
-#ifdef CONFIG_VIDEO_D4XX_SERDES
-	/* D58x on a MAX96712 deserializer runs the serdes link in PIXEL mode. */
-	state->d58x_pixel_mode = (dev_type == DS5_DEVICE_TYPE_D58X) &&
-				 (state->dser_ops == &max96712_interface);
-#endif
 
 	/* For fimware version starting from: 5.16,
 	   IMU will have 32bit axis values.

--- a/kernel/realsense/d4xx.c
+++ b/kernel/realsense/d4xx.c
@@ -1675,11 +1675,21 @@ static const struct ds5_format ds5_y_formats_d58x[] = {
 	},
 };
 
+#define DS5_D58X_NV12_SOURCE_DT		0x18
+#define DS5_D58X_NV12_CARRIER_DT	0x31
+
 static const struct ds5_format ds5_rgb_formats_d58x[] = {
 	{
 		/* First format: default */
 		.data_type = GMSL_CSI_DT_YUV422_8,	/* UYVY */
 		.mbus_code = MEDIA_BUS_FMT_YUYV8_1X16,
+		.n_resolutions = ARRAY_SIZE(d58x_rgb_sizes),
+		.resolutions = d58x_rgb_sizes,
+	}, {
+		/* Flat NV12 bytes use UD31 as an opaque 8-bit CSI carrier. */
+		.data_type = DS5_D58X_NV12_SOURCE_DT,
+		.override_data_type = DS5_D58X_NV12_CARRIER_DT,
+		.mbus_code = MEDIA_BUS_FMT_RS_NV12_UD31_1X8,
 		.n_resolutions = ARRAY_SIZE(d58x_rgb_sizes),
 		.resolutions = d58x_rgb_sizes,
 	}, {
@@ -1692,9 +1702,6 @@ static const struct ds5_format ds5_rgb_formats_d58x[] = {
 		.resolutions = d58x_calibration_sizes,
 	},
 };
-
-#define DS5_D58X_NV12_SOURCE_DT		0x18
-#define DS5_D58X_NV12_CARRIER_DT	0x31
 
 /* Keep shared YUYV and calibration entries aligned with the base table. */
 static const struct ds5_format ds5_rgb_formats_d58x_tunnel[] = {
@@ -2227,10 +2234,10 @@ static int ds5_configure(struct ds5 *state)
 		sensor = &state->rgb.sensor;
 		dt_addr = DS5_RGB_STREAM_DT;
 		md_addr = DS5_RGB_STREAM_MD;
-		/* D58x tunnel formats always program the stream override contract:
+		/* D58x formats always program the stream override contract:
 		 * non-zero selects a carrier DT and zero clears any prior carrier.
 		 * The format cache avoids redundant I2C writes. D4xx is unchanged. */
-		override_addr = (ds5_is_d58x(state) && !state->d58x_pixel_mode) ||
+		override_addr = ds5_is_d58x(state) ||
 			sensor->config.format->mbus_code == MEDIA_BUS_FMT_SBGGR8_1X8 ?
 			DS5_RGB_OVERRIDE : 0;
 		fps_addr = DS5_RGB_FPS;
@@ -2364,11 +2371,10 @@ static int ds5_configure(struct ds5 *state)
 	}
 
 	if (override_addr != 0) {
-		/* D58x tunnel uses an explicit per-format carrier contract, including
+		/* D58x uses an explicit per-format carrier contract, including
 		 * zero to clear a previous override. Preserve the existing D4xx
 		 * depth/IR override values. */
-		if (state->is_rgb && ds5_is_d58x(state) &&
-		    !state->d58x_pixel_mode)
+		if (state->is_rgb && ds5_is_d58x(state))
 			dt_value = sensor->config.format->override_data_type;
 		else
 			dt_value = sensor->config.format->data_type;

--- a/nvidia-oot/6.0/0013-Receive-flat-NV12-over-UD31.patch
+++ b/nvidia-oot/6.0/0013-Receive-flat-NV12-over-UD31.patch
@@ -1,0 +1,192 @@
+From 168b4e389da3ab461252c9d3be806edfe0bba51e Mon Sep 17 00:00:00 2001
+From: zhou <shengyong.zhou@realsenseai.com>
+Date: Mon, 17 Aug 2026 10:25:24 +0800
+Subject: [PATCH] media: tegra: receive flat NV12 over UD31
+
+Add a private media-bus tuple that matches UD31 while DMAing an opaque
+T_R8 surface. Apply the RAW8 receive-parser override only to the current
+capture descriptor, expand the transport height to H*3/2, and expose the
+resulting byte-identical surface through the standard NV12 V4L2 ABI.
+
+Scope NV12 buffer sizing and channel-format lookup to the private tuple,
+while preserving legacy lookup behavior for every other FourCC.
+---
+ .../media/platform/tegra/camera/vi/channel.c  |  9 +++++++++
+ drivers/media/platform/tegra/camera/vi/core.c | 16 ++++++++++++++--
+ .../media/platform/tegra/camera/vi/vi5_fops.c | 12 +++++++
+ .../platform/tegra/camera/vi/vi5_formats.h    | 32 +++++++++++++++++++
+ 4 files changed, 67 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/media/platform/tegra/camera/vi/channel.c b/drivers/media/platform/tegra/camera/vi/channel.c
+index ac5e0e9c..9eee67ba 100644
+--- a/drivers/media/platform/tegra/camera/vi/channel.c
++++ b/drivers/media/platform/tegra/camera/vi/channel.c
+@@ -295,6 +295,9 @@ static void tegra_channel_update_format(struct tegra_channel *chan,
+ 
+ 	if (fourcc == V4L2_PIX_FMT_NV16)
+ 		chan->format.sizeimage *= 2;
++	else if (fourcc == V4L2_PIX_FMT_NV12 &&
++		 chan->fmtinfo->code == MEDIA_BUS_FMT_RS_NV12_UD31_1X8)
++		chan->format.sizeimage = chan->format.sizeimage * 3 / 2;
+ }
+ 
+ static void tegra_channel_fmts_bitmap_init(struct tegra_channel *chan)
+@@ -2126,8 +2129,14 @@ __tegra_channel_try_format(struct tegra_channel *chan,
+ 				&pix->width, &pix->height, &pix->bytesperline);
+ 	pix->sizeimage = get_aligned_buffer_size(chan,
+ 			pix->bytesperline, pix->height);
++	if (vfmt->fourcc == V4L2_PIX_FMT_NV12 &&
++	    vfmt->code == MEDIA_BUS_FMT_RS_NV12_UD31_1X8) {
++		pix->sizeimage = pix->sizeimage * 3 / 2;
++		return ret;
++	}
++
+ 	if (chan->fmtinfo->fourcc == V4L2_PIX_FMT_NV16)
+ 		pix->sizeimage *= 2;
+ 
+ 	return ret;
+ }
+diff --git a/drivers/media/platform/tegra/camera/vi/core.c b/drivers/media/platform/tegra/camera/vi/core.c
+index f0bde35a..e3ca4a64 100644
+--- a/drivers/media/platform/tegra/camera/vi/core.c
++++ b/drivers/media/platform/tegra/camera/vi/core.c
+@@ -6,6 +6,7 @@
+  */
+ 
+ #include <linux/export.h>
++#include <linux/bitmap.h>
+ #include <linux/kernel.h>
+ #include <linux/of.h>
+ #include <linux/nospec.h>
+@@ -26,6 +27,15 @@ static const struct tegra_video_format tegra_default_format[] = {
+ 	},
+ };
+ 
++static bool tegra_core_format_is_available(struct tegra_channel *chan,
++		unsigned int index)
++{
++	return chan->video_formats[index]->code !=
++		MEDIA_BUS_FMT_RS_NV12_UD31_1X8 ||
++		bitmap_empty(chan->fmts_bitmap, MAX_FORMAT_NUM) ||
++		test_bit(index, chan->fmts_bitmap);
++}
++
+ /* -----------------------------------------------------------------------------
+  * Helper functions
+  */
+@@ -96,7 +104,8 @@ int tegra_core_get_code_by_fourcc(struct tegra_channel *chan,
+ 	unsigned int i;
+ 
+ 	for (i = offset; i < chan->num_video_formats; ++i) {
+-		if (chan->video_formats[i]->fourcc == fourcc)
++		if (chan->video_formats[i]->fourcc == fourcc &&
++		    tegra_core_format_is_available(chan, i))
+ 			return chan->video_formats[i]->code;
+ 	}
+ 	spec_bar();
+@@ -156,7 +165,8 @@ tegra_core_get_format_by_fourcc(struct tegra_channel *chan, u32 fourcc)
+ 	unsigned int i;
+ 
+ 	for (i = 0; i < chan->num_video_formats; ++i) {
+-		if (chan->video_formats[i]->fourcc == fourcc)
++		if (chan->video_formats[i]->fourcc == fourcc &&
++		    tegra_core_format_is_available(chan, i))
+ 			return chan->video_formats[i];
+ 	}
+ 	spec_bar();
+diff --git a/drivers/media/platform/tegra/camera/vi/vi5_fops.c b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
+index c05f5f8f..f1282282 100644
+--- a/drivers/media/platform/tegra/camera/vi/vi5_fops.c
++++ b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
+@@ -67,6 +67,8 @@ static const struct capture_descriptor capture_template = {
+ 	,
+ 
+ 	.ch_cfg = {
++		.dt_enable = 0,
++		.dt_override = 0,
+ 		.pixfmt_enable = 0,		/* no output */
+ 		.match = {
+ 			.stream = 0,		/* one-hot bit encoding */
+@@ -395,6 +397,8 @@ static void vi5_setup_surface(struct tegra_channel *chan,
+ 	u32 format = chan->fmtinfo->img_fmt;
+ 	u32 bpl = chan->format.bytesperline;
+ 	u32 data_type = chan->fmtinfo->img_dt;
++	const struct tegra_vi_surface_override *surface_override =
++		tegra_vi_get_surface_override(chan->fmtinfo->code);
+ 	u32 nvcsi_stream = chan->port[vi_port];
+ 	struct capture_descriptor_memoryinfo *desc_memoryinfo =
+ 		&chan->tegra_vi_channel[vi_port]->
+@@ -413,6 +417,9 @@ static void vi5_setup_surface(struct tegra_channel *chan,
+ 	 */
+ 	if (chan->fmtinfo->fourcc == V4L2_PIX_FMT_Y16I)
+ 		width *= 2;
++	if (surface_override)
++		height = height * surface_override->height_numerator /
++			surface_override->height_denominator;
+ 
+ 	memcpy(desc, &capture_template, sizeof(capture_template));
+ 	memset(desc_memoryinfo, 0, sizeof(*desc_memoryinfo));
+@@ -424,6 +431,11 @@ static void vi5_setup_surface(struct tegra_channel *chan,
+ 	desc->ch_cfg.frame.frame_y = height;
+ 	desc->ch_cfg.match.datatype = data_type;
+ 	desc->ch_cfg.match.datatype_mask = 0x3f;
++	if (surface_override && surface_override->dt_override) {
++		desc->ch_cfg.dt_enable = 1;
++		desc->ch_cfg.dt_override = surface_override->dt_override;
++	}
++
+ 	desc->ch_cfg.pixfmt_enable = 1;
+ 	desc->ch_cfg.pixfmt.format = format;
+ 
+diff --git a/drivers/media/platform/tegra/camera/vi/vi5_formats.h b/drivers/media/platform/tegra/camera/vi/vi5_formats.h
+index 3db81c7c..96d4ff90 100644
+--- a/drivers/media/platform/tegra/camera/vi/vi5_formats.h
++++ b/drivers/media/platform/tegra/camera/vi/vi5_formats.h
+@@ -76,6 +76,36 @@ enum tegra_image_format {
+ 	TEGRA_IMAGE_FORMAT_T_DPCM_RAW20,
+ };
+ 
++struct tegra_vi_surface_override {
++	u32 code;
++	u8 dt_override;
++	u8 height_numerator;
++	u8 height_denominator;
++};
++
++static const struct tegra_vi_surface_override
++tegra_vi_surface_overrides[] = {
++	{
++		.code = MEDIA_BUS_FMT_RS_NV12_UD31_1X8,
++		.dt_override = TEGRA_IMAGE_DT_RAW8,
++		.height_numerator = 3,
++		.height_denominator = 2,
++	},
++};
++
++static const struct tegra_vi_surface_override *
++tegra_vi_get_surface_override(u32 code)
++{
++	unsigned int i;
++
++	for (i = 0; i < ARRAY_SIZE(tegra_vi_surface_overrides); i++) {
++		if (tegra_vi_surface_overrides[i].code == code)
++			return &tegra_vi_surface_overrides[i];
++	}
++
++	return NULL;
++}
++
+ static const struct tegra_video_format vi5_video_formats[] = {
+ 	/* RAW 6: TODO */
+ 
+@@ -153,6 +183,8 @@ static const struct tegra_video_format vi5_video_formats[] = {
+ 				RAW16, Y16I, "Y16I 32"),
+ 	TEGRA_VIDEO_FORMAT(RAW16, 16, SGRBG16_1X16, 2, 1, T_R16,
+ 				RAW16, RW16, "RW16 16"),
++	TEGRA_VIDEO_FORMAT(RAW8, 8, RS_NV12_UD31_1X8, 1, 1, T_R8,
++				USER_2, NV12, "YUV 4:2:0 NV12 UD31"),
+ 
+ };
+ 
+-- 
+2.34.1

--- a/nvidia-oot/6.0/0013-Receive-flat-NV12-over-UD31.patch
+++ b/nvidia-oot/6.0/0013-Receive-flat-NV12-over-UD31.patch
@@ -9,14 +9,34 @@ capture descriptor, expand the transport height to H*3/2, and expose the
 resulting byte-identical surface through the standard NV12 V4L2 ABI.
 
 Scope NV12 buffer sizing and channel-format lookup to the private tuple,
-while preserving legacy lookup behavior for every other FourCC.
+while preserving legacy lookup behavior for every other FourCC. Classify
+UD31 with the existing RAW8 double-pixel handling in MAX9295 Pixel Mode.
 ---
+ drivers/media/i2c/max9295.c                   |  7 +++++--
  .../media/platform/tegra/camera/vi/channel.c  |  9 +++++++++
  drivers/media/platform/tegra/camera/vi/core.c | 16 ++++++++++++++--
  .../media/platform/tegra/camera/vi/vi5_fops.c | 12 +++++++
  .../platform/tegra/camera/vi/vi5_formats.h    | 32 +++++++++++++++++++
- 4 files changed, 67 insertions(+), 2 deletions(-)
+ 5 files changed, 72 insertions(+), 4 deletions(-)
 
+diff --git a/drivers/media/i2c/max9295.c b/drivers/media/i2c/max9295.c
+index 5b9a4dcf..f360ec4c 100644
+--- a/drivers/media/i2c/max9295.c
++++ b/drivers/media/i2c/max9295.c
+@@ -576,8 +576,11 @@ static int __max9295_set_pipe(struct device *dev, int pipe_id, u8 data_type1,
+ 		{0x0102, 0x0E}, // LIM_HEART Pipe X: Disabled
+ 	};
+ 
+-	if (data_type1 == GMSL_CSI_DT_RAW_8 || data_type1 == GMSL_CSI_DT_EMBED
+-	    || data_type2 == GMSL_CSI_DT_RAW_8 || data_type2 == GMSL_CSI_DT_EMBED) {
++	bool has_ud31_8bit = data_type1 == 0x31 || data_type2 == 0x31;
++
++	if (data_type1 == GMSL_CSI_DT_RAW_8 || data_type1 == GMSL_CSI_DT_EMBED ||
++	    data_type2 == GMSL_CSI_DT_RAW_8 || data_type2 == GMSL_CSI_DT_EMBED ||
++	    has_ud31_8bit) {
+ 		map_bpp8dbl[0].val |= (1 << pipe_id);
+ 	} else {
+ 		map_bpp8dbl[0].val &= ~(1 << pipe_id);
 diff --git a/drivers/media/platform/tegra/camera/vi/channel.c b/drivers/media/platform/tegra/camera/vi/channel.c
 index ac5e0e9c..9eee67ba 100644
 --- a/drivers/media/platform/tegra/camera/vi/channel.c

--- a/nvidia-oot/6.1/0013-Receive-flat-NV12-over-UD31.patch
+++ b/nvidia-oot/6.1/0013-Receive-flat-NV12-over-UD31.patch
@@ -1,0 +1,1 @@
+../6.0/0013-Receive-flat-NV12-over-UD31.patch

--- a/nvidia-oot/6.2/0013-Receive-flat-NV12-over-UD31.patch
+++ b/nvidia-oot/6.2/0013-Receive-flat-NV12-over-UD31.patch
@@ -1,0 +1,1 @@
+../6.0/0013-Receive-flat-NV12-over-UD31.patch

--- a/nvidia-oot/7.0/0013-Receive-flat-NV12-over-UD31.patch
+++ b/nvidia-oot/7.0/0013-Receive-flat-NV12-over-UD31.patch
@@ -9,14 +9,34 @@ capture descriptor, expand the transport height to H*3/2, and expose the
 resulting byte-identical surface through the standard NV12 V4L2 ABI.
 
 Scope NV12 buffer sizing and channel-format lookup to the private tuple,
-while preserving legacy lookup behavior for every other FourCC.
+while preserving legacy lookup behavior for every other FourCC. Classify
+UD31 with the existing RAW8 double-pixel handling in MAX9295 Pixel Mode.
 ---
+ drivers/media/i2c/max9295.c                   |  7 +++++--
  .../media/platform/tegra/camera/vi/channel.c  | 14 ++++++++++++++
  drivers/media/platform/tegra/camera/vi/core.c | 16 ++++++++++++++--
  .../media/platform/tegra/camera/vi/vi5_fops.c | 12 +++++++
  .../platform/tegra/camera/vi/vi5_formats.h    | 32 +++++++++++++++++++
- 4 files changed, 72 insertions(+), 2 deletions(-)
+ 5 files changed, 77 insertions(+), 4 deletions(-)
 
+diff --git a/drivers/media/i2c/max9295.c b/drivers/media/i2c/max9295.c
+index 5b9a4dcf..f360ec4c 100644
+--- a/drivers/media/i2c/max9295.c
++++ b/drivers/media/i2c/max9295.c
+@@ -576,8 +576,11 @@ static int __max9295_set_pipe(struct device *dev, int pipe_id, u8 data_type1,
+ 		{0x0102, 0x0E}, // LIM_HEART Pipe X: Disabled
+ 	};
+ 
+-	if (data_type1 == GMSL_CSI_DT_RAW_8 || data_type1 == GMSL_CSI_DT_EMBED
+-	    || data_type2 == GMSL_CSI_DT_RAW_8 || data_type2 == GMSL_CSI_DT_EMBED) {
++	bool has_ud31_8bit = data_type1 == 0x31 || data_type2 == 0x31;
++
++	if (data_type1 == GMSL_CSI_DT_RAW_8 || data_type1 == GMSL_CSI_DT_EMBED ||
++	    data_type2 == GMSL_CSI_DT_RAW_8 || data_type2 == GMSL_CSI_DT_EMBED ||
++	    has_ud31_8bit) {
+ 		map_bpp8dbl[0].val |= (1 << pipe_id);
+ 	} else {
+ 		map_bpp8dbl[0].val &= ~(1 << pipe_id);
 diff --git a/drivers/media/platform/tegra/camera/vi/channel.c b/drivers/media/platform/tegra/camera/vi/channel.c
 index 993db7bd..0405886e 100644
 --- a/drivers/media/platform/tegra/camera/vi/channel.c

--- a/nvidia-oot/7.0/0013-Receive-flat-NV12-over-UD31.patch
+++ b/nvidia-oot/7.0/0013-Receive-flat-NV12-over-UD31.patch
@@ -1,0 +1,201 @@
+From 84728655e3f873dd6615045613a6f84fd60cf74d Mon Sep 17 00:00:00 2001
+From: zhou <shengyong.zhou@realsenseai.com>
+Date: Mon, 17 Aug 2026 10:25:24 +0800
+Subject: [PATCH] media: tegra: receive flat NV12 over UD31
+
+Add a private media-bus tuple that matches UD31 while DMAing an opaque
+T_R8 surface. Apply the RAW8 receive-parser override only to the current
+capture descriptor, expand the transport height to H*3/2, and expose the
+resulting byte-identical surface through the standard NV12 V4L2 ABI.
+
+Scope NV12 buffer sizing and channel-format lookup to the private tuple,
+while preserving legacy lookup behavior for every other FourCC.
+---
+ .../media/platform/tegra/camera/vi/channel.c  | 14 ++++++++++++++
+ drivers/media/platform/tegra/camera/vi/core.c | 16 ++++++++++++++--
+ .../media/platform/tegra/camera/vi/vi5_fops.c | 12 +++++++
+ .../platform/tegra/camera/vi/vi5_formats.h    | 32 +++++++++++++++++++
+ 4 files changed, 72 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/media/platform/tegra/camera/vi/channel.c b/drivers/media/platform/tegra/camera/vi/channel.c
+index 993db7bd..0405886e 100644
+--- a/drivers/media/platform/tegra/camera/vi/channel.c
++++ b/drivers/media/platform/tegra/camera/vi/channel.c
+@@ -329,6 +329,9 @@ static void tegra_channel_update_format(struct tegra_channel *chan,
+ 
+ 	if (fourcc == V4L2_PIX_FMT_NV16)
+ 		chan->format.sizeimage *= 2;
++	else if (fourcc == V4L2_PIX_FMT_NV12 &&
++		 chan->fmtinfo->code == MEDIA_BUS_FMT_RS_NV12_UD31_1X8)
++		chan->format.sizeimage = chan->format.sizeimage * 3 / 2;
+ }
+ 
+ static void tegra_channel_fmts_bitmap_init(struct tegra_channel *chan)
+@@ -2219,12 +2222,22 @@ __tegra_channel_try_format(struct tegra_channel *chan,
+ 				&pix->width, &pix->height, &pix->bytesperline);
+ 	pix->sizeimage = get_aligned_buffer_size(chan,
+ 			pix->bytesperline, pix->height);
++	if (vfmt->fourcc == V4L2_PIX_FMT_NV12 &&
++	    vfmt->code == MEDIA_BUS_FMT_RS_NV12_UD31_1X8) {
++		if (__builtin_umul_overflow(pix->sizeimage, 3, &pix->sizeimage)) {
++			dev_err(chan->vi->dev, "%s: update size image failed due to an overflow\n",
++				__func__);
++			return -EOVERFLOW;
++		}
++		pix->sizeimage /= 2;
++		return ret;
++	}
++
+ 	if (chan->fmtinfo->fourcc == V4L2_PIX_FMT_NV16) {
+ 		if (__builtin_umul_overflow(pix->sizeimage, 2, &pix->sizeimage)) {
+ 			dev_err(chan->vi->dev, "%s: update size image failed due to an overflow\n",
+ 			__func__);
+ 			return -EOVERFLOW;
+ 		}
+ 	}
+ 
+ 	return ret;
+diff --git a/drivers/media/platform/tegra/camera/vi/core.c b/drivers/media/platform/tegra/camera/vi/core.c
+index 30ed1307..63c8b7ca 100644
+--- a/drivers/media/platform/tegra/camera/vi/core.c
++++ b/drivers/media/platform/tegra/camera/vi/core.c
+@@ -6,6 +6,7 @@
+  */
+ 
+ #include <linux/export.h>
++#include <linux/bitmap.h>
+ #include <linux/kernel.h>
+ #include <linux/of.h>
+ #include <linux/nospec.h>
+@@ -26,6 +27,15 @@ static const struct tegra_video_format tegra_default_format[] = {
+ 	},
+ };
+ 
++static bool tegra_core_format_is_available(struct tegra_channel *chan,
++		unsigned int index)
++{
++	return chan->video_formats[index]->code !=
++		MEDIA_BUS_FMT_RS_NV12_UD31_1X8 ||
++		bitmap_empty(chan->fmts_bitmap, MAX_FORMAT_NUM) ||
++		test_bit(index, chan->fmts_bitmap);
++}
++
+ /* -----------------------------------------------------------------------------
+  * Helper functions
+  */
+@@ -106,7 +114,8 @@ int tegra_core_get_code_by_fourcc(struct tegra_channel *chan,
+ 	unsigned int i;
+ 
+ 	for (i = offset; i < chan->num_video_formats; ++i) {
+-		if (chan->video_formats[i]->fourcc == fourcc)
++		if (chan->video_formats[i]->fourcc == fourcc &&
++		    tegra_core_format_is_available(chan, i))
+ 			return chan->video_formats[i]->code;
+ 	}
+ 	spec_bar();
+@@ -166,7 +175,8 @@ tegra_core_get_format_by_fourcc(struct tegra_channel *chan, u32 fourcc)
+ 	unsigned int i;
+ 
+ 	for (i = 0; i < chan->num_video_formats; ++i) {
+-		if (chan->video_formats[i]->fourcc == fourcc)
++		if (chan->video_formats[i]->fourcc == fourcc &&
++		    tegra_core_format_is_available(chan, i))
+ 			return chan->video_formats[i];
+ 	}
+ 	spec_bar();
+diff --git a/drivers/media/platform/tegra/camera/vi/vi5_fops.c b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
+index 9b8be688..df21fdfe 100644
+--- a/drivers/media/platform/tegra/camera/vi/vi5_fops.c
++++ b/drivers/media/platform/tegra/camera/vi/vi5_fops.c
+@@ -58,6 +58,8 @@ static const struct capture_descriptor capture_template = {
+ 	,
+ 
+ 	.ch_cfg = {
++		.dt_enable = 0,
++		.dt_override = 0,
+ 		.pixfmt_enable = 0,		/* no output */
+ 		.match = {
+ 			.stream = 0,		/* one-hot bit encoding */
+@@ -393,6 +395,8 @@ static void vi5_setup_surface(struct tegra_channel *chan,
+ 	u32 format = chan->fmtinfo->img_fmt;
+ 	u32 bpl = chan->format.bytesperline;
+ 	u32 data_type = chan->fmtinfo->img_dt;
++	const struct tegra_vi_surface_override *surface_override =
++		tegra_vi_get_surface_override(chan->fmtinfo->code);
+ 	u32 nvcsi_stream = chan->port[vi_port];
+ 	unsigned int range = 0;
+ 	struct capture_descriptor_memoryinfo *desc_memoryinfo =
+@@ -427,6 +431,9 @@ static void vi5_setup_surface(struct tegra_channel *chan,
+ 	 */
+ 	if (chan->fmtinfo->fourcc == V4L2_PIX_FMT_Y16I)
+ 		width *= 2;
++	if (surface_override)
++		height = height * surface_override->height_numerator /
++			surface_override->height_denominator;
+ 
+ 	memcpy(desc, &capture_template, sizeof(capture_template));
+ 	memset(desc_memoryinfo, 0, sizeof(*desc_memoryinfo));
+@@ -438,6 +445,11 @@ static void vi5_setup_surface(struct tegra_channel *chan,
+ 	desc->ch_cfg.frame.frame_y = height;
+ 	desc->ch_cfg.match.datatype = data_type;
+ 	desc->ch_cfg.match.datatype_mask = 0x3f;
++	if (surface_override && surface_override->dt_override) {
++		desc->ch_cfg.dt_enable = 1;
++		desc->ch_cfg.dt_override = surface_override->dt_override;
++	}
++
+ 	desc->ch_cfg.pixfmt_enable = 1;
+ 	desc->ch_cfg.pixfmt.format = format;
+ 
+diff --git a/drivers/media/platform/tegra/camera/vi/vi5_formats.h b/drivers/media/platform/tegra/camera/vi/vi5_formats.h
+index 307f398f..0ae63202 100644
+--- a/drivers/media/platform/tegra/camera/vi/vi5_formats.h
++++ b/drivers/media/platform/tegra/camera/vi/vi5_formats.h
+@@ -82,6 +82,36 @@ enum tegra_image_format {
+ 	TEGRA_IMAGE_FORMAT_T_DPCM_RAW20,
+ };
+ 
++struct tegra_vi_surface_override {
++	u32 code;
++	u8 dt_override;
++	u8 height_numerator;
++	u8 height_denominator;
++};
++
++static const struct tegra_vi_surface_override
++tegra_vi_surface_overrides[] = {
++	{
++		.code = MEDIA_BUS_FMT_RS_NV12_UD31_1X8,
++		.dt_override = TEGRA_IMAGE_DT_RAW8,
++		.height_numerator = 3,
++		.height_denominator = 2,
++	},
++};
++
++static const struct tegra_vi_surface_override *
++tegra_vi_get_surface_override(u32 code)
++{
++	unsigned int i;
++
++	for (i = 0; i < ARRAY_SIZE(tegra_vi_surface_overrides); i++) {
++		if (tegra_vi_surface_overrides[i].code == code)
++			return &tegra_vi_surface_overrides[i];
++	}
++
++	return NULL;
++}
++
+ static const struct tegra_video_format vi5_video_formats[] = {
+ 	/* RAW 6: TODO */
+ 
+@@ -169,6 +199,8 @@ static const struct tegra_video_format vi5_video_formats[] = {
+ 				RAW16, Y16I, "Y16I 32"),
+ 	TEGRA_VIDEO_FORMAT(RAW16, 16, SGRBG16_1X16, 2, 1, T_R16,
+ 				RAW16, RW16, "RW16 16"),
++	TEGRA_VIDEO_FORMAT(RAW8, 8, RS_NV12_UD31_1X8, 1, 1, T_R8,
++				USER_2, NV12, "YUV 4:2:0 NV12 UD31"),
+ 
+ };
+ 
+-- 
+2.34.1

--- a/nvidia-oot/7.1/0013-Receive-flat-NV12-over-UD31.patch
+++ b/nvidia-oot/7.1/0013-Receive-flat-NV12-over-UD31.patch
@@ -1,0 +1,1 @@
+../7.0/0013-Receive-flat-NV12-over-UD31.patch

--- a/nvidia-oot/7.2/0013-Receive-flat-NV12-over-UD31.patch
+++ b/nvidia-oot/7.2/0013-Receive-flat-NV12-over-UD31.patch
@@ -1,0 +1,1 @@
+../7.0/0013-Receive-flat-NV12-over-UD31.patch


### PR DESCRIPTION
## Summary

- Expose D58x Pixel Mode RGB NV12 through the same CSI-2 UD31 carrier used by tunnel mode.
- Program the per-format HKR override for D58x Pixel Mode while preserving zero-clear behavior when switching formats.
- Treat UD31 as the existing RAW8/double-8bit class in MAX9295, then expose the byte-identical result through `V4L2_PIX_FMT_NV12`.

## Why UD31

The target SerDes default mapping defines UD30 as `UDP24` and UD31-UD37 as `UDP8`. UD31 therefore carries each flat NV12 byte as one 8-bit sample and avoids UD30 padding or a tunnel/Pixel DT remap.

## Scope

- Stacked on the tunnel implementation in PR #585.
- D58x Pixel Mode format table and D58x RGB override handling only.
- One UD31 addition to MAX9295's existing RAW8 double-pixel classification, carried by the existing JP5/JP6/JP7 feature patches.
- No D4x format table, MAX96712 mapping, device-tree, or build-system change.

## Dependencies

- Tunnel receiver: https://github.com/realsenseai/realsense_mipi_platform_driver/pull/585
- HKR device manager: https://github.com/RealSenseAI-Internal/soc-rs-soc-device-mgr/pull/471
- HKR HIF MIPI: https://github.com/RealSenseAI-Internal/soc-rs-soc-io-drivers/pull/548

## Verification

- JP6.2.1 clean patch reset/replay: PASS.
- JP6.2.1 full kernel, NVIDIA OOT modules, DTB, and rootfs staging build: PASS.
- Full rootfs staging deployed on jetson43 (AGX Orin, MAX96712 Pixel Mode); module hashes matched the build.
- D4x Pixel regression on the shared MAX96712 setup: D401 Z16, D415 RGB YUYV, D457 GREY, and D430 Z16 each captured 30 continuous frames at about 30fps.
- No VI/NVCSI timeout, CHANSEL, or CRC error was observed after regression.

## Open validation gate

jetson43 currently has D401, D415, D457, and D430 attached, but no D58x. D58x NV12 Pixel Mode frame capture and byte-layout validation remain open; keep this PR as draft until a D58x is connected to a Pixel Mode link.
