### PR TITLE
[D5xx] Expose sync_mode range 2-3 to match FW register 0x2C semantics

### DIFF
--- a/kernel/realsense/d4xx.c
+++ b/kernel/realsense/d4xx.c
@@ -2548,6 +2548,20 @@ enum ds5_sync_mode {
 	DS5_SYNC_MODE_EXTERNAL = 2,
 };
 
+/* D5xx (D58X) sync mode values — FW register 0x2C accepts these literally;
+ * mirrors RS2_D500_INTERCAM_SYNC_PWM_MASTER / _EXTERNAL_MASTER in the SDK. */
+enum ds5_d5xx_sync_mode {
+	DS5_D5XX_SYNC_MODE_INTERNAL         = 2,
+	DS5_D5XX_SYNC_MODE_EXTERNAL_MASTER  = 3,
+};
+
+static inline bool ds5_sync_val_is_external(const struct ds5 *state, int val)
+{
+	if (state->ds5_dev->cached_device_type == DS5_DEVICE_TYPE_D58X)
+		return val == DS5_D5XX_SYNC_MODE_EXTERNAL_MASTER;
+	return val == DS5_SYNC_MODE_EXTERNAL;
+}
+
 #define DS5_CAMERA_CID_PWM			(DS5_CAMERA_CID_BASE+22)
 #define DS5_CAMERA_CID_SOC_PVT_TEMPERATURE	(DS5_CAMERA_CID_BASE+24)
 #define DS5_CAMERA_CID_PROJECTOR_TEMPERATURE	(DS5_CAMERA_CID_BASE+25)
@@ -3041,7 +3055,7 @@ static int ds5_hw_reset_with_recovery(struct ds5 *state)
 	/* Re-apply ESYNC tunneling to match cached sync_mode control */
 	if (state->ctrls.sync_mode) {
 		int sync_val = state->ctrls.sync_mode->cur.val;
-		bool need_esync = (sync_val == DS5_SYNC_MODE_EXTERNAL);
+		bool need_esync = ds5_sync_val_is_external(state, sync_val);
 
 		ret = ds5_set_ser_esync_tunneling(state, need_esync);
 		if (ret)
@@ -3442,7 +3456,7 @@ static int ds5_s_ctrl(struct v4l2_ctrl *ctrl)
 			dev_info(&state->client->dev, "%s(): SYNC_MODE command passed to FW, addr: 0x%x, value: %d, ret: %d\n",
 				__func__, base | DS5_CAMERA_SYNC_MODE, ctrl->val, ret);
 			if (!ret) {
-				bool need_esync = (ctrl->val == DS5_SYNC_MODE_EXTERNAL);
+				bool need_esync = ds5_sync_val_is_external(state, ctrl->val);
 
 				dev_dbg(&state->client->dev,
 					"%s(): sync_mode=%d -> serializer ESYNC %s\n",
@@ -4163,6 +4177,12 @@ static const char * const sync_mode_menu[] = {
 	[DS5_SYNC_MODE_DEFAULT]  = "Default",
 	[DS5_SYNC_MODE_MASTER]   = "Master",
 	[DS5_SYNC_MODE_EXTERNAL] = "External Sync",
+};
+
+/* D5xx menu — FW register 0x2C values are 2/3, not 0-based. */
+static const char * const d5xx_sync_mode_menu[] = {
+	[DS5_D5XX_SYNC_MODE_INTERNAL]        = "Internal",
+	[DS5_D5XX_SYNC_MODE_EXTERNAL_MASTER] = "External Master",
 };
 
 static struct v4l2_ctrl_config ds5_ctrl_sync_mode = {
@@ -6921,12 +6941,23 @@ static void ds5_adjust_sync_mode_control(struct i2c_client *client, struct ds5 *
 	case DS5_DEVICE_TYPE_D41X:
 	case DS5_DEVICE_TYPE_D43X:
 	case DS5_DEVICE_TYPE_D45X:
-	case DS5_DEVICE_TYPE_D58X:
 		/* Unified 3-value public interface (RSDEV-6449): Default/Master/External */
 		__v4l2_ctrl_modify_range(state->ctrls.sync_mode,
 					 0, DS5_SYNC_MODE_EXTERNAL, 0, 0);
 		state->ctrls.sync_mode->qmenu = sync_mode_menu;
 		dev_dbg(&client->dev, "%s(): sync mode: 0-2 (Default/Master/External)\n",
+			__func__);
+		break;
+	case DS5_DEVICE_TYPE_D58X:
+		/* D5xx FW register 0x2C uses literal values 2 (Internal / PWM master) and
+		 * 3 (External master); mirrors RS2_D500_INTERCAM_SYNC_* in the SDK. */
+		__v4l2_ctrl_modify_range(state->ctrls.sync_mode,
+					 DS5_D5XX_SYNC_MODE_INTERNAL,
+					 DS5_D5XX_SYNC_MODE_EXTERNAL_MASTER,
+					 0,
+					 DS5_D5XX_SYNC_MODE_INTERNAL);
+		state->ctrls.sync_mode->qmenu = d5xx_sync_mode_menu;
+		dev_dbg(&client->dev, "%s(): sync mode: 2-3 (Internal/External Master)\n",
 			__func__);
 		break;
 	default:


### PR DESCRIPTION
Tracked by: RSDEV-9254

## Why
On D585 GMSL the depth-sensor `Inter Cam Sync Mode` was exposed as a slider ranging 0-2 with menu labels {Default, Master, External Sync}, but the D5xx FW register `0x2C` accepts literal values `2 = Internal (PWM master)` and `3 = External master` — mirroring `RS2_D500_INTERCAM_SYNC_PWM_MASTER` / `_EXTERNAL_MASTER` in the SDK. Result: value `3` was rejected by V4L2 (out of range), value `2` was written raw to FW and interpreted as "Internal" while the driver label read "External Sync", and the SerDes ESYNC tunneling fired on `val == 2` even though for D5xx that means "Internal".

The librealsense viewer also fell back to a slider (instead of the Internal / External combo) because the SDK's `description_per_value` map is keyed on `{2, 3}` — walking the advertised 0-2 range hit `nullptr` at `0` and `1`, so `option_model::is_enum()` returned false.

## Summary
- Add `enum ds5_d5xx_sync_mode` (`INTERNAL=2`, `EXTERNAL_MASTER=3`) and a `d5xx_sync_mode_menu` with matching labels.
- Split `DS5_DEVICE_TYPE_D58X` out of the shared D4xx case in `ds5_adjust_sync_mode_control()` and set range `{min=2, max=3, def=2}` with `d5xx_sync_mode_menu`. D4xx (D40X/D41X/D43X/D45X) behavior unchanged.
- Introduce `ds5_sync_val_is_external(state, val)` helper — returns `val == 3` on D58X, `val == 2` otherwise — and use it in the two ESYNC-tunneling call sites (`ds5_hw_reset_with_recovery` and `ds5_s_ctrl` under `DS5_CAMERA_CID_SYNC_MODE`).

## Test plan
- [x] Build on JP6.2 and load on D585 GMSL host.
- [x] `v4l2-ctl -d /dev/video0 --list-ctrls-menus` — confirm `camera_sync_mode` shows range 2..3 with menu `2: Internal`, `3: External Master`.
- [x] `v4l2-ctl -d /dev/video0 --set-ctrl=camera_sync_mode=3` succeeds; read back returns 3; SerDes ESYNC enabled in dmesg.
- [x] `--set-ctrl=camera_sync_mode=2` succeeds; read back returns 2; SerDes ESYNC disabled in dmesg.
- [x] `--set-ctrl=camera_sync_mode=0` and `=1` are rejected (out of range).
- [x] realsense-viewer on D585 GMSL renders `Inter Cam Sync Mode` as a combo box with `Internal` / `External` and round-trips both values.
- [ ] Regression: D457 (D45X) still exposes range 0..2 with menu `Default / Master / External Sync`; ESYNC still fires on value 2.

---
🤖 Generated by AI